### PR TITLE
Remove empty lines from function bodies

### DIFF
--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -37,19 +37,15 @@ Exits with error code 1 if the given branch is a perennial branch or the main br
 // Does not return error because "Ensure" functions will call exit directly
 func getDiffParentConfig(args []string) (config diffParentConfig) {
 	initialBranch := git.GetCurrentBranchName()
-
 	if len(args) == 0 {
 		config.branch = initialBranch
 	} else {
 		config.branch = args[0]
 	}
-
 	if initialBranch != config.branch {
 		git.EnsureHasLocalBranch(config.branch)
 	}
-
 	git.Config().EnsureIsFeatureBranch(config.branch, "You can only diff-parent feature branches.")
-
 	prompt.EnsureKnowsParentBranches([]string{config.branch})
 	config.parentBranch = git.Config().GetParentBranch(config.branch)
 	return

--- a/src/cmd/install_fish_autocompletion.go
+++ b/src/cmd/install_fish_autocompletion.go
@@ -93,7 +93,6 @@ func buildAutocompletionDefinition() string {
 		{name: "sync", description: syncCmd.Short},
 		{name: "undo", description: undoCmd.Short},
 	}
-
 	commandsSpaceSeparated := ""
 	for _, command := range commands {
 		commandsSpaceSeparated += command.name + " "
@@ -102,7 +101,6 @@ func buildAutocompletionDefinition() string {
 	for _, command := range commands {
 		commandAutocompletion += fmt.Sprintf("complete --command git --arguments %q --description %q --condition '__fish_complete_git_town_no_command' --no-files\n", command.name, command.description)
 	}
-
 	return fmt.Sprintf(fishAutocompletionTemplate, commandsSpaceSeparated, commandAutocompletion)
 }
 

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -50,31 +50,25 @@ Does not delete perennial branches nor the main branch.`,
 
 func getKillConfig(args []string) (result killConfig, err error) {
 	result.InitialBranch = git.GetCurrentBranchName()
-
 	if len(args) == 0 {
 		result.TargetBranch = result.InitialBranch
 	} else {
 		result.TargetBranch = args[0]
 	}
-
 	git.Config().EnsureIsFeatureBranch(result.TargetBranch, "You can only kill feature branches.")
-
 	result.IsTargetBranchLocal = git.HasLocalBranch(result.TargetBranch)
 	if result.IsTargetBranchLocal {
 		prompt.EnsureKnowsParentBranches([]string{result.TargetBranch})
 	}
-
 	if git.HasRemote("origin") && !git.Config().IsOffline() {
 		err := script.Fetch()
 		if err != nil {
 			return result, err
 		}
 	}
-
 	if result.InitialBranch != result.TargetBranch {
 		git.EnsureHasBranch(result.TargetBranch)
 	}
-
 	return
 }
 

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -55,7 +55,6 @@ func getPruneBranchesStepList() (result steps.StepList) {
 		if initialBranchName == branchName {
 			result.Append(&steps.CheckoutBranchStep{BranchName: git.Config().GetMainBranch()})
 		}
-
 		parent := git.Config().GetParentBranch(branchName)
 		if parent != "" {
 			for _, child := range git.Config().GetChildBranches(branchName) {
@@ -63,11 +62,9 @@ func getPruneBranchesStepList() (result steps.StepList) {
 			}
 			result.Append(&steps.DeleteParentBranchStep{BranchName: branchName})
 		}
-
 		if git.Config().IsPerennialBranch(branchName) {
 			result.Append(&steps.RemoveFromPerennialBranches{BranchName: branchName})
 		}
-
 		result.Append(&steps.DeleteLocalBranchStep{BranchName: branchName})
 	}
 	result.Wrap(steps.WrapOptions{RunInGitRoot: false, StashOpenChanges: false})

--- a/src/drivers/core_test.go
+++ b/src/drivers/core_test.go
@@ -12,7 +12,6 @@ func TestGetDriver_DriverType_Bitbucket(t *testing.T) {
 		DriverType: "bitbucket",
 		OriginURL:  "git@self-hosted-bitbucket.com:git-town/git-town.git",
 	})
-
 	assert.NotNil(t, driver)
 	assert.Equal(t, "Bitbucket", driver.HostingServiceName())
 	assert.Equal(t, "https://self-hosted-bitbucket.com/git-town/git-town", driver.GetRepositoryURL())
@@ -23,7 +22,6 @@ func TestGetDriver_DriverType_GitHub(t *testing.T) {
 		DriverType: "github",
 		OriginURL:  "git@self-hosted-github.com:git-town/git-town.git",
 	})
-
 	assert.NotNil(t, driver)
 	assert.Equal(t, "GitHub", driver.HostingServiceName())
 	assert.Equal(t, "https://self-hosted-github.com/git-town/git-town", driver.GetRepositoryURL())
@@ -34,7 +32,6 @@ func TestGetDriver_DriverType_GitLab(t *testing.T) {
 		DriverType: "gitlab",
 		OriginURL:  "git@self-hosted-gitlab.com:git-town/git-town.git",
 	})
-
 	assert.NotNil(t, driver)
 	assert.Equal(t, "GitLab", driver.HostingServiceName())
 	assert.Equal(t, "https://self-hosted-gitlab.com/git-town/git-town", driver.GetRepositoryURL())
@@ -45,7 +42,6 @@ func TestGetDriver_OriginHostname_Bitbucket(t *testing.T) {
 		OriginURL:      "git@my-ssh-identity.com:git-town/git-town.git",
 		OriginHostname: "bitbucket.org",
 	})
-
 	assert.NotNil(t, driver)
 	assert.Equal(t, "Bitbucket", driver.HostingServiceName())
 	assert.Equal(t, "https://bitbucket.org/git-town/git-town", driver.GetRepositoryURL())
@@ -56,7 +52,6 @@ func TestGetDriver_OriginHostname_GitHub(t *testing.T) {
 		OriginURL:      "git@my-ssh-identity.com:git-town/git-town.git",
 		OriginHostname: "github.com",
 	})
-
 	assert.NotNil(t, driver)
 	assert.Equal(t, "GitHub", driver.HostingServiceName())
 	assert.Equal(t, "https://github.com/git-town/git-town", driver.GetRepositoryURL())
@@ -67,7 +62,6 @@ func TestGetDriver_OriginHostname_GitLab(t *testing.T) {
 		OriginURL:      "git@my-ssh-identity.com:git-town/git-town.git",
 		OriginHostname: "gitlab.com",
 	})
-
 	assert.NotNil(t, driver)
 	assert.Equal(t, "GitLab", driver.HostingServiceName())
 	assert.Equal(t, "https://gitlab.com/git-town/git-town", driver.GetRepositoryURL())

--- a/src/drivers/github_test.go
+++ b/src/drivers/github_test.go
@@ -33,10 +33,8 @@ func setupDriver(t *testing.T, token string) (CodeHostingDriver, func()) {
 func TestGitHubDriver_CanMergePullRequest(t *testing.T) {
 	driver, teardown := setupDriver(t, "TOKEN")
 	defer teardown()
-
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1, "title": "my title" }]`))
 	canMerge, defaultCommintMessage, err := driver.CanMergePullRequest("feature", "main")
