### PR TITLE
Test cleanup: remote branches

### DIFF
--- a/features/git-sync-fork.feature
+++ b/features/git-sync-fork.feature
@@ -3,16 +3,15 @@ Feature: Git Sync-Fork
   Scenario: on the main branch with an upstream commit
     Given I am on the main branch
     And my repo has an upstream repo
-    And the following commits exist in the upstream repository
-      | location | message         | file name     |
-      | upstream | upstream commit | upstream_file |
+    And the following commits exist in my repository
+      | branch | location | message         | file name     |
+      | main   | upstream | upstream commit | upstream_file |
     And I have an uncommitted file with name: "uncommitted" and content: "stuff"
     When I run `git sync-fork`
     Then I am still on the "main" branch
     And I see the following commits
-      | branch                  | location         | message         | files         |
-      | main                    | local and remote | upstream commit | upstream_file |
-      | remotes/upstream/main   | remote           | upstream commit | upstream_file |
+      | branch | location                    | message         | files         |
+      | main   | local, remote, and upstream | upstream commit | upstream_file |
     And now I have the following committed files
       | branch | files         |
       | main   | upstream_file |

--- a/features/step_definitions/branch_steps.rb
+++ b/features/step_definitions/branch_steps.rb
@@ -105,12 +105,7 @@ end
 
 
 Then /^there are no more feature branches$/ do
-  expected_branches = [ 'master',
-                        "* main",
-                        "remotes/origin/main",
-                        'remotes/origin/master' ].sort
-  actual_branches = run("git branch -a").out.split("\n").map(&:strip).sort
-  expect(actual_branches).to eql expected_branches
+  expect(existing_branches).to match_array ['main', 'origin/main']
 end
 
 
@@ -121,12 +116,12 @@ Then /^the branch "(.*?)" is deleted everywhere$/ do |branch_name|
     expect(existing_local_branches).to_not include(branch_name)
   end
 
-  expect(existing_remote_branches).to_not include("remotes/origin/#{branch_name}")
+  expect(existing_remote_branches).to_not include("origin/#{branch_name}")
 end
 
 
 Then /^the branch "(.+?)" still exists$/ do |branch_name|
-  expect(existing_remote_branches).to include("remotes/origin/#{branch_name}")
+  expect(existing_remote_branches).to include("origin/#{branch_name}")
 end
 
 

--- a/features/step_definitions/commit_steps.rb
+++ b/features/step_definitions/commit_steps.rb
@@ -12,13 +12,6 @@ Given /^the following commits? exists? in Charlie's repository$/ do |commits_tab
 end
 
 
-Given /^the following commits? exists? in the upstream repository$/ do |commits_table|
-  at_path local_repository_path do
-    create_commits commits_table.hashes
-  end
-end
-
-
 
 
 Then /^my branch and its remote still have (\d+) and (\d+) different commits$/ do |local_count, remote_count|

--- a/features/support/branch_helpers.rb
+++ b/features/support/branch_helpers.rb
@@ -12,9 +12,10 @@ end
 
 
 # Returns the names of the existing feature branches
-def existing_feature_branches
-  existing_local_branches - %w[main]
+def existing_branches
+  existing_local_branches + existing_remote_branches
 end
+
 
 # Returns the names of all existing local branches.
 #
@@ -35,11 +36,10 @@ end
 #
 # Does not return the "master" branch.
 def existing_remote_branches
-  remote_branches = array_output_of 'git branch -a | grep remotes'
-  remote_branches.delete 'remotes/origin/master'
-  remote_branches.delete 'remotes/origin/HEAD -> origin/master'
-  remote_branches
+  remote_branches = array_output_of 'git branch -r'
+  remote_branches.reject { |b| b.include?('HEAD') || b.include?('master') }
 end
+
 
 def number_of_branches_out_of_sync
   integer_output_of "git branch -vv | grep -o '\[.*\]' | tr -d '[]' | awk '{ print $2 }' | grep . | wc -l"
