### PR TITLE
Simplify commit verification step

### DIFF
--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -43,7 +43,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | main    | git checkout feature |
     And I am still on the "feature" branch
     And there is no merge in progress
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
@@ -66,7 +66,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |
@@ -89,7 +89,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -62,7 +62,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |
 
@@ -85,6 +85,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -62,7 +62,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
@@ -90,7 +90,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -99,7 +99,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -100,7 +100,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -47,7 +47,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
@@ -57,7 +57,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """
@@ -76,7 +76,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME        |
       | main    | local, remote | conflicting main commit                                    | conflicting_file |
       | feature | local, remote | conflicting feature commit                                 | conflicting_file |
@@ -101,7 +101,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME        |
       | main    | local, remote | conflicting main commit                                    | conflicting_file |
       | feature | local, remote | conflicting feature commit                                 | conflicting_file |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
@@ -44,7 +44,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """
@@ -62,7 +62,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
       | main    | local    | conflicting main commit          | conflicting_file |
       | feature | local    | conflicting feature commit       | conflicting_file |
@@ -83,7 +83,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | feature | git stash pop |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
       | main    | local    | conflicting main commit          | conflicting_file |
       | feature | local    | conflicting feature commit       | conflicting_file |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
@@ -45,7 +45,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
@@ -54,7 +54,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """
@@ -73,7 +73,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | conflicting main commit          | conflicting_file |
       | feature | local, remote | conflicting feature commit       | conflicting_file |
@@ -95,7 +95,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | conflicting main commit          | conflicting_file |
       | feature | local, remote | conflicting feature commit       | conflicting_file |
@@ -117,7 +117,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository still has the following commits
+    And my repository now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | conflicting main commit          | conflicting_file |
       | feature | local, remote | conflicting feature commit       | conflicting_file |

--- a/test/steps/commit_steps.go
+++ b/test/steps/commit_steps.go
@@ -15,7 +15,7 @@ func CommitSteps(suite *godog.Suite, fs *FeatureState) {
 		return compareExistingCommits(fs, fs.activeScenarioState.originalCommitTable)
 	})
 
-	suite.Step(`^my repository (?:now|still) has the following commits$`, func(table *messages.PickleStepArgument_PickleTable) error {
+	suite.Step(`^my repository now has the following commits$`, func(table *messages.PickleStepArgument_PickleTable) error {
 		return compareExistingCommits(fs, table)
 	})
 


### PR DESCRIPTION
The step `my repository is left with my original commits` is redundant with `my repository still has the following commits`, and shorter.