### PR TITLE
Open links in native browser on ChromeOS

### DIFF
--- a/src/browsers/browsers.go
+++ b/src/browsers/browsers.go
@@ -17,7 +17,8 @@ func GetOpenBrowserCommand() string {
 		return "start"
 	}
 	var openBrowserCommands = []string{
-		"wsl-open", // for Windows Subsystem for Linux, see https://github.com/git-town/git-town/issues/1344
+		"wsl-open",           // for Windows Subsystem for Linux, see https://github.com/git-town/git-town/issues/1344
+		"garcon-url-handler", // opens links in native browser on ChromeOS
 		"xdg-open",
 		"open",
 		"cygstart",


### PR DESCRIPTION
When installing Firefox into the Linux subsystem of ChromeOS, it automatically becomes the default browser for links opened from within Linux. This change makes Git Town always open the native Chrome browser.