-
 	assert.Nil(t, err)
 	assert.True(t, canMerge)
 	assert.Equal(t, "my title (#1)", defaultCommintMessage)
@@ -45,10 +43,8 @@ func TestGitHubDriver_CanMergePullRequest(t *testing.T) {
 func TestGitHubDriver_CanMergePullRequest_EmptyGithubToken(t *testing.T) {
 	driver, teardown := setupDriver(t, "")
 	defer teardown()
-
 	driver.SetAPIToken("")
 	canMerge, _, err := driver.CanMergePullRequest("feature", "main")
-
 	assert.Nil(t, err)
 	assert.False(t, canMerge)
 }
@@ -56,20 +52,16 @@ func TestGitHubDriver_CanMergePullRequest_EmptyGithubToken(t *testing.T) {
 func TestGitHubDriver_CanMergePullRequest_GetPullRequestNumberFails(t *testing.T) {
 	driver, teardown := setupDriver(t, "TOKEN")
 	defer teardown()
-
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(404, ""))
 	_, _, err := driver.CanMergePullRequest("feature", "main")
-
 	assert.Error(t, err)
 }
 
 func TestGitHubDriver_CanMergePullRequest_NoPullRequestForBranch(t *testing.T) {
 	driver, teardown := setupDriver(t, "TOKEN")
 	defer teardown()
-
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, "[]"))
 	canMerge, _, err := driver.CanMergePullRequest("feature", "main")
-
 	assert.Nil(t, err)
 	assert.False(t, canMerge)
 }
