### PR TITLE
Remove unnecessary Background steps

### DIFF
--- a/features/git-town-config/already_set.feature
+++ b/features/git-town-config/already_set.feature
@@ -5,12 +5,9 @@ Feature: listing the configuration
   So that I can change it more effectively
 
 
-  Background:
-    Given my repository has the feature branches "production" and "qa"
-
-
   Scenario: everything is configured
-    Given the main branch is configured as "main"
+    Given my repository has the feature branches "production" and "qa"
+    And the main branch is configured as "main"
     And the perennial branches are configured as "qa"
     When I run "git-town config setup" and answer the prompts:
       | PROMPT                                     | ANSWER                      |

--- a/features/git-town-config/prompt.feature
+++ b/features/git-town-config/prompt.feature
@@ -5,11 +5,8 @@ Feature: Automatically running the configuration wizard if Git Town is unconfigu
   So that I use a properly configured tool at all times.
 
 
-  Background:
-    Given I haven't configured Git Town yet
-
-
   Scenario Outline: All Git Town commands show the configuration prompt if running unconfigured
+    Given I haven't configured Git Town yet
     When I run "<COMMAND>" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |

--- a/features/git-town/help/help_unconfigured.feature
+++ b/features/git-town/help/help_unconfigured.feature
@@ -2,12 +2,8 @@ Feature: show help screen when Git Town is not configured
 
   (see ./help_configured.feature)
 
-
-  Background:
-    Given I haven't configured Git Town yet
-
-
   Scenario Outline:
+    Given I haven't configured Git Town yet
     When I run "<COMMAND>"
     Then it prints
       """


### PR DESCRIPTION
Addressing https://github.com/git-town/git-town/pull/1385#r425464338

While going through all Background blocks, I noticed that many features have one because they follow our structure but are missing additional scenarios that check `undo`  and `abort`. I leave these specs as is to allow adding these tests later.