### PR TITLE
Create child feature branches without Git Town

### DIFF
--- a/features/git-town-set-parent-branch/set_parent_branch.feature
+++ b/features/git-town-set-parent-branch/set_parent_branch.feature
@@ -8,6 +8,7 @@ Feature: update the parent of a nested feature branch
   Background:
     Given my repository has a feature branch named "parent-feature"
     And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    And I am on the "child-feature" branch
 
 
   Scenario: selecting the default branch (current parent)

--- a/test/git_repository.go
+++ b/test/git_repository.go
@@ -210,12 +210,12 @@ func (repo *GitRepository) CreateBranch(name, parent string) error {
 
 // CreateChildFeatureBranch creates a branch with the given name and parent in this repository.
 // The parent branch must already exist.
-func (repo *GitRepository) CreateChildFeatureBranch(name string, parentBranch string) error {
-	err := repo.CheckoutBranch(parentBranch)
+func (repo *GitRepository) CreateChildFeatureBranch(name string, parent string) error {
+	outcome, err := repo.Shell.Run("git", "branch", name, parent)
 	if err != nil {
-		return fmt.Errorf("cannot checkout parent branch %q: %w", parentBranch, err)
+		return fmt.Errorf("cannot create child branch %q: %w\n%v", name, err, outcome)
 	}
-	outcome, err := repo.Shell.Run("git", "town", "append", name)
+	outcome, err = repo.Shell.Run("git", "config", fmt.Sprintf("git-town-branch.%s.parent", name), parent)
 	if err != nil {
 		return fmt.Errorf("cannot create child branch %q: %w\n%v", name, err, outcome)
 	}

--- a/test/git_repository_test.go
+++ b/test/git_repository_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -146,9 +147,10 @@ func TestGitRepo_CreateChildFeatureBranch(t *testing.T) {
 	assert.Nil(t, err)
 	err = repo.CreateChildFeatureBranch("f1a", "f1")
 	assert.Nil(t, err)
-	branches, err := repo.Branches()
+	res, err := repo.Shell.Run("git", "town", "config")
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"main", "f1", "f1a", "master"}, branches)
+	has := strings.Contains(res.OutputSanitized(), "Branch Ancestry:\n  main\n    f1\n      f1a")
+	assert.True(t, has)
 }
 
 func TestGitRepository_CreateCommit(t *testing.T) {


### PR DESCRIPTION
Calling Git Town in test setup pollutes the undo stack of the test repo. Which breaks some `git ship` tests that expect an empty undo stack. 

In the future, this would ideally be implemented using the Git Town business logic in the tests.