### PR TITLE
Run cukes in parallel on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,6 @@ jobs:
       - run: mv ./git-town /go/bin/
       - run: mv ./godog /go/bin/
       - run: mv ./golangci-lint /go/bin/
-      - run: make unit
-      - run: make lint-go
       - run:
           find features -type f -name '*.feature' | grep git-town-s | xargs
           godog --concurrency=$(nproc --all) --format=progress --strict

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
-      - run: mv ./git-town /home/circleci/bin/
-      - run: mv ./godog /home/circleci/bin/
-      - run: mv ./golangci-lint /home/circleci/bin/
+      - run: mv ./git-town /go/bin/
+      - run: mv ./godog /go/bin/
+      - run: mv ./golangci-lint /go/bin/
       - run: make unit
       - run: make lint-go
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: make lint-go
       - run:
           find . -type f -name '*.feature' | grep -v git-town-sync | xargs godog
-          --concurrency=$(shell nproc --all) --format=progress --strict
+          --concurrency=$(nproc --all) --format=progress --strict
   go-sync:
     docker:
       - image: circleci/golang:1.14.2
@@ -45,7 +45,7 @@ jobs:
       - run: make lint-go
       - run:
           find . -type f -name '*.feature' | grep git-town-sync | xargs godog
-          --concurrency=$(shell nproc --all) --format=progress --strict
+          --concurrency=$(nproc --all) --format=progress --strict
   markdown:
     docker:
       - image: circleci/node:12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,10 @@ jobs:
       - attach_workspace:
           at: /home/circleci
       # move the binary into the PATH
-      - run: mv ./git-town /go/bin/
-      - run: mv ./godog /go/bin/
-      - run: mv ./golangci-lint /go/bin/
+      - run: mkdir /home/circleci/bin
+      - run: mv ./git-town /home/circleci/bin/
+      - run: mv ./godog /home/circleci/bin/
+      - run: mv ./golangci-lint /home/circleci/bin/
       - run: cd tools/text-runner && yarn
       - run: make lint
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: make unit
       - run: make lint-go
       - run:
-          find . -type f -name '*.feature' | grep -v git-town-sync | xargs godog
+          find . -type f -name '*.feature' | grep -v git-town-s | xargs godog
           --concurrency=$(nproc --all) --format=progress --strict
   go-sync:
     docker:
@@ -44,19 +44,20 @@ jobs:
       - run: make unit
       - run: make lint-go
       - run:
-          find . -type f -name '*.feature' | grep git-town-sync | xargs godog
+          find . -type f -name '*.feature' | grep git-town-s | xargs godog
           --concurrency=$(nproc --all) --format=progress --strict
-  markdown:
+  lint:
     docker:
       - image: circleci/node:12
     steps:
       - attach_workspace:
           at: /home/circleci
       # move the binary into the PATH
-      - run: mkdir /home/circleci/bin
-      - run: mv ./git-town /home/circleci/bin/
+      - run: mv ./git-town /go/bin/
+      - run: mv ./godog /go/bin/
+      - run: mv ./golangci-lint /go/bin/
       - run: cd tools/text-runner && yarn
-      - run: make test-md
+      - run: make lint
 workflows:
   version: 2
   all_tests:
@@ -68,6 +69,6 @@ workflows:
       - go-sync:
           requires:
             - clone
-      - markdown:
+      - lint:
           requires:
             - clone

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,11 @@ jobs:
       # build the binary for the Markdown tests
       # and store it in the workspace
       - run: make build
+      - run: make setup-go
       - run: cp /go/bin/git-town /home/circleci/project/
+      - run: cp /go/bin/godog /home/circleci/project/
+      - run: cp /go/bin/golangci-lint /home/circleci/project/
+      - run: ls /go/bin
       - persist_to_workspace:
           root: /home/circleci
           paths:
@@ -20,8 +24,28 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
-      - run: make setup-go
-      - run: make test-go
+      - run: mv ./git-town /home/circleci/bin/
+      - run: mv ./godog /home/circleci/bin/
+      - run: mv ./golangci-lint /home/circleci/bin/
+      - run: make unit
+      - run: make lint-go
+      - run:
+          find . -type f -name '*.feature' | grep -v git-town-sync | xargs godog
+          --concurrency=$(shell nproc --all) --format=progress --strict
+  go-sync:
+    docker:
+      - image: circleci/golang:1.14.2
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run: mv ./git-town /home/circleci/bin/
+      - run: mv ./godog /home/circleci/bin/
+      - run: mv ./golangci-lint /home/circleci/bin/
+      - run: make unit
+      - run: make lint-go
+      - run:
+          find . -type f -name '*.feature' | grep git-town-sync | xargs godog
+          --concurrency=$(shell nproc --all) --format=progress --strict
   markdown:
     docker:
       - image: circleci/node:12
@@ -39,6 +63,9 @@ workflows:
     jobs:
       - clone
       - go:
+          requires:
+            - clone
+      - go-sync:
           requires:
             - clone
       - markdown:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,9 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
-      - run: mv ./git-town /home/circleci/bin/
-      - run: mv ./godog /home/circleci/bin/
-      - run: mv ./golangci-lint /home/circleci/bin/
+      - run: mv ./git-town /go/bin/
+      - run: mv ./godog /go/bin/
+      - run: mv ./golangci-lint /go/bin/
       - run: make unit
       - run: make lint-go
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,7 @@ jobs:
       - image: circleci/golang:1.14.2
     steps:
       - checkout
-      # build the binary for the Markdown tests
-      # and store it in the workspace
+      # build the binaries and store them in the workspace
       - run: make build
       - run: make setup-go
       - run: cp /go/bin/git-town /home/circleci/project/
@@ -30,9 +29,9 @@ jobs:
       - run: make unit
       - run: make lint-go
       - run:
-          find . -type f -name '*.feature' | grep -v git-town-s | xargs godog
-          --concurrency=$(nproc --all) --format=progress --strict
-  go-sync:
+          find features -type f -name '*.feature' | grep -v git-town-s | xargs
+          godog --concurrency=$(nproc --all) --format=progress --strict
+  go-s:
     docker:
       - image: circleci/golang:1.14.2
     steps:
@@ -44,9 +43,9 @@ jobs:
       - run: make unit
       - run: make lint-go
       - run:
-          find . -type f -name '*.feature' | grep git-town-s | xargs godog
-          --concurrency=$(nproc --all) --format=progress --strict
-  lint:
+          find features -type f -name '*.feature' | grep git-town-s | xargs
+          godog --concurrency=$(nproc --all) --format=progress --strict
+  markdown:
     docker:
       - image: circleci/node:12
     steps:
@@ -58,7 +57,7 @@ jobs:
       - run: mv ./godog /home/circleci/bin/
       - run: mv ./golangci-lint /home/circleci/bin/
       - run: cd tools/text-runner && yarn
-      - run: make lint
+      - run: make test-md
 workflows:
   version: 2
   all_tests:
@@ -67,9 +66,9 @@ workflows:
       - go:
           requires:
             - clone
-      - go-sync:
+      - go-s:
           requires:
             - clone
-      - lint:
+      - markdown:
           requires:
             - clone


### PR DESCRIPTION
Parallelizes long tests on CircleCI. Previously, the Cukes took 1 minute to run:

![screenshot-circleci com-2020 05 15-09_44_38](https://user-images.githubusercontent.com/268934/82063181-c868f480-9690-11ea-8d84-6007df9a57b0.png)

Now it runs the `ship` and `sync` cukes in parallel with the rest, resulting in getting the complete cuke results in around 30 seconds:

![screenshot-circleci com-2020 05 15-09_46_14](https://user-images.githubusercontent.com/268934/82063405-0cf49000-9691-11ea-896f-2f260b1b02b7.png)

This reduces the time to get CI results from around 90s to 60s. This in turn helps reduce cycle and waiting time.