### PR TITLE
Merge no edit

### DIFF
--- a/helpers/git_helpers.sh
+++ b/helpers/git_helpers.sh
@@ -167,7 +167,7 @@ function has_branch {
 function merge_branch {
   local branch_name=$1
   local current_branch_name=`get_current_branch_name`
-  run_command "git merge $branch_name"
+  run_command "git merge --no-edit $branch_name"
   if [ $? != 0 ]; then error_merge_branch; fi
 }
 


### PR DESCRIPTION
From http://git-scm.com/docs/git-merge
The `--no-edit` option can be used to accept the auto-generated message (this is generally discouraged).

`merge_branch` is only used for merging the main branch into a feature branch.
Although generally discouraged it prevents the extra step of having to close the editor.
I have not ran into the case where I would edit the message.
