### PR TITLE
Use GitHub issues to track who is working on what

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ and stores this information in the Git configuration of your project.
 
 ## development
 
+* assign yourself to the respective <a href="https://github.com/originate/git-town/issues" target="_blank">GitHub issue</a>
 * run all tests: `cucumber`
 * run a single test: `cucumber -n 'scenario/feature name'` or `cucumber [filename]:[lineno]`
 


### PR DESCRIPTION
@charlierudolph This is more a workflow change than a code change. Let's use GitHub issues to see who works on what, so that we don't double-implement things, or step on each others toes. What do you think about this?
