### PR TITLE
Remove redundant API request for PR number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:  # prints all make targets
 lint: lint-go lint-md   # lints all the source code
 
 lint-go:  # lints the Go files
-	golangci-lint run --enable-all -D dupl -D lll -D gochecknoglobals -D gochecknoinits -D goconst -D wsl -D gomnd src/... test/...
+	golangci-lint run --enable-all -D dupl -D lll -D gochecknoglobals -D gochecknoinits -D goconst -D wsl -D gomnd -D dogsled src/... test/...
 
 lint-md:   # lints the Markdown files
 	tools/prettier/node_modules/.bin/prettier -l .

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -127,6 +127,7 @@ func getShipStepList(config shipConfig) (steps.StepList, error) {
 	result.Append(&steps.EnsureHasShippableChangesStep{BranchName: config.BranchToShip})
 	result.Append(&steps.CheckoutBranchStep{BranchName: branchToMergeInto})
 	canShipWithDriver, defaultCommitMessage, pullRequestNumber, err := getCanShipWithDriver(config.BranchToShip, branchToMergeInto)
+	fmt.Println("PR number:", pullRequestNumber)
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -127,7 +127,6 @@ func getShipStepList(config shipConfig) (steps.StepList, error) {
 	result.Append(&steps.EnsureHasShippableChangesStep{BranchName: config.BranchToShip})
 	result.Append(&steps.CheckoutBranchStep{BranchName: branchToMergeInto})
 	canShipWithDriver, defaultCommitMessage, pullRequestNumber, err := getCanShipWithDriver(config.BranchToShip, branchToMergeInto)
-	fmt.Println("PR number:", pullRequestNumber)
 	if err != nil {
 		return result, err
 	}

--- a/src/drivers/bitbucket.go
+++ b/src/drivers/bitbucket.go
@@ -19,8 +19,8 @@ func (d *bitbucketCodeHostingDriver) CanBeUsed(driverType string) bool {
 	return driverType == "bitbucket" || d.hostname == "bitbucket.org"
 }
 
-func (d *bitbucketCodeHostingDriver) CanMergePullRequest(branch, parentBranch string) (canMerge bool, defaultCommitMessage string, err error) {
-	return false, "", nil
+func (d *bitbucketCodeHostingDriver) CanMergePullRequest(branch, parentBranch string) (canMerge bool, defaultCommitMessage string, pullRequestNumber int, err error) {
+	return false, "", 0, nil
 }
 
 func (d *bitbucketCodeHostingDriver) GetNewPullRequestURL(branch, parentBranch string) string {

--- a/src/drivers/code_hosting_driver.go
+++ b/src/drivers/code_hosting_driver.go
@@ -10,7 +10,7 @@ type CodeHostingDriver interface {
 
 	// CanMergePullRequest returns whether or not MergePullRequest should be
 	// called when shipping. If true, also returns the default commit message
-	CanMergePullRequest(branch, parentBranch string) (canMerge bool, defaultCommitMessage string, err error)
+	CanMergePullRequest(branch, parentBranch string) (canMerge bool, defaultCommitMessage string, pullRequestNumber int, err error)
 
 	// GetNewPullRequestURL returns the URL of the page
 	// to create a new pull request online

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -118,12 +118,11 @@ func (d *githubCodeHostingDriver) getPullRequests(branch, parentBranch string) (
 }
 
 func (d *githubCodeHostingDriver) mergePullRequest(options MergePullRequestOptions) (mergeSha string, err error) {
-	pullRequestNumber := options.PullRequestNumber
-	if pullRequestNumber == 0 {
+	if options.PullRequestNumber == 0 {
 		return "", fmt.Errorf("cannot merge via Github since there is no pull request")
 	}
 	if options.LogRequests {
-		printLog(fmt.Sprintf("GitHub API: Merging PR #%d", pullRequestNumber))
+		printLog(fmt.Sprintf("GitHub API: Merging PR #%d", options.PullRequestNumber))
 	}
 	commitMessageParts := strings.SplitN(options.CommitMessage, "\n", 2)
 	githubCommitTitle := commitMessageParts[0]
@@ -131,7 +130,7 @@ func (d *githubCodeHostingDriver) mergePullRequest(options MergePullRequestOptio
 	if len(commitMessageParts) == 2 {
 		githubCommitMessage = commitMessageParts[1]
 	}
-	result, _, err := d.client.PullRequests.Merge(context.Background(), d.owner, d.repository, pullRequestNumber, githubCommitMessage, &github.PullRequestOptions{
+	result, _, err := d.client.PullRequests.Merge(context.Background(), d.owner, d.repository, options.PullRequestNumber, githubCommitMessage, &github.PullRequestOptions{
 		MergeMethod: "squash",
 		CommitTitle: githubCommitTitle,
 	})

--- a/src/drivers/github_test.go
+++ b/src/drivers/github_test.go
@@ -35,11 +35,12 @@ func TestGitHubDriver_CanMergePullRequest(t *testing.T) {
 	defer teardown()
 
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1, "title": "my title" }]`))
-	canMerge, defaultCommintMessage, err := driver.CanMergePullRequest("feature", "main")
+	canMerge, defaultCommintMessage, pullRequestNumber, err := driver.CanMergePullRequest("feature", "main")
 
 	assert.Nil(t, err)
 	assert.True(t, canMerge)
 	assert.Equal(t, "my title (#1)", defaultCommintMessage)
+	assert.Equal(t, 1, pullRequestNumber)
 }
 
 func TestGitHubDriver_CanMergePullRequest_EmptyGithubToken(t *testing.T) {
@@ -47,7 +48,7 @@ func TestGitHubDriver_CanMergePullRequest_EmptyGithubToken(t *testing.T) {
 	defer teardown()
 
 	driver.SetAPIToken("")
-	canMerge, _, err := driver.CanMergePullRequest("feature", "main")
+	canMerge, _, _, err := driver.CanMergePullRequest("feature", "main")
 
 	assert.Nil(t, err)
 	assert.False(t, canMerge)
@@ -58,7 +59,7 @@ func TestGitHubDriver_CanMergePullRequest_GetPullRequestNumberFails(t *testing.T
 	defer teardown()
 
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(404, ""))
-	_, _, err := driver.CanMergePullRequest("feature", "main")
+	_, _, _, err := driver.CanMergePullRequest("feature", "main")
 
 	assert.Error(t, err)
 }
@@ -68,7 +69,7 @@ func TestGitHubDriver_CanMergePullRequest_NoPullRequestForBranch(t *testing.T) {
 	defer teardown()
 
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, "[]"))
-	canMerge, _, err := driver.CanMergePullRequest("feature", "main")
+	canMerge, _, _, err := driver.CanMergePullRequest("feature", "main")
 
 	assert.Nil(t, err)
 	assert.False(t, canMerge)
@@ -79,7 +80,7 @@ func TestGitHubDriver_CanMergePullRequest_MultiplePullRequestsForBranch(t *testi
 	defer teardown()
 
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1}, {"number": 2}]`))
-	canMerge, _, err := driver.CanMergePullRequest("feature", "main")
+	canMerge, _, _, err := driver.CanMergePullRequest("feature", "main")
 
 	assert.Nil(t, err)
 	assert.False(t, canMerge)

--- a/src/drivers/github_test.go
+++ b/src/drivers/github_test.go
@@ -118,31 +118,17 @@ func TestGitHubDriver_MergePullRequest_PullRequestNotFound(t *testing.T) {
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, "[]"))
 	_, err := driver.MergePullRequest(options)
 	assert.Error(t, err)
-	assert.Equal(t, "no pull request found", err.Error())
-}
-
-func TestGitHubDriver_MergePullRequest_MultiplePullRequestsFound(t *testing.T) {
-	driver, teardown := setupDriver(t, "TOKEN")
-	defer teardown()
-	options := MergePullRequestOptions{
-		Branch:        "feature",
-		CommitMessage: "title\nextra detail1\nextra detail2",
-		ParentBranch:  "main",
-	}
-	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, "[]"))
-	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1}, {"number": 2}]`))
-	_, err := driver.MergePullRequest(options)
-	assert.Error(t, err)
-	assert.Equal(t, "multiple pull requests found: 1, 2", err.Error())
+	assert.Equal(t, "cannot merge via Github since there is no pull request", err.Error())
 }
 
 func TestGitHubDriver_MergePullRequest(t *testing.T) {
 	driver, teardown := setupDriver(t, "TOKEN")
 	defer teardown()
 	options := MergePullRequestOptions{
-		Branch:        "feature",
-		CommitMessage: "title\nextra detail1\nextra detail2",
-		ParentBranch:  "main",
+		Branch:            "feature",
+		PullRequestNumber: 1,
+		CommitMessage:     "title\nextra detail1\nextra detail2",
+		ParentBranch:      "main",
 	}
 	var mergeRequest *http.Request
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, "[]"))
@@ -179,9 +165,10 @@ func TestGitHubDriver_MergePullRequest_UpdateChildPRs(t *testing.T) {
 	driver, teardown := setupDriver(t, "TOKEN")
 	defer teardown()
 	options := MergePullRequestOptions{
-		Branch:        "feature",
-		CommitMessage: "title\nextra detail1\nextra detail2",
-		ParentBranch:  "main",
+		Branch:            "feature",
+		PullRequestNumber: 1,
+		CommitMessage:     "title\nextra detail1\nextra detail2",
+		ParentBranch:      "main",
 	}
 	var updateRequest1, updateRequest2 *http.Request
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, `[{"number": 2}, {"number": 3}]`))

--- a/src/drivers/gitlab.go
+++ b/src/drivers/gitlab.go
@@ -18,8 +18,8 @@ func (d *gitlabCodeHostingDriver) CanBeUsed(driverType string) bool {
 	return driverType == "gitlab" || d.hostname == "gitlab.com"
 }
 
-func (d *gitlabCodeHostingDriver) CanMergePullRequest(branch, parentBranch string) (canMerge bool, defaultCommitMessage string, err error) {
-	return false, "", nil
+func (d *gitlabCodeHostingDriver) CanMergePullRequest(branch, parentBranch string) (canMerge bool, defaultCommitMessage string, pullRequestNumber int, err error) {
+	return false, "", 0, nil
 }
 
 func (d *gitlabCodeHostingDriver) GetNewPullRequestURL(branch, parentBranch string) string {

--- a/src/drivers/merge_pull_request_options.go
+++ b/src/drivers/merge_pull_request_options.go
@@ -2,8 +2,9 @@ package drivers
 
 // MergePullRequestOptions defines the options to the MergePullRequest function
 type MergePullRequestOptions struct {
-	Branch        string
-	CommitMessage string
-	LogRequests   bool
-	ParentBranch  string
+	Branch            string
+	PullRequestNumber int
+	CommitMessage     string
+	LogRequests       bool
+	ParentBranch      string
 }

--- a/src/steps/driver_merge_pull_request_step.go
+++ b/src/steps/driver_merge_pull_request_step.go
@@ -12,6 +12,7 @@ import (
 type DriverMergePullRequestStep struct {
 	NoOpStep
 	BranchName                string
+	PullRequestNumber         int
 	CommitMessage             string
 	DefaultCommitMessage      string
 	enteredEmptyCommitMessage bool
@@ -69,10 +70,11 @@ func (step *DriverMergePullRequestStep) Run() error {
 	}
 	driver := drivers.GetActiveDriver()
 	step.mergeSha, step.mergeError = driver.MergePullRequest(drivers.MergePullRequestOptions{
-		Branch:        step.BranchName,
-		CommitMessage: commitMessage,
-		LogRequests:   true,
-		ParentBranch:  git.GetCurrentBranchName(),
+		Branch:            step.BranchName,
+		PullRequestNumber: step.PullRequestNumber,
+		CommitMessage:     commitMessage,
+		LogRequests:       true,
+		ParentBranch:      git.GetCurrentBranchName(),
 	})
 	return step.mergeError
 }


### PR DESCRIPTION
Addresses https://github.com/git-town/git-town/issues/1453#issuecomment-632667146 based on an observation from @blaggacao.

Shipping via GitHub still works with these changes (tested manually).

@charlierudolph what do you think?