### PR TITLE
Cross-platform Cucumber test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ cross-compile:  # builds the binary for all platforms
 			-output "dist/{{.Dir}}-${TRAVIS_TAG}-{{.OS}}-{{.Arch}}"
 
 cuke: build   # runs the new Godog-based feature tests
-	godog --concurrency=$(shell nproc --all) --format=progress --strict
+	go test
 
 deploy:  # deploys the website
 	git checkout gh-pages

--- a/main_test.go
+++ b/main_test.go
@@ -45,8 +45,5 @@ func TestMain(m *testing.M) {
 		Strict:      true,
 		Paths:       []string{"features/"},
 	})
-	if st := m.Run(); st > status {
-		status = st
-	}
 	os.Exit(status)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/cucumber/godog"
@@ -39,8 +40,10 @@ func TestMain(m *testing.M) {
 	status := godog.RunWithOptions("godog", func(s *godog.Suite) {
 		FeatureContext(s)
 	}, godog.Options{
-		Format: "pretty",
-		Paths:  []string{"features/git-town-append/on-perennial-branch.feature"},
+		Format:      "progress",
+		Concurrency: runtime.NumCPU(),
+		Strict:      true,
+		Paths:       []string{"features/"},
 	})
 	if st := m.Run(); st > status {
 		status = st


### PR DESCRIPTION
I have evaluated a number of options and ended up on this one as the most convenient and least hacky one. With this setup you run:

- `go test` for all cukes in parallel
- `godog` for individual cukes (with nice auto-completion of filenames in Fish)
- `go test ./src/... ./test/...` for the unit tests

This still allows debugging individual cukes as well.