@@ -77,10 +69,8 @@ func TestGitHubDriver_CanMergePullRequest_NoPullRequestForBranch(t *testing.T) {
 func TestGitHubDriver_CanMergePullRequest_MultiplePullRequestsForBranch(t *testing.T) {
 	driver, teardown := setupDriver(t, "TOKEN")
 	defer teardown()
-
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1}, {"number": 2}]`))
 	canMerge, _, err := driver.CanMergePullRequest("feature", "main")
-
 	assert.Nil(t, err)
 	assert.False(t, canMerge)
 }
@@ -93,10 +83,8 @@ func TestGitHubDriver_MergePullRequest_GetPullRequestIdsFails(t *testing.T) {
 		CommitMessage: "title\nextra detail1\nextra detail2",
 		ParentBranch:  "main",
 	}
-
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(404, ""))
 	_, err := driver.MergePullRequest(options)
-
 	assert.Error(t, err)
 }
 
@@ -108,10 +96,8 @@ func TestGitHubDriver_MergePullRequest_GetPullRequestToMergeFails(t *testing.T) 
 		CommitMessage: "title\nextra detail1\nextra detail2",
 		ParentBranch:  "main",
 	}
-
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, "[]"))
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(404, ""))
-
 	_, err := driver.MergePullRequest(options)
 	assert.Error(t, err)
 }
@@ -124,11 +110,9 @@ func TestGitHubDriver_MergePullRequest_PullRequestNotFound(t *testing.T) {
 		CommitMessage: "title\nextra detail1\nextra detail2",
 		ParentBranch:  "main",
 	}
-
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, "[]"))
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, "[]"))
 	_, err := driver.MergePullRequest(options)
-
 	assert.Error(t, err)
 	assert.Equal(t, "no pull request found", err.Error())
 }
@@ -141,11 +125,9 @@ func TestGitHubDriver_MergePullRequest_MultiplePullRequestsFound(t *testing.T) {
 		CommitMessage: "title\nextra detail1\nextra detail2",
 		ParentBranch:  "main",
 	}
-
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, "[]"))
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1}, {"number": 2}]`))
 	_, err := driver.MergePullRequest(options)
-
 	assert.Error(t, err)
 	assert.Equal(t, "multiple pull requests found: 1, 2", err.Error())
 }
@@ -158,7 +140,6 @@ func TestGitHubDriver_MergePullRequest(t *testing.T) {
 		CommitMessage: "title\nextra detail1\nextra detail2",
 		ParentBranch:  "main",
 	}
-
 	var mergeRequest *http.Request
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, "[]"))
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1}]`))
@@ -167,7 +148,6 @@ func TestGitHubDriver_MergePullRequest(t *testing.T) {
 		return httpmock.NewStringResponse(200, `{"sha": "abc123"}`), nil
 	})
 	sha, err := driver.MergePullRequest(options)
-
 	assert.Nil(t, err)
 	assert.Equal(t, "abc123", sha)
 	mergeParameters := getRequestData(mergeRequest)
@@ -184,12 +164,10 @@ func TestGitHubDriver_MergePullRequest_MergeFails(t *testing.T) {
 		CommitMessage: "title\nextra detail1\nextra detail2",
 		ParentBranch:  "main",
 	}
-
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, "[]"))
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1}]`))
 	httpmock.RegisterResponder("PUT", mergePullRequestURL, httpmock.NewStringResponder(404, ""))
 	_, err := driver.MergePullRequest(options)
-
 	assert.Error(t, err)
 }
 
@@ -201,7 +179,6 @@ func TestGitHubDriver_MergePullRequest_UpdateChildPRs(t *testing.T) {
 		CommitMessage: "title\nextra detail1\nextra detail2",
 		ParentBranch:  "main",
 	}
-
 	var updateRequest1, updateRequest2 *http.Request
 	httpmock.RegisterResponder("GET", childPullRequestsURL, httpmock.NewStringResponder(200, `[{"number": 2}, {"number": 3}]`))
 	httpmock.RegisterResponder("PATCH", updatePullRequestBaseURL1, func(req *http.Request) (*http.Response, error) {
@@ -215,7 +192,6 @@ func TestGitHubDriver_MergePullRequest_UpdateChildPRs(t *testing.T) {
 	httpmock.RegisterResponder("GET", currentPullRequestURL, httpmock.NewStringResponder(200, `[{"number": 1}]`))
 	httpmock.RegisterResponder("PUT", mergePullRequestURL, httpmock.NewStringResponder(200, `{"sha": "abc123"}`))
 	_, err := driver.MergePullRequest(options)
-
 	assert.Nil(t, err)
 	updateParameters1 := getRequestData(updateRequest1)
 	assert.Equal(t, "main", updateParameters1["base"])


### PR DESCRIPTION
For the sake of making it easier to format the code base consistently, let's remove empty lines from function bodies. Almost all function bodies have a reasonable length that doesn't need empty lines. And this just invites people to empty lines in their own style.