### PR TITLE
Use non-capturing syntax for cosmetic regex

### DIFF
--- a/features/step_definitions/branch_steps.rb
+++ b/features/step_definitions/branch_steps.rb
@@ -22,7 +22,7 @@ end
 
 
 
-Then /^I (end up|am still) on the feature branch$/ do |_|
+Then /^I (?:end up|am still) on the feature branch$/ do
   expect(current_branch_name).to eql 'feature'
 end
 
@@ -32,7 +32,7 @@ Then /^I end up on my feature branch$/  do
 end
 
 
-Then /^I (end up|am still) on the "(.+?)" branch$/ do |_, branch_name|
+Then /^I (?:end up|am still) on the "(.+?)" branch$/ do |branch_name|
   expect(current_branch_name).to eql branch_name
 end
 

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -53,7 +53,7 @@ Then /^my branch and its remote still have (\d+) and (\d+) different commits$/ d
 end
 
 
-Then /^(now )?I (still )?have the following commits$/ do |_, _, commits_data|
+Then /^(?:now )?I (?:still )?have the following commits$/ do |commits_data|
   expected_commits = commits_data.hashes
                                  .each do |commit_data|
                                     symbolize_keys_deep! commit_data

--- a/features/step_definitions/files_steps.rb
+++ b/features/step_definitions/files_steps.rb
@@ -18,7 +18,7 @@ Then /^there are no merge conflicts anymore$/ do
 end
 
 
-Then /^(now I|I still) have the following committed files$/ do |_, files_data|
+Then /^(?:now I|I still) have the following committed files$/ do |files_data|
 
   # Get all files in all branches
   actual_files = []
@@ -61,7 +61,7 @@ Then /^I don't have an uncommitted file with name: "(.*?)"$/ do |file_name|
 end
 
 
-Then /^I (still|again) have an uncommitted file with name: "([^"]+)" and content: "([^"]+)"?$/ do |_, expected_name, expected_content|
+Then /^I (?:still|again) have an uncommitted file with name: "([^"]+)" and content: "([^"]+)"?$/ do |expected_name, expected_content|
   actual_files = run("git status --porcelain | awk '{print $2}'")[:out].split("\n")
   expect(actual_files).to eql [expected_name]
 

--- a/features/step_definitions/rebase_steps.rb
+++ b/features/step_definitions/rebase_steps.rb
@@ -6,7 +6,7 @@ end
 
 
 
-Then /^my repo (still )?has a rebase in progress$/ do |_|
+Then /^my repo (?:still )?has a rebase in progress$/ do
   expect(rebase_in_progress).to be_truthy
 end
 


### PR DESCRIPTION
@charlierudolph @alexdavid this prevents the unnecessary `_` variable names in the block signatures for the step definitions.
