### PR TITLE
Skip deleting environments

### DIFF
--- a/test/steps/suite_steps.go
+++ b/test/steps/suite_steps.go
@@ -60,12 +60,7 @@ func SuiteSteps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.AfterScenario(func(scenario *messages.Pickle, e error) {
-		if e == nil {
-			err := state.gitEnv.Remove()
-			if err != nil {
-				log.Fatalf("error removing the Git environment after scenario %q: %v", scenarioName(scenario), err)
-			}
-		} else {
+		if e != nil {
 			fmt.Printf("failed scenario, investigate state in %q\n", state.gitEnv.Dir)
 		}
 	})


### PR DESCRIPTION
Doesn't delete GitEnvironments from the tmp directory after a scenario is done. The computer reclaims this disk space on the next reboot.

On my machine, this shaves 6 seconds off the time it takes to run `make cuke`, i.e. reduces its duration from 44s to 38s. Updated flamegraph attached.

![screenshot-www speedscope app-2020 05 17-09_36_18](https://user-images.githubusercontent.com/268934/82151756-ce8eda80-9822-11ea-8192-fe1ce359dbf4.png)
