### PR TITLE
fix cuke-go for mac

### DIFF
--- a/test/steps/suite_steps.go
+++ b/test/steps/suite_steps.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 	"sync"
 
 	"github.com/cucumber/godog"
@@ -40,7 +41,12 @@ func SuiteSteps(suite *godog.Suite, fs *FeatureState) {
 			if err != nil {
 				log.Fatalf("cannot create base directory for feature specs: %s", err)
 			}
-			gitManager = test.NewGitManager(baseDir)
+			// Evaluate symlinks as Mac temp dir is symlinked
+			evalBaseDir, err := filepath.EvalSymlinks(baseDir)
+			if err != nil {
+				log.Fatalf("cannot evaluate symlinks of base directory for feature specs: %s", err)
+			}
+			gitManager = test.NewGitManager(evalBaseDir)
 			err = gitManager.CreateMemoizedEnvironment()
 			if err != nil {
 				log.Fatalf("Cannot create memoized environment: %s", err)


### PR DESCRIPTION
Hit error while trying to run cuke-go on my mac:

![Screen Shot 2020-05-06 at 8 28 54 PM](https://user-images.githubusercontent.com/1676758/81251898-4bc37f80-8fd9-11ea-85fa-d22e70ed44c1.png)

Updated to make the base dir follow symlinks and that fixed it.

Related: nproc doesn't exist on my mac, but can deal with that separately as I'll just remove it for development for now.