### PR TITLE
Unify "repository" and "repo" in features

### DIFF
--- a/features/environment.feature
+++ b/features/environment.feature
@@ -1,7 +1,7 @@
 Feature: Git Town performs correctly depending on the environment
 
   Scenario Outline: Git Town commands run outside of a Git repository
-    Given my workspace is currently not a Git repository
+    Given my workspace is currently not a Git repo
     When I run "<COMMAND>"
     Then it prints the error:
       """

--- a/features/git-town-alias/alias.feature
+++ b/features/git-town-alias/alias.feature
@@ -40,6 +40,6 @@ Feature: git town: alias
 
 
   Scenario: works outside of a Git repository
-    Given my workspace is currently not a Git repository
+    Given my workspace is currently not a Git repo
     When I run "git-town alias true"
     Then it does not print "Not a git repository"

--- a/features/git-town-append/hack-push-flag.feature
+++ b/features/git-town-append/hack-push-flag.feature
@@ -26,7 +26,7 @@ Feature: push branch to remote upon creation
       |           | git stash pop                |
     And I end up on the "new-child" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE     |
       | main      | local, remote | main_commit |
       | new-child | local, remote | main_commit |
@@ -47,6 +47,6 @@ Feature: push branch to remote upon creation
       |           | git stash pop              |
     And I end up on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, remote | main_commit |

--- a/features/git-town-append/hack-push-flag.feature
+++ b/features/git-town-append/hack-push-flag.feature
@@ -5,7 +5,7 @@ Feature: push branch to remote upon creation
 
   Background:
     Given the new-branch-push-flag configuration is true
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     |
       | main   | remote   | main_commit |
     And I am on the "main" branch

--- a/features/git-town-append/offline.feature
+++ b/features/git-town-append/offline.feature
@@ -1,6 +1,6 @@
 Feature: git append: offline mode
 
-    When having no internet connection
+  When having no internet connection
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 

--- a/features/git-town-append/offline.feature
+++ b/features/git-town-append/offline.feature
@@ -8,7 +8,7 @@ Feature: git append: offline mode
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing feature commit |
     And I am on the "existing-feature" branch

--- a/features/git-town-append/offline.feature
+++ b/features/git-town-append/offline.feature
@@ -1,13 +1,13 @@
 Feature: git append: offline mode
 
-  When having no internet connection
+    When having no internet connection
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 
 
   Background:
     Given Git Town is in offline mode
-    And my repository has a feature branch named "existing-feature"
+    And my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing feature commit |

--- a/features/git-town-append/offline.feature
+++ b/features/git-town-append/offline.feature
@@ -30,7 +30,7 @@ Feature: git append: offline mode
       |                  | git checkout new-feature                    |
       | new-feature      | git stash pop                               |
     And I end up on the "new-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing feature commit |
       | new-feature      | local         | existing feature commit |
@@ -50,7 +50,7 @@ Feature: git append: offline mode
       | existing-feature | git stash pop                 |
     And I end up on the "existing-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH           | PARENT |
       | existing-feature | main   |

--- a/features/git-town-append/on-child-branch.feature
+++ b/features/git-town-append/on-child-branch.feature
@@ -7,7 +7,7 @@ Feature: Appending a branch to a feature branch
 
   Background:
     Given my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch

--- a/features/git-town-append/on-child-branch.feature
+++ b/features/git-town-append/on-child-branch.feature
@@ -6,7 +6,7 @@ Feature: Appending a branch to a feature branch
 
 
   Background:
-    Given my repository has a feature branch named "existing-feature"
+    Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |

--- a/features/git-town-append/on-child-branch.feature
+++ b/features/git-town-append/on-child-branch.feature
@@ -31,7 +31,7 @@ Feature: Appending a branch to a feature branch
       | new-child        | git stash pop                               |
     And I end up on the "new-child" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |
       | new-child        | local         | existing_feature_commit |
@@ -55,7 +55,7 @@ Feature: Appending a branch to a feature branch
       | existing-feature | git stash pop                 |
     And I end up on the "existing-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH           | PARENT |
       | existing-feature | main   |

--- a/features/git-town-append/on-feature-branch.feature
+++ b/features/git-town-append/on-feature-branch.feature
@@ -7,7 +7,7 @@ Feature: Appending a branch to a feature branch
 
   Background:
     Given my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch

--- a/features/git-town-append/on-feature-branch.feature
+++ b/features/git-town-append/on-feature-branch.feature
@@ -6,7 +6,7 @@ Feature: Appending a branch to a feature branch
 
 
   Background:
-    Given my repository has a feature branch named "existing-feature"
+    Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |

--- a/features/git-town-append/on-feature-branch.feature
+++ b/features/git-town-append/on-feature-branch.feature
@@ -31,7 +31,7 @@ Feature: Appending a branch to a feature branch
       | new-child        | git stash pop                               |
     And I end up on the "new-child" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |
       | new-child        | local         | existing_feature_commit |
@@ -55,7 +55,7 @@ Feature: Appending a branch to a feature branch
       | existing-feature | git stash pop                 |
     And I end up on the "existing-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH           | PARENT |
       | existing-feature | main   |

--- a/features/git-town-append/on-main-branch.feature
+++ b/features/git-town-append/on-main-branch.feature
@@ -6,7 +6,7 @@ Feature: Appending a branch to a feature branch
 
 
   Background:
-    Given the following commits exist in my repository
+    Given the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     |
       | main   | remote   | main_commit |
     And I am on the "main" branch

--- a/features/git-town-append/on-main-branch.feature
+++ b/features/git-town-append/on-main-branch.feature
@@ -26,7 +26,7 @@ Feature: Appending a branch to a feature branch
       | new-child | git stash pop             |
     And I end up on the "new-child" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE     |
       | main      | local, remote | main_commit |
       | new-child | local         | main_commit |
@@ -46,6 +46,6 @@ Feature: Appending a branch to a feature branch
       |           | git stash pop           |
     And I end up on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, remote | main_commit |

--- a/features/git-town-append/on-perennial-branch.feature
+++ b/features/git-town-append/on-perennial-branch.feature
@@ -7,7 +7,7 @@ Feature: Appending a branch to a perennial branch
 
   Background:
     Given my repo has the perennial branches "qa" and "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION | MESSAGE           |
       | production | remote   | production_commit |
     And I am on the "production" branch

--- a/features/git-town-append/on-perennial-branch.feature
+++ b/features/git-town-append/on-perennial-branch.feature
@@ -6,7 +6,7 @@ Feature: Appending a branch to a perennial branch
 
 
   Background:
-    Given my repository has the perennial branches "qa" and "production"
+    Given my repo has the perennial branches "qa" and "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION | MESSAGE           |
       | production | remote   | production_commit |

--- a/features/git-town-append/on-perennial-branch.feature
+++ b/features/git-town-append/on-perennial-branch.feature
@@ -27,7 +27,7 @@ Feature: Appending a branch to a perennial branch
       | new-child  | git stash pop                   |
     And I end up on the "new-child" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           |
       | new-child  | local         | production_commit |
       | production | local, remote | production_commit |
@@ -47,6 +47,6 @@ Feature: Appending a branch to a perennial branch
       |            | git stash pop           |
     And I end up on the "production" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           |
       | production | local, remote | production_commit |

--- a/features/git-town-config/already_set.feature
+++ b/features/git-town-config/already_set.feature
@@ -6,7 +6,7 @@ Feature: listing the configuration
 
 
   Scenario: everything is configured
-    Given my repository has the feature branches "production" and "qa"
+    Given my repo has the feature branches "production" and "qa"
     And the main branch is configured as "main"
     And the perennial branches are configured as "qa"
     When I run "git-town config setup" and answer the prompts:

--- a/features/git-town-config/reset.feature
+++ b/features/git-town-config/reset.feature
@@ -9,24 +9,24 @@ Feature: resetting the configuration
     Given the main branch is configured as "main"
     And the perennial branches are configured as "qa" and "staging"
     When I run "git-town config reset"
-    Then Git Town is no longer configured for this repository
+    Then Git Town is no longer configured for this repo
 
 
   Scenario: the main branch is configured but the perennial branches are not
     Given the main branch is configured as "main"
     And the perennial branches are not configured
     When I run "git-town config reset"
-    Then Git Town is no longer configured for this repository
+    Then Git Town is no longer configured for this repo
 
 
   Scenario: the main branch is not configured but the perennial branches are
     Given the main branch name is not configured
     And the perennial branches are configured as "qa"
     When I run "git-town config reset"
-    Then Git Town is no longer configured for this repository
+    Then Git Town is no longer configured for this repo
 
 
   Scenario: nothing is configured yet
     Given I haven't configured Git Town yet
     When I run "git-town config reset"
-    Then Git Town is no longer configured for this repository
+    Then Git Town is no longer configured for this repo

--- a/features/git-town-config/setup.feature
+++ b/features/git-town-config/setup.feature
@@ -6,7 +6,7 @@ Feature: Initial configuration
 
 
   Scenario: succeeds on valid main branch and perennial branch names
-    Given my repository has the feature branches "production" and "dev"
+    Given my repo has the feature branches "production" and "dev"
     And I haven't configured Git Town yet
     When I run "git-town config setup" and answer the prompts:
       | PROMPT                                     | ANSWER                      |

--- a/features/git-town-config/view.feature
+++ b/features/git-town-config/view.feature
@@ -22,10 +22,10 @@ Feature: listing the configuration
 
   Scenario: everything is configured and there are nested branches
     Given the main branch is configured as "main"
-    And my repository has the perennial branches "qa" and "staging"
-    And my repository has the feature branches "parent-feature" and "stand-alone-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
-    And my repository has a feature branch named "qa-hotfix" as a child of "qa"
+    And my repo has the perennial branches "qa" and "staging"
+    And my repo has the feature branches "parent-feature" and "stand-alone-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    And my repo has a feature branch named "qa-hotfix" as a child of "qa"
     When I run "git-town config"
     Then it prints:
       """

--- a/features/git-town-diff-parent/current_branch/on_feature_branch/no_parent_branch.feature
+++ b/features/git-town-diff-parent/current_branch/on_feature_branch/no_parent_branch.feature
@@ -1,14 +1,14 @@
 Feature: git town-parent-diff: diffing the current feature branch
 
-    As a user running parent-diff
-    With no arguments
-    On a feature branch that has no parent branch defined
-    I should see a prompt to supply a parent branch
-    So that the command can work as I expect
+  As a user running parent-diff
+  With no arguments
+  On a feature branch that has no parent branch defined
+  I should see a prompt to supply a parent branch
+  So that the command can work as I expect
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature" with no parent
+    Given my repo has a feature branch named "feature" with no parent
     And I am on the "feature" branch
     When I run "git-town diff-parent" and answer the prompts:
       | PROMPT                                        | ANSWER  |

--- a/features/git-town-diff-parent/current_branch/on_feature_branch/with_parent_branch.feature
+++ b/features/git-town-diff-parent/current_branch/on_feature_branch/with_parent_branch.feature
@@ -7,8 +7,8 @@ Feature: git town-parent-diff: diffing the current feature branch
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And I am on the "feature-2" branch
     When I run "git-town diff-parent"
     Then it runs the commands

--- a/features/git-town-diff-parent/current_branch/on_main_branch.feature
+++ b/features/git-town-diff-parent/current_branch/on_main_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-diff-parent: errors when trying to diff the main branch
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And I am on the "main" branch
     When I run "git-town diff-parent"
     Then it runs no commands

--- a/features/git-town-diff-parent/current_branch/on_non_feature_branch.feature
+++ b/features/git-town-diff-parent/current_branch/on_non_feature_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-diff-parent: errors when trying to diff a perennial branch
 
 
   Scenario: result
-    Given my repository has the perennial branch "qa"
+    Given my repo has the perennial branch "qa"
     And I am on the "qa" branch
     When I run "git-town diff-parent"
     Then it runs no commands

--- a/features/git-town-diff-parent/supplied_branch/feature_branch/on_main_branch.feature
+++ b/features/git-town-diff-parent/supplied_branch/feature_branch/on_main_branch.feature
@@ -4,8 +4,8 @@ Feature: git town-diff-parent: diffing a given feature branch
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And I am on the "main" branch
     When I run "git-town diff-parent feature-2"
     Then it runs the commands

--- a/features/git-town-diff-parent/supplied_branch/feature_branch/on_main_branch_no_parent.feature
+++ b/features/git-town-diff-parent/supplied_branch/feature_branch/on_main_branch_no_parent.feature
@@ -1,14 +1,14 @@
 Feature: git town-parent-diff: diffing the current feature branch
 
-    As a user running parent-diff
-    With a supplied branch
-    On the main branch
-    I should see a prompt to identify a parent branch
-    So that the command can work as I expect
+  As a user running parent-diff
+  With a supplied branch
+  On the main branch
+  I should see a prompt to identify a parent branch
+  So that the command can work as I expect
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature" with no parent
+    Given my repo has a feature branch named "feature" with no parent
     And I am on the "main" branch
     When I run "git-town diff-parent feature" and answer the prompts:
       | PROMPT                                        | ANSWER  |

--- a/features/git-town-diff-parent/supplied_branch/feature_branch/on_parent_branch.feature
+++ b/features/git-town-diff-parent/supplied_branch/feature_branch/on_parent_branch.feature
@@ -4,8 +4,8 @@ Feature: git town-diff-parent: diffing a given feature branch
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And I am on the "feature-1" branch
     When I run "git-town diff-parent feature-2"
     Then it runs the commands

--- a/features/git-town-diff-parent/supplied_branch/main_branch.feature
+++ b/features/git-town-diff-parent/supplied_branch/main_branch.feature
@@ -4,7 +4,7 @@ Feature: git town-diff-parent: errors when trying to diff the main branch
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And I am on the "feature" branch
     When I run "git-town diff-parent main"
     Then it runs no commands

--- a/features/git-town-diff-parent/supplied_branch/on_supplied_feature_branch/has_parent.feature
+++ b/features/git-town-diff-parent/supplied_branch/on_supplied_feature_branch/has_parent.feature
@@ -4,8 +4,8 @@ Feature: git town-diff-parent: diffing a given feature branch
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And I am on the "feature-2" branch
     When I run "git-town diff-parent feature-2"
     Then it runs the commands

--- a/features/git-town-diff-parent/supplied_branch/on_supplied_feature_branch/no_parent_branch.feature
+++ b/features/git-town-diff-parent/supplied_branch/on_supplied_feature_branch/no_parent_branch.feature
@@ -1,14 +1,14 @@
 Feature: git town-parent-diff: diffing the current feature branch
 
-    As a user running parent-diff
-    With a supplied branch that matches my current branch
-    On a branch that has no parent branch defined
-    I should see a prompt to supply a parent branch
-    So that the command can work as I expect
+  As a user running parent-diff
+  With a supplied branch that matches my current branch
+  On a branch that has no parent branch defined
+  I should see a prompt to supply a parent branch
+  So that the command can work as I expect
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature" with no parent
+    Given my repo has a feature branch named "feature" with no parent
     And I am on the "feature" branch
     When I run "git-town diff-parent feature" and answer the prompts:
       | PROMPT                                        | ANSWER  |

--- a/features/git-town-diff-parent/supplied_branch/perennial_branch.feature
+++ b/features/git-town-diff-parent/supplied_branch/perennial_branch.feature
@@ -4,8 +4,8 @@ Feature: git town-diff-parent: errors when trying to diff a perennial branch
 
 
   Scenario: result
-    Given my repository has a feature branch named "feature"
-    And my repository has the perennial branch "qa"
+    Given my repo has a feature branch named "feature"
+    And my repo has the perennial branch "qa"
     And I am on the "feature" branch
     When I run "git-town diff-parent qa"
     Then it runs no commands

--- a/features/git-town-hack/branch_exists_locally.feature
+++ b/features/git-town-hack/branch_exists_locally.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: errors when the branch exists locally
 
 
   Background:
-    Given my repository has a feature branch named "existing-feature"
+    Given my repo has a feature branch named "existing-feature"
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack existing-feature"

--- a/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
@@ -43,7 +43,7 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
     And I end up on the "existing-feature" branch
     And my workspace has the uncommitted file again
     And there is no rebase in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -68,7 +68,7 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
       | new-feature | git stash pop               |
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        |
       | main        | local, remote | conflicting remote commit | conflicting_file |
       |             |               | conflicting local commit  | conflicting_file |
@@ -88,7 +88,7 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
       | new-feature | git stash pop               |
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        |
       | main        | local, remote | conflicting remote commit | conflicting_file |
       |             |               | conflicting local commit  | conflicting_file |

--- a/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
 
   Background:
     Given my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
       | main   | local    | conflicting local commit  | conflicting_file | local content  |
       |        | remote   | conflicting remote commit | conflicting_file | remote content |

--- a/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-hack/main_branch_rebase_tracking_branch_conflict.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
 
 
   Background:
-    Given my repository has a feature branch named "existing-feature"
+    Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
       | main   | local    | conflicting local commit  | conflicting_file | local content  |

--- a/features/git-town-hack/new_branch_push_flag.feature
+++ b/features/git-town-hack/new_branch_push_flag.feature
@@ -1,6 +1,6 @@
 Feature: git town-hack: push branch to remote upon creation
 
-  When creating a new feature branch and having enough CI server bandwidth for an extra CI run
+    When creating a new feature branch and having enough CI server bandwidth for an extra CI run
   I want it to be pushed to the CI server right away
   So that I can push and pull from the remote branch right away without having to run "git sync" first
 
@@ -23,7 +23,7 @@ Feature: git town-hack: push branch to remote upon creation
       |         | git checkout feature       |
       | feature | git push -u origin feature |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE       |
       | main    | local, remote | remote commit |
       | feature | local, remote | remote commit |

--- a/features/git-town-hack/new_branch_push_flag.feature
+++ b/features/git-town-hack/new_branch_push_flag.feature
@@ -7,7 +7,7 @@ Feature: git town-hack: push branch to remote upon creation
 
   Background:
     Given the new-branch-push-flag configuration is true
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE       |
       | main   | remote   | remote commit |
     And I am on the "main" branch

--- a/features/git-town-hack/new_branch_push_flag.feature
+++ b/features/git-town-hack/new_branch_push_flag.feature
@@ -1,6 +1,6 @@
 Feature: git town-hack: push branch to remote upon creation
 
-    When creating a new feature branch and having enough CI server bandwidth for an extra CI run
+  When creating a new feature branch and having enough CI server bandwidth for an extra CI run
   I want it to be pushed to the CI server right away
   So that I can push and pull from the remote branch right away without having to run "git sync" first
 

--- a/features/git-town-hack/offline.feature
+++ b/features/git-town-hack/offline.feature
@@ -1,6 +1,6 @@
 Feature: git town-hack: offline mode
 
-  When having no internet connection
+    When having no internet connection
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 
@@ -26,7 +26,7 @@ Feature: git town-hack: offline mode
       | feature | git stash pop           |
     And I end up on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |
       | feature | local         | main commit |

--- a/features/git-town-hack/offline.feature
+++ b/features/git-town-hack/offline.feature
@@ -7,7 +7,7 @@ Feature: git town-hack: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, remote | main commit |
     And I am on the "main" branch

--- a/features/git-town-hack/offline.feature
+++ b/features/git-town-hack/offline.feature
@@ -1,6 +1,6 @@
 Feature: git town-hack: offline mode
 
-    When having no internet connection
+  When having no internet connection
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 

--- a/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE       | FILE NAME        |
       | main    | local, remote | main commit   | main_file        |

--- a/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
@@ -7,7 +7,7 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE       | FILE NAME        |
       | main    | local, remote | main commit   | main_file        |
       | feature | local, remote | folder commit | new_folder/file1 |

