### PR TITLE
Increase timeout before sending input

### DIFF
--- a/src/command/run.go
+++ b/src/command/run.go
@@ -30,7 +30,7 @@ type Options struct {
 }
 
 // InputDelay defines how long to wait before writing the next input string into the subprocess.
-const InputDelay = 300 * time.Millisecond
+const InputDelay = 500 * time.Millisecond
 
 // MustRun executes an essential subshell command given in argv notation.
 // Essential subshell commands are essential for the functioning of Git Town.

--- a/src/command/run.go
+++ b/src/command/run.go
@@ -30,7 +30,7 @@ type Options struct {
 }
 
 // InputDelay defines how long to wait before writing the next input string into the subprocess.
-const InputDelay = 100 * time.Millisecond
+const InputDelay = 300 * time.Millisecond
 
 // MustRun executes an essential subshell command given in argv notation.
 // Essential subshell commands are essential for the functioning of Git Town.


### PR DESCRIPTION
CircleCI seems to run tests on hardware that is shared with lots of other users. This means we run lots of tests in parallel, but each test is slow. Tests keep getting stuck because we send input into subshells before they are able to receive it. See https://github.com/git-town/git-town/blob/master/src/command/run.go#L84-L90 for more details.