@@ -63,7 +63,7 @@ def verify_branches branches_array
     when 'local'
       expect(existing_local_branches).to match_array(branch_names)
     when 'remote'
-      branch_names = branch_names.map { |n| "remotes/origin/#{n}" }
+      branch_names = branch_names.map { |n| "origin/#{n}" }
       expect(existing_remote_branches).to match_array(branch_names)
     when 'coworker'
       at_path coworker_repository_path do

--- a/features/support/commit_helpers.rb
+++ b/features/support/commit_helpers.rb
@@ -3,20 +3,10 @@ def commits_in_repo
   current_branch = run('git rev-parse --abbrev-ref HEAD').out
 
   result = []
-  existing_local_branches.map do |local_branch_name|
-    run "git checkout #{local_branch_name}"
+  existing_branches.map do |branch_name|
+    run "git checkout #{branch_name}"
     commits = local_commits.each do |commit|
-      commit[:location] = 'local'
-      commit[:branch] = local_branch_name
-    end
-    result.concat commits
-  end
-
-  existing_remote_branches.map do |remote_branch_name|
-    run "git checkout #{remote_branch_name}"
-    commits = local_commits.each do |commit|
-      commit[:location] = 'remote'
-      commit[:branch] = remote_branch_name
+      commit[:branch] = branch_name
     end
     result.concat commits
   end
@@ -91,12 +81,6 @@ def create_commits commits_array
 end
 
 
-# Returns whether the given branch name is simple ('feature')
-# or not ('remotes/origin/feature')
-def is_local_branch_name? branch_name
-  /^[^\/]+$/.match branch_name
-end
-
 # Returns the commits in the currently checked out branch
 def local_commits
   result = run("git log --oneline").out
@@ -132,13 +116,9 @@ def verify_commits commits_table:, repository_path:
     # Create individual expected commits for each location provided
     Kappamaki.from_sentence(commit_data[:location]).map do |location|
       commit_data_clone = commit_data.clone
-      commit_data_clone[:location] = location
-
-      # Convert a local branch name ('feature')
-      # into its corresponding tracking branch name ('remotes/origin/feature')
-      if location == 'remote' && is_local_branch_name?(commit_data_clone[:branch])
-        commit_data_clone[:branch] = "remotes/origin/#{commit_data_clone[:branch]}"
-      end
+      commit_data_clone.delete(:location)
+      commit_data_clone[:branch] = "origin/#{commit_data_clone[:branch]}" if location == 'remote'
+      commit_data_clone[:branch] = "upstream/#{commit_data_clone[:branch]}" if location == 'upstream'
       commit_data_clone
     end
   end.flatten

--- a/features/support/rspec_matchers.rb
+++ b/features/support/rspec_matchers.rb
@@ -15,8 +15,8 @@ RSpec::Matchers.define :match_commits do |expected|
 
   failure_message_for_should do |actual|
     result = ""
-    expected.sort! {|x, y| commit_sorted(x) <=> commit_sorted(y) }
-    actual.sort! {|x, y| commit_sorted(x) <=> commit_sorted(y) }
+    expected.sort! {|x, y| commit_to_s(x) <=> commit_to_s(y) }
+    actual.sort! {|x, y| commit_to_s(x) <=> commit_to_s(y) }
 
     result << "\nEXPECTED VALUES\n"
     expected.each do |commit|
@@ -54,10 +54,6 @@ RSpec::Matchers.define :match_commits do |expected|
   end
 
   def commit_to_s commit
-    "#{commit[:branch]} branch (#{commit[:location]}): '#{commit[:message]}' with #{commit[:files]}\n"
-  end
-
-  def commit_sorted commit
-    "#{commit[:message]} #{commit[:branch]} #{commit[:location]} #{commit[:files]}"
+    "#{commit[:branch]} branch: '#{commit[:message]}' with #{commit[:files]}\n"
   end
 end


### PR DESCRIPTION
@kevgo removed "remotes/" from remote branch names.
