### PR TITLE
Fix "all branches are now synchronized" step

### DIFF
--- a/features/step_definitions/branch_steps.rb
+++ b/features/step_definitions/branch_steps.rb
@@ -82,7 +82,7 @@ end
 
 
 Then /^all branches are now synchronized$/ do
-  run("git branch -vv | grep -o '\[.*\]' | tr -d '[]' | awk '{ print $2 }' | tr -d '\n' | wc -m")[:out] == '0'
+  expect(number_of_branches_out_of_sync).to eql 0
 end
 
 

--- a/features/support/branch_helpers.rb
+++ b/features/support/branch_helpers.rb
@@ -47,6 +47,10 @@ def existing_remote_branches
   remote_branches
 end
 
+def number_of_branches_out_of_sync
+  run("git branch -vv | grep -o '\[.*\]' | tr -d '[]' | awk '{ print $2 }' | grep . | wc -l")[:out].to_i
+end
+
 
 def remote_branch_exists branch_name
   run("git branch -a | grep remotes/origin/#{branch_name} | wc -l")[:out] != '0'


### PR DESCRIPTION
The execution was not working as expected as `grep $1` was erring and printing a usage message.
Also the step was just evaluating a expressions instead of using as expectation so it could never fail.
