### PR TITLE
Run only changed unit tests in test-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ stats:  # shows code statistics
 test: lint unit cuke  # runs all the tests
 .PHONY: test
 
-test-go: build unit cuke lint-go  # runs all tests for Golang
+test-go: build u cuke lint-go  # runs all tests for Golang
 
 test-md: lint-md   # runs all Markdown tests
 


### PR DESCRIPTION
`make test-go` is a shortcut for development, it should run only the changed unit tests. We still run all unit tests in `make test`.