### PR TITLE
Flamegraphs for Cucumber runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ cross-compile:  # builds the binary for all platforms
 cuke: build   # runs the new Godog-based feature tests
 	go test
 
+cuke-prof: build  # creates a flamegraph
+	go test . -v -cpuprofile=godog.out
+	@rm git-town.test
+	@echo Please open https://www.speedscope.app and load the file godog.out
+
 deploy:  # deploys the website
 	git checkout gh-pages
 	git pull

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ cross-compile:  # builds the binary for all platforms
 			-output "dist/{{.Dir}}-${TRAVIS_TAG}-{{.OS}}-{{.Arch}}"
 
 cuke: build   # runs the new Godog-based feature tests
-	@go test ./features -v -count=1
+	@go test . -v -count=1
 
 cuke-prof: build  # creates a flamegraph
-	go test ./features -v -cpuprofile=godog.out
+	go test . -v -cpuprofile=godog.out
 	@rm features.test
 	@echo Please open https://www.speedscope.app and load the file godog.out
 

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ cross-compile:  # builds the binary for all platforms
 			-output "dist/{{.Dir}}-${TRAVIS_TAG}-{{.OS}}-{{.Arch}}"
 
 cuke: build   # runs the new Godog-based feature tests
-	go test
+	@go test ./features -v -count=1
 
 cuke-prof: build  # creates a flamegraph
-	go test . -v -cpuprofile=godog.out
-	@rm git-town.test
+	go test ./features -v -cpuprofile=godog.out
+	@rm features.test
 	@echo Please open https://www.speedscope.app and load the file godog.out
 
 deploy:  # deploys the website

--- a/features/godog_test.go
+++ b/features/godog_test.go
@@ -1,4 +1,4 @@
-package main_test
+package features
 
 import (
 	"runtime"
@@ -47,7 +47,7 @@ func TestGodog(t *testing.T) {
 		Format:      "progress",
 		Concurrency: runtime.NumCPU(),
 		Strict:      true,
-		Paths:       []string{"features/"},
+		Paths:       []string{"./"},
 	})
 	if status > 0 {
 		t.FailNow()

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
@@ -41,14 +40,16 @@ func FeatureContext(suite *godog.Suite) {
 	steps.CoworkerSteps(suite, state)
 }
 
-func TestMain(m *testing.M) {
+func TestGodog(t *testing.T) {
 	status := godog.RunWithOptions("godog", func(s *godog.Suite) {
 		FeatureContext(s)
 	}, godog.Options{
 		Format:      "progress",
 		Concurrency: runtime.NumCPU(),
 		Strict:      true,
-		Paths:       []string{"features/environment.feature"},
+		Paths:       []string{"features/"},
 	})
-	os.Exit(status)
+	if status > 0 {
+		t.FailNow()
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 		Format:      "progress",
 		Concurrency: runtime.NumCPU(),
 		Strict:      true,
-		Paths:       []string{"features/"},
+		Paths:       []string{"features/environment.feature"},
 	})
 	os.Exit(status)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-package features
+package main_test
 
 import (
 	"runtime"


### PR DESCRIPTION
Runs the Cucumber specs as a normal unit test in the `github.com/git-town/git-town/features` import path (it's the only "unit test" in there). We no longer overwrite the standard Go testsuite runner. This is less invasive, more compatible, and allows using all built-in tooling of the built-in Go test runner when running Cucumber.

With this setup in place, we are now able to run the Cucumber specs with the built-in profiler enabled: `go test ./features -v -cpuprofile=godog.out`. This shows where our tests burn CPU time. The attached flame graph shows the current state as it runs on my machine. It was created by loading the generated `godog.out` file into https://www.speedscope.app.

Having flame graphs for test runs enables data-driven performance optimizations, i.e. focus on things that move the needle, and evaluate for each optimization if the realized speed improvement is worth the additional complexity. 

It's amazing how easy Go makes such things!

For example, I see that we are burning a lot of time deleting the GitEnvironment instances in https://github.com/git-town/git-town/blob/master/test/steps/suite_steps.go#L64, and a ton of time copying a GitEnvironment for each scenario. This should probably be cached in memory and written to disk in parallel. It might also be worth disabling the garbage collector for tests.

![screenshot-www speedscope app-2020 05 17-08_09_53](https://user-images.githubusercontent.com/268934/82148231-9aaeb780-9818-11ea-9ab8-58e9918e7d31.png)


