### PR TITLE
Travis-CI Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 
 language: go
 go: 1.14


### PR DESCRIPTION
Trusty is a 6 year old Linux (14.04). This updates Travis to 18.04. See https://docs.travis-ci.com/user/reference/overview/#linux