### PR TITLE
Allow commands to output color

### DIFF
--- a/helpers/git_helpers.sh
+++ b/helpers/git_helpers.sh
@@ -25,7 +25,7 @@ function checkout_main_branch {
 function cherry_pick {
   local SHAs=$*
   run_command "git cherry-pick $SHAs"
-  if [ $command_exit_status != 0 ]; then error_cherry_pick $SHAs; fi
+  if [ $? != 0 ]; then error_cherry_pick $SHAs; fi
 }
 
 # Creates a new feature branch with the given name.
@@ -158,7 +158,7 @@ function merge_branch {
   local branch_name=$1
   local current_branch_name=`get_current_branch_name`
   run_command "git merge $branch_name"
-  if [ $command_exit_status != 0 ]; then error_merge_branch; fi
+  if [ $? != 0 ]; then error_merge_branch; fi
 }
 
 
@@ -185,7 +185,7 @@ function pull_branch {
   if [ `has_tracking_branch` == true ]; then
     fetch_repo
     run_command "git $strategy origin/$current_branch_name"
-    if [ $command_exit_status != 0 ]; then error_pull_branch $current_branch_name; fi
+    if [ $? != 0 ]; then error_pull_branch $current_branch_name; fi
   else
     echo "Branch '$current_branch_name' has no remote branch, skipping pull of updates"
   fi
@@ -197,7 +197,7 @@ function pull_upstream_branch {
   local current_branch_name=`get_current_branch_name`
   fetch_upstream
   run_command "git rebase upstream/$current_branch_name"
-  if [ $command_exit_status != 0 ]; then error_pull_upstream_branch; fi
+  if [ $? != 0 ]; then error_pull_upstream_branch; fi
 }
 
 
@@ -242,13 +242,11 @@ function squash_merge {
   local commit_message=$2
   local current_branch_name=`get_current_branch_name`
   run_command "git merge --squash $branch_name"
-  if [ $command_exit_status != 0 ]; then error_squash_merge; fi
+  if [ $? != 0 ]; then error_squash_merge; fi
   if [ "$commit_message" == "" ]; then
-    print_command "git commit -a"
-    git commit -a
+    run_command "git commit -a"
   else
-    print_command "git commit -a -m \"$commit_message\""
-    git commit -a -m "$commit_message"
+    run_command "git commit -a -m '$commit_message'"
   fi
 }
 

--- a/helpers/terminal_helpers.sh
+++ b/helpers/terminal_helpers.sh
@@ -100,20 +100,12 @@ function output_style_reset {
 function print_command {
   local branch_name=`get_current_branch_name`
   echo_header "[$branch_name] $*"
-  commands_printed=$((commands_printed+1))
 }
 
 
 # Run a command, prints command and output
-command_exit_status=0
 function run_command {
   local cmd=$*
   print_command $cmd
-
-  local output; output=`$cmd 2>&1`
-  command_exit_status=$?
-
-  if [ -n "$output" ]; then
-    echo "$output"
-  fi
+  eval $cmd 2>&1
 }


### PR DESCRIPTION
By running them in the main shell instead of in a sub-shell the commands can output color.
Removes the special cases for the commit commands
