### PR TITLE
Test Architecture Tweak

### DIFF
--- a/features/git-ship.feature
+++ b/features/git-ship.feature
@@ -18,7 +18,7 @@ Feature: Git Ship
 
 
   Scenario: feature branch with non-pulled updates in the repo
-    Given I am on a feature branch with a remote tracking branch
+    Given I am on a feature branch
     And the following commit exists
       | location | file name    | file content    |
       | remote   | feature_file | feature content |
@@ -54,7 +54,7 @@ Feature: Git Ship
 
 
   Scenario: conflict after pulling the feature branch
-    Given I am on a feature branch with a remote tracking branch
+    Given I am on a feature branch
     And the following commits exist
       | location | message                   | file name        | file content   |
       | remote   | conflicting remote commit | conflicting_file | remote content |

--- a/features/git-sync.feature
+++ b/features/git-sync.feature
@@ -50,7 +50,7 @@ Feature: Git Sync
 
 
   Scenario: on a feature branch with a remote branch
-    Given I am on a feature branch with a remote tracking branch
+    Given I am on a feature branch
     And the following commits exist
       | branch  | location | message               | file name           |
       | main    | local    | local main commit     | local_main_file     |
@@ -80,7 +80,7 @@ Feature: Git Sync
 
 
   Scenario: user aborts after a merge conflict when pulling the feature branch
-    Given I am on a feature branch with a remote tracking branch
+    Given I am on a feature branch
     And the following commits exist
       | branch  | location | message                   | file name          | file content               |
       | main    | local    | main branch update        | main_branch_update | main branch update         |
@@ -109,7 +109,7 @@ Feature: Git Sync
 
 
   Scenario: user continues after resolving a merge conflict when pulling the feature branch
-    Given I am on a feature branch with a remote tracking branch
+    Given I am on a feature branch
     And the following commits exist
       | branch  | location | message                   | file name          | file content               |
       | feature | remote   | remote conflicting commit | conflicting_file   | remote conflicting content |

--- a/features/step_definitions/branch_steps.rb
+++ b/features/step_definitions/branch_steps.rb
@@ -1,10 +1,6 @@
-Given /^I am on a feature branch( with a remote tracking branch)?$/ do |_|
-  in_repository coworker_repository do
-    run 'git checkout -b feature main'
-    run 'git push -u origin feature'
-  end
-  run 'git fetch'
-  run 'git checkout feature'
+Given /^I am on a feature branch$/ do
+  run "git checkout -b feature main"
+  run "git push -u origin feature"
 end
 
 

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -28,6 +28,7 @@ Given /^the following commits? exists?$/ do |commits_data|
     end
     if options[:commit_location].delete :remote
       in_repository coworker_repository do
+        run 'git fetch'
         create_local_commit options
         run 'git push'
       end


### PR DESCRIPTION
As I was starting to write tests for sync-fork, wanted to try and simplify the test architecture a little bit.
Tests now update the remote with a second repository instead of using local and resetting.
This was just easier for me to think about and more closely mirrors reality.

@kevgo what do you think?

Note: I used git-extract to pull this off my sync-fork branch.
