### PR TITLE
More consistent formatting of steps

### DIFF
--- a/features/git-town-config/view.feature
+++ b/features/git-town-config/view.feature
@@ -9,7 +9,7 @@ Feature: listing the configuration
     Given the main branch is configured as "main"
     And the perennial branches are configured as "qa" and "staging"
     When I run "git-town config"
-    Then it prints
+    Then it prints:
       """
       Main branch:
         main
@@ -27,7 +27,7 @@ Feature: listing the configuration
     And my repository has a feature branch named "child-feature" as a child of "parent-feature"
     And my repository has a feature branch named "qa-hotfix" as a child of "qa"
     When I run "git-town config"
-    Then it prints
+    Then it prints:
       """
       Main branch:
         main
@@ -49,7 +49,7 @@ Feature: listing the configuration
     Given the main branch is configured as "main"
     And the perennial branches are not configured
     When I run "git-town config"
-    Then it prints
+    Then it prints:
       """
       Main branch:
         main
@@ -63,7 +63,7 @@ Feature: listing the configuration
     Given the main branch name is not configured
     And the perennial branches are configured as "qa" and "staging"
     When I run "git-town config"
-    Then it prints
+    Then it prints:
       """
       Main branch:
         [none]
@@ -77,7 +77,7 @@ Feature: listing the configuration
   Scenario: nothing is configured yet
     Given I haven't configured Git Town yet
     When I run "git-town config"
-    Then it prints
+    Then it prints:
       """
       Main branch:
         [none]

--- a/features/git-town-install-fish-autocompletion/install_fish_autocomplete.feature
+++ b/features/git-town-install-fish-autocompletion/install_fish_autocomplete.feature
@@ -8,7 +8,7 @@ Feature: Installing Fish Shell autocomplete definitions
   Scenario: without existing fish autocompletion folder
     Given I have no fish autocompletion file
     When I run "git-town install-fish-autocompletion"
-    Then it prints
+    Then it prints:
       """
       Git autocompletion for Fish shell installed
       """
@@ -18,7 +18,7 @@ Feature: Installing Fish Shell autocomplete definitions
   Scenario: with empty fish autocompletion folder
     Given I have an empty fish autocompletion folder
     When I run "git-town install-fish-autocompletion"
-    Then it prints
+    Then it prints:
       """
       Git autocompletion for Fish shell installed
       """

--- a/features/git-town-main_branch/display.feature
+++ b/features/git-town-main_branch/display.feature
@@ -8,7 +8,7 @@ Feature: display the main branch configuration
   Scenario: main branch not yet configured
     Given I don't have a main branch name configured
     When I run "git-town main-branch"
-    Then it prints
+    Then it prints:
       """
       [none]
       """
@@ -17,7 +17,7 @@ Feature: display the main branch configuration
   Scenario: main branch is configured
     Given the main branch is configured as "main"
     When I run "git-town main-branch"
-    Then it prints
+    Then it prints:
       """
       main
       """

--- a/features/git-town-new-branch-push-flag/display.feature
+++ b/features/git-town-new-branch-push-flag/display.feature
@@ -7,7 +7,7 @@ Feature: displaying the new branch push flag configuration
 
   Scenario: default setting
     When I run "git-town new-branch-push-flag"
-    Then it prints
+    Then it prints:
       """
       false
       """
@@ -16,7 +16,7 @@ Feature: displaying the new branch push flag configuration
   Scenario: set to "true"
     Given the new-branch-push-flag configuration is true
     When I run "git-town new-branch-push-flag"
-    Then it prints
+    Then it prints:
       """
       true
       """
@@ -25,7 +25,7 @@ Feature: displaying the new branch push flag configuration
   Scenario: set to "false"
     Given the new-branch-push-flag configuration is false
     When I run "git-town new-branch-push-flag"
-    Then it prints
+    Then it prints:
       """
       false
       """
@@ -34,7 +34,7 @@ Feature: displaying the new branch push flag configuration
   Scenario: globally set to "true", local unset
     Given the global new-branch-push-flag configuration is true
     When I run "git-town new-branch-push-flag"
-    Then it prints
+    Then it prints:
       """
       true
       """
@@ -44,7 +44,7 @@ Feature: displaying the new branch push flag configuration
     Given the global new-branch-push-flag configuration is true
     And the new-branch-push-flag configuration is false
     When I run "git-town new-branch-push-flag"
-    Then it prints
+    Then it prints:
       """
       false
       """

--- a/features/git-town-new-branch-push-flag/global_display.feature
+++ b/features/git-town-new-branch-push-flag/global_display.feature
@@ -2,7 +2,7 @@ Feature: displaying the global new branch push flag configuration
 
   Scenario: default set
     When I run "git-town new-branch-push-flag --global"
-    Then it prints
+    Then it prints:
       """
       false
       """
@@ -11,7 +11,7 @@ Feature: displaying the global new branch push flag configuration
   Scenario: set to "true"
     Given the global new-branch-push-flag configuration is true
     When I run "git-town new-branch-push-flag --global"
-    Then it prints
+    Then it prints:
       """
       true
       """
@@ -20,7 +20,7 @@ Feature: displaying the global new branch push flag configuration
   Scenario: set to false
     Given the global new-branch-push-flag configuration is false
     When I run "git-town new-branch-push-flag --global"
-    Then it prints
+    Then it prints:
       """
       false
       """

--- a/features/git-town-offline-mode/display.feature
+++ b/features/git-town-offline-mode/display.feature
@@ -1,6 +1,6 @@
 Feature: Displaying the current offline status
 
-  When configuring offline mode
+    When configuring offline mode
   I want to know the current value for it
   So that I can decide whether I want to adjust it.
 
@@ -8,7 +8,7 @@ Feature: Displaying the current offline status
   Scenario: set to "true"
     Given Git Town is in offline mode
     When I run "git-town offline"
-    Then it prints
+    Then it prints:
       """
       true
       """
@@ -16,7 +16,7 @@ Feature: Displaying the current offline status
 
   Scenario: set to "false"
     When I run "git-town offline"
-    Then it prints
+    Then it prints:
       """
       false
       """

--- a/features/git-town-offline-mode/display.feature
+++ b/features/git-town-offline-mode/display.feature
@@ -1,6 +1,6 @@
 Feature: Displaying the current offline status
 
-    When configuring offline mode
+  When configuring offline mode
   I want to know the current value for it
   So that I can decide whether I want to adjust it.
 

--- a/features/git-town-perennial_branches/display.feature
+++ b/features/git-town-perennial_branches/display.feature
@@ -8,7 +8,7 @@ Feature: display the perennial branches configuration
   Scenario: perennial branches are not configured
     Given the perennial branches are not configured
     When I run "git-town perennial-branches"
-    Then it prints
+    Then it prints:
       """
       [none]
       """
@@ -17,7 +17,7 @@ Feature: display the perennial branches configuration
   Scenario: perennial branches are configured
     Given the perennial branches are configured as "qa" and "production"
     When I run "git-town perennial-branches"
-    Then it prints
+    Then it prints:
       """
       qa
       production

--- a/features/git-town-pull_branch_strategy/display.feature
+++ b/features/git-town-pull_branch_strategy/display.feature
@@ -7,7 +7,7 @@ Feature: passing an invalid option to the pull strategy configuration
 
   Scenario: default setting
     When I run "git-town pull-branch-strategy"
-    Then it prints
+    Then it prints:
       """
       rebase
       """
@@ -16,7 +16,7 @@ Feature: passing an invalid option to the pull strategy configuration
   Scenario: explicit rebase
     Given the pull-branch-strategy configuration is "rebase"
     When I run "git-town pull-branch-strategy"
-    Then it prints
+    Then it prints:
       """
       rebase
       """
@@ -25,7 +25,7 @@ Feature: passing an invalid option to the pull strategy configuration
   Scenario: explicit merge
     Given the pull-branch-strategy configuration is "merge"
     When I run "git-town pull-branch-strategy"
-    Then it prints
+    Then it prints:
       """
       merge
       """

--- a/features/git-town-version/version.feature
+++ b/features/git-town-version/version.feature
@@ -7,7 +7,7 @@ Feature: git town: show the current Git Town version
 
   Scenario: Using "version" flag
     When I run "git-town version"
-    Then it prints
+    Then it prints:
       """
       Git Town v0.0.0-test (today)
       """
@@ -16,7 +16,7 @@ Feature: git town: show the current Git Town version
   Scenario: Running outside of a Git repository
     Given my workspace is currently not a Git repository
     When I run "git-town version"
-    Then it prints
+    Then it prints:
       """
       Git Town v0.0.0-test (today)
       """

--- a/features/git-town/help/help_configured.feature
+++ b/features/git-town/help/help_configured.feature
@@ -7,7 +7,7 @@ Feature: show help screen when Git Town is configured
 
   Scenario Outline:
     When I run "<COMMAND>"
-    Then it prints
+    Then it prints:
       """
       Usage:
         git-town [command]

--- a/features/git-town/help/help_outside_git_repo.feature
+++ b/features/git-town/help/help_outside_git_repo.feature
@@ -6,7 +6,7 @@ Feature: show help screen even outside of a Git repository
   Scenario Outline: Running outside of a Git repository
     Given my workspace is currently not a Git repository
     When I run "<COMMAND>"
-    Then it prints
+    Then it prints:
       """
       Usage:
         git-town [command]

--- a/features/git-town/help/help_unconfigured.feature
+++ b/features/git-town/help/help_unconfigured.feature
@@ -5,7 +5,7 @@ Feature: show help screen when Git Town is not configured
   Scenario Outline:
     Given I haven't configured Git Town yet
     When I run "<COMMAND>"
-    Then it prints
+    Then it prints:
       """
       Usage:
         git-town [command]

--- a/features/shared/unfinished_state.feature
+++ b/features/shared/unfinished_state.feature
@@ -26,7 +26,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
       | PROMPT                       | ANSWER  |
       | Please choose how to proceed | [ENTER] |
     Then it runs no commands
-    And it prints
+    And it prints:
       """
       You have an unfinished `sync` command that ended on the `main` branch now.
       """

--- a/test/steps/print_steps.go
+++ b/test/steps/print_steps.go
@@ -17,7 +17,7 @@ func PrintSteps(suite *godog.Suite, fs *FeatureState) {
 		return nil
 	})
 
-	suite.Step(`^it prints$`, func(expected *messages.PickleStepArgument_PickleDocString) error {
+	suite.Step(`^it prints:$`, func(expected *messages.PickleStepArgument_PickleDocString) error {
 		if !strings.Contains(fs.activeScenarioState.lastRunResult.OutputSanitized(), expected.Content) {
 			return fmt.Errorf("text not found:\n\nEXPECTED: %q\n\nACTUAL:\n\n%q", expected.Content, fs.activeScenarioState.lastRunResult.OutputSanitized())
 		}


### PR DESCRIPTION
We check errors as `Then it prints the error:` but normal output as `Then it prints`. This makes both have a colon at the end.