### PR TITLE
Clearer separation of configuration from StepList creation

### DIFF
--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -68,11 +68,7 @@ and Git Town will leave it up to your origin server to delete the remote branch.
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		stepList, err := getShipStepList(config)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		stepList := getShipStepList(config)
 		runState := steps.NewRunState("ship", stepList)
 		err = steps.Run(runState)
 		if err != nil {
@@ -135,8 +131,7 @@ func ensureParentBranchIsMainOrPerennialBranch(branchName string) {
 	}
 }
 
-// nolint: unparam
-func getShipStepList(config shipConfig) (steps.StepList, error) {
+func getShipStepList(config shipConfig) steps.StepList {
 	result := steps.StepList{}
 	result.AppendList(steps.GetSyncBranchSteps(config.branchToMergeInto, true))
 	result.AppendList(steps.GetSyncBranchSteps(config.BranchToShip, false))
@@ -170,7 +165,7 @@ func getShipStepList(config shipConfig) (steps.StepList, error) {
 		result.Append(&steps.CheckoutBranchStep{BranchName: config.InitialBranch})
 	}
 	result.Wrap(steps.WrapOptions{RunInGitRoot: true, StashOpenChanges: !config.isShippingInitialBranch})
-	return result, nil
+	return result
 }
 
 func getCanShipWithDriver(branch, parentBranch string) (canShip bool, defaultCommitMessage string, pullRequestNumber int, err error) {

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -19,7 +19,7 @@ type shipConfig struct {
 	pullRequestNumber            int
 	branchToShip                 string
 	branchToMergeInto            string
-	initialBranch                string // the name of the branch that was checked out when running this command
+	initialBranch                string
 	defaultCommitMessage         string
 	canShipWithDriver            bool
 	hasOrigin                    bool


### PR DESCRIPTION
An example implementation of #1460 

@charlierudolph was there a reason why we determine some of the configuration in `gitShipConfig` and some other parts inline in `getShipStepList`? I think the setup that this PR proposes is cleaner and allows for better testing. It also reduces the complexity of the code to create step lists, which helps make sure it is sound. What do you think?