### PR TITLE
Remove all unnecessary files from memoized repo

### DIFF
--- a/test/git_environment.go
+++ b/test/git_environment.go
@@ -107,7 +107,18 @@ func NewStandardGitEnvironment(dir string) (gitEnv *GitEnvironment, err error) {
 		return gitEnv, fmt.Errorf("cannot clone developer repo %q from origin %q: %w", gitEnv.originRepoPath(), gitEnv.developerRepoPath(), err)
 	}
 	err = gitEnv.initializeWorkspace(&gitEnv.DevRepo)
-	return gitEnv, err
+	if err != nil {
+		return gitEnv, fmt.Errorf("cannot create new standard Git environment: %w", err)
+	}
+	err = gitEnv.DevRepo.RemoveUnnecessaryFiles()
+	if err != nil {
+		return gitEnv, err
+	}
+	err = gitEnv.OriginRepo.RemoveUnnecessaryFiles()
+	if err != nil {
+		return gitEnv, err
+	}
+	return gitEnv, nil
 }
 
 // AddUpstream adds an upstream repository.

--- a/test/git_repo.go
+++ b/test/git_repo.go
@@ -524,6 +524,18 @@ func (repo *GitRepo) RemoveRemote(name string) error {
 	return err
 }
 
+// RemoveUnnecessaryFiles trims all files that aren't necessary in this repo.
+func (repo *GitRepo) RemoveUnnecessaryFiles() error {
+	fullPath := filepath.Join(repo.Dir, ".git", "hooks")
+	err := os.RemoveAll(fullPath)
+	if err != nil {
+		return fmt.Errorf("cannot remove unnecessary files in %q: %w", fullPath, err)
+	}
+	_ = os.Remove(filepath.Join(repo.Dir, ".git", "COMMIT_EDITMSG"))
+	_ = os.Remove(filepath.Join(repo.Dir, ".git", "description"))
+	return nil
+}
+
 // SetOffline enables or disables offline mode for this GitRepository.
 func (repo *GitRepo) SetOffline(enabled bool) error {
 	outcome, err := repo.Shell.Run("git", "config", "--global", "git-town.offline", strconv.FormatBool(enabled))


### PR DESCRIPTION
Implements hypothesis 2 from #1448. While the flamegraphs show a clear reduction of the work done to copy files in `filepath.walk`, and this obviously helps extend the life of our SSD drives (which allow only a limited number of write operations), this doesn't reduce the overall time to run Cucumber tests as much as I had hoped.

Before: full memoized GitEnvironment

![master](https://user-images.githubusercontent.com/268934/82324699-ac6e9700-999f-11ea-963d-d6bd290caac0.png)

After: trimmed memoized GitEnvironment 

![faster](https://user-images.githubusercontent.com/268934/82324711-b2647800-999f-11ea-9067-2039df9184d1.png)