--- a/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_committed_subfolder.feature
@@ -31,7 +31,7 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
     And I end up on the "new-feature" branch
     And I am in the project root folder
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE       |
       | main        | local, remote | main commit   |
       | feature     | local, remote | folder commit |

--- a/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH | LOCATION      | MESSAGE     | FILE NAME |
       | main   | local, remote | main commit | main_file |

--- a/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
@@ -7,7 +7,7 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE     | FILE NAME |
       | main   | local, remote | main commit | main_file |
     And I am on the "feature" branch

--- a/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
+++ b/features/git-town-hack/on_feature_branch/in_uncommitted_subfolder.feature
@@ -31,7 +31,7 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
     And I end up on the "new-feature" branch
     And I am in the project root folder
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE     |
       | main        | local, remote | main commit |
       | new-feature | local         | main commit |

--- a/features/git-town-hack/on_feature_branch/with_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/with_remote_origin.feature
@@ -7,7 +7,7 @@ Feature: git town-hack: starting a new feature from a feature branch (with remot
 
   Background:
     Given my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION | MESSAGE                 |
       | main             | remote   | main commit             |
       | existing-feature | local    | existing feature commit |

--- a/features/git-town-hack/on_feature_branch/with_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/with_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: starting a new feature from a feature branch (with remot
 
 
   Background:
-    Given my repository has a feature branch named "existing-feature"
+    Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION | MESSAGE                 |
       | main             | remote   | main commit             |

--- a/features/git-town-hack/on_feature_branch/with_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/with_remote_origin.feature
@@ -29,7 +29,7 @@ Feature: git town-hack: starting a new feature from a feature branch (with remot
       | new-feature      | git stash pop               |
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION      | MESSAGE                 |
       | main             | local, remote | main commit             |
       | existing-feature | local         | existing feature commit |

--- a/features/git-town-hack/on_feature_branch/without_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/without_remote_origin.feature
@@ -8,7 +8,7 @@ Feature: git town-hack: starting a new feature from a feature branch (without re
   Background:
     Given my repo has a feature branch named "existing-feature"
     And my repo does not have a remote origin
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION | MESSAGE                 |
       | main             | local    | main commit             |
       | existing-feature | local    | existing feature commit |

--- a/features/git-town-hack/on_feature_branch/without_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/without_remote_origin.feature
@@ -27,7 +27,7 @@ Feature: git town-hack: starting a new feature from a feature branch (without re
       | new-feature      | git stash pop               |
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION | MESSAGE                 |
       | main             | local    | main commit             |
       | existing-feature | local    | existing feature commit |

--- a/features/git-town-hack/on_feature_branch/without_remote_origin.feature
+++ b/features/git-town-hack/on_feature_branch/without_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: starting a new feature from a feature branch (without re
 
 
   Background:
-    Given my repository has a feature branch named "existing-feature"
+    Given my repo has a feature branch named "existing-feature"
     And my repo does not have a remote origin
     And the following commits exist in my repository
       | BRANCH           | LOCATION | MESSAGE                 |

--- a/features/git-town-hack/on_main_branch/in_subfolder.feature
+++ b/features/git-town-hack/on_main_branch/in_subfolder.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: starting a new feature from a subfolder on the main bran
 
 
   Background:
-    Given the following commits exist in my repository
+    Given the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE       | FILE NAME        |
       | main   | local    | folder commit | new_folder/file1 |
     And I am on the "main" branch

--- a/features/git-town-hack/on_main_branch/in_subfolder.feature
+++ b/features/git-town-hack/on_main_branch/in_subfolder.feature
@@ -30,7 +30,7 @@ Feature: git town-hack: starting a new feature from a subfolder on the main bran
     And I am in the project root folder
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE       |
       | main        | local, remote | folder commit |
       | new-feature | local         | folder commit |

--- a/features/git-town-hack/on_main_branch/with_remote_origin.feature
+++ b/features/git-town-hack/on_main_branch/with_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: starting a new feature from the main branch (with remote
 
 
   Background:
-    Given the following commits exist in my repository
+    Given the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     |
       | main   | remote   | main_commit |
     And I am on the "main" branch

--- a/features/git-town-hack/on_main_branch/with_remote_origin.feature
+++ b/features/git-town-hack/on_main_branch/with_remote_origin.feature
@@ -26,7 +26,7 @@ Feature: git town-hack: starting a new feature from the main branch (with remote
       | new-feature | git stash pop               |
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE     |
       | main        | local, remote | main_commit |
       | new-feature | local         | main_commit |

--- a/features/git-town-hack/on_main_branch/with_upstream.feature
+++ b/features/git-town-hack/on_main_branch/with_upstream.feature
@@ -2,7 +2,7 @@ Feature: git-hack: on the main branch with a upstream remote
 
   Background:
     Given my repo has an upstream repo
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE         |
       | main   | upstream | upstream commit |
     And I am on the "main" branch

--- a/features/git-town-hack/on_main_branch/with_upstream.feature
+++ b/features/git-town-hack/on_main_branch/with_upstream.feature
@@ -25,7 +25,7 @@ Feature: git-hack: on the main branch with a upstream remote
       | new-feature | git stash pop               |
     And I am still on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION                | MESSAGE         |
       | main        | local, remote, upstream | upstream commit |
       | new-feature | local                   | upstream commit |

--- a/features/git-town-hack/on_main_branch/without_remote_origin.feature
+++ b/features/git-town-hack/on_main_branch/without_remote_origin.feature
@@ -25,7 +25,7 @@ Feature: git town-hack: starting a new feature from the main branch (without rem
       | new-feature | git stash pop               |
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION | MESSAGE     | FILE NAME |
       | main        | local    | main_commit | main_file |
       | new-feature | local    | main_commit | main_file |

--- a/features/git-town-hack/on_main_branch/without_remote_origin.feature
+++ b/features/git-town-hack/on_main_branch/without_remote_origin.feature
@@ -7,7 +7,7 @@ Feature: git town-hack: starting a new feature from the main branch (without rem
 
   Background:
     Given my repo does not have a remote origin
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     | FILE NAME |
       | main   | local    | main_commit | main_file |
     And I am on the "main" branch

--- a/features/git-town-hack/prompt_for_parent.feature
+++ b/features/git-town-hack/prompt_for_parent.feature
@@ -25,7 +25,7 @@ Feature: git town-hack: prompt for parent branch
       | new-feature | git stash pop               |
     And I end up on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE     |
       | main        | local, remote | main_commit |
       | new-feature | local         | main_commit |
@@ -53,7 +53,7 @@ Feature: git town-hack: prompt for parent branch
       | hotfix     | git stash pop                |
     And I end up on the "hotfix" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           |
       | hotfix     | local         | production_commit |
       | production | local, remote | production_commit |

--- a/features/git-town-hack/prompt_for_parent.feature
+++ b/features/git-town-hack/prompt_for_parent.feature
@@ -32,7 +32,7 @@ Feature: git town-hack: prompt for parent branch
 
 
   Scenario: selecting another branch
-    Given my repository has the perennial branch "production"
+    Given my repo has the perennial branch "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION | MESSAGE           |
       | production | remote   | production_commit |

--- a/features/git-town-hack/prompt_for_parent.feature
+++ b/features/git-town-hack/prompt_for_parent.feature
@@ -6,7 +6,7 @@ Feature: git town-hack: prompt for parent branch
 
 
   Scenario: selecting the default branch (the main development branch)
-    Given the following commits exist in my repository
+    Given the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     |
       | main   | remote   | main_commit |
     And I am on the "main" branch
@@ -33,7 +33,7 @@ Feature: git town-hack: prompt for parent branch
 
   Scenario: selecting another branch
     Given my repo has the perennial branch "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION | MESSAGE           |
       | production | remote   | production_commit |
     And I am on the "main" branch

--- a/features/git-town-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
@@ -31,7 +31,7 @@ Feature: git town-kill: killing the current feature branch with a deleted tracki
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
 
@@ -49,7 +49,7 @@ Feature: git town-kill: killing the current feature branch with a deleted tracki
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, other-feature                  |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local         | current feature commit |
       | other-feature   | local, remote | other feature commit   |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-kill: killing the current feature branch with a deleted tracki
 
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |
       | other-feature   | local, remote | other feature commit   |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: killing the current feature branch with a deleted tracki
 
 
   Background:
-    Given my repository has the feature branches "current-feature" and "other-feature"
+    Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
@@ -34,7 +34,7 @@ Feature: git town-kill: killing the current feature branch with child branches
       | REPOSITORY | BRANCHES                   |
       | local      | main, feature-1, feature-3 |
       | remote     | main, feature-1, feature-3 |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |
       | feature-3 | local, remote | feature 3 commit |
@@ -58,7 +58,7 @@ Feature: git town-kill: killing the current feature branch with child branches
       | REPOSITORY | BRANCHES                              |
       | local      | main, feature-1, feature-2, feature-3 |
       | remote     | main, feature-1, feature-2, feature-3 |
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT    |
       | feature-1 | main      |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
@@ -6,9 +6,9 @@ Feature: git town-kill: killing the current feature branch with child branches
 
 
   Background:
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
-    And my repository has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
+    And my repo has a feature branch named "feature-3" as a child of "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
@@ -9,7 +9,7 @@ Feature: git town-kill: killing the current feature branch with child branches
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And my repo has a feature branch named "feature-3" as a child of "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |
       | feature-2 | local, remote | feature 2 commit |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-kill: killing the current feature branch with a tracking branc
 
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |
       | other-feature   | local, remote | other feature commit   |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: killing the current feature branch with a tracking branc
 
 
   Background:
-    Given my repository has the feature branches "current-feature" and "other-feature"
+    Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |

--- a/features/git-town-kill/current_branch/on_feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/with_tracking_branch.feature
@@ -31,7 +31,7 @@ Feature: git town-kill: killing the current feature branch with a tracking branc
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
 
@@ -50,4 +50,4 @@ Feature: git town-kill: killing the current feature branch with a tracking branc
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, current-feature, other-feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/current_branch/on_feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/without_remote_origin.feature
@@ -26,7 +26,7 @@ Feature: git town-kill: killing the current feature branch without a tracking br
     And the existing branches are
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION | MESSAGE              |
       | other-feature | local    | other feature commit |
 
@@ -43,4 +43,4 @@ Feature: git town-kill: killing the current feature branch without a tracking br
     And the existing branches are
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/current_branch/on_feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/without_remote_origin.feature
@@ -5,7 +5,7 @@ Feature: git town-kill: killing the current feature branch without a tracking br
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has the local feature branches "current-feature" and "other-feature"
+    And my repo has the local feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION | MESSAGE                |
       | current-feature | local    | current feature commit |

--- a/features/git-town-kill/current_branch/on_feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/without_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: killing the current feature branch without a tracking br
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION | MESSAGE                |
       | current-feature | local    | current feature commit |
       | other-feature   | local    | other feature commit   |

--- a/features/git-town-kill/current_branch/on_feature_branch/without_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/without_tracking_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-kill: killing the current feature branch without a tracking br
   Background:
     Given my repo has a feature branch named "other-feature"
     And my repo has a local feature branch named "current-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local         | current feature commit |
       | other-feature   | local, remote | other feature commit   |

--- a/features/git-town-kill/current_branch/on_feature_branch/without_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/without_tracking_branch.feature
@@ -6,8 +6,8 @@ Feature: git town-kill: killing the current feature branch without a tracking br
 
 
   Background:
-    Given my repository has a feature branch named "other-feature"
-    And my repository has a local feature branch named "current-feature"
+    Given my repo has a feature branch named "other-feature"
+    And my repo has a local feature branch named "current-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local         | current feature commit |

--- a/features/git-town-kill/current_branch/on_feature_branch/without_tracking_branch.feature
+++ b/features/git-town-kill/current_branch/on_feature_branch/without_tracking_branch.feature
@@ -30,7 +30,7 @@ Feature: git town-kill: killing the current feature branch without a tracking br
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
 
@@ -48,4 +48,4 @@ Feature: git town-kill: killing the current feature branch without a tracking br
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, other-feature                  |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/current_branch/on_main_branch.feature
+++ b/features/git-town-kill/current_branch/on_main_branch.feature
@@ -27,4 +27,4 @@ Feature: git town-kill: errors when trying to kill the main branch
       | REPOSITORY | BRANCHES      |
       | local      | main, feature |
       | remote     | main, feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/current_branch/on_main_branch.feature
+++ b/features/git-town-kill/current_branch/on_main_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: errors when trying to kill the main branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |

--- a/features/git-town-kill/current_branch/on_main_branch.feature
+++ b/features/git-town-kill/current_branch/on_main_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-kill: errors when trying to kill the main branch
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |
     And I am on the "main" branch

--- a/features/git-town-kill/current_branch/on_non_feature_branch.feature
+++ b/features/git-town-kill/current_branch/on_non_feature_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-kill: errors when trying to kill a perennial branch
 
   Background:
     Given my repo has the perennial branch "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE   |
       | qa     | local, remote | qa commit |
     And I am on the "qa" branch

--- a/features/git-town-kill/current_branch/on_non_feature_branch.feature
+++ b/features/git-town-kill/current_branch/on_non_feature_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: errors when trying to kill a perennial branch
 
 
   Background:
-    Given my repository has the perennial branch "qa"
+    Given my repo has the perennial branch "qa"
     And the following commits exist in my repository
       | BRANCH | LOCATION      | MESSAGE   |
       | qa     | local, remote | qa commit |

--- a/features/git-town-kill/current_branch/on_non_feature_branch.feature
+++ b/features/git-town-kill/current_branch/on_non_feature_branch.feature
@@ -27,4 +27,4 @@ Feature: git town-kill: errors when trying to kill a perennial branch
       | REPOSITORY | BRANCHES |
       | local      | main, qa |
       | remote     | main, qa |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/feature_branch/remote_branch.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/remote_branch.feature
@@ -2,7 +2,7 @@ Feature: git town-kill: killing a remote only branch
 
   Background:
     Given my origin has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | remote   | feature commit |
     And I am on the "main" branch

--- a/features/git-town-kill/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/with_child_branches.feature
@@ -7,7 +7,7 @@ Feature: git town-kill: killing the given branch with child branches
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And my repo has a feature branch named "feature-3" as a child of "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |
       | feature-2 | local, remote | feature 2 commit |

--- a/features/git-town-kill/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/with_child_branches.feature
@@ -4,9 +4,9 @@ Feature: git town-kill: killing the given branch with child branches
 
 
   Background:
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
-    And my repository has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
+    And my repo has a feature branch named "feature-3" as a child of "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |

--- a/features/git-town-kill/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/with_child_branches.feature
@@ -29,7 +29,7 @@ Feature: git town-kill: killing the given branch with child branches
       | REPOSITORY | BRANCHES                   |
       | local      | main, feature-1, feature-3 |
       | remote     | main, feature-1, feature-3 |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |
       | feature-3 | local, remote | feature 3 commit |
@@ -51,7 +51,7 @@ Feature: git town-kill: killing the given branch with child branches
       | REPOSITORY | BRANCHES                              |
       | local      | main, feature-1, feature-2, feature-3 |
       | remote     | main, feature-1, feature-2, feature-3 |
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT    |
       | feature-1 | main      |

--- a/features/git-town-kill/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-kill: killing the given feature branch
 
   Background:
     Given my repo has the feature branches "good-feature" and "dead-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
       | main         | local, remote | conflicting with uncommitted changes | conflicting_file |
       | dead-feature | local, remote | dead-end commit                      | unfortunate_file |

--- a/features/git-town-kill/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -29,7 +29,7 @@ Feature: git town-kill: killing the given feature branch
       | REPOSITORY | BRANCHES           |
       | local      | main, good-feature |
       | remote     | main, good-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
       | main         | local, remote | conflicting with uncommitted changes | conflicting_file |
       | good-feature | local, remote | good commit                          | good_file        |
@@ -47,4 +47,4 @@ Feature: git town-kill: killing the given feature branch
       | REPOSITORY | BRANCHES                         |
       | local      | main, dead-feature, good-feature |
       | remote     | main, dead-feature, good-feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: killing the given feature branch
 
 
   Background:
-    Given my repository has the feature branches "good-feature" and "dead-feature"
+    Given my repo has the feature branches "good-feature" and "dead-feature"
     And the following commits exist in my repository
       | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
       | main         | local, remote | conflicting with uncommitted changes | conflicting_file |

--- a/features/git-town-kill/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/without_remote_origin.feature
@@ -5,7 +5,7 @@ Feature: git town-kill: killing the given feature branch (without remote repo)
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has the local feature branches "current-feature" and "other-feature"
+    And my repo has the local feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION | MESSAGE                | FILE NAME            |
       | main            | local    | main commit            | conflicting_file     |

--- a/features/git-town-kill/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/without_remote_origin.feature
@@ -28,7 +28,7 @@ Feature: git town-kill: killing the given feature branch (without remote repo)
     And the existing branches are
       | REPOSITORY | BRANCHES              |
       | local      | main, current-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH          | LOCATION | MESSAGE                | FILE NAME            |
       | main            | local    | main commit            | conflicting_file     |
       | current-feature | local    | current feature commit | current_feature_file |
@@ -47,4 +47,4 @@ Feature: git town-kill: killing the given feature branch (without remote repo)
     And the existing branches are
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/supplied_branch/feature_branch/without_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: killing the given feature branch (without remote repo)
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION | MESSAGE                | FILE NAME            |
       | main            | local    | main commit            | conflicting_file     |
       | current-feature | local    | current feature commit | current_feature_file |

--- a/features/git-town-kill/supplied_branch/main_branch.feature
+++ b/features/git-town-kill/supplied_branch/main_branch.feature
@@ -5,7 +5,7 @@ Feature: git town-kill: errors when trying to kill the main branch
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |
       | feature | local, remote | good commit |

--- a/features/git-town-kill/supplied_branch/main_branch.feature
+++ b/features/git-town-kill/supplied_branch/main_branch.feature
@@ -26,4 +26,4 @@ Feature: git town-kill: errors when trying to kill the main branch
       | REPOSITORY | BRANCHES      |
       | local      | main, feature |
       | remote     | main, feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/main_branch.feature
+++ b/features/git-town-kill/supplied_branch/main_branch.feature
@@ -4,7 +4,7 @@ Feature: git town-kill: errors when trying to kill the main branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |

--- a/features/git-town-kill/supplied_branch/offline/local_branch.feature
+++ b/features/git-town-kill/supplied_branch/offline/local_branch.feature
@@ -1,13 +1,13 @@
 Feature: git town-kill: killing a local branch in offline mode
 
-  When offline
+    When offline
   I want to be able to still delete the current branch including all open changes
   So that I can work as much as possible despite no internet connection.
 
 
   Background:
     Given Git Town is in offline mode
-    And my repository has the feature branches "current-feature" and "other-feature"
+    And my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |

--- a/features/git-town-kill/supplied_branch/offline/local_branch.feature
+++ b/features/git-town-kill/supplied_branch/offline/local_branch.feature
@@ -1,6 +1,6 @@
 Feature: git town-kill: killing a local branch in offline mode
 
-    When offline
+  When offline
   I want to be able to still delete the current branch including all open changes
   So that I can work as much as possible despite no internet connection.
 

--- a/features/git-town-kill/supplied_branch/offline/local_branch.feature
+++ b/features/git-town-kill/supplied_branch/offline/local_branch.feature
@@ -30,7 +30,7 @@ Feature: git town-kill: killing a local branch in offline mode
       | REPOSITORY | BRANCHES                             |
       | local      | main, other-feature                  |
       | remote     | main, current-feature, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | remote        | current feature commit |
       | other-feature   | local, remote | other feature commit   |
@@ -49,4 +49,4 @@ Feature: git town-kill: killing a local branch in offline mode
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, current-feature, other-feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/offline/local_branch.feature
+++ b/features/git-town-kill/supplied_branch/offline/local_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-kill: killing a local branch in offline mode
   Background:
     Given Git Town is in offline mode
     And my repo has the feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |
       | other-feature   | local, remote | other feature commit   |

--- a/features/git-town-kill/supplied_branch/offline/remote_branch.feature
+++ b/features/git-town-kill/supplied_branch/offline/remote_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-kill: killing a remote branch in offline mode
   Background:
     Given Git Town is in offline mode
     And my origin has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | remote   | feature commit |
     And my repo knows about the remote branch

--- a/features/git-town-kill/supplied_branch/offline/remote_branch.feature
+++ b/features/git-town-kill/supplied_branch/offline/remote_branch.feature
@@ -1,6 +1,6 @@
 Feature: git town-kill: killing a remote branch in offline mode
 
-  When offline and trying to kill a remote branch
+    When offline and trying to kill a remote branch
   I want to be notified that this operation is not possible
   So that I know about my mistake and can do more appropriate actions instead.
 
@@ -11,7 +11,7 @@ Feature: git town-kill: killing a remote branch in offline mode
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | remote   | feature commit |
-    And my repository knows about the remote branch
+    And my repo knows about the remote branch
     And I am on the "main" branch
     When I run "git-town kill feature"
 

--- a/features/git-town-kill/supplied_branch/offline/remote_branch.feature
+++ b/features/git-town-kill/supplied_branch/offline/remote_branch.feature
@@ -1,6 +1,6 @@
 Feature: git town-kill: killing a remote branch in offline mode
 
-    When offline and trying to kill a remote branch
+  When offline and trying to kill a remote branch
   I want to be notified that this operation is not possible
   So that I know about my mistake and can do more appropriate actions instead.
 

--- a/features/git-town-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
@@ -31,7 +31,7 @@ Feature: git town-kill: killing the given feature branch when on it
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
 
@@ -50,4 +50,4 @@ Feature: git town-kill: killing the given feature branch when on it
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
       | remote     | main, current-feature, other-feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-kill: killing the given feature branch when on it
 
   Background:
     Given my repo has the feature branches "other-feature" and "current-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |
       | other-feature   | local, remote | other feature commit   |

--- a/features/git-town-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
+++ b/features/git-town-kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: killing the given feature branch when on it
 
 
   Background:
-    Given my repository has the feature branches "other-feature" and "current-feature"
+    Given my repo has the feature branches "other-feature" and "current-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current feature commit |

--- a/features/git-town-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: killing the given feature branch when on it (without rem
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION | MESSAGE                |
       | current-feature | local    | current feature commit |
       | other-feature   | local    | other feature commit   |

--- a/features/git-town-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
@@ -27,7 +27,7 @@ Feature: git town-kill: killing the given feature branch when on it (without rem
     And the existing branches are
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION | MESSAGE              |
       | other-feature | local    | other feature commit |
 
@@ -44,4 +44,4 @@ Feature: git town-kill: killing the given feature branch when on it (without rem
     And the existing branches are
       | REPOSITORY | BRANCHES                             |
       | local      | main, current-feature, other-feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
+++ b/features/git-town-kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
@@ -5,7 +5,7 @@ Feature: git town-kill: killing the given feature branch when on it (without rem
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has the local feature branches "current-feature" and "other-feature"
+    And my repo has the local feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION | MESSAGE                |
       | current-feature | local    | current feature commit |

--- a/features/git-town-kill/supplied_branch/perennial_branch.feature
+++ b/features/git-town-kill/supplied_branch/perennial_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-kill: errors when trying to kill a perennial branch
   Background:
     Given my repo has a feature branch named "feature"
     And my repo has the perennial branch "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |
       | qa      | local, remote | qa commit   |

--- a/features/git-town-kill/supplied_branch/perennial_branch.feature
+++ b/features/git-town-kill/supplied_branch/perennial_branch.feature
@@ -27,4 +27,4 @@ Feature: git town-kill: errors when trying to kill a perennial branch
       | REPOSITORY | BRANCHES          |
       | local      | main, feature, qa |
       | remote     | main, feature, qa |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-kill/supplied_branch/perennial_branch.feature
+++ b/features/git-town-kill/supplied_branch/perennial_branch.feature
@@ -4,8 +4,8 @@ Feature: git town-kill: errors when trying to kill a perennial branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
-    And my repository has the perennial branch "qa"
+    Given my repo has a feature branch named "feature"
+    And my repo has the perennial branch "qa"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |

--- a/features/git-town-main_branch/update.feature
+++ b/features/git-town-main_branch/update.feature
@@ -13,7 +13,7 @@ Feature: set the main branch configuration
 
 
   Scenario: main branch is configured
-    Given my repository has the branches "main-old" and "main-new"
+    Given my repo has the branches "main-old" and "main-new"
     And the main branch is configured as "main-old"
     When I run "git-town main-branch main-new"
     Then it prints no output

--- a/features/git-town-new-pull-request/bitbucket.feature
+++ b/features/git-town-new-pull-request/bitbucket.feature
@@ -6,7 +6,7 @@ Feature: git-new-pull-request when origin is on Bitbucket
 
 
   Scenario Outline: normal origin
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "<ORIGIN>"
     And my computer has the "open" tool installed
     And I am on the "feature" branch
@@ -27,7 +27,7 @@ Feature: git-new-pull-request when origin is on Bitbucket
 
 
   Scenario Outline: origin includes path that looks like a URL
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "<ORIGIN>"
     And my computer has the "open" tool installed
     And I am on the "feature" branch
@@ -48,7 +48,7 @@ Feature: git-new-pull-request when origin is on Bitbucket
 
 
   Scenario Outline: SSH style origin
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "<ORIGIN>"
     And my computer has the "open" tool installed
     And I am on the "feature" branch

--- a/features/git-town-new-pull-request/conflict.feature
+++ b/features/git-town-new-pull-request/conflict.feature
@@ -6,7 +6,7 @@ Feature: Syncing before creating the pull request
 
 
   Background:
-    Given my repository has a local feature branch named "feature"
+    Given my repo has a local feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | main commit    | conflicting_file | main_content    |

--- a/features/git-town-new-pull-request/conflict.feature
+++ b/features/git-town-new-pull-request/conflict.feature
@@ -49,7 +49,7 @@ Feature: Syncing before creating the pull request
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -79,7 +79,7 @@ Feature: Syncing before creating the pull request
       """
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | main commit                      | conflicting_file |
       | feature | local, remote | feature commit                   | conflicting_file |
@@ -102,7 +102,7 @@ Feature: Syncing before creating the pull request
       """
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | main commit                      | conflicting_file |
       | feature | local, remote | feature commit                   | conflicting_file |

--- a/features/git-town-new-pull-request/conflict.feature
+++ b/features/git-town-new-pull-request/conflict.feature
@@ -7,7 +7,7 @@ Feature: Syncing before creating the pull request
 
   Background:
     Given my repo has a local feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | main commit    | conflicting_file | main_content    |
       | feature | local         | feature commit | conflicting_file | feature content |

--- a/features/git-town-new-pull-request/error_opening_browser.feature
+++ b/features/git-town-new-pull-request/error_opening_browser.feature
@@ -1,6 +1,6 @@
 Feature: Print URL when opening browser fails
 
-    When using Git Town on a machine with a broken open browser command
+  When using Git Town on a machine with a broken open browser command
   I want that it prints the URL of the website
   So that I can copy-and-paste it into my browser.
 

--- a/features/git-town-new-pull-request/error_opening_browser.feature
+++ b/features/git-town-new-pull-request/error_opening_browser.feature
@@ -1,11 +1,11 @@
 Feature: Print URL when opening browser fails
 
-  When using Git Town on a machine with a broken open browser command
+    When using Git Town on a machine with a broken open browser command
   I want that it prints the URL of the website
   So that I can copy-and-paste it into my browser.
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "git@github.com:git-town/git-town"
     And my computer has a broken "open" tool installed
     And I am on the "feature" branch

--- a/features/git-town-new-pull-request/github.feature
+++ b/features/git-town-new-pull-request/github.feature
@@ -10,7 +10,7 @@ Feature: git-new-pull-request when origin is on GitHub
 
 
   Scenario Outline: normal origin
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -30,7 +30,7 @@ Feature: git-new-pull-request when origin is on GitHub
 
 
   Scenario Outline: origin contains path that looks like a URL
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -50,7 +50,7 @@ Feature: git-new-pull-request when origin is on GitHub
 
 
   Scenario Outline: proper URL encoding
-    Given my repository has a feature branch named "<BRANCH_NAME>"
+    Given my repo has a feature branch named "<BRANCH_NAME>"
     And my repo's origin is "https://github.com/git-town/git-town"
     And I am on the "<BRANCH_NAME>" branch
     When I run "git-town new-pull-request"
@@ -68,7 +68,7 @@ Feature: git-new-pull-request when origin is on GitHub
 
 
   Scenario Outline: SSH style origin
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -84,8 +84,8 @@ Feature: git-new-pull-request when origin is on GitHub
 
 
   Scenario: nested feature branch with known parent
-    Given my repository has a feature branch named "parent-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch named "parent-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And my repo's origin is "git@github.com:git-town/git-town.git"
     And I am on the "child-feature" branch
     When I run "git-town new-pull-request"

--- a/features/git-town-new-pull-request/gitlab.feature
+++ b/features/git-town-new-pull-request/gitlab.feature
@@ -10,7 +10,7 @@ Feature: git-new-pull-request when origin is on GitLab
 
 
   Scenario Outline: creating pull-requests
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -26,8 +26,8 @@ Feature: git-new-pull-request when origin is on GitLab
 
 
   Scenario: nested feature branch with known parent
-    Given my repository has a feature branch named "parent-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch named "parent-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And my repo's origin is "git@gitlab.com:kadu/kadu.git"
     And I am on the "child-feature" branch
     When I run "git-town new-pull-request"

--- a/features/git-town-new-pull-request/multi_platform_support.feature
+++ b/features/git-town-new-pull-request/multi_platform_support.feature
@@ -1,7 +1,7 @@
 Feature: git-new-pull-request: multi-platform support
 
   Scenario Outline: supported tool installed
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And my computer has the "<TOOL>" tool installed
     And I am on the "feature" branch
@@ -24,7 +24,7 @@ Feature: git-new-pull-request: multi-platform support
 
 
   Scenario: no supported tool installed
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And my computer has no tool to open browsers installed
     And I am on the "feature" branch

--- a/features/git-town-new-pull-request/no_tool.feature
+++ b/features/git-town-new-pull-request/no_tool.feature
@@ -5,7 +5,7 @@ Feature: print URL when unable to open browser
   So that I can copy-and-paste the URL to open it on my local computer.
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo's origin is "git@github.com:git-town/git-town"
     And my computer has no tool to open browsers installed
     And I am on the "feature" branch

--- a/features/git-town-new-pull-request/on_outdated_branch.feature
+++ b/features/git-town-new-pull-request/on_outdated_branch.feature
@@ -8,7 +8,7 @@ Feature: Syncing before creating the pull request
   Background:
     Given my code base has a feature branch named "parent-feature"
     And my code base has a feature branch named "child-feature" as a child of "parent-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH         | LOCATION | MESSAGE              | FILE NAME          |
       | main           | local    | local main commit    | local_main_file    |
       |                | remote   | remote main commit   | remote_main_file   |

--- a/features/git-town-new-pull-request/on_outdated_branch.feature
+++ b/features/git-town-new-pull-request/on_outdated_branch.feature
@@ -48,7 +48,7 @@ Feature: Syncing before creating the pull request
       """
     And I am still on the "child-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH         | LOCATION      | MESSAGE                                                                  | FILE NAME          |
       | main           | local, remote | remote main commit                                                       | remote_main_file   |
       |                |               | local main commit                                                        | local_main_file    |

--- a/features/git-town-new-pull-request/self_hosted.feature
+++ b/features/git-town-new-pull-request/self_hosted.feature
@@ -7,7 +7,7 @@ Feature: git-town new-pull-request: when origin is a self hosted servie
 
   Scenario Outline: self hosted
     And my computer has the "open" tool installed
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
     And my repo has "git-town.code-hosting-driver" set to "<DRIVER>"
     And I am on the "feature" branch

--- a/features/git-town-new-pull-request/ssh_identity.feature
+++ b/features/git-town-new-pull-request/ssh_identity.feature
@@ -7,7 +7,7 @@ Feature: git-town new-pull-request: when origin is an ssh identity
 
   Scenario Outline: ssh identity
     And my computer has the "open" tool installed
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
     And my repo has "git-town.code-hosting-origin-hostname" set to "<ORIGIN_HOSTNAME>"
     And I am on the "feature" branch

--- a/features/git-town-new-pull-request/unsupported_hosting_service.feature
+++ b/features/git-town-new-pull-request/unsupported_hosting_service.feature
@@ -6,7 +6,7 @@ Feature: git-new-pull-request: when origin is unsupported
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
 

--- a/features/git-town-perennial_branches/add_branch.feature
+++ b/features/git-town-perennial_branches/add_branch.feature
@@ -6,7 +6,7 @@ Feature: add a branch to the perennial branches configuration
 
 
   Background:
-    Given my repository has the branches "staging" and "qa"
+    Given my repo has the branches "staging" and "qa"
     And the perennial branches are configured as "qa"
 
 

--- a/features/git-town-perennial_branches/remove_branch.feature
+++ b/features/git-town-perennial_branches/remove_branch.feature
@@ -6,7 +6,7 @@ Feature: remove a branch from the perennial branches configuration
 
 
   Background:
-    Given my repository has the branches "staging" and "qa"
+    Given my repo has the branches "staging" and "qa"
     And the perennial branches are configured as "staging" and "qa"
 
 

--- a/features/git-town-prepend/hack-push-flag.feature
+++ b/features/git-town-prepend/hack-push-flag.feature
@@ -28,7 +28,7 @@ Feature: push branch to remote upon creation
       |                  | git stash pop                 |
     And I end up on the "new-parent" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |
     And Git Town is now aware of this branch hierarchy
@@ -51,7 +51,7 @@ Feature: push branch to remote upon creation
       | existing-feature | git stash pop                 |
     And I end up on the "existing-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH           | PARENT |
       | existing-feature | main   |

--- a/features/git-town-prepend/hack-push-flag.feature
+++ b/features/git-town-prepend/hack-push-flag.feature
@@ -6,7 +6,7 @@ Feature: push branch to remote upon creation
   Background:
     Given the new-branch-push-flag configuration is true
     And my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch

--- a/features/git-town-prepend/hack-push-flag.feature
+++ b/features/git-town-prepend/hack-push-flag.feature
@@ -5,7 +5,7 @@ Feature: push branch to remote upon creation
 
   Background:
     Given the new-branch-push-flag configuration is true
-    And my repository has a feature branch named "existing-feature"
+    And my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |

--- a/features/git-town-prepend/offline.feature
+++ b/features/git-town-prepend/offline.feature
@@ -28,7 +28,7 @@ Feature: git prepend: offline mode
       | new-parent       | git stash pop              |
     And I end up on the "new-parent" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |
     And Git Town is now aware of this branch hierarchy
@@ -50,7 +50,7 @@ Feature: git prepend: offline mode
       | existing-feature | git stash pop                 |
     And I end up on the "existing-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH           | PARENT |
       | existing-feature | main   |

--- a/features/git-town-prepend/offline.feature
+++ b/features/git-town-prepend/offline.feature
@@ -8,7 +8,7 @@ Feature: git prepend: offline mode
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch

--- a/features/git-town-prepend/offline.feature
+++ b/features/git-town-prepend/offline.feature
@@ -1,13 +1,13 @@
 Feature: git prepend: offline mode
 
-  When having no internet connection
+    When having no internet connection
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 
 
   Background:
     Given Git Town is in offline mode
-    And my repository has a feature branch named "existing-feature"
+    And my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |

--- a/features/git-town-prepend/offline.feature
+++ b/features/git-town-prepend/offline.feature
@@ -1,6 +1,6 @@
 Feature: git prepend: offline mode
 
-    When having no internet connection
+  When having no internet connection
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 

--- a/features/git-town-prepend/on-feature-branch.feature
+++ b/features/git-town-prepend/on-feature-branch.feature
@@ -7,7 +7,7 @@ Feature: Prepending a branch to a feature branch
 
   Background:
     Given my repo has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch

--- a/features/git-town-prepend/on-feature-branch.feature
+++ b/features/git-town-prepend/on-feature-branch.feature
@@ -28,7 +28,7 @@ Feature: Prepending a branch to a feature branch
       | new-parent       | git stash pop              |
     And I end up on the "new-parent" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |
     And Git Town is now aware of this branch hierarchy
@@ -50,7 +50,7 @@ Feature: Prepending a branch to a feature branch
       | existing-feature | git stash pop                 |
     And I end up on the "existing-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH           | PARENT |
       | existing-feature | main   |

--- a/features/git-town-prepend/on-feature-branch.feature
+++ b/features/git-town-prepend/on-feature-branch.feature
@@ -6,7 +6,7 @@ Feature: Prepending a branch to a feature branch
 
 
   Background:
-    Given my repository has a feature branch named "existing-feature"
+    Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |

--- a/features/git-town-prepend/on-main-branch.feature
+++ b/features/git-town-prepend/on-main-branch.feature
@@ -7,7 +7,7 @@ Feature: git town-prepend: errors when trying to prepend something in front of t
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |
     And I am on the "main" branch

--- a/features/git-town-prepend/on-main-branch.feature
+++ b/features/git-town-prepend/on-main-branch.feature
@@ -6,7 +6,7 @@ Feature: git town-prepend: errors when trying to prepend something in front of t
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |

--- a/features/git-town-prepend/on-main-branch.feature
+++ b/features/git-town-prepend/on-main-branch.feature
@@ -29,4 +29,4 @@ Feature: git town-prepend: errors when trying to prepend something in front of t
       | REPOSITORY | BRANCHES      |
       | local      | main, feature |
       | remote     | main, feature |
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-prepend/on-perennial-branch.feature
+++ b/features/git-town-prepend/on-perennial-branch.feature
@@ -6,7 +6,7 @@ Feature: git town-prepend: errors when trying to prepend something in front of t
 
 
   Background:
-    Given my repository has the perennial branches "qa" and "production"
+    Given my repo has the perennial branches "qa" and "production"
     And I am on the "production" branch
     When I run "git-town prepend new-parent"
 

--- a/features/git-town-prune-branches/nested_branches.feature
+++ b/features/git-town-prune-branches/nested_branches.feature
@@ -9,8 +9,8 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
 
 
   Background:
-    Given my repository has a feature branch named "feature"
-    And my repository has a feature branch named "feature-child" as a child of "feature"
+    Given my repo has a feature branch named "feature"
+    And my repo has a feature branch named "feature-child" as a child of "feature"
     And the following commits exist in my repository
       | BRANCH        | LOCATION      | MESSAGE              |
       | feature       | local, remote | feature commit       |

--- a/features/git-town-prune-branches/nested_branches.feature
+++ b/features/git-town-prune-branches/nested_branches.feature
@@ -11,7 +11,7 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
   Background:
     Given my repo has a feature branch named "feature"
     And my repo has a feature branch named "feature-child" as a child of "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH        | LOCATION      | MESSAGE              |
       | feature       | local, remote | feature commit       |
       | feature-child | local, remote | feature-child commit |

--- a/features/git-town-prune-branches/normal_branch.feature
+++ b/features/git-town-prune-branches/normal_branch.feature
@@ -10,7 +10,7 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
 
 
   Background:
-    Given my repository has the feature branches "active-feature" and "deleted-feature"
+    Given my repo has the feature branches "active-feature" and "deleted-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                |
       | active-feature  | local, remote | active-feature commit  |

--- a/features/git-town-prune-branches/normal_branch.feature
+++ b/features/git-town-prune-branches/normal_branch.feature
@@ -11,7 +11,7 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
 
   Background:
     Given my repo has the feature branches "active-feature" and "deleted-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | active-feature  | local, remote | active-feature commit  |
       | deleted-feature | local, remote | deleted-feature commit |

--- a/features/git-town-prune-branches/perennial_branch.feature
+++ b/features/git-town-prune-branches/perennial_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-prune-branches: remove perennial branch configuration when pru
   Background:
     Given my repo has the branches "active-perennial" and "deleted-perennial"
     And the perennial branches are configured as "active-perennial" and "deleted-perennial"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH            | LOCATION      | MESSAGE                  |
       | active-perennial  | local, remote | active-perennial commit  |
       | deleted-perennial | local, remote | deleted-perennial commit |

--- a/features/git-town-prune-branches/perennial_branch.feature
+++ b/features/git-town-prune-branches/perennial_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-prune-branches: remove perennial branch configuration when pru
 
 
   Background:
-    Given my repository has the branches "active-perennial" and "deleted-perennial"
+    Given my repo has the branches "active-perennial" and "deleted-perennial"
     And the perennial branches are configured as "active-perennial" and "deleted-perennial"
     And the following commits exist in my repository
       | BRANCH            | LOCATION      | MESSAGE                  |

--- a/features/git-town-rename-branch/branch_does_not_exist.feature
+++ b/features/git-town-rename-branch/branch_does_not_exist.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: errors if the feature branch does not exist
 
 
   Background:
-    Given the following commits exist in my repository
+    Given the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, remote | main commit |
     And I am on the "main" branch

--- a/features/git-town-rename-branch/branch_does_not_exist.feature
+++ b/features/git-town-rename-branch/branch_does_not_exist.feature
@@ -24,4 +24,4 @@ Feature: git town-rename-branch: errors if the feature branch does not exist
       """
     And I end up on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/current_branch.feature
+++ b/features/git-town-rename-branch/current_branch.feature
@@ -28,7 +28,7 @@ Feature: git town-rename-branch: rename current branch implicitly
       |                 | git branch -D feature              |
     And I end up on the "renamed-feature" branch
     And the perennial branches are now configured as "production"
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH          | LOCATION      | MESSAGE     |
       | main            | local, remote | main commit |
       | production      | local, remote | prod commit |
@@ -44,7 +44,7 @@ Feature: git town-rename-branch: rename current branch implicitly
       Cannot rename branch to current name.
       """
     And I end up on the "feature" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: rename perennial branch
@@ -70,7 +70,7 @@ Feature: git town-rename-branch: rename current branch implicitly
       |                    | git branch -D production                 |
     And I end up on the "renamed-production" branch
     And the perennial branches are now configured as "renamed-production"
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH             | LOCATION      | MESSAGE     |
       | main               | local, remote | main commit |
       | feature            | local, remote | feat commit |
@@ -90,7 +90,7 @@ Feature: git town-rename-branch: rename current branch implicitly
       | feature         | git branch -D renamed-feature              |
     And I end up on the "feature" branch
     And the perennial branches are now configured as "production"
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE     |
       | main       | local, remote | main commit |
       | feature    | local, remote | feat commit |

--- a/features/git-town-rename-branch/current_branch.feature
+++ b/features/git-town-rename-branch/current_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-rename-branch: rename current branch implicitly
   Background:
     Given my repo has a feature branch named "feature"
     And my repo has the perennial branch "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE     |
       | main       | local, remote | main commit |
       | feature    | local, remote | feat commit |

--- a/features/git-town-rename-branch/current_branch.feature
+++ b/features/git-town-rename-branch/current_branch.feature
@@ -6,8 +6,8 @@ Feature: git town-rename-branch: rename current branch implicitly
 
 
   Background:
-    Given my repository has a feature branch named "feature"
-    And my repository has the perennial branch "production"
+    Given my repo has a feature branch named "feature"
+    And my repo has the perennial branch "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE     |
       | main       | local, remote | main commit |

--- a/features/git-town-rename-branch/destination_branch_exists_locally.feature
+++ b/features/git-town-rename-branch/destination_branch_exists_locally.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: errors when the destination branch exists local
 
 
   Background:
-    Given my repository has the feature branches "current-feature" and "existing-feature"
+    Given my repo has the feature branches "current-feature" and "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 |
       | current-feature  | local, remote | current-feature commit  |

--- a/features/git-town-rename-branch/destination_branch_exists_locally.feature
+++ b/features/git-town-rename-branch/destination_branch_exists_locally.feature
@@ -26,4 +26,4 @@ Feature: git town-rename-branch: errors when the destination branch exists local
       """
     And I am still on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/destination_branch_exists_locally.feature
+++ b/features/git-town-rename-branch/destination_branch_exists_locally.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: errors when the destination branch exists local
 
   Background:
     Given my repo has the feature branches "current-feature" and "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | current-feature  | local, remote | current-feature commit  |
       | existing-feature | local, remote | existing-feature commit |

--- a/features/git-town-rename-branch/destination_branch_exists_remotely.feature
+++ b/features/git-town-rename-branch/destination_branch_exists_remotely.feature
@@ -4,7 +4,7 @@ Feature: git town-rename-branch: errors when the destination branch exists remot
 
 
   Background:
-    Given my repository has a feature branch named "current-feature"
+    Given my repo has a feature branch named "current-feature"
     And my coworker has a feature branch named "existing-feature"
     And the following commits exist in my repository
       | BRANCH           | LOCATION      | MESSAGE                 |

--- a/features/git-town-rename-branch/destination_branch_exists_remotely.feature
+++ b/features/git-town-rename-branch/destination_branch_exists_remotely.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: errors when the destination branch exists remot
   Background:
     Given my repo has a feature branch named "current-feature"
     And my coworker has a feature branch named "existing-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | current-feature  | local, remote | current-feature commit  |
       | existing-feature | remote        | existing-feature commit |

--- a/features/git-town-rename-branch/destination_branch_exists_remotely.feature
+++ b/features/git-town-rename-branch/destination_branch_exists_remotely.feature
@@ -25,4 +25,4 @@ Feature: git town-rename-branch: errors when the destination branch exists remot
       """
     And I am still on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: does nothing if renaming a feature branch onto 
 
   Background:
     Given my repo has a feature branch named "current-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current-feature commit |
     And I am on the "current-feature" branch

--- a/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: does nothing if renaming a feature branch onto 
 
 
   Background:
-    Given my repository has a feature branch named "current-feature"
+    Given my repo has a feature branch named "current-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local, remote | current-feature commit |

--- a/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/feature_branch/branch_and_destination_same.feature
@@ -23,4 +23,4 @@ Feature: git town-rename-branch: does nothing if renaming a feature branch onto 
       """
     And I end up on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -26,7 +26,7 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
       |                        | git push origin :parent-feature                  |
       |                        | git branch -D parent-feature                     |
     And I end up on the "renamed-parent-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH                 | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | child-feature          | local, remote | child feature commit  | child_feature_file  | child feature content  |
       | renamed-parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |
@@ -46,7 +46,7 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
       |                        | git checkout parent-feature                                 |
       | parent-feature         | git branch -D renamed-parent-feature                        |
     And I end up on the "parent-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |
       | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -6,8 +6,8 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
 
 
   Background:
-    Given my repository has a feature branch named "parent-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch named "parent-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And the following commits exist in my repository
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -8,7 +8,7 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
   Background:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |
       | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
 
 
   Background:
-    Given my repository has a feature branch named "current-feature"
+    Given my repo has a feature branch named "current-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE               |
       | main            | local, remote | main commit           |

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -27,4 +27,4 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
       """
     And I end up on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
 
   Background:
     Given my repo has a feature branch named "current-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE               |
       | main            | local, remote | main commit           |
       | current-feature | local, remote | feature commit        |

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
 
 
   Background:
-    Given my repository has a feature branch named "current-feature"
+    Given my repo has a feature branch named "current-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE              |
       | main            | local, remote | main commit          |

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
 
   Background:
     Given my repo has a feature branch named "current-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE              |
       | main            | local, remote | main commit          |
       | current-feature | local, remote | feature commit       |

--- a/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-town-rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -27,4 +27,4 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
       """
     And I end up on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/offline.feature
+++ b/features/git-town-rename-branch/offline.feature
@@ -8,7 +8,7 @@ Feature: git town-rename-branch: offline mode
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |
       | feature | local, remote | feat commit |

--- a/features/git-town-rename-branch/offline.feature
+++ b/features/git-town-rename-branch/offline.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |

--- a/features/git-town-rename-branch/offline.feature
+++ b/features/git-town-rename-branch/offline.feature
@@ -23,7 +23,7 @@ Feature: git town-rename-branch: offline mode
       |                 | git checkout renamed-feature       |
       | renamed-feature | git branch -D feature              |
     And I end up on the "renamed-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH          | LOCATION      | MESSAGE     |
       | main            | local, remote | main commit |
       | feature         | remote        | feat commit |
@@ -38,7 +38,7 @@ Feature: git town-rename-branch: offline mode
       |                 | git checkout feature                       |
       | feature         | git branch -D renamed-feature              |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |
       | feature | local, remote | feat commit |

--- a/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
@@ -23,4 +23,4 @@ Feature: git town-rename-branch: does nothing if renaming a perennial branch ont
       """
     And I end up on the "production" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: does nothing if renaming a perennial branch ont
 
 
   Background:
-    Given my repository has the perennial branch "production"
+    Given my repo has the perennial branch "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE           |
       | production | local, remote | production commit |

--- a/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
+++ b/features/git-town-rename-branch/perennial_branch/branch_and_destination_same.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: does nothing if renaming a perennial branch ont
 
   Background:
     Given my repo has the perennial branch "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE           |
       | production | local, remote | production commit |
     And I am on the "production" branch

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
 
 
   Background:
-    Given my repository has the perennial branches "qa" and "production"
+    Given my repo has the perennial branches "qa" and "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE           |
       | main       | local, remote | main commit       |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
@@ -38,7 +38,7 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
     And I end up on the "renamed-production" branch
     And the perennial branches are now configured as "qa" and "renamed-production"
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH             | LOCATION      | MESSAGE           |
       | main               | local, remote | main commit       |
       | qa                 | local, remote | qa commit         |
@@ -58,7 +58,7 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
     And I end up on the "production" branch
     And the perennial branches are now configured as "qa" and "production"
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           |
       | main       | local, remote | main commit       |
       | production | local, remote | production commit |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
 
   Background:
     Given my repo has the perennial branches "qa" and "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE           |
       | main       | local, remote | main commit       |
       | production | local, remote | production commit |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -27,7 +27,7 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
       |                    | git branch -D production                 |
     And I end up on the "renamed-production" branch
     And the perennial branches are now configured as "renamed-production"
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH             | LOCATION      | MESSAGE              | FILE NAME          | FILE CONTENT          |
       | child-feature      | local, remote | child feature commit | child_feature_file | child feature content |
       | renamed-production | local, remote | production commit    | production_file    | production content    |
@@ -47,7 +47,7 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
       | production         | git branch -D renamed-production                    |
     And I end up on the "production" branch
     And the perennial branches are now configured as "production"
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              | FILE NAME          | FILE CONTENT          |
       | child-feature | local, remote | child feature commit | child_feature_file | child feature content |
       | production    | local, remote | production commit    | production_file    | production content    |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -8,7 +8,7 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
   Background:
     Given my repo has the perennial branch "production"
     And my repo has a feature branch named "child-feature" as a child of "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH        | LOCATION      | MESSAGE              | FILE NAME          | FILE CONTENT          |
       | child-feature | local, remote | child feature commit | child_feature_file | child feature content |
       | production    | local, remote | production commit    | production_file    | production content    |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -6,8 +6,8 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
 
 
   Background:
-    Given my repository has the perennial branch "production"
-    And my repository has a feature branch named "child-feature" as a child of "production"
+    Given my repo has the perennial branch "production"
+    And my repo has a feature branch named "child-feature" as a child of "production"
     And the following commits exist in my repository
       | BRANCH        | LOCATION      | MESSAGE              | FILE NAME          | FILE CONTENT          |
       | child-feature | local, remote | child feature commit | child_feature_file | child feature content |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
 
 
   Background:
-    Given my repository has the perennial branch "production"
+    Given my repo has the perennial branch "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE                  |
       | main       | local, remote | main commit              |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -27,4 +27,4 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
       """
     And I end up on the "production" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
 
   Background:
     Given my repo has the perennial branch "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE                  |
       | main       | local, remote | main commit              |
       | production | local, remote | production commit        |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -6,7 +6,7 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
 
 
   Background:
-    Given my repository has the perennial branch "production"
+    Given my repo has the perennial branch "production"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE                  |
       | main       | local, remote | main commit              |

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -27,4 +27,4 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
       """
     And I end up on the "production" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/git-town-rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -7,7 +7,7 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
 
   Background:
     Given my repo has the perennial branch "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE                  |
       | main       | local, remote | main commit              |
       | production | local, remote | production commit        |

--- a/features/git-town-set-parent-branch/set_parent_branch.feature
+++ b/features/git-town-set-parent-branch/set_parent_branch.feature
@@ -6,8 +6,8 @@ Feature: update the parent of a nested feature branch
 
 
   Background:
-    Given my repository has a feature branch named "parent-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch named "parent-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And I am on the "child-feature" branch
 
 

--- a/features/git-town-ship/current_branch/on_coworker_feature_branch.feature
+++ b/features/git-town-ship/current_branch/on_coworker_feature_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping a coworker's feature branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE         | FILE NAME     | AUTHOR                          |
       | feature | local, remote | coworker commit | coworker_file | coworker <coworker@example.com> |

--- a/features/git-town-ship/current_branch/on_coworker_feature_branch.feature
+++ b/features/git-town-ship/current_branch/on_coworker_feature_branch.feature
@@ -29,6 +29,6 @@ Feature: git town-ship: shipping a coworker's feature branch
       |         | git push                                                                |
       |         | git push origin :feature                                                |
       |         | git branch -D feature                                                   |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME     | AUTHOR                          |
       | main   | local, remote | feature done | coworker_file | coworker <coworker@example.com> |

--- a/features/git-town-ship/current_branch/on_coworker_feature_branch.feature
+++ b/features/git-town-ship/current_branch/on_coworker_feature_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: shipping a coworker's feature branch
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE         | FILE NAME     | AUTHOR                          |
       | feature | local, remote | coworker commit | coworker_file | coworker <coworker@example.com> |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/offline.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/offline.feature
@@ -28,7 +28,7 @@ Feature: git town-ship: offline mode
       |         | git commit -m "feature done"       |
       |         | git branch -D feature              |
     And I end up on the "main" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE        |
       | main    | local    | feature done   |
       | feature | remote   | feature commit |
@@ -45,7 +45,7 @@ Feature: git town-ship: offline mode
       | main    | git reset --hard {{ sha 'Initial commit' }}   |
       |         | git checkout feature                          |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |
     And Git Town is now aware of this branch hierarchy

--- a/features/git-town-ship/current_branch/on_feature_branch/offline.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/offline.feature
@@ -1,13 +1,13 @@
 Feature: git town-ship: offline mode
 
-  When offline
+    When offline
   I want to be able to ship branches on my local machine
   So that I can keep working as much as possible despite having no internet connection.
 
 
   Background:
     Given Git Town is in offline mode
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |

--- a/features/git-town-ship/current_branch/on_feature_branch/offline.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/offline.feature
@@ -1,6 +1,6 @@
 Feature: git town-ship: offline mode
 
-    When offline
+  When offline
   I want to be able to ship branches on my local machine
   So that I can keep working as much as possible despite having no internet connection.
 

--- a/features/git-town-ship/current_branch/on_feature_branch/offline.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/offline.feature
@@ -8,7 +8,7 @@ Feature: git town-ship: offline mode
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/on_child_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/on_child_branch.feature
@@ -31,7 +31,7 @@ Feature: git town-ship: shipping a child branch
       Please ship "feature-1" first.
       """
     And I end up on the "feature-3" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is still aware of this branch hierarchy
       | BRANCH    | PARENT    |
       | feature-1 | main      |
@@ -47,4 +47,4 @@ Feature: git town-ship: shipping a child branch
       Nothing to undo
       """
     And I am still on the "feature-3" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-ship/current_branch/on_feature_branch/on_child_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/on_child_branch.feature
@@ -6,9 +6,9 @@ Feature: git town-ship: shipping a child branch
 
 
   Background:
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
-    And my repository has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
+    And my repo has a feature branch named "feature-3" as a child of "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME      | FILE CONTENT      |
       | feature-1 | local, remote | feature 1 commit | feature_1_file | feature 1 content |

--- a/features/git-town-ship/current_branch/on_feature_branch/on_child_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/on_child_branch.feature
@@ -9,7 +9,7 @@ Feature: git town-ship: shipping a child branch
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And my repo has a feature branch named "feature-3" as a child of "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME      | FILE CONTENT      |
       | feature-1 | local, remote | feature 1 commit | feature_1_file | feature 1 content |
       | feature-2 | local, remote | feature 2 commit | feature_2_file | feature 2 content |

--- a/features/git-town-ship/current_branch/on_feature_branch/on_parent_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/on_parent_branch.feature
@@ -6,8 +6,8 @@ Feature: git town-ship: shipping a parent branch
 
 
   Background:
-    Given my repository has a feature branch named "parent-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch named "parent-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And the following commits exist in my repository
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |

--- a/features/git-town-ship/current_branch/on_feature_branch/on_parent_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/on_parent_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-ship: shipping a parent branch
   Background:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |

--- a/features/git-town-ship/current_branch/on_feature_branch/on_parent_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/on_parent_branch.feature
@@ -31,7 +31,7 @@ Feature: git town-ship: shipping a parent branch
       |                | git push                                  |
       |                | git branch -D parent-feature              |
     And I end up on the "main" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | main           | local, remote | parent feature done   | parent_feature_file | parent feature content |
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |
@@ -52,7 +52,7 @@ Feature: git town-ship: shipping a parent branch
       | parent-feature | git checkout main                                           |
       | main           | git checkout parent-feature                                 |
     And I end up on the "parent-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH         | LOCATION      | MESSAGE                      | FILE NAME           |
       | main           | local, remote | parent feature done          | parent_feature_file |
       |                |               | Revert "parent feature done" | parent_feature_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/with_open_changes.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/with_open_changes.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: errors if there are open changes
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my workspace has an uncommitted file
     And I am on the "feature" branch
     When I run "git-town ship"

--- a/features/git-town-ship/current_branch/on_feature_branch/with_open_changes.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/with_open_changes.feature
@@ -20,7 +20,7 @@ Feature: git town-ship: errors if there are open changes
       """
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION |
 
 

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
@@ -35,7 +35,7 @@ Feature: git town-ship: shipping the current feature branch
       | local      | main     |
       | remote     | main     |
     And I don't have any uncommitted files
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                            | FILE NAME    |
       | main   | local, remote | message containing "double quotes" | feature_file |
 
@@ -52,7 +52,7 @@ Feature: git town-ship: shipping the current feature branch
       | feature | git checkout main                                         |
       | main    | git checkout feature                                      |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                     | FILE NAME    |
       | main    | local, remote | message containing "double quotes"          | feature_file |
       |         |               | Revert "message containing "double quotes"" | feature_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: shipping the current feature branch
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local, remote | feature commit | feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping the current feature branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local, remote | feature commit | feature_file | feature content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -43,7 +43,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | main    | git checkout feature |
     And I am still on the "feature" branch
     And there is no merge in progress
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
@@ -66,7 +66,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |
@@ -89,7 +89,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
       |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -41,7 +41,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | main    | git checkout feature |
     And I am still on the "feature" branch
     And there is no merge in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing after resolving the conflicts
@@ -62,7 +62,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |
 
@@ -85,6 +85,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       |         | remote   | conflicting remote commit | conflicting_file | remote conflicting content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -38,7 +38,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       |        | git checkout feature |
     And I am still on the "feature" branch
     And there is no rebase in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing after resolving the conflicts
@@ -62,7 +62,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
@@ -90,7 +90,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
@@ -35,7 +35,7 @@ Feature: git town-ship: trying the ship of the current feature branch without ed
       Aborted because commit exited with error
       """
     And I am still on the "feature" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: undo
@@ -45,4 +45,4 @@ Feature: git town-ship: trying the ship of the current feature branch without ed
       Nothing to undo
       """
     And I am still on the "feature" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: trying the ship of the current feature branch without ed
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: trying the ship of the current feature branch without ed
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
@@ -7,7 +7,7 @@ Feature: Skip deleting the remote branch when shipping the current branch
 
   Background:
     Given my code base has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    |
       | feature | local, remote | feature commit | feature_file |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
@@ -1,6 +1,6 @@
 Feature: Skip deleting the remote branch when shipping the current branch
 
-    When using GitHub's feature to automatically delete head branches of pull requests.
+  When using GitHub's feature to automatically delete head branches of pull requests.
   I want "git ship" to skip deleting the remote feature branch
   So that I can keep using Git Town in this situation.
 

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
@@ -1,6 +1,6 @@
 Feature: Skip deleting the remote branch when shipping the current branch
 
-  When using GitHub's feature to automatically delete head branches of pull requests.
+    When using GitHub's feature to automatically delete head branches of pull requests.
   I want "git ship" to skip deleting the remote feature branch
   So that I can keep using Git Town in this situation.
 
@@ -35,7 +35,7 @@ Feature: Skip deleting the remote branch when shipping the current branch
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
 
@@ -51,7 +51,7 @@ Feature: Skip deleting the remote branch when shipping the current branch
       | feature | git checkout main                             |
       | main    | git checkout feature                          |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE               | FILE NAME    |
       | main    | local, remote | feature done          | feature_file |
       |         |               | Revert "feature done" | feature_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
@@ -35,7 +35,7 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
       Aborted because commit exited with error
       """
     And I am still on the "feature" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: undo
@@ -45,4 +45,4 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
       Nothing to undo
       """
     And I am still on the "feature" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: shipping the current feature branch from a subfolder
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME               | FILE CONTENT    |
       | feature | local, remote | feature commit | new_folder/feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping the current feature branch from a subfolder
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME               | FILE CONTENT    |
       | feature | local, remote | feature commit | new_folder/feature_file | feature content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
@@ -36,7 +36,7 @@ Feature: git town-ship: shipping the current feature branch from a subfolder
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME               |
       | main   | local, remote | feature done | new_folder/feature_file |
 
@@ -55,7 +55,7 @@ Feature: git town-ship: shipping the current feature branch from a subfolder
       | main    | git checkout feature                          |
       | <none>  | cd {{ folder "new_folder" }}                  |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE               | FILE NAME               |
       | main    | local, remote | feature done          | new_folder/feature_file |
       |         |               | Revert "feature done" | new_folder/feature_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: shipping a coworker's feature branch
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE         | AUTHOR                            |
       | feature | local    | feature commit1 | developer <developer@example.com> |
       |         |          | feature commit2 | developer <developer@example.com> |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
@@ -19,7 +19,7 @@ Feature: git town-ship: shipping a coworker's feature branch
     When I run "git-town ship -m 'feature done'" and answer the prompts:
       | PROMPT                                        | ANSWER   |
       | Please choose an author for the squash commit | <ANSWER> |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | AUTHOR           |
       | main   | local, remote | feature done | <FEATURE_AUTHOR> |
 

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping a coworker's feature branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE         | AUTHOR                            |
       | feature | local    | feature commit1 | developer <developer@example.com> |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: errors when trying to ship the current feature branch th
 
 
   Background:
-    Given my repository has a feature branch named "empty-feature"
+    Given my repo has a feature branch named "empty-feature"
     And the following commits exist in my repository
       | BRANCH        | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
       | main          | remote   | main commit    | common_file | common content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
@@ -42,7 +42,7 @@ Feature: git town-ship: errors when trying to ship the current feature branch th
       Nothing to undo
       """
     And I am still on the "empty-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE        | FILE NAME   |
       | main          | local, remote | main commit    | common_file |
       | empty-feature | local         | feature commit | common_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: errors when trying to ship the current feature branch th
 
   Background:
     Given my repo has a feature branch named "empty-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH        | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
       | main          | remote   | main commit    | common_file | common content |
       | empty-feature | local    | feature commit | common_file | common content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local, remote | feature commit | feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local, remote | feature commit | feature_file | feature content |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
@@ -34,7 +34,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
 
@@ -51,7 +51,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
       | feature | git checkout main                             |
       | main    | git checkout feature                          |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE               | FILE NAME    |
       | main    | local, remote | feature done          | feature_file |
       |         |               | Revert "feature done" | feature_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping the current feature branch without a remote ori
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo does not have a remote origin
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
@@ -8,7 +8,7 @@ Feature: git town-ship: shipping the current feature branch without a remote ori
   Background:
     Given my repo has a feature branch named "feature"
     And my repo does not have a remote origin
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
@@ -27,7 +27,7 @@ Feature: git town-ship: shipping the current feature branch without a remote ori
     And the existing branches are
       | REPOSITORY | BRANCHES |
       | local      | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION | MESSAGE      | FILE NAME    |
       | main   | local    | feature done | feature_file |
 
@@ -40,7 +40,7 @@ Feature: git town-ship: shipping the current feature branch without a remote ori
       |        | git revert {{ sha 'feature done' }}           |
       |        | git checkout feature                          |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME    |
       | main    | local    | feature done          | feature_file |
       |         |          | Revert "feature done" | feature_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
@@ -30,7 +30,7 @@ Feature: git town-ship: shipping the current feature branch without a tracking b
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
 
@@ -46,7 +46,7 @@ Feature: git town-ship: shipping the current feature branch without a tracking b
       | feature | git checkout main                             |
       | main    | git checkout feature                          |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE               | FILE NAME    |
       | main    | local, remote | feature done          | feature_file |
       |         |               | Revert "feature done" | feature_file |

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: shipping the current feature branch without a tracking b
 
   Background:
     Given my repo has a local feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: shipping the current feature branch without a tracking b
 
 
   Background:
-    Given my repository has a local feature branch named "feature"
+    Given my repo has a local feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |

--- a/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
@@ -1,13 +1,13 @@
 Feature: git town-ship: shipping hotfixes
 
-  When working on hotfix branches
+    When working on hotfix branches
   I want to ship them similar to feature branches
   So that I can use Git Town to work on hotfixes as well.
 
 
   Background:
-    Given my repository has the perennial branch "production"
-    And my repository has a feature branch named "hotfix" as a child of "production"
+    Given my repo has the perennial branch "production"
+    And my repo has a feature branch named "hotfix" as a child of "production"
     And the following commits exist in my repository
       | BRANCH | LOCATION      | MESSAGE       | FILE NAME   | FILE CONTENT   |
       | hotfix | local, remote | hotfix commit | hotfix_file | hotfix content |

--- a/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-ship: shipping hotfixes
   Background:
     Given my repo has the perennial branch "production"
     And my repo has a feature branch named "hotfix" as a child of "production"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE       | FILE NAME   | FILE CONTENT   |
       | hotfix | local, remote | hotfix commit | hotfix_file | hotfix content |
     And I am on the "hotfix" branch

--- a/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
@@ -35,6 +35,6 @@ Feature: git town-ship: shipping hotfixes
       | REPOSITORY | BRANCHES         |
       | local      | main, production |
       | remote     | main, production |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE     | FILE NAME   |
       | production | local, remote | hotfix done | hotfix_file |

--- a/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
@@ -1,6 +1,6 @@
 Feature: git town-ship: shipping hotfixes
 
-    When working on hotfix branches
+  When working on hotfix branches
   I want to ship them similar to feature branches
   So that I can use Git Town to work on hotfixes as well.
 

--- a/features/git-town-ship/current_branch/on_main_branch.feature
+++ b/features/git-town-ship/current_branch/on_main_branch.feature
@@ -16,5 +16,5 @@ Feature: git town-ship: errors when trying to ship the main branch
       The branch "main" is not a feature branch. Only feature branches can be shipped.
       """
     And I am still on the "main" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION |

--- a/features/git-town-ship/current_branch/on_non_feature_branch.feature
+++ b/features/git-town-ship/current_branch/on_non_feature_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: errors when trying to ship a perennial branch
 
 
   Background:
-    Given my repository has the perennial branches "qa" and "production"
+    Given my repo has the perennial branches "qa" and "production"
     And I am on the "production" branch
     When I run "git-town ship"
 

--- a/features/git-town-ship/current_branch/on_non_feature_branch.feature
+++ b/features/git-town-ship/current_branch/on_non_feature_branch.feature
@@ -20,5 +20,5 @@ Feature: git town-ship: errors when trying to ship a perennial branch
       The branch "production" is not a feature branch. Only feature branches can be shipped.
       """
     And I am still on the "production" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -47,7 +47,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And I end up on the "other-feature" branch
     And my workspace still contains my uncommitted file
     And there is no merge in progress
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        |
       | main    | local, remote | conflicting main commit    | conflicting_file |
       | feature | local         | conflicting feature commit | conflicting_file |
@@ -73,7 +73,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |
@@ -99,7 +99,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -45,7 +45,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And I end up on the "other-feature" branch
     And my workspace still contains my uncommitted file
     And there is no merge in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing after resolving the conflicts
@@ -69,7 +69,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |
 
@@ -95,6 +95,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
       |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       |         | remote   | conflicting remote commit | conflicting_file | remote conflicting content |

--- a/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -42,7 +42,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
     And I am still on the "other-feature" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing after resolving the conflicts
@@ -69,7 +69,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
@@ -100,7 +100,7 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
@@ -1,6 +1,6 @@
 Feature: Skip deleting the remote branch when shipping another branch
 
-    When using GitHub's feature to automatically delete head branches of pull requests.
+  When using GitHub's feature to automatically delete head branches of pull requests.
   I want "git ship" to skip deleting the remote feature branch
   So that I can keep using Git Town in this situation.
 

--- a/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
@@ -1,12 +1,12 @@
 Feature: Skip deleting the remote branch when shipping another branch
 
-  When using GitHub's feature to automatically delete head branches of pull requests.
+    When using GitHub's feature to automatically delete head branches of pull requests.
   I want "git ship" to skip deleting the remote feature branch
   So that I can keep using Git Town in this situation.
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH        | LOCATION      | MESSAGE        | FILE NAME    |
       | feature       | local, remote | feature commit | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
@@ -7,7 +7,7 @@ Feature: Skip deleting the remote branch when shipping another branch
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH        | LOCATION      | MESSAGE        | FILE NAME    |
       | feature       | local, remote | feature commit | feature_file |
       | other-feature | local         | other commit   | other_file   |

--- a/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
@@ -37,7 +37,7 @@ Feature: Skip deleting the remote branch when shipping another branch
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE      | FILE NAME    |
       | main          | local, remote | feature done | feature_file |
       | other-feature | local         | other commit | other_file   |
@@ -55,7 +55,7 @@ Feature: Skip deleting the remote branch when shipping another branch
       | feature       | git checkout main                             |
       | main          | git checkout other-feature                    |
     And I end up on the "other-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE               | FILE NAME    |
       | main          | local, remote | feature done          | feature_file |
       |               |               | Revert "feature done" | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
@@ -40,4 +40,4 @@ Feature: git town-ship: aborting the ship of the supplied feature branch by ente
       """
     And I am still on the "other-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: aborting the ship of the supplied feature branch by ente
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | main    | local, remote | main commit    | main_file    | main content    |
       | feature | local         | feature commit | feature_file | feature content |

--- a/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/empty_commit_message.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: aborting the ship of the supplied feature branch by ente
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | main    | local, remote | main commit    | main_file    | main content    |

--- a/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: shipping the supplied feature branch from a subfolder
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature commit | feature_file | feature content |
     And I am on the "other-feature" branch

--- a/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: shipping the supplied feature branch from a subfolder
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature commit | feature_file | feature content |

--- a/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/in_subfolder.feature
@@ -40,6 +40,6 @@ Feature: git town-ship: shipping the supplied feature branch from a subfolder
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/no_diff.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/no_diff.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: errors when trying to ship the supplied feature branch t
 
   Background:
     Given my repo has the feature branches "empty-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH        | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
       | main          | remote   | main commit    | common_file | common content |
       | empty-feature | local    | feature commit | common_file | common content |

--- a/features/git-town-ship/supplied_branch/feature_branch/no_diff.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/no_diff.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: errors when trying to ship the supplied feature branch t
 
 
   Background:
-    Given my repository has the feature branches "empty-feature" and "other-feature"
+    Given my repo has the feature branches "empty-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH        | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
       | main          | remote   | main commit    | common_file | common content |

--- a/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/with_open_changes.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/with_open_changes.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: errors if on supplied branch and there are open changes
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my workspace has an uncommitted file
     And I am on the "feature" branch
     When I run "git-town ship feature"

--- a/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/with_open_changes.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/with_open_changes.feature
@@ -18,5 +18,5 @@ Feature: git town-ship: errors if on supplied branch and there are open changes
       """
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION |

--- a/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local, remote | feature commit | feature_file | feature content |

--- a/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
@@ -32,7 +32,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
 
@@ -49,7 +49,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
       | feature | git checkout main                             |
       | main    | git checkout feature                          |
     And I end up on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE               | FILE NAME    |
       | main    | local, remote | feature done          | feature_file |
       |         |               | Revert "feature done" | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local, remote | feature commit | feature_file | feature content |
     And I am on the "feature" branch

--- a/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
 
 
   Background:
-    Given my repository has a feature branch named "other-feature"
+    Given my repo has a feature branch named "other-feature"
     And my origin has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |

--- a/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
@@ -8,7 +8,7 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
   Background:
     Given my repo has a feature branch named "other-feature"
     And my origin has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature commit | feature_file | feature content |
     And I am on the "other-feature" branch

--- a/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/remote_only_branch.feature
@@ -43,6 +43,6 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_child_branches.feature
@@ -30,7 +30,7 @@ Feature: git town-ship: shipping a parent branch
       |                | git branch -D parent-feature              |
       |                | git checkout child-feature                |
     And I end up on the "child-feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | main           | local, remote | parent feature done   | parent_feature_file | parent feature content |
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_child_branches.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping a parent branch
   Background:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_child_branches.feature
@@ -4,8 +4,8 @@ Feature: git town-ship: shipping a parent branch
 
 
   Background:
-    Given my repository has a feature branch named "parent-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch named "parent-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And the following commits exist in my repository
       | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
       | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_parent_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_parent_branch.feature
@@ -4,9 +4,9 @@ Feature: git town-ship: shipping a child branch
 
 
   Background:
-    Given my repository has a feature branch named "feature-1"
-    And my repository has a feature branch named "feature-2" as a child of "feature-1"
-    And my repository has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch named "feature-1"
+    And my repo has a feature branch named "feature-2" as a child of "feature-1"
+    And my repo has a feature branch named "feature-3" as a child of "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME      | FILE CONTENT      |
       | feature-1 | local, remote | feature 1 commit | feature_1_file | feature 1 content |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_parent_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_parent_branch.feature
@@ -29,7 +29,7 @@ Feature: git town-ship: shipping a child branch
       Please ship "feature-1" first.
       """
     And I end up on the "feature-1" branch
-    And my repository is left with my original commits
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT    |
       | feature-1 | main      |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_parent_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_parent_branch.feature
@@ -7,7 +7,7 @@ Feature: git town-ship: shipping a child branch
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
     And my repo has a feature branch named "feature-3" as a child of "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME      | FILE CONTENT      |
       | feature-1 | local, remote | feature 1 commit | feature_1_file | feature 1 content |
       | feature-2 | local, remote | feature 2 commit | feature_2_file | feature 2 content |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -38,6 +38,6 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature commit | feature_file | feature content |

--- a/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature commit | feature_file | feature content |
     And I am on the "other-feature" branch

--- a/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git town-ship: shipping the supplied feature branch without a remote or
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And my repo does not have a remote origin
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "other-feature" branch

--- a/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
@@ -32,6 +32,6 @@ Feature: git town-ship: shipping the supplied feature branch without a remote or
     And the existing branches are
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION | MESSAGE      | FILE NAME    |
       | main   | local    | feature done | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_remote_origin.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: shipping the supplied feature branch without a remote or
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And my repo does not have a remote origin
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |

--- a/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: shipping the supplied feature branch without a tracking 
 
 
   Background:
-    Given my repository has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |

--- a/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
@@ -38,6 +38,6 @@ Feature: git town-ship: shipping the supplied feature branch without a tracking 
       | REPOSITORY | BRANCHES            |
       | local      | main, other-feature |
       | remote     | main, other-feature |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |

--- a/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-town-ship/supplied_branch/feature_branch/without_tracking_branch.feature
@@ -5,7 +5,7 @@ Feature: git town-ship: shipping the supplied feature branch without a tracking 
 
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    | FILE CONTENT    |
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "other-feature" branch

--- a/features/git-town-ship/supplied_branch/main_branch.feature
+++ b/features/git-town-ship/supplied_branch/main_branch.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: errors when trying to ship the main branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town ship main"

--- a/features/git-town-ship/supplied_branch/perennial_branch.feature
+++ b/features/git-town-ship/supplied_branch/perennial_branch.feature
@@ -4,7 +4,7 @@ Feature: git town-ship: errors when trying to ship a perennial branch
 
 
   Background:
-    Given my repository has the perennial branches "qa" and "production"
+    Given my repo has the perennial branches "qa" and "production"
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town ship production"

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME            | FILE CONTENT             |
       | main      | remote        | main commit             | conflicting_file     | main content             |
       | feature-1 | local         | feature-1 local commit  | conflicting_file     | feature-1 local content  |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
@@ -44,7 +44,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop                                       |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME            |
       | main      | local, remote | main commit             | conflicting_file     |
       | feature-1 | local         | feature-1 local commit  | conflicting_file     |
@@ -67,7 +67,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                                       |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME            |
       | main      | local, remote | main commit                        | conflicting_file     |
       | feature-1 | local         | feature-1 local commit             | conflicting_file     |
@@ -105,7 +105,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME            |
       | main      | local, remote | main commit                                                    | conflicting_file     |
       | feature-1 | local, remote | feature-1 local commit                                         | conflicting_file     |
@@ -134,7 +134,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME            |
       | main      | local, remote | main commit                                                    | conflicting_file     |
       | feature-1 | local, remote | feature-1 local commit                                         | conflicting_file     |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling merge conflicts between feature branch and main branch
 
   Background:
-    Given my repository has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME            | FILE CONTENT             |
       | main      | remote        | main commit             | conflicting_file     | main content             |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME            | FILE CONTENT             |
       | main      | remote        | main commit             | conflicting_file     | main content             |
       | feature-1 | local, remote | feature-1 commit        | feature1_file        | feature-1 content        |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling merge conflicts between feature branch and main branch
 
   Background:
-    Given my repository has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME            | FILE CONTENT             |
       | main      | remote        | main commit             | conflicting_file     | main content             |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
@@ -49,7 +49,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop                                       |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME            |
       | main      | local, remote | main commit                        | conflicting_file     |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file        |
@@ -70,7 +70,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                                       |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME            |
       | main      | local, remote | main commit                        | conflicting_file     |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file        |
@@ -104,7 +104,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME            |
       | main      | local, remote | main commit                                                    | conflicting_file     |
       | feature-1 | local, remote | feature-1 commit                                               | feature1_file        |
@@ -129,7 +129,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME            |
       | main      | local, remote | main commit                                                    | conflicting_file     |
       | feature-1 | local, remote | feature-1 commit                                               | feature1_file        |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
@@ -40,7 +40,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: skipping
@@ -54,14 +54,14 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop            |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION | MESSAGE                            | FILE NAME        |
       | main      | local    | main commit                        | conflicting_file |
       | feature-1 | local    | feature-1 commit                   | conflicting_file |
       | feature-2 | local    | feature-2 commit                   | feature2_file    |
       |           |          | main commit                        | conflicting_file |
       |           |          | Merge branch 'main' into feature-2 |                  |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | feature-1 content |
@@ -79,7 +79,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-1" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | feature-1 content |
@@ -98,7 +98,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop            |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION | MESSAGE                            | FILE NAME        |
       | main      | local    | main commit                        | conflicting_file |
       | feature-1 | local    | feature-1 commit                   | conflicting_file |
@@ -107,7 +107,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local    | feature-2 commit                   | feature2_file    |
       |           |          | main commit                        | conflicting_file |
       |           |          | Merge branch 'main' into feature-2 |                  |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | resolved content  |
@@ -127,7 +127,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop            |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION | MESSAGE                            | FILE NAME        |
       | main      | local    | main commit                        | conflicting_file |
       | feature-1 | local    | feature-1 commit                   | conflicting_file |
@@ -136,7 +136,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local    | feature-2 commit                   | feature2_file    |
       |           |          | main commit                        | conflicting_file |
       |           |          | Merge branch 'main' into feature-2 |                  |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | resolved content  |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
@@ -3,7 +3,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | local    | main commit      | conflicting_file | main content      |
       | feature-1 | local    | feature-1 commit | conflicting_file | feature-1 content |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has the local feature branches "feature-1" and "feature-2"
+    And my repo has the local feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | local    | main commit      | conflicting_file | main content      |
@@ -61,7 +61,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local    | feature-2 commit                   | feature2_file    |
       |           |          | main commit                        | conflicting_file |
       |           |          | Merge branch 'main' into feature-2 |                  |
-  And my repository now has the following committed files
+    And my repository now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | feature-1 content |
@@ -80,10 +80,10 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo still has a merge in progress
     And my repository now has the following committed files
-        | BRANCH    | NAME             | CONTENT           |
-        | main      | conflicting_file | main content      |
-        | feature-1 | conflicting_file | feature-1 content |
-        | feature-2 | feature2_file    | feature-2 content |
+      | BRANCH    | NAME             | CONTENT           |
+      | main      | conflicting_file | main content      |
+      | feature-1 | conflicting_file | feature-1 content |
+      | feature-2 | feature2_file    | feature-2 content |
 
 
   Scenario: continuing after resolving the conflicts

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
@@ -3,7 +3,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | local    | main commit      | conflicting_file | main content      |
       | feature-1 | local    | feature-1 commit | feature1_file    | feature-1 content |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has the local feature branches "feature-1" and "feature-2"
+    And my repo has the local feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | local    | main commit      | conflicting_file | main content      |
@@ -36,12 +36,12 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH    | COMMAND                                        |
-      | feature-2 | git merge --abort                              |
-      |           | git checkout feature-1                         |
+      | BRANCH    | COMMAND                                       |
+      | feature-2 | git merge --abort                             |
+      |           | git checkout feature-1                        |
       | feature-1 | git reset --hard {{ sha 'feature-1 commit' }} |
-      |           | git checkout main                              |
-      | main      | git stash pop                                  |
+      |           | git checkout main                             |
+      | main      | git stash pop                                 |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
     And my repository is left with my original commits
@@ -74,7 +74,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
@@ -44,7 +44,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop                                 |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: skipping
@@ -56,14 +56,14 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION | MESSAGE                            | FILE NAME        |
       | main      | local    | main commit                        | conflicting_file |
       | feature-1 | local    | feature-1 commit                   | feature1_file    |
       |           |          | main commit                        | conflicting_file |
       |           |          | Merge branch 'main' into feature-1 |                  |
       | feature-2 | local    | feature-2 commit                   | conflicting_file |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | main content      |
@@ -93,7 +93,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION | MESSAGE                            | FILE NAME        |
       | main      | local    | main commit                        | conflicting_file |
       | feature-1 | local    | feature-1 commit                   | feature1_file    |
@@ -102,7 +102,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local    | feature-2 commit                   | conflicting_file |
       |           |          | main commit                        | conflicting_file |
       |           |          | Merge branch 'main' into feature-2 |                  |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | main content      |
@@ -120,7 +120,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION | MESSAGE                            | FILE NAME        |
       | main      | local    | main commit                        | conflicting_file |
       | feature-1 | local    | feature-1 commit                   | feature1_file    |
@@ -129,7 +129,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local    | feature-2 commit                   | conflicting_file |
       |           |          | main commit                        | conflicting_file |
       |           |          | Merge branch 'main' into feature-2 |                  |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | main content      |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
@@ -42,7 +42,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME        |
       | main      | local, remote | main commit      | conflicting_file |
       | feature-1 | local, remote | feature-1 commit | conflicting_file |
@@ -63,7 +63,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | conflicting_file |
       | feature-1 | local, remote | feature-1 commit                   | conflicting_file |
@@ -100,7 +100,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | conflicting_file |
       | feature-1 | local, remote | feature-1 commit                   | conflicting_file |
@@ -127,7 +127,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | conflicting_file |
       | feature-1 | local, remote | feature-1 commit                   | conflicting_file |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling merge conflicts between feature branch and main branch
 
   Background:
-    Given my repository has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | remote        | main commit      | conflicting_file | main content      |
@@ -75,7 +75,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | remote        | main commit      | conflicting_file | main content      |
       | feature-1 | local, remote | feature-1 commit | conflicting_file | feature-1 content |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
@@ -47,7 +47,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop          |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | conflicting_file |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file    |
@@ -66,7 +66,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | conflicting_file |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file    |
@@ -99,7 +99,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | conflicting_file |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file    |
@@ -122,7 +122,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | conflicting_file |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file    |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling merge conflicts between feature branch and main branch
 
   Background:
-    Given my repository has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | remote        | main commit      | conflicting_file | main content      |
@@ -78,7 +78,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME        | FILE CONTENT      |
       | main      | remote        | main commit      | conflicting_file | main content      |
       | feature-1 | local, remote | feature-1 commit | feature1_file    | feature-1 content |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
@@ -42,7 +42,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME        |
       | main      | local, remote | main commit             | main_file        |
       | feature-1 | local         | feature-1 local commit  | conflicting_file |
@@ -64,7 +64,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | main_file        |
       | feature-1 | local         | feature-1 local commit             | conflicting_file |
@@ -103,7 +103,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME        |
       | main      | local, remote | main commit                                                    | main_file        |
       | feature-1 | local, remote | feature-1 local commit                                         | conflicting_file |
@@ -133,7 +133,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop                        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME        |
       | main      | local, remote | main commit                                                    | main_file        |
       | feature-1 | local, remote | feature-1 local commit                                         | conflicting_file |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT             |
       | main      | remote        | main commit             | main_file        | main content             |
       | feature-1 | local         | feature-1 local commit  | conflicting_file | feature-1 local content  |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling merge conflicts between feature branch and its tracking branch
 
   Background:
-    Given my repository has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT             |
       | main      | remote        | main commit             | main_file        | main content             |
@@ -77,7 +77,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error:  
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling merge conflicts between feature branch and its tracking branch
 
   Background:
-    Given my repository has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT             |
       | main      | remote        | main commit             | main_file        | main content             |
@@ -80,7 +80,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
@@ -47,7 +47,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | git stash pop          |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | main_file        |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file    |
@@ -67,7 +67,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME        |
       | main      | local, remote | main commit                        | main_file        |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file    |
@@ -102,7 +102,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop            |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME        |
       | main      | local, remote | main commit                                                    | main_file        |
       | feature-1 | local, remote | feature-1 commit                                               | feature1_file    |
@@ -128,7 +128,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           | git stash pop            |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                                                        | FILE NAME        |
       | main      | local, remote | main commit                                                    | main_file        |
       | feature-1 | local, remote | feature-1 commit                                               | feature1_file    |

--- a/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
 
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT             |
       | main      | remote        | main commit             | main_file        | main content             |
       | feature-1 | local, remote | feature-1 commit        | feature1_file    | feature-1 content        |

--- a/features/git-town-sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE            | FILE NAME        | FILE CONTENT        |
       | main    | local    | main local commit  | conflicting_file | main local content  |
       | main    | remote   | main remote commit | conflicting_file | main remote content |

--- a/features/git-town-sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -36,7 +36,7 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |        | git stash pop      |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE            | FILE NAME        |
       | main    | local    | main local commit  | conflicting_file |
       |         | remote   | main remote commit | conflicting_file |
@@ -70,7 +70,7 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |         | git stash pop                      |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | main remote commit               | conflicting_file |
       |         |               | main local commit                | conflicting_file |
@@ -96,7 +96,7 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |         | git stash pop                      |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | main remote commit               | conflicting_file |
       |         |               | main local commit                | conflicting_file |

--- a/features/git-town-sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling rebase conflicts between main branch and its tracking branch
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE            | FILE NAME        | FILE CONTENT        |
       | main    | local    | main local commit  | conflicting_file | main local content  |

--- a/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
 
   Background:
     Given my repo has the perennial branches "production" and "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME        | FILE CONTENT              |
       | main       | remote        | main commit              | main_file        | main content              |
       | production | local         | production local commit  | conflicting_file | production local content  |

--- a/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling rebase conflicts between perennial branch and its tracking branch
 
   Background:
-    Given my repository has the perennial branches "production" and "qa"
+    Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME        | FILE CONTENT              |
       | main       | remote        | main commit              | main_file        | main content              |

--- a/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
@@ -42,7 +42,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | main       | git stash pop      |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME        |
       | main       | local, remote | main commit              | main_file        |
       | production | local         | production local commit  | conflicting_file |
@@ -62,7 +62,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |            | git stash pop        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME        |
       | main       | local, remote | main commit              | main_file        |
       | production | local         | production local commit  | conflicting_file |
@@ -95,7 +95,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |            | git stash pop         |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME        |
       | main       | local, remote | main commit              | main_file        |
       | production | local, remote | production remote commit | conflicting_file |
@@ -117,7 +117,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |            | git stash pop        |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME        |
       | main       | local, remote | main commit              | main_file        |
       | production | local, remote | production remote commit | conflicting_file |

--- a/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
@@ -45,7 +45,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | main       | git stash pop           |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           | FILE NAME        |
       | main       | local, remote | main commit       | main_file        |
       | production | local, remote | production commit | production_file  |
@@ -63,7 +63,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |        | git stash pop      |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           | FILE NAME        |
       | main       | local, remote | main commit       | main_file        |
       | production | local, remote | production commit | production_file  |
@@ -94,7 +94,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |        | git stash pop         |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           | FILE NAME        |
       | main       | local, remote | main commit       | main_file        |
       | production | local, remote | production commit | production_file  |
@@ -114,7 +114,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |        | git stash pop     |
     And I end up on the "main" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE           | FILE NAME        |
       | main       | local, remote | main commit       | main_file        |
       | production | local, remote | production commit | production_file  |

--- a/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
 
   Background:
     Given my repo has the perennial branches "production" and "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE           | FILE NAME        | FILE CONTENT       |
       | main       | remote        | main commit       | main_file        | main content       |
       | production | local, remote | production commit | production_file  | production content |

--- a/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
+++ b/features/git-town-sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: handling rebase conflicts between perennial branch and its tracking branch
 
   Background:
-    Given my repository has the perennial branches "production" and "qa"
+    Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE           | FILE NAME        | FILE CONTENT       |
       | main       | remote        | main commit       | main_file        | main content       |

--- a/features/git-town-sync/all_branches/feature_branches.feature
+++ b/features/git-town-sync/all_branches/feature_branches.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: syncs all feature branches
 
   Background:
-    Given my repository has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME     |
       | main      | remote        | main commit      | main_file     |

--- a/features/git-town-sync/all_branches/feature_branches.feature
+++ b/features/git-town-sync/all_branches/feature_branches.feature
@@ -34,7 +34,7 @@ Feature: git-town sync --all: syncs all feature branches
     And I am still on the "feature-1" branch
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME     |
       | main      | local, remote | main commit                        | main_file     |
       | feature-1 | local, remote | feature-1 commit                   | feature1_file |

--- a/features/git-town-sync/all_branches/feature_branches.feature
+++ b/features/git-town-sync/all_branches/feature_branches.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: syncs all feature branches
 
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          | FILE NAME     |
       | main      | remote        | main commit      | main_file     |
       | feature-1 | local, remote | feature-1 commit | feature1_file |

--- a/features/git-town-sync/all_branches/perennial_branches.feature
+++ b/features/git-town-sync/all_branches/perennial_branches.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: syncs all perennial branches
 
   Background:
     Given my repo has the perennial branches "production" and "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION | MESSAGE                  | FILE NAME              |
       | main       | remote   | main commit              | main_file              |
       | production | local    | production local commit  | production_local_file  |

--- a/features/git-town-sync/all_branches/perennial_branches.feature
+++ b/features/git-town-sync/all_branches/perennial_branches.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: syncs all perennial branches
 
   Background:
-    Given my repository has the perennial branches "production" and "qa"
+    Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repository
       | BRANCH     | LOCATION | MESSAGE                  | FILE NAME              |
       | main       | remote   | main commit              | main_file              |

--- a/features/git-town-sync/all_branches/perennial_branches.feature
+++ b/features/git-town-sync/all_branches/perennial_branches.feature
@@ -33,7 +33,7 @@ Feature: git-town sync --all: syncs all perennial branches
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME              |
       | main       | local, remote | main commit              | main_file              |
       | production | local, remote | production remote commit | production_remote_file |

--- a/features/git-town-sync/all_branches/remote_only_branches.feature
+++ b/features/git-town-sync/all_branches/remote_only_branches.feature
@@ -30,7 +30,7 @@ Feature: git-town sync --all: does not sync remote only branches
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH     | LOCATION      | MESSAGE                             | FILE NAME     |
       | main       | local, remote | main commit                         | main_file     |
       | co-feature | remote        | coworker commit                     | coworker_file |

--- a/features/git-town-sync/all_branches/remote_only_branches.feature
+++ b/features/git-town-sync/all_branches/remote_only_branches.feature
@@ -3,7 +3,7 @@ Feature: git-town sync --all: does not sync remote only branches
   Background:
     Given my repo has a feature branch named "my-feature"
     And my coworker has a feature branch named "co-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE         | FILE NAME     |
       | main       | remote        | main commit     | main_file     |
       | my-feature | local, remote | my commit       | my_file       |

--- a/features/git-town-sync/all_branches/remote_only_branches.feature
+++ b/features/git-town-sync/all_branches/remote_only_branches.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync --all: does not sync remote only branches
 
   Background:
-    Given my repository has a feature branch named "my-feature"
+    Given my repo has a feature branch named "my-feature"
     And my coworker has a feature branch named "co-feature"
     And the following commits exist in my repository
       | BRANCH     | LOCATION      | MESSAGE         | FILE NAME     |

--- a/features/git-town-sync/all_branches/without_remote_origin.feature
+++ b/features/git-town-sync/all_branches/without_remote_origin.feature
@@ -25,7 +25,7 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
       | feature-1 | git stash pop            |
     And I am still on the "feature-1" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH    | LOCATION | MESSAGE                            | FILE NAME     |
       | main      | local    | main commit                        | main_file     |
       | feature-1 | local    | feature-1 commit                   | feature1_file |
@@ -34,7 +34,7 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
       | feature-2 | local    | feature-2 commit                   | feature2_file |
       |           |          | main commit                        | main_file     |
       |           |          | Merge branch 'main' into feature-2 |               |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH    | NAME          | CONTENT           |
       | main      | main_file     | main content      |
       | feature-1 | feature1_file | feature-1 content |

--- a/features/git-town-sync/all_branches/without_remote_origin.feature
+++ b/features/git-town-sync/all_branches/without_remote_origin.feature
@@ -3,7 +3,7 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "feature-1" and "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION | MESSAGE          | FILE NAME     | FILE CONTENT      |
       | main      | local    | main commit      | main_file     | main content      |
       | feature-1 | local    | feature-1 commit | feature1_file | feature-1 content |

--- a/features/git-town-sync/all_branches/without_remote_origin.feature
+++ b/features/git-town-sync/all_branches/without_remote_origin.feature
@@ -2,7 +2,7 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has the local feature branches "feature-1" and "feature-2"
+    And my repo has the local feature branches "feature-1" and "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION | MESSAGE          | FILE NAME     | FILE CONTENT      |
       | main      | local    | main commit      | main_file     | main content      |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -2,7 +2,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync: resolving conflicts between the current feature branch and the main branch (with tracking branch updates)
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -47,7 +47,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
@@ -76,7 +76,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME        |
       | main    | local, remote | conflicting main commit                                    | conflicting_file |
       | feature | local, remote | conflicting feature commit                                 | conflicting_file |
@@ -84,7 +84,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |                  |
       |         |               | conflicting main commit                                    | conflicting_file |
       |         |               | Merge branch 'main' into feature                           |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
@@ -101,7 +101,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME        |
       | main    | local, remote | conflicting main commit                                    | conflicting_file |
       | feature | local, remote | conflicting feature commit                                 | conflicting_file |
@@ -109,7 +109,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |                  |
       |         |               | conflicting main commit                                    | conflicting_file |
       |         |               | Merge branch 'main' into feature                           |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
@@ -2,7 +2,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has a local feature branch named "feature"
+    And my repo has a local feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
@@ -3,7 +3,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
   Background:
     Given my repo does not have a remote origin
     And my repo has a local feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
@@ -38,7 +38,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -62,13 +62,13 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
       | main    | local    | conflicting main commit          | conflicting_file |
       | feature | local    | conflicting feature commit       | conflicting_file |
       |         |          | conflicting main commit          | conflicting_file |
       |         |          | Merge branch 'main' into feature |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
@@ -83,13 +83,13 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | feature | git stash pop |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE                          | FILE NAME        |
       | main    | local    | conflicting main commit          | conflicting_file |
       | feature | local    | conflicting feature commit       | conflicting_file |
       |         |          | conflicting main commit          | conflicting_file |
       |         |          | Merge branch 'main' into feature |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
@@ -45,7 +45,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
@@ -73,13 +73,13 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | conflicting main commit          | conflicting_file |
       | feature | local, remote | conflicting feature commit       | conflicting_file |
       |         |               | conflicting main commit          | conflicting_file |
       |         |               | Merge branch 'main' into feature |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
@@ -95,13 +95,13 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop        |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | conflicting main commit          | conflicting_file |
       | feature | local, remote | conflicting feature commit       | conflicting_file |
       |         |               | conflicting main commit          | conflicting_file |
       |         |               | Merge branch 'main' into feature |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH  | NAME             | CONTENT         |
       | main    | conflicting_file | main content    |
       | feature | conflicting_file | feature content |
@@ -117,13 +117,13 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop |
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
       | main    | local, remote | conflicting main commit          | conflicting_file |
       | feature | local, remote | conflicting feature commit       | conflicting_file |
       |         |               | conflicting main commit          | conflicting_file |
       |         |               | Merge branch 'main' into feature |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
@@ -2,7 +2,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
@@ -1,7 +1,7 @@
 Feature: git-town sync: resolving conflicts between the current feature branch and the main branch
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
@@ -54,7 +54,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
       |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -48,7 +48,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
     And there is no merge in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -74,12 +74,12 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop            |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME        |
       | feature | local, remote | local conflicting commit                                   | conflicting_file |
       |         |               | remote conflicting commit                                  | conflicting_file |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |                  |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |
 
@@ -95,11 +95,11 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       |         | git stash pop            |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME        |
       | feature | local, remote | local conflicting commit                                   | conflicting_file |
       |         |               | remote conflicting commit                                  | conflicting_file |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |                  |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/features/git-town-sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -43,7 +43,7 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -71,13 +71,13 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       |         | git stash pop                      |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                   | FILE NAME        |
       | main    | local, remote | conflicting remote commit | conflicting_file |
       |         |               | conflicting local commit  | conflicting_file |
       | feature | local, remote | conflicting remote commit | conflicting_file |
       |         |               | conflicting local commit  | conflicting_file |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |
@@ -97,13 +97,13 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       |         | git stash pop                      |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                   | FILE NAME        |
       | main    | local, remote | conflicting remote commit | conflicting_file |
       |         |               | conflicting local commit  | conflicting_file |
       | feature | local, remote | conflicting remote commit | conflicting_file |
       |         |               | conflicting local commit  | conflicting_file |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |

--- a/features/git-town-sync/current_branch/feature_branch/deleted_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/deleted_tracking_branch.feature
@@ -25,6 +25,6 @@ Feature: git-town sync: restores deleted tracking branch
       | feature | git merge --no-edit main   |
       |         | git push -u origin feature |
     And I am still on the "feature" branch
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    |
       | feature | local, remote | feature commit | feature_file |

--- a/features/git-town-sync/current_branch/feature_branch/deleted_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/deleted_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: restores deleted tracking branch
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    |
       | feature | local, remote | feature commit | feature_file |

--- a/features/git-town-sync/current_branch/feature_branch/deleted_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/deleted_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: restores deleted tracking branch
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME    |
       | feature | local, remote | feature commit | feature_file |
     And the "feature" branch gets deleted on the remote

--- a/features/git-town-sync/current_branch/feature_branch/dry_run.feature
+++ b/features/git-town-sync/current_branch/feature_branch/dry_run.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |
       |         | remote   | remote main commit    | remote_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/dry_run.feature
+++ b/features/git-town-sync/current_branch/feature_branch/dry_run.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |

--- a/features/git-town-sync/current_branch/feature_branch/dry_run.feature
+++ b/features/git-town-sync/current_branch/feature_branch/dry_run.feature
@@ -34,7 +34,7 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
       |         | git stash pop                      |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |
       |         | remote   | remote main commit    | remote_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
+++ b/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
@@ -8,7 +8,7 @@ Feature: git-town sync: syncing a nested feature branch (with known parent branc
   Scenario:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH         | LOCATION | MESSAGE                      | FILE NAME                  |
       | main           | local    | local main commit            | local_main_file            |
       |                | remote   | remote main commit           | remote_main_file           |

--- a/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
+++ b/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
@@ -6,8 +6,8 @@ Feature: git-town sync: syncing a nested feature branch (with known parent branc
 
 
   Scenario:
-    Given my repository has a feature branch named "parent-feature"
-    And my repository has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch named "parent-feature"
+    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And the following commits exist in my repository
       | BRANCH         | LOCATION | MESSAGE                      | FILE NAME                  |
       | main           | local    | local main commit            | local_main_file            |

--- a/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
+++ b/features/git-town-sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
@@ -38,7 +38,7 @@ Feature: git-town sync: syncing a nested feature branch (with known parent branc
       |                | git stash pop                             |
     And I am still on the "child-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH         | LOCATION      | MESSAGE                                                                  | FILE NAME                  |
       | main           | local, remote | remote main commit                                                       | remote_main_file           |
       |                |               | local main commit                                                        | local_main_file            |

--- a/features/git-town-sync/current_branch/feature_branch/offline.feature
+++ b/features/git-town-sync/current_branch/feature_branch/offline.feature
@@ -1,6 +1,6 @@
 Feature: git-town sync: offline mode
 
-    When offline
+  When offline
   I still want to be able to sync my branches locally
   So that I can work despite having no internet connection.
 

--- a/features/git-town-sync/current_branch/feature_branch/offline.feature
+++ b/features/git-town-sync/current_branch/feature_branch/offline.feature
@@ -32,7 +32,7 @@ Feature: git-town sync: offline mode
       |         | git stash pop                      |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE                          | FILE NAME           |
       | main    | local    | local main commit                | local_main_file     |
       |         | remote   | remote main commit               | remote_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/offline.feature
+++ b/features/git-town-sync/current_branch/feature_branch/offline.feature
@@ -1,13 +1,13 @@
 Feature: git-town sync: offline mode
 
-  When offline
+    When offline
   I still want to be able to sync my branches locally
   So that I can work despite having no internet connection.
 
 
   Background:
     Given Git Town is in offline mode
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |

--- a/features/git-town-sync/current_branch/feature_branch/offline.feature
+++ b/features/git-town-sync/current_branch/feature_branch/offline.feature
@@ -8,7 +8,7 @@ Feature: git-town sync: offline mode
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |
       |         | remote   | remote main commit    | remote_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/tags.feature
+++ b/features/git-town-sync/current_branch/feature_branch/tags.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: syncing a feature branch pulls tags
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And my repo has the following tags
       | NAME       | LOCATION |
       | local-tag  | local    |
@@ -17,6 +17,6 @@ Feature: git-town sync: syncing a feature branch pulls tags
 
   Scenario: result
     Then my repo now has the following tags
-      | NAME       | LOCATION         |
-      | local-tag  | local            |
+      | NAME       | LOCATION      |
+      | local-tag  | local         |
       | remote-tag | local, remote |

--- a/features/git-town-sync/current_branch/feature_branch/two_collaborators.feature
+++ b/features/git-town-sync/current_branch/feature_branch/two_collaborators.feature
@@ -10,7 +10,7 @@ Feature: git-town sync: collaborative feature branch syncing
     And my repo has a feature branch named "feature"
     And my coworker fetches updates
     And my coworker sets the parent branch of "feature" as "main"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE         | FILE NAME     |
       | feature | local    | my commit       | my_file       |
       |         | coworker | coworker commit | coworker_file |

--- a/features/git-town-sync/current_branch/feature_branch/two_collaborators.feature
+++ b/features/git-town-sync/current_branch/feature_branch/two_collaborators.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: collaborative feature branch syncing
 
   Background:
     Given I am collaborating with a coworker
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And my coworker fetches updates
     And my coworker sets the parent branch of "feature" as "main"
     And the following commits exist in my repository

--- a/features/git-town-sync/current_branch/feature_branch/two_collaborators.feature
+++ b/features/git-town-sync/current_branch/feature_branch/two_collaborators.feature
@@ -28,7 +28,7 @@ Feature: git-town sync: collaborative feature branch syncing
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |
       |         | git push                           |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE         | FILE NAME     |
       | feature | local, remote | my commit       | my_file       |
       |         | coworker      | coworker commit | coworker_file |
@@ -44,7 +44,7 @@ Feature: git-town sync: collaborative feature branch syncing
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |
       |         | git push                           |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION                | MESSAGE                                                    | FILE NAME     |
       | feature | local, coworker, remote | my commit                                                  | my_file       |
       |         | coworker, remote        | coworker commit                                            | coworker_file |
@@ -60,7 +60,7 @@ Feature: git-town sync: collaborative feature branch syncing
       |         | git checkout feature               |
       | feature | git merge --no-edit origin/feature |
       |         | git merge --no-edit main           |
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION                | MESSAGE                                                    | FILE NAME     |
       | feature | local, coworker, remote | coworker commit                                            | coworker_file |
       |         |                         | my commit                                                  | my_file       |

--- a/features/git-town-sync/current_branch/feature_branch/with_ignored_files.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_ignored_files.feature
@@ -9,7 +9,7 @@ Feature: syncing with ignored files
 
   Scenario: running "git sync" with ignored files
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE   | FILE NAME  | FILE CONTENT |
       | feature | local, remote | my commit | .gitignore | ignored      |
     And I am on the "feature" branch

--- a/features/git-town-sync/current_branch/feature_branch/with_ignored_files.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_ignored_files.feature
@@ -8,7 +8,7 @@ Feature: syncing with ignored files
 
 
   Scenario: running "git sync" with ignored files
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE   | FILE NAME  | FILE CONTENT |
       | feature | local, remote | my commit | .gitignore | ignored      |

--- a/features/git-town-sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
@@ -7,7 +7,7 @@ Feature: git-sync: on a feature branch with merge pull branch strategy
 
   Background:
     Given the pull-branch-strategy configuration is "merge"
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |

--- a/features/git-town-sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
@@ -8,7 +8,7 @@ Feature: git-sync: on a feature branch with merge pull branch strategy
   Background:
     Given the pull-branch-strategy configuration is "merge"
     And my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |
       |         | remote   | remote main commit    | remote_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
@@ -35,7 +35,7 @@ Feature: git-sync: on a feature branch with merge pull branch strategy
       |         | git stash pop                      |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME           |
       | main    | local, remote | local main commit                                          | local_main_file     |
       |         |               | remote main commit                                         | remote_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |
       |         | remote   | remote main commit    | remote_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE               | FILE NAME           |
       | main    | local    | local main commit     | local_main_file     |

--- a/features/git-town-sync/current_branch/feature_branch/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_tracking_branch.feature
@@ -34,7 +34,7 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
       |         | git stash pop                      |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME           |
       | main    | local, remote | remote main commit                                         | remote_main_file    |
       |         |               | local main commit                                          | local_main_file     |

--- a/features/git-town-sync/current_branch/feature_branch/with_upstream.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_upstream.feature
@@ -30,7 +30,7 @@ Feature: git-sync: on a feature branch with a upstream remote
       |         | git stash pop                      |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION                | MESSAGE                          |
       | main    | local, remote, upstream | upstream commit                  |
       | feature | local, remote           | local commit                     |

--- a/features/git-town-sync/current_branch/feature_branch/with_upstream.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_upstream.feature
@@ -3,7 +3,7 @@ Feature: git-sync: on a feature branch with a upstream remote
   Background:
     Given my repo has an upstream repo
     And my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE         |
       | main    | upstream | upstream commit |
       | feature | local    | local commit    |

--- a/features/git-town-sync/current_branch/feature_branch/with_upstream.feature
+++ b/features/git-town-sync/current_branch/feature_branch/with_upstream.feature
@@ -2,7 +2,7 @@ Feature: git-sync: on a feature branch with a upstream remote
 
   Background:
     Given my repo has an upstream repo
-    And my repository has a feature branch named "feature"
+    And my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE         |
       | main    | upstream | upstream commit |

--- a/features/git-town-sync/current_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/without_remote_origin.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: syncing the current feature branch (without a tracking b
   Background:
     Given my repo does not have a remote origin
     And my repo has a local feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE              | FILE NAME          | FILE CONTENT    |
       | main    | local    | local main commit    | local_main_file    | main content    |
       | feature | local    | local feature commit | local_feature_file | feature content |

--- a/features/git-town-sync/current_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/without_remote_origin.feature
@@ -5,7 +5,7 @@ Feature: git-town sync: syncing the current feature branch (without a tracking b
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has a local feature branch named "feature"
+    And my repo has a local feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE              | FILE NAME          | FILE CONTENT    |
       | main    | local    | local main commit    | local_main_file    | main content    |

--- a/features/git-town-sync/current_branch/feature_branch/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/feature_branch/without_remote_origin.feature
@@ -24,13 +24,13 @@ Feature: git-town sync: syncing the current feature branch (without a tracking b
       |         | git stash pop            |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION | MESSAGE                          | FILE NAME          |
       | main    | local    | local main commit                | local_main_file    |
       | feature | local    | local feature commit             | local_feature_file |
       |         |          | local main commit                | local_main_file    |
       |         |          | Merge branch 'main' into feature |                    |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH  | NAME               | CONTENT         |
       | main    | local_main_file    | main content    |
       | feature | local_feature_file | feature content |

--- a/features/git-town-sync/current_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/without_tracking_branch.feature
@@ -4,7 +4,7 @@ Feature: git-town sync: syncing the current feature branch without a tracking br
 
 
   Background:
-    Given my repository has a local feature branch named "feature"
+    Given my repo has a local feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | MESSAGE              | FILE NAME          |
       | main    | local    | local main commit    | local_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/without_tracking_branch.feature
@@ -30,7 +30,7 @@ Feature: git-town sync: syncing the current feature branch without a tracking br
       |         | git stash pop              |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME          |
       | main    | local, remote | remote main commit               | remote_main_file   |
       |         |               | local main commit                | local_main_file    |

--- a/features/git-town-sync/current_branch/feature_branch/without_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/feature_branch/without_tracking_branch.feature
@@ -5,7 +5,7 @@ Feature: git-town sync: syncing the current feature branch without a tracking br
 
   Background:
     Given my repo has a local feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE              | FILE NAME          |
       | main    | local    | local main commit    | local_main_file    |
       |         | remote   | remote main commit   | remote_main_file   |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
@@ -28,7 +28,7 @@ Feature: git-town sync: syncing the main branch
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE       | FILE NAME   |
       | main   | local, remote | remote commit | remote_file |
       |        |               | local commit  | local_file  |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: syncing the main branch
 
   Background:
     Given I am on the "main" branch
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | LOCATION | MESSAGE       | FILE NAME   |
       | local    | local commit  | local_file  |
       | remote   | remote commit | remote_file |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream.feature
@@ -24,6 +24,6 @@ Feature: git-sync: on the main branch with a upstream remote
       |        | git stash pop            |
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION                | MESSAGE         |
       | main   | local, remote, upstream | upstream commit |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream.feature
@@ -2,7 +2,7 @@ Feature: git-sync: on the main branch with a upstream remote
 
   Background:
     Given my repo has an upstream repo
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE         |
       | main   | upstream | upstream commit |
     And I am on the "main" branch

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream_disabled.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream_disabled.feature
@@ -2,7 +2,7 @@ Feature: git-sync: on the main branch with a upstream remote
 
   Background:
     Given my repo has an upstream repo
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE         |
       | main   | local    | local commit    |
       |        | remote   | remote commit   |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream_disabled.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/with_upstream_disabled.feature
@@ -25,7 +25,7 @@ Feature: git-sync: on the main branch with a upstream remote
       |        | git stash pop            |
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE         |
       | main   | local, remote | remote commit   |
       |        |               | local commit    |

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
@@ -23,4 +23,4 @@ Feature: git-town sync: syncing the main branch (without remote repo)
       |        | git stash pop |
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
@@ -8,7 +8,7 @@ Feature: git-town sync: syncing the main branch (without remote repo)
   Background:
     Given my repo does not have a remote origin
     And I am on the "main" branch
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE      | FILE NAME  |
       | main   | local    | local commit | local_file |
     And my workspace has an uncommitted file

--- a/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
 
   Background:
     Given I am on the "main" branch
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |

--- a/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
@@ -40,7 +40,7 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -65,11 +65,11 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       |        | git stash pop         |
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
 
@@ -85,10 +85,10 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       |        | git stash pop   |
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: syncing the current perennial branch
 
   Background:
     Given my repo has the perennial branches "production" and "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE       | FILE NAME   |
       | qa     | local         | local commit  | local_file  |
       |        | remote        | remote commit | remote_file |

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
@@ -30,7 +30,7 @@ Feature: git-town sync: syncing the current perennial branch
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE       | FILE NAME   |
       | main   | local, remote | main commit   | main_file   |
       | qa     | local, remote | remote commit | remote_file |

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: syncing the current perennial branch
 
 
   Background:
-    Given my repository has the perennial branches "production" and "qa"
+    Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repository
       | BRANCH | LOCATION      | MESSAGE       | FILE NAME   |
       | qa     | local         | local commit  | local_file  |

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
@@ -25,4 +25,4 @@ Feature: git-town sync: syncing the current perennial branch (without remote rep
       |        | git stash pop |
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
-    And my repository is left with my original commits
+    And my repo is left with my original commits

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
@@ -8,7 +8,7 @@ Feature: git-town sync: syncing the current perennial branch (without remote rep
   Background:
     Given my repo does not have a remote origin
     And my repo has the local perennial branches "production" and "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE      | FILE NAME  |
       | main   | local    | main commit  | main_file  |
       | qa     | local    | local commit | local_file |

--- a/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: syncing the current perennial branch (without remote rep
 
   Background:
     Given my repo does not have a remote origin
-    And my repository has the local perennial branches "production" and "qa"
+    And my repo has the local perennial branches "production" and "qa"
     And the following commits exist in my repository
       | BRANCH | LOCATION | MESSAGE      | FILE NAME  |
       | main   | local    | main commit  | main_file  |

--- a/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
@@ -42,7 +42,7 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -67,11 +67,11 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
       |        | git stash pop         |
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | qa     | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |
 
@@ -87,10 +87,10 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
       |        | git stash pop   |
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        |
       | qa     | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
-    And my repository now has the following committed files
+    And my repo now has the following committed files
       | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |

--- a/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
 
   Background:
     Given my repo has the perennial branches "production" and "qa"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | qa     | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |

--- a/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
 
 
   Background:
-    Given my repository has the perennial branches "production" and "qa"
+    Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repository
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | qa     | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/features/git-town-sync/current_branch/perennial_branch/tags.feature
+++ b/features/git-town-sync/current_branch/perennial_branch/tags.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: syncing the current perennial branch syncs the tags
 
 
   Background:
-    Given my repository has the perennial branches "production" and "qa"
+    Given my repo has the perennial branches "production" and "qa"
     And I am on the "production" branch
     And my repo has the following tags
       | NAME       | LOCATION |

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
@@ -5,7 +5,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
 
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main            | local, remote | conflicting main commit    | conflicting_file | main content    |
       | current-feature | local         | conflicting feature commit | conflicting_file | feature content |

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
@@ -46,7 +46,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And I am still on the "current-feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository is left with my original commits
+    And my repo is left with my original commits
 
 
   Scenario: continuing without resolving the conflicts
@@ -79,7 +79,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And I am still on the "current-feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH          | LOCATION      | MESSAGE                                  | FILE NAME        |
       | main            | local, remote | conflicting main commit                  | conflicting_file |
       | current-feature | local, remote | conflicting feature commit               | conflicting_file |
@@ -89,7 +89,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
       | other-feature   | local, remote | other feature commit                     | file2            |
       |                 |               | conflicting main commit                  | conflicting_file |
       |                 |               | Merge branch 'main' into other-feature   |                  |
-    And my repository still has the following committed files
+    And my repo still has the following committed files
       | BRANCH          | NAME             | CONTENT          |
       | main            | conflicting_file | main content     |
       | current-feature | conflicting_file | resolved content |

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/conflict.feature
@@ -4,7 +4,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
 
 
   Background:
-    Given my repository has the feature branches "current-feature" and "other-feature"
+    Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main            | local, remote | conflicting main commit    | conflicting_file | main content    |
@@ -52,7 +52,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
-    And it prints the error: 
+    And it prints the error:
       """
       You must resolve the conflicts before continuing
       """
@@ -80,15 +80,15 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repository now has the following commits
-      | BRANCH          | LOCATION         | MESSAGE                                  | FILE NAME        |
+      | BRANCH          | LOCATION      | MESSAGE                                  | FILE NAME        |
       | main            | local, remote | conflicting main commit                  | conflicting_file |
       | current-feature | local, remote | conflicting feature commit               | conflicting_file |
-      |                 |                  | folder commit                            | new_folder/file1 |
-      |                 |                  | conflicting main commit                  | conflicting_file |
-      |                 |                  | Merge branch 'main' into current-feature |                  |
+      |                 |               | folder commit                            | new_folder/file1 |
+      |                 |               | conflicting main commit                  | conflicting_file |
+      |                 |               | Merge branch 'main' into current-feature |                  |
       | other-feature   | local, remote | other feature commit                     | file2            |
-      |                 |                  | conflicting main commit                  | conflicting_file |
-      |                 |                  | Merge branch 'main' into other-feature   |                  |
+      |                 |               | conflicting main commit                  | conflicting_file |
+      |                 |               | Merge branch 'main' into other-feature   |                  |
     And my repository still has the following committed files
       | BRANCH          | NAME             | CONTENT          |
       | main            | conflicting_file | main content     |

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
@@ -40,7 +40,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
       | <none>          | cd {{ folder "new_folder" }}               |
     And I am still on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repository now has the following commits
+    And my repo now has the following commits
       | BRANCH          | LOCATION      | MESSAGE                                  | FILE NAME        |
       | main            | local, remote | main commit                              | main_file        |
       | current-feature | local, remote | folder commit                            | new_folder/file1 |

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
@@ -7,7 +7,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
 
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE              | FILE NAME        |
       | main            | local, remote | main commit          | main_file        |
       | current-feature | local, remote | folder commit        | new_folder/file1 |

--- a/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
+++ b/features/git-town-sync/folder_does_not_exist_on_main_branch/no_conflict.feature
@@ -6,7 +6,7 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
 
 
   Background:
-    Given my repository has the feature branches "current-feature" and "other-feature"
+    Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repository
       | BRANCH          | LOCATION      | MESSAGE              | FILE NAME        |
       | main            | local, remote | main commit          | main_file        |

--- a/features/git-town-version/version.feature
+++ b/features/git-town-version/version.feature
@@ -14,7 +14,7 @@ Feature: git town: show the current Git Town version
 
 
   Scenario: Running outside of a Git repository
-    Given my workspace is currently not a Git repository
+    Given my workspace is currently not a Git repo
     When I run "git-town version"
     Then it prints:
       """

--- a/features/git-town/help/help_outside_git_repo.feature
+++ b/features/git-town/help/help_outside_git_repo.feature
@@ -4,7 +4,7 @@ Feature: show help screen even outside of a Git repository
 
 
   Scenario Outline: Running outside of a Git repository
-    Given my workspace is currently not a Git repository
+    Given my workspace is currently not a Git repo
     When I run "<COMMAND>"
     Then it prints:
       """

--- a/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_deleted.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_deleted.feature
@@ -4,7 +4,7 @@ Feature: deleting the current and previous branches makes the main branch the ne
 
 
   Scenario: prune-branches
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And the "previous" branch gets deleted on the remote
     And the "current" branch gets deleted on the remote
     And I am on the "current" branch with "previous" as the previous Git branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_same.feature
@@ -14,7 +14,7 @@ Feature: Git checkout history is preserved when deleting the current branch
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
     And the "current" branch gets deleted on the remote
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH   | LOCATION | FILE NAME     | FILE CONTENT     |
       | previous | local    | previous_file | previous content |
     And I am on the "current" branch with "previous" as the previous Git branch
@@ -25,7 +25,7 @@ Feature: Git checkout history is preserved when deleting the current branch
 
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | current | remote   | feature_file | feature content |
     And I am on the "current" branch with "previous" as the previous Git branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_same.feature
@@ -4,7 +4,7 @@ Feature: Git checkout history is preserved when deleting the current branch
 
 
   Scenario: kill
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town kill"
     Then I end up on the "main" branch
@@ -12,7 +12,7 @@ Feature: Git checkout history is preserved when deleting the current branch
 
 
   Scenario: prune-branches
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And the "current" branch gets deleted on the remote
     And the following commits exist in my repository
       | BRANCH   | LOCATION | FILE NAME     | FILE CONTENT     |
@@ -24,7 +24,7 @@ Feature: Git checkout history is preserved when deleting the current branch
 
 
   Scenario: ship
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | current | remote   | feature_file | feature content |

--- a/features/shared/checkout_previous_branch_after_success/current_branch_new/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_new/previous_branch_same.feature
@@ -4,7 +4,7 @@ Feature: creating a new branch makes the current branch the new previous branch
 
 
   Scenario: hack
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town hack new"
     Then I end up on the "new" branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_renamed/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_renamed/previous_branch_same.feature
@@ -4,7 +4,7 @@ Feature: Git checkout history is preserved when renaming the current branch
 
 
   Scenario: rename-branch
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town rename-branch current current-new"
     Then I end up on the "current-new" branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
@@ -14,7 +14,7 @@ Feature: deleting the current branch makes the main branch the new previous bran
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
     And the "previous" branch gets deleted on the remote
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | current | local    | current_file | current content |
     And I am on the "current" branch with "previous" as the previous Git branch
@@ -25,7 +25,7 @@ Feature: deleting the current branch makes the main branch the new previous bran
 
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH   | LOCATION | FILE NAME    | FILE CONTENT    |
       | previous | remote   | feature_file | feature content |
     And I am on the "current" branch with "previous" as the previous Git branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
@@ -4,7 +4,7 @@ Feature: deleting the current branch makes the main branch the new previous bran
 
 
   Scenario: kill
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town kill previous"
     Then I am still on the "current" branch
@@ -12,7 +12,7 @@ Feature: deleting the current branch makes the main branch the new previous bran
 
 
   Scenario: prune-branches
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And the "previous" branch gets deleted on the remote
     And the following commits exist in my repository
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
@@ -24,7 +24,7 @@ Feature: deleting the current branch makes the main branch the new previous bran
 
 
   Scenario: ship
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And the following commits exist in my repository
       | BRANCH   | LOCATION | FILE NAME    | FILE CONTENT    |
       | previous | remote   | feature_file | feature content |

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_renamed.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_renamed.feature
@@ -4,7 +4,7 @@ Feature: renaming the previous branch makes the main branch the new previous bra
 
 
   Scenario: rename-branch
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town rename-branch previous previous-renamed"
     Then I end up on the "current" branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
@@ -6,8 +6,8 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
 
   Scenario: kill
-    Given my repository has the feature branches "previous" and "current"
-    And my repository has a feature branch named "victim"
+    Given my repo has the feature branches "previous" and "current"
+    And my repo has a feature branch named "victim"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town kill victim"
     Then I am still on the "current" branch
@@ -15,7 +15,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
 
   Scenario: new-pull-request
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And my computer has the "open" tool installed
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And I am on the "current" branch with "previous" as the previous Git branch
@@ -25,7 +25,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
 
   Scenario: prune-branches
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And the following commits exist in my repository
       | BRANCH   | LOCATION | FILE NAME     | FILE CONTENT     |
       | previous | local    | previous_file | previous content |
@@ -37,7 +37,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
 
   Scenario: repo
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And my computer has the "open" tool installed
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And I am on the "current" branch with "previous" as the previous Git branch
@@ -47,8 +47,8 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
 
   Scenario: ship
-    Given my repository has the feature branches "previous" and "current"
-    And my repository has a feature branch named "feature"
+    Given my repo has the feature branches "previous" and "current"
+    And my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature_file | feature content |
@@ -59,7 +59,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
 
   Scenario: sync
-    Given my repository has the feature branches "previous" and "current"
+    Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town sync"
     Then I am still on the "current" branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
@@ -26,7 +26,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH   | LOCATION | FILE NAME     | FILE CONTENT     |
       | previous | local    | previous_file | previous content |
       | current  | local    | current_file  | current content  |
@@ -49,7 +49,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"
     And my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
       | feature | remote   | feature_file | feature content |
     And I am on the "current" branch with "previous" as the previous Git branch

--- a/features/shared/continuing_after_success.feature
+++ b/features/shared/continuing_after_success.feature
@@ -16,7 +16,7 @@ Feature: Show clear error if trying to continue after executing a successful com
 
   Scenario: continuing after successful git-ship
     Given my repo has a feature branch named "current-feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH          | FILE NAME    |
       | current-feature | feature_file |
     And I am on the "current-feature" branch
@@ -30,7 +30,7 @@ Feature: Show clear error if trying to continue after executing a successful com
 
   Scenario: continuing after successful git-sync
     Given I am on the "main" branch
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | LOCATION | FILE NAME   |
       | local    | local_file  |
       | remote   | remote_file |

--- a/features/shared/continuing_after_success.feature
+++ b/features/shared/continuing_after_success.feature
@@ -15,7 +15,7 @@ Feature: Show clear error if trying to continue after executing a successful com
 
 
   Scenario: continuing after successful git-ship
-    Given my repository has a feature branch named "current-feature"
+    Given my repo has a feature branch named "current-feature"
     And the following commits exist in my repository
       | BRANCH          | FILE NAME    |
       | current-feature | feature_file |

--- a/features/shared/entering_parent_branch.feature
+++ b/features/shared/entering_parent_branch.feature
@@ -6,7 +6,7 @@ Feature: Entering a parent branch name when prompted
 
 
   Background:
-    Given my repository has the branches "feature-1" and "feature-2"
+    Given my repo has the branches "feature-1" and "feature-2"
     And I am on the "feature-2" branch
 
 

--- a/features/shared/prompting_for_parent_branch.feature
+++ b/features/shared/prompting_for_parent_branch.feature
@@ -61,7 +61,7 @@ Feature: Prompt for parent branch when unknown
 
   Scenario: prompting for parent branch when running git town-sync
     Given my repo has a branch "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | main    | local, remote | main commit    |
       | feature | local, remote | feature commit |
@@ -80,7 +80,7 @@ Feature: Prompt for parent branch when unknown
   Scenario: prompting for parent branch when running git town-sync --all
     Given my repo has a branch "feature-1"
     And my repo has a branch "feature-2"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          |
       | main      | local, remote | main commit      |
       | feature-1 | local, remote | feature-1 commit |

--- a/features/shared/prompting_for_parent_branch.feature
+++ b/features/shared/prompting_for_parent_branch.feature
@@ -6,7 +6,7 @@ Feature: Prompt for parent branch when unknown
 
 
   Scenario: prompting for parent branch when running git town-append
-    Given my repository has a branch "feature-1"
+    Given my repo has a branch "feature-1"
     And I am on the "feature-1" branch
     When I run "git-town append feature-2" and answer the prompts:
       | PROMPT                                          | ANSWER  |
@@ -19,7 +19,7 @@ Feature: Prompt for parent branch when unknown
 
 
   Scenario: prompting for parent branch when running git town-hack -p
-    Given my repository has a branch "feature-1"
+    Given my repo has a branch "feature-1"
     And I am on the "feature-1" branch
     When I run "git-town hack -p feature-2" and answer the prompts:
       | PROMPT                                          | ANSWER        |
@@ -33,7 +33,7 @@ Feature: Prompt for parent branch when unknown
 
 
   Scenario: prompting for parent branch when running git town-kill
-    Given my repository has a branch "feature"
+    Given my repo has a branch "feature"
     And I am on the "feature" branch
     When I run "git-town kill" and answer the prompts:
       | PROMPT                                        | ANSWER  |
@@ -47,7 +47,7 @@ Feature: Prompt for parent branch when unknown
 
   Scenario: prompting for parent branch when running git town-new-pull-request
     And my computer has the "open" tool installed
-    And my repository has a branch "feature"
+    And my repo has a branch "feature"
     And my repo's origin is "git@github.com:git-town/git-town.git"
     And I am on the "feature" branch
     When I run "git-town new-pull-request" and answer the prompts:
@@ -60,7 +60,7 @@ Feature: Prompt for parent branch when unknown
 
 
   Scenario: prompting for parent branch when running git town-sync
-    Given my repository has a branch "feature"
+    Given my repo has a branch "feature"
     And the following commits exist in my repository
       | BRANCH  | LOCATION      | MESSAGE        |
       | main    | local, remote | main commit    |
@@ -78,8 +78,8 @@ Feature: Prompt for parent branch when unknown
 
 
   Scenario: prompting for parent branch when running git town-sync --all
-    Given my repository has a branch "feature-1"
-    And my repository has a branch "feature-2"
+    Given my repo has a branch "feature-1"
+    And my repo has a branch "feature-2"
     And the following commits exist in my repository
       | BRANCH    | LOCATION      | MESSAGE          |
       | main      | local, remote | main commit      |

--- a/features/shared/prompting_for_parent_branch.feature
+++ b/features/shared/prompting_for_parent_branch.feature
@@ -69,7 +69,7 @@ Feature: Prompt for parent branch when unknown
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                        | ANSWER  |
       | Please specify the parent branch of 'feature' | [ENTER] |
-    Then my repository now has the following commits
+    Then my repo now has the following commits
       | BRANCH  | LOCATION      | MESSAGE                          |
       | main    | local, remote | main commit                      |
       | feature | local, remote | feature commit                   |
@@ -90,7 +90,7 @@ Feature: Prompt for parent branch when unknown
       | PROMPT                                          | ANSWER  |
       | Please specify the parent branch of 'feature-1' | [ENTER] |
       | Please specify the parent branch of 'feature-2' | [ENTER] |
-    Then my repository now has the following commits
+    Then my repo now has the following commits
       | BRANCH    | LOCATION      | MESSAGE                            |
       | main      | local, remote | main commit                        |
       | feature-1 | local, remote | feature-1 commit                   |

--- a/features/shared/undo.feature
+++ b/features/shared/undo.feature
@@ -6,7 +6,7 @@ Feature: cannot double undo
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And I am on the "feature" branch
     And I run "git-town kill"
     And I end up on the "main" branch

--- a/features/shared/unfinished_state.feature
+++ b/features/shared/unfinished_state.feature
@@ -7,7 +7,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
 
   Background:
     Given my repo has a feature branch named "feature"
-    And the following commits exist in my repository
+    And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |

--- a/features/shared/unfinished_state.feature
+++ b/features/shared/unfinished_state.feature
@@ -6,7 +6,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
 
 
   Background:
-    Given my repository has a feature branch named "feature"
+    Given my repo has a feature branch named "feature"
     And the following commits exist in my repository
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/test/steps.go
+++ b/test/steps.go
@@ -430,15 +430,15 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repository has a branch "([^"]*)"$`, func(branch string) error {
+	suite.Step(`^my repo has a branch "([^"]*)"$`, func(branch string) error {
 		return state.gitEnv.DevRepo.CreateBranch(branch, "main")
 	})
 
-	suite.Step(`^my repository has a feature branch named "([^"]*)" with no parent$`, func(branch string) error {
+	suite.Step(`^my repo has a feature branch named "([^"]*)" with no parent$`, func(branch string) error {
 		return state.gitEnv.DevRepo.CreateFeatureBranchNoParent(branch)
 	})
 
-	suite.Step(`^my repository has a feature branch named "([^"]+)" as a child of "([^"]+)"$`, func(childBranch, parentBranch string) error {
+	suite.Step(`^my repo has a feature branch named "([^"]+)" as a child of "([^"]+)"$`, func(childBranch, parentBranch string) error {
 		err := state.gitEnv.DevRepo.CreateChildFeatureBranch(childBranch, parentBranch)
 		if err != nil {
 			return fmt.Errorf("cannot create feature branch %q: %w", childBranch, err)
@@ -446,7 +446,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.PushBranch(childBranch)
 	})
 
-	suite.Step(`^my repository has a (local )?feature branch named "([^"]*)"$`, func(localStr, branch string) error {
+	suite.Step(`^my repo has a (local )?feature branch named "([^"]*)"$`, func(localStr, branch string) error {
 		isLocal := localStr != ""
 		err := state.gitEnv.DevRepo.CreateFeatureBranch(branch)
 		if err != nil {
@@ -495,7 +495,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repository has the branches "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
+	suite.Step(`^my repo has the branches "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
 		err := state.gitEnv.DevRepo.CreateBranch(branch1, "main")
 		if err != nil {
 			return err
@@ -507,7 +507,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.CreateTags(table)
 	})
 
-	suite.Step(`^my repository has the (local )?feature branches "([^"]+)" and "([^"]+)"$`, func(localStr, branch1, branch2 string) error {
+	suite.Step(`^my repo has the (local )?feature branches "([^"]+)" and "([^"]+)"$`, func(localStr, branch1, branch2 string) error {
 		isLocal := localStr != ""
 		err := state.gitEnv.DevRepo.CreateFeatureBranch(branch1)
 		if err != nil {
@@ -527,7 +527,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repository has the (local )?perennial branches "([^"]+)" and "([^"]+)"$`, func(localStr, branch1, branch2 string) error {
+	suite.Step(`^my repo has the (local )?perennial branches "([^"]+)" and "([^"]+)"$`, func(localStr, branch1, branch2 string) error {
 		isLocal := localStr != ""
 		err := state.gitEnv.DevRepo.CreatePerennialBranches(branch1, branch2)
 		if err != nil {
@@ -543,7 +543,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repository has the perennial branch "([^"]+)"`, func(branch1 string) error {
+	suite.Step(`^my repo has the perennial branch "([^"]+)"`, func(branch1 string) error {
 		err := state.gitEnv.DevRepo.CreatePerennialBranches(branch1)
 		if err != nil {
 			return fmt.Errorf("cannot create perennial branches: %w", err)

--- a/test/steps.go
+++ b/test/steps.go
@@ -688,7 +688,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my workspace is currently not a Git repository$`, func() error {
+	suite.Step(`^my workspace is currently not a Git repo$`, func() error {
 		os.RemoveAll(filepath.Join(state.gitEnv.DevRepo.WorkingDir(), ".git"))
 		return nil
 	})
@@ -738,7 +738,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.OriginRepo.RemoveBranch(name)
 	})
 
-	suite.Step(`^the following commits exist in my repository$`, func(table *messages.PickleStepArgument_PickleTable) error {
+	suite.Step(`^the following commits exist in my repo$`, func(table *messages.PickleStepArgument_PickleTable) error {
 		state.initialCommits = table
 		commits, err := FromGherkinTable(table)
 		if err != nil {

--- a/test/steps.go
+++ b/test/steps.go
@@ -86,7 +86,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town is no longer configured for this repository$`, func() error {
+	suite.Step(`^Git Town is no longer configured for this repo$`, func() error {
 		res, err := state.gitEnv.DevRepo.HasGitTownConfigNow()
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -551,7 +551,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.PushBranch(branch1)
 	})
 
-	suite.Step(`^my repository is left with my original commits$`, func() error {
+	suite.Step(`^my repo is left with my original commits$`, func() error {
 		return compareExistingCommits(state, state.initialCommits)
 	})
 
@@ -564,11 +564,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repository knows about the remote branch$`, func() error {
+	suite.Step(`^my repo knows about the remote branch$`, func() error {
 		return state.gitEnv.DevRepo.Fetch()
 	})
 
-	suite.Step(`^my repository now has the following commits$`, func(table *messages.PickleStepArgument_PickleTable) error {
+	suite.Step(`^my repo now has the following commits$`, func(table *messages.PickleStepArgument_PickleTable) error {
 		return compareExistingCommits(state, table)
 	})
 
@@ -608,7 +608,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repository (?:now|still) has the following committed files$`, func(table *messages.PickleStepArgument_PickleTable) error {
+	suite.Step(`^my repo (?:now|still) has the following committed files$`, func(table *messages.PickleStepArgument_PickleTable) error {
 		fileTable, err := state.gitEnv.DevRepo.FilesInBranches()
 		if err != nil {
 			return fmt.Errorf("cannot determine files in branches in the developer repo: %w", err)


### PR DESCRIPTION
Some features use "repo", others "repository". I am fine either way but think there should be only one form. Going with "repo" since that is shorter and everybody understands it.