### PR TITLE
cleanup: merge and rebase helpers

### DIFF
--- a/git-extract
+++ b/git-extract
@@ -15,8 +15,8 @@ function error_cherry_pick {
 }
 
 
-# Called when pull_branch fails on the main branch
-function error_pull_main_branch {
+# Called when rebase_branch fails on the main branch
+function error_rebase_branch {
   create_rebase_conflict_abort_script
   exit_with_script_messages
 }
@@ -43,7 +43,9 @@ function perform_extract {
 
   stash_open_changes
   checkout_main_branch
-  sync_branch 'rebase'
+  fetch_repo
+  rebase_tracking_branch
+  push_branch
   create_and_checkout_feature_branch "$target_branch_name"
   cherry_pick "$user_input"
   push_branch

--- a/git-hack
+++ b/git-hack
@@ -2,8 +2,8 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 
-# Called when pull_branch fails on the main branch
-function error_pull_main_branch {
+# Called when rebase_branch fails on the main branch
+function error_rebase_branch {
   create_rebase_conflict_abort_script
   exit_with_script_messages
 }
@@ -22,7 +22,9 @@ function perform_hack {
   ensure_does_not_have_branch "$target_branch_name"
   stash_open_changes
   checkout_main_branch
-  sync_branch 'rebase'
+  fetch_repo
+  rebase_tracking_branch
+  push_branch
   create_and_checkout_feature_branch "$target_branch_name"
   restore_open_changes
 }

--- a/git-ship
+++ b/git-ship
@@ -28,15 +28,8 @@ function error_is_not_feature_branch {
 }
 
 
-# Called when pull_branch fails on the feature branch
-function error_pull_feature_branch {
-  create_merge_conflict_abort_script
-  exit_with_script_messages
-}
-
-
-# Called when pull_branch fails on the main branch
-function error_pull_main_branch {
+# Called when rebase_branch fails on the main branch
+function error_rebase_branch {
   create_rebase_conflict_abort_script
   exit_with_script_messages
 }
@@ -75,9 +68,11 @@ function perform_ship {
   ensure_is_feature_branch "$target_branch_name" "Only feature branches can be shipped."
 
   checkout_main_branch
-  sync_branch 'rebase'
+  fetch_repo
+  rebase_tracking_branch
+  push_branch
   checkout_branch "$target_branch_name"
-  pull_branch
+  merge_tracking_branch
   merge_branch "$main_branch_name"
   ensure_has_shippable_changes
   checkout_main_branch

--- a/git-sync
+++ b/git-sync
@@ -2,14 +2,18 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 
-# Called when pull_branch fails on the feature branch
-function error_pull_feature_branch {
+# Called when merge_branch fails
+function error_merge_branch {
+  local branch_being_merged="$1"
+
   create_merge_conflict_abort_script
 
   # Create the continue script
   add_to_continue_script "initial_open_changes=$initial_open_changes"
   add_to_continue_script "continue_merge"
-  add_to_continue_script "merge_branch $main_branch_name"
+  if [ "$branch_being_merged" != "$main_branch_name" ]; then
+    add_to_continue_script "merge_branch $main_branch_name"
+  fi
   add_to_continue_script "push_branch"
   add_to_continue_script "restore_open_changes"
 
@@ -17,8 +21,8 @@ function error_pull_feature_branch {
 }
 
 
-# Called when pull_branch fails on the main branch
-function error_pull_main_branch {
+# Called when rebase_branch fails
+function error_rebase_branch {
   create_rebase_conflict_abort_script
 
   # Create the continue script
@@ -27,7 +31,7 @@ function error_pull_main_branch {
   if [ "$(is_feature_branch "$initial_branch_name")" == true ]; then
     add_to_continue_script "push_branch"
     add_to_continue_script "checkout_branch $initial_branch_name"
-    add_to_continue_script "pull_branch"
+    add_to_continue_script "merge_tracking_branch"
     add_to_continue_script "merge_branch $main_branch_name"
     add_to_continue_script "push_branch"
   else
@@ -40,49 +44,27 @@ function error_pull_main_branch {
 }
 
 
-# Called when pull_branch fails on a non feature branch
-function error_pull_non_feature_branch {
-  create_rebase_conflict_abort_script
-
-  # Create the continue script
-  add_to_continue_script "initial_open_changes=$initial_open_changes"
-  add_to_continue_script "continue_rebase"
-  add_to_continue_script "push_branch"
-  add_to_continue_script "push_tags"
-  add_to_continue_script "restore_open_changes"
-
-  exit_with_script_messages
-}
-
-
-# Called when merge_branch fails
-function error_merge_branch {
-  create_merge_conflict_abort_script
-
-  # Create the continue script
-  add_to_continue_script "initial_open_changes=$initial_open_changes"
-  add_to_continue_script "continue_merge"
-  add_to_continue_script "push_branch"
-  add_to_continue_script "restore_open_changes"
-
-  exit_with_script_messages
-}
-
-
 # Perform the sync operation
 function perform_sync {
   stash_open_changes
+
   if [ "$(is_feature_branch "$initial_branch_name")" == true ]; then
     checkout_main_branch
-    sync_branch 'rebase'
+  fi
+
+  fetch_repo
+  rebase_tracking_branch
+  push_branch
+
+  if [ "$(is_feature_branch "$initial_branch_name")" == true ]; then
     checkout_branch "$initial_branch_name"
-    pull_branch
+    merge_tracking_branch
     merge_branch "$main_branch_name"
     push_branch
   else
-    sync_branch 'rebase'
     push_tags
   fi
+
   restore_open_changes
 }
 

--- a/git-sync-fork
+++ b/git-sync-fork
@@ -2,8 +2,8 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/helpers/helpers.sh"
 
 
-# Called by pull_feature_branch when the merge fails with conflicts
-function error_pull_upstream_branch {
+# Called when rebase_branch fails
+function error_rebase_branch {
   create_rebase_conflict_abort_script
   exit_with_script_messages
 }
@@ -26,7 +26,8 @@ function sync_fork {
   local branch_name=$(get_current_branch_name)
   stash_open_changes
   checkout_main_branch
-  pull_upstream_branch
+  fetch_upstream
+  rebase_branch "upstream/$main_branch_name"
   push_branch
   checkout_branch "$branch_name"
   restore_open_changes

--- a/helpers/git_helpers.sh
+++ b/helpers/git_helpers.sh
@@ -206,18 +206,6 @@ function ensure_on_feature_branch {
 }
 
 
-# Called by pull_branch when the merge/rebase fails with conflicts
-function error_pull_branch {
-  if [ "$(is_feature_branch "$1")" == true ]; then
-    error_pull_feature_branch
-  elif [ "$1" == "$main_branch_name" ]; then
-    error_pull_main_branch
-  else
-    error_pull_non_feature_branch
-  fi
-}
-
-
 # Fetches updates from the central repository.
 #
 # It is safe to call this method multiple times per session,
@@ -317,9 +305,17 @@ function local_merged_branches {
 # Merges the given branch into the current branch
 function merge_branch {
   local branch_name=$1
-  local current_branch_name=$(get_current_branch_name)
   run_command "git merge --no-edit $branch_name"
-  if [ $? != 0 ]; then error_merge_branch; fi
+  if [ $? != 0 ]; then error_merge_branch "$branch_name"; fi
+}
+
+
+# Merges the tracking branch, if one exists, into the current branch
+function merge_tracking_branch {
+  local branch_name=$(get_current_branch_name)
+  if [ "$(has_tracking_branch "$branch_name")" == true ]; then
+    merge_branch "origin/$branch_name"
+  fi
 }
 
 
@@ -332,28 +328,6 @@ function needs_pushing {
   else
     echo false
   fi
-}
-
-
-# Pulls updates of the feature branch from the remote repo
-function pull_branch {
-  local strategy=$1
-  local current_branch_name=$(get_current_branch_name)
-  if [ -z "$strategy" ]; then strategy='merge'; fi
-  if [ "$(has_tracking_branch "$current_branch_name")" == true ]; then
-    fetch_repo
-    run_command "git $strategy origin/$current_branch_name"
-    if [ $? != 0 ]; then error_pull_branch "$current_branch_name"; fi
-  fi
-}
-
-
-# Pulls updates of the current branch from the upstream repo
-function pull_upstream_branch {
-  local current_branch_name=$(get_current_branch_name)
-  fetch_upstream
-  run_command "git rebase upstream/$current_branch_name"
-  if [ $? != 0 ]; then error_pull_upstream_branch; fi
 }
 
 
@@ -376,12 +350,29 @@ function push_tags {
 }
 
 
+# Rebases the given branch into the current branch
+function rebase_branch {
+  local branch_name=$1
+  run_command "git rebase $branch_name"
+  if [ $? != 0 ]; then error_rebase_branch "$branch_name"; fi
+}
+
+
 # Determines whether the current branch has a rebase in progress
 function rebase_in_progress {
   if [ "$(git status | grep -c "rebase in progress")" == 1 ]; then
     echo true
   else
     echo false
+  fi
+}
+
+
+# Rebases the tracking branch, if one exists, into the current branch
+function rebase_tracking_branch {
+  local branch_name=$(get_current_branch_name)
+  if [ "$(has_tracking_branch "$branch_name")" == true ]; then
+    rebase_branch "origin/$branch_name"
   fi
 }
 
@@ -408,7 +399,6 @@ function remote_domain {
 function remote_repository_name {
   remote_url | sed "s#.*[:/]\([^/]*/[^/]*\)\.git#\1#"
 }
-
 
 
 # Resets the current branch to the commit described by the given SHA
@@ -456,12 +446,4 @@ function stash_open_changes {
   if [ "$initial_open_changes" = true ]; then
     run_command "git stash -u"
   fi
-}
-
-
-# Push and pull the current branch
-function sync_branch {
-  local strategy=$1
-  pull_branch "$strategy"
-  push_branch
 }


### PR DESCRIPTION
@kevgo 

Remove `sync_branch` and `pull_branch` helpers in favor of more explicit commands. Needed for command list architecture.
