### PR TITLE
Improve naming

### DIFF
--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -14,10 +14,10 @@ func NewProdRepo() *ProdRepo {
 	shell := command.ShellInCurrentDir{}
 	config := NewConfiguration(shell)
 	silentRunner := Runner{
-		Shell:          shell,
-		currentBranch:  &CurrentBranchTracker{},
-		remoteBranches: &RemoteBranches{},
-		Configuration:  config,
+		Shell:             shell,
+		currentBranch:     &CurrentBranchTracker{},
+		remoteBranchCache: &RemoteBranchCache{},
+		Configuration:     config,
 	}
 	return &ProdRepo{Silent: silentRunner, Configuration: config}
 }

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -16,7 +16,7 @@ func NewProdRepo() *ProdRepo {
 	silentRunner := Runner{
 		Shell:          shell,
 		currentBranch:  &CurrentBranchTracker{},
-		remoteBranches: &RemoteBranchTracker{},
+		remoteBranches: &RemoteBranchCache{},
 		Configuration:  config,
 	}
 	return &ProdRepo{Silent: silentRunner, Configuration: config}

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -16,7 +16,7 @@ func NewProdRepo() *ProdRepo {
 	silentRunner := Runner{
 		Shell:          shell,
 		currentBranch:  &CurrentBranchTracker{},
-		remoteBranches: &RemoteBranchCache{},
+		remoteBranches: &RemoteBranches{},
 		Configuration:  config,
 	}
 	return &ProdRepo{Silent: silentRunner, Configuration: config}

--- a/src/git/remote_branch_cache.go
+++ b/src/git/remote_branch_cache.go
@@ -2,23 +2,23 @@ package git
 
 // RemoteBranches caches the known remote branches of a Git repository.
 // The zero value is valid.
-type RemoteBranches struct {
+type RemoteBranchCache struct {
 	branches    []string
 	initialized bool
 }
 
 // Initialized indicates whether this RemoteBranchTracker is initialized.
-func (rbt *RemoteBranches) Initialized() bool {
+func (rbt *RemoteBranchCache) Initialized() bool {
 	return rbt.initialized
 }
 
 // Get provides the currently known remote branches.
-func (rbt *RemoteBranches) Get() []string {
+func (rbt *RemoteBranchCache) Get() []string {
 	return rbt.branches
 }
 
 // Set stores the given remote branches.
-func (rbt *RemoteBranches) Set(branches []string) {
+func (rbt *RemoteBranchCache) Set(branches []string) {
 	rbt.branches = branches
 	rbt.initialized = true
 }

--- a/src/git/remote_branch_cache.go
+++ b/src/git/remote_branch_cache.go
@@ -2,23 +2,23 @@ package git
 
 // RemoteBranchTracker caches the known remote branches of a Git repository.
 // The zero value is valid.
-type RemoteBranchTracker struct {
+type RemoteBranchCache struct {
 	branches    []string
 	initialized bool
 }
 
 // Initialized indicates whether this RemoteBranchTracker is initialized.
-func (rbt *RemoteBranchTracker) Initialized() bool {
+func (rbt *RemoteBranchCache) Initialized() bool {
 	return rbt.initialized
 }
 
 // Branches provides the currently known remote branches.
-func (rbt *RemoteBranchTracker) Branches() []string {
+func (rbt *RemoteBranchCache) Branches() []string {
 	return rbt.branches
 }
 
 // Set stores the given remote branches.
-func (rbt *RemoteBranchTracker) Set(branches []string) {
+func (rbt *RemoteBranchCache) Set(branches []string) {
 	rbt.branches = branches
 	rbt.initialized = true
 }

--- a/src/git/remote_branch_cache.go
+++ b/src/git/remote_branch_cache.go
@@ -1,24 +1,24 @@
 package git
 
-// RemoteBranchTracker caches the known remote branches of a Git repository.
+// RemoteBranches caches the known remote branches of a Git repository.
 // The zero value is valid.
-type RemoteBranchCache struct {
+type RemoteBranches struct {
 	branches    []string
 	initialized bool
 }
 
 // Initialized indicates whether this RemoteBranchTracker is initialized.
-func (rbt *RemoteBranchCache) Initialized() bool {
+func (rbt *RemoteBranches) Initialized() bool {
 	return rbt.initialized
 }
 
-// Branches provides the currently known remote branches.
-func (rbt *RemoteBranchCache) Branches() []string {
+// Get provides the currently known remote branches.
+func (rbt *RemoteBranches) Get() []string {
 	return rbt.branches
 }
 
 // Set stores the given remote branches.
-func (rbt *RemoteBranchCache) Set(branches []string) {
+func (rbt *RemoteBranches) Set(branches []string) {
 	rbt.branches = branches
 	rbt.initialized = true
 }

--- a/src/git/remote_branch_tracker_test.go
+++ b/src/git/remote_branch_tracker_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRemoteBranchTracker(t *testing.T) {
-	rbt := git.RemoteBranchTracker{}
+	rbt := git.RemoteBranchCache{}
 	assert.False(t, rbt.Initialized())
 	rbt.Set([]string{"one", "two"})
 	assert.True(t, rbt.Initialized())

--- a/src/git/remote_branch_tracker_test.go
+++ b/src/git/remote_branch_tracker_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRemoteBranchTracker(t *testing.T) {
-	rbt := git.RemoteBranches{}
+	rbt := git.RemoteBranchCache{}
 	assert.False(t, rbt.Initialized())
 	rbt.Set([]string{"one", "two"})
 	assert.True(t, rbt.Initialized())

--- a/src/git/remote_branch_tracker_test.go
+++ b/src/git/remote_branch_tracker_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestRemoteBranchTracker(t *testing.T) {
-	rbt := git.RemoteBranchCache{}
+	rbt := git.RemoteBranches{}
 	assert.False(t, rbt.Initialized())
 	rbt.Set([]string{"one", "two"})
 	assert.True(t, rbt.Initialized())
-	assert.Equal(t, []string{"one", "two"}, rbt.Branches())
+	assert.Equal(t, []string{"one", "two"}, rbt.Get())
 }

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -17,12 +17,12 @@ import (
 type Runner struct {
 	command.Shell                        // for running console commands
 	currentBranch  *CurrentBranchTracker // tracks the currently checked out branch of this Git repo
-	remoteBranches *RemoteBranchTracker  // caches the remote branches of this Git repo
+	remoteBranches *RemoteBranchCache    // caches the remote branches of this Git repo
 	*Configuration                       // caches Git configuration settings
 }
 
 // NewRunner provides Runner instances.
-func NewRunner(shell command.Shell, currentBranch *CurrentBranchTracker, remoteBranches *RemoteBranchTracker, config *Configuration) Runner {
+func NewRunner(shell command.Shell, currentBranch *CurrentBranchTracker, remoteBranches *RemoteBranchCache, config *Configuration) Runner {
 	return Runner{shell, currentBranch, remoteBranches, config}
 }
 

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -17,12 +17,12 @@ import (
 type Runner struct {
 	command.Shell                        // for running console commands
 	currentBranch  *CurrentBranchTracker // tracks the currently checked out branch of this Git repo
-	remoteBranches *RemoteBranchCache    // caches the remote branches of this Git repo
+	remoteBranches *RemoteBranches       // caches the remote branches of this Git repo
 	*Configuration                       // caches Git configuration settings
 }
 
 // NewRunner provides Runner instances.
-func NewRunner(shell command.Shell, currentBranch *CurrentBranchTracker, remoteBranches *RemoteBranchCache, config *Configuration) Runner {
+func NewRunner(shell command.Shell, currentBranch *CurrentBranchTracker, remoteBranches *RemoteBranches, config *Configuration) Runner {
 	return Runner{shell, currentBranch, remoteBranches, config}
 }
 
@@ -466,7 +466,7 @@ func (r *Runner) PushBranch(name string) error {
 // RemoteBranches provides the names of the remote branches in this repo.
 func (r *Runner) RemoteBranches() ([]string, error) {
 	if r.remoteBranches.Initialized() {
-		return r.remoteBranches.Branches(), nil
+		return r.remoteBranches.Get(), nil
 	}
 	outcome, err := r.Run("git", "branch", "-r")
 	if err != nil {

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -15,14 +15,14 @@ import (
 
 // Runner executes Git commands.
 type Runner struct {
-	command.Shell                        // for running console commands
-	currentBranch  *CurrentBranchTracker // tracks the currently checked out branch of this Git repo
-	remoteBranches *RemoteBranches       // caches the remote branches of this Git repo
-	*Configuration                       // caches Git configuration settings
+	command.Shell                           // for running console commands
+	currentBranch     *CurrentBranchTracker // tracks the currently checked out branch of this Git repo
+	remoteBranchCache *RemoteBranchCache    // caches the remote branches of this Git repo
+	*Configuration                          // caches Git configuration settings
 }
 
 // NewRunner provides Runner instances.
-func NewRunner(shell command.Shell, currentBranch *CurrentBranchTracker, remoteBranches *RemoteBranches, config *Configuration) Runner {
+func NewRunner(shell command.Shell, currentBranch *CurrentBranchTracker, remoteBranches *RemoteBranchCache, config *Configuration) Runner {
 	return Runner{shell, currentBranch, remoteBranches, config}
 }
 
@@ -465,8 +465,8 @@ func (r *Runner) PushBranch(name string) error {
 
 // RemoteBranches provides the names of the remote branches in this repo.
 func (r *Runner) RemoteBranches() ([]string, error) {
-	if r.remoteBranches.Initialized() {
-		return r.remoteBranches.Get(), nil
+	if r.remoteBranchCache.Initialized() {
+		return r.remoteBranchCache.Get(), nil
 	}
 	outcome, err := r.Run("git", "branch", "-r")
 	if err != nil {
@@ -479,7 +479,7 @@ func (r *Runner) RemoteBranches() ([]string, error) {
 			result = append(result, strings.TrimSpace(lines[l]))
 		}
 	}
-	r.remoteBranches.Set(result)
+	r.remoteBranchCache.Set(result)
 	remoteBranchesInitialized = true
 	return result, nil
 }

--- a/test/repo.go
+++ b/test/repo.go
@@ -50,7 +50,7 @@ func InitRepo(workingDir, homeDir, binDir string) (Repo, error) {
 // The directory must contain an existing Git repo.
 func NewRepo(workingDir, homeDir, binDir string) Repo {
 	shell := NewMockingShell(workingDir, homeDir, binDir)
-	runner := git.NewRunner(shell, &git.CurrentBranchTracker{}, &git.RemoteBranchCache{}, git.NewConfiguration(shell))
+	runner := git.NewRunner(shell, &git.CurrentBranchTracker{}, &git.RemoteBranches{}, git.NewConfiguration(shell))
 	return Repo{runner, shell}
 }
 

--- a/test/repo.go
+++ b/test/repo.go
@@ -50,7 +50,7 @@ func InitRepo(workingDir, homeDir, binDir string) (Repo, error) {
 // The directory must contain an existing Git repo.
 func NewRepo(workingDir, homeDir, binDir string) Repo {
 	shell := NewMockingShell(workingDir, homeDir, binDir)
-	runner := git.NewRunner(shell, &git.CurrentBranchTracker{}, &git.RemoteBranchTracker{}, git.NewConfiguration(shell))
+	runner := git.NewRunner(shell, &git.CurrentBranchTracker{}, &git.RemoteBranchCache{}, git.NewConfiguration(shell))
 	return Repo{runner, shell}
 }
 

--- a/test/repo.go
+++ b/test/repo.go
@@ -50,7 +50,7 @@ func InitRepo(workingDir, homeDir, binDir string) (Repo, error) {
 // The directory must contain an existing Git repo.
 func NewRepo(workingDir, homeDir, binDir string) Repo {
 	shell := NewMockingShell(workingDir, homeDir, binDir)
-	runner := git.NewRunner(shell, &git.CurrentBranchTracker{}, &git.RemoteBranches{}, git.NewConfiguration(shell))
+	runner := git.NewRunner(shell, &git.CurrentBranchTracker{}, &git.RemoteBranchCache{}, git.NewConfiguration(shell))
 	return Repo{runner, shell}
 }
 


### PR DESCRIPTION
We are really caching the remote branches here, not tracking them.