### PR TITLE
Improve error logging

### DIFF
--- a/src/command/run_test.go
+++ b/src/command/run_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCommand_Run(t *testing.T) {
 	res, err := command.Run("echo", "foo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "foo\n", res.Output())
 }
 
@@ -34,27 +34,27 @@ func TestCommand_Run_ExitCode(t *testing.T) {
 
 func TestCommand_RunInDir(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	dirPath := filepath.Join(dir, "mydir")
 	err = os.Mkdir(dirPath, 0744)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = ioutil.WriteFile(filepath.Join(dirPath, "one"), []byte{}, 0744)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	res, err := command.RunInDir(dirPath, "ls", "-1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "one", res.OutputSanitized())
 }
 
 func TestCommand_Result_OutputContainsText(t *testing.T) {
 	res, err := command.Run("echo", "hello world how are you?")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, res.OutputContainsText("world"), "should contain 'world'")
 	assert.False(t, res.OutputContainsText("zonk"), "should not contain 'zonk'")
 }
 
 func TestCommand_Result_OutputContainsLine(t *testing.T) {
 	res, err := command.Run("echo", "hello world")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, res.OutputContainsLine("hello world"), `should contain "hello world"`)
 	assert.False(t, res.OutputContainsLine("hello"), `partial match should return false`)
 	assert.False(t, res.OutputContainsLine("zonk"), `should not contain "zonk"`)

--- a/src/command/silent_shell_test.go
+++ b/src/command/silent_shell_test.go
@@ -18,7 +18,7 @@ func TestSilentShell_MustRun(t *testing.T) {
 func TestSilentShell_Run_arguments(t *testing.T) {
 	shell := command.SilentShell{}
 	res, err := shell.Run("echo", "hello", "world")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "hello world", res.OutputSanitized())
 }
 
@@ -30,9 +30,9 @@ func TestSilentShell_RunMany(t *testing.T) {
 		{"touch", "tmp/second"},
 	})
 	defer os.RemoveAll("tmp")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	infos, err := ioutil.ReadDir("tmp")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "first", infos[0].Name())
 	assert.Equal(t, "second", infos[1].Name())
 }
@@ -41,7 +41,7 @@ func TestSilentShell_RunString(t *testing.T) {
 	shell := command.SilentShell{}
 	_, err := shell.RunString("touch first")
 	defer os.Remove("first")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = os.Stat("first")
 	assert.False(t, os.IsNotExist(err))
 }
@@ -49,6 +49,6 @@ func TestSilentShell_RunString(t *testing.T) {
 func TestSilentShell_RunStringWith(t *testing.T) {
 	shell := command.SilentShell{}
 	res, err := shell.RunStringWith("ls -1", command.Options{Dir: ".."})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Contains(t, res.OutputSanitized(), "cmd")
 }

--- a/src/git/runner_test.go
+++ b/src/git/runner_test.go
@@ -14,25 +14,25 @@ import (
 func TestRunner_AddRemote(t *testing.T) {
 	runner := CreateTestGitTownRepo(t).Runner
 	err := runner.AddRemote("foo", "bar")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	remotes, err := runner.Remotes()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"foo"}, remotes)
 }
 
 func TestRunner_CheckoutBranch(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateBranch("branch1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CheckoutBranch("branch1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	currentBranch, err := runner.CurrentBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "branch1", currentBranch)
 	err = runner.CheckoutBranch("master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	currentBranch, err = runner.CurrentBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "master", currentBranch)
 }
 
@@ -44,16 +44,16 @@ func TestRunner_Commits(t *testing.T) {
 		FileContent: "hello",
 		Message:     "first commit",
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateCommit(git.Commit{
 		Branch:      "master",
 		FileName:    "file2",
 		FileContent: "hello again",
 		Message:     "second commit",
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	commits, err := runner.Commits([]string{"FILE NAME", "FILE CONTENT"})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, commits, 2)
 	assert.Equal(t, "master", commits[0].Branch)
 	assert.Equal(t, "file1", commits[0].FileName)
@@ -79,38 +79,38 @@ func TestRunner_ConnectTrackingBranch(t *testing.T) {
 	origin := test.CreateRepo(t)
 	repoDir := filepath.Join(test.CreateTempDir(t), "repo") // need a non-existing directory
 	err := test.CopyDirectory(origin.WorkingDir(), repoDir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	runner := test.NewRepo(repoDir, repoDir, "").Runner
 	err = runner.AddRemote("origin", origin.WorkingDir())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.Fetch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.ConnectTrackingBranch("master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.PushBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRunner_CreateBranch(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateBranch("branch1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	currentBranch, err := runner.CurrentBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "master", currentBranch)
 	branches, err := runner.LocalBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"branch1", "master"}, branches)
 }
 
 func TestRunner_CreateChildFeatureBranch(t *testing.T) {
 	runner := CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranch("f1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateChildFeatureBranch("f1a", "f1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	res, err := runner.Run("git", "town", "config")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	has := strings.Contains(res.OutputSanitized(), "Branch Ancestry:\n  main\n    f1\n      f1a")
 	assert.True(t, has)
 }
@@ -123,9 +123,9 @@ func TestRunner_CreateCommit(t *testing.T) {
 		FileContent: "hello world",
 		Message:     "test commit",
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	commits, err := runner.Commits([]string{"FILE NAME", "FILE CONTENT"})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, commits, 1)
 	assert.Equal(t, "hello.txt", commits[0].FileName)
 	assert.Equal(t, "hello world", commits[0].FileContent)
@@ -142,9 +142,9 @@ func TestRunner_CreateCommit_Author(t *testing.T) {
 		Message:     "test commit",
 		Author:      "developer <developer@example.com>",
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	commits, err := runner.Commits([]string{"FILE NAME", "FILE CONTENT"})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, commits, 1)
 	assert.Equal(t, "hello.txt", commits[0].FileName)
 	assert.Equal(t, "hello world", commits[0].FileContent)
@@ -156,7 +156,7 @@ func TestRunner_CreateCommit_Author(t *testing.T) {
 func TestRunner_CreateFeatureBranch(t *testing.T) {
 	runner := CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranch("f1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	runner.Configuration.Reload()
 	assert.True(t, runner.Configuration.IsFeatureBranch("f1"))
 	assert.Equal(t, []string{"main"}, runner.Configuration.GetAncestorBranches("f1"))
@@ -165,7 +165,7 @@ func TestRunner_CreateFeatureBranch(t *testing.T) {
 func TestRunner_CreateFeatureBranchNoParent(t *testing.T) {
 	runner := CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranchNoParent("f1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	runner.Configuration.Reload()
 	assert.True(t, runner.Configuration.IsFeatureBranch("f1"))
 	assert.Equal(t, []string(nil), runner.Configuration.GetAncestorBranches("f1"))
@@ -192,9 +192,9 @@ func TestRunner_CreateFile_InSubFolder(t *testing.T) {
 func TestRunner_CreatePerennialBranches(t *testing.T) {
 	runner := CreateTestGitTownRepo(t).Runner
 	err := runner.CreatePerennialBranches("p1", "p2")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branches, err := runner.LocalBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"main", "master", "p1", "p2"}, branches)
 	runner.Configuration.Reload()
 	assert.True(t, runner.Configuration.IsPerennialBranch("p1"))
@@ -204,18 +204,18 @@ func TestRunner_CreatePerennialBranches(t *testing.T) {
 func TestRunner_CurrentBranch(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CheckoutBranch("master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CheckoutBranch("b1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branch, err := runner.CurrentBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "b1", branch)
 	err = runner.CheckoutBranch("master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branch, err = runner.CurrentBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "master", branch)
 }
 
@@ -223,9 +223,9 @@ func TestRunner_Fetch(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	origin := test.CreateRepo(t)
 	err := runner.AddRemote("origin", origin.WorkingDir())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.Fetch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRunner_FileContentInCommit(t *testing.T) {
@@ -236,117 +236,117 @@ func TestRunner_FileContentInCommit(t *testing.T) {
 		FileContent: "hello world",
 		Message:     "commit",
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	commits, err := runner.CommitsInBranch("master", []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, commits, 1)
 	content, err := runner.FileContentInCommit(commits[0].SHA, "hello.txt")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "hello world", content)
 }
 
 func TestRunner_FilesInCommit(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateFile("f1.txt", "one")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateFile("f2.txt", "two")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.StageFiles("f1.txt", "f2.txt")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CommitStagedChanges("stuff")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	commits, err := runner.Commits([]string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, commits, 1)
 	fileNames, err := runner.FilesInCommit(commits[0].SHA)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"f1.txt", "f2.txt"}, fileNames)
 }
 
 func TestRunner_HasBranchesOutOfSync_synced(t *testing.T) {
 	env, err := test.NewStandardGitEnvironment(test.CreateTempDir(t))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	runner := env.DevRepo.Runner
 	err = runner.CreateBranch("branch1", "main")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CheckoutBranch("branch1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateFile("file1", "content")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.StageFiles("file1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CommitStagedChanges("stuff")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.PushBranchSetUpstream("branch1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	have, err := runner.HasBranchesOutOfSync()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, have)
 }
 
 func TestRunner_HasBranchesOutOfSync_branchAhead(t *testing.T) {
 	env, err := test.NewStandardGitEnvironment(test.CreateTempDir(t))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	runner := env.DevRepo.Runner
 	err = runner.CreateBranch("branch1", "main")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.PushBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateFile("file1", "content")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.StageFiles("file1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CommitStagedChanges("stuff")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	have, err := runner.HasBranchesOutOfSync()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, have)
 }
 
 func TestRunner_HasBranchesOutOfSync_branchBehind(t *testing.T) {
 	env, err := test.NewStandardGitEnvironment(test.CreateTempDir(t))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.DevRepo.CreateBranch("branch1", "main")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.DevRepo.PushBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.OriginRepo.CheckoutBranch("main")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.OriginRepo.CreateFile("file1", "content")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.OriginRepo.StageFiles("file1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.OriginRepo.CommitStagedChanges("stuff")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.OriginRepo.CheckoutBranch("master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = env.DevRepo.Fetch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	have, err := env.DevRepo.Runner.HasBranchesOutOfSync()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, have)
 }
 
 func TestRunner_HasGitTownConfigNow(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	res, err := runner.HasGitTownConfigNow()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, res)
 	err = runner.CreateBranch("main", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateFeatureBranch("foo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	res, err = runner.HasGitTownConfigNow()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, res)
 }
 
 func TestRunner_HasFile(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateFile("f1.txt", "one")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	has, err := runner.HasFile("f1.txt", "one")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, has)
 	_, err = runner.HasFile("f1.txt", "zonk")
 	assert.Error(t, err)
@@ -357,38 +357,38 @@ func TestRunner_HasLocalBranch(t *testing.T) {
 	origin := test.CreateRepo(t)
 	repoDir := test.CreateTempDir(t)
 	repo, err := origin.Clone(repoDir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b2", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	has, err := repo.HasLocalBranch("b1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, has)
 	has, err = repo.HasLocalBranch("b2")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, has)
 	has, err = repo.HasLocalBranch("b3")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, has)
 }
 
 func TestRunner_HasOpenChanges(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	has, err := runner.HasOpenChanges()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, has)
 	err = runner.CreateFile("foo", "bar")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	has, err = runner.HasOpenChanges()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, has)
 }
 
 func TestRunner_HasRebaseInProgress(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	has, err := runner.HasRebaseInProgress()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, has)
 }
 
@@ -396,42 +396,42 @@ func TestRunner_HasRemote(t *testing.T) {
 	origin := test.CreateRepo(t)
 	repoDir := test.CreateTempDir(t)
 	repo, err := origin.Clone(repoDir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	has, err := repo.Runner.HasRemote("origin")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, has)
 	has, err = repo.Runner.HasRemote("zonk")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, has)
 }
 
 func TestRunner_HasTrackingBranch(t *testing.T) {
 	origin := test.CreateRepo(t)
 	err := origin.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	repoDir := test.CreateTempDir(t)
 	repo, err := origin.Clone(repoDir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	runner := repo.Runner
 	err = runner.CheckoutBranch("b1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateBranch("b2", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	has, err := runner.HasTrackingBranch("b1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, has)
 	has, err = runner.HasTrackingBranch("b2")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, has)
 	has, err = runner.HasTrackingBranch("b3")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, has)
 }
 
 func TestRunner_LastActiveDir(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	dir, err := runner.LastActiveDir()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, runner.WorkingDir(), dir)
 }
 
@@ -439,17 +439,17 @@ func TestRunner_LocalBranches(t *testing.T) {
 	origin := test.CreateRepo(t)
 	repoDir := test.CreateTempDir(t)
 	repo, err := origin.Clone(repoDir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b2", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = origin.CreateBranch("b3", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.Fetch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branches, err := repo.Runner.LocalBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"b1", "b2", "master"}, branches)
 }
 
@@ -457,32 +457,32 @@ func TestRunner_LocalAndRemoteBranches(t *testing.T) {
 	origin := test.CreateRepo(t)
 	repoDir := test.CreateTempDir(t)
 	repo, err := origin.Clone(repoDir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b2", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = origin.CreateBranch("b3", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.Fetch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branches, err := repo.Runner.LocalAndRemoteBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"b1", "b2", "b3", "master"}, branches)
 }
 
 func TestRunner_PreviouslyCheckedOutBranch(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateBranch("feature1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateBranch("feature2", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CheckoutBranch("feature1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CheckoutBranch("feature2")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	have, err := runner.PreviouslyCheckedOutBranch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "feature1", have)
 }
 
@@ -490,13 +490,13 @@ func TestRunner_PushBranch(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	origin := test.CreateRepo(t)
 	err := runner.AddRemote("origin", origin.WorkingDir())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.PushBranchSetUpstream("b1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branches, err := origin.LocalBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"b1", "master"}, branches)
 }
 
@@ -504,17 +504,17 @@ func TestRunner_RemoteBranches(t *testing.T) {
 	origin := test.CreateRepo(t)
 	repoDir := test.CreateTempDir(t)
 	repo, err := origin.Clone(repoDir)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.CreateBranch("b2", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = origin.CreateBranch("b3", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.Fetch()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branches, err := repo.Runner.RemoteBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"origin/b3", "origin/master"}, branches)
 }
 
@@ -522,23 +522,23 @@ func TestRunner_Remotes(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	origin := test.CreateRepo(t)
 	err := runner.AddRemote("origin", origin.WorkingDir())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	remotes, err := runner.Remotes()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"origin"}, remotes)
 }
 
 func TestRunner_RemoveBranch(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateBranch("b1", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branches, err := runner.LocalBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"b1", "master"}, branches)
 	err = runner.RemoveBranch("b1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	branches, err = runner.LocalBranches()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"master"}, branches)
 }
 
@@ -546,64 +546,64 @@ func TestRunner_RemoveRemote(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	origin := test.CreateRepo(t)
 	err := runner.AddRemote("origin", origin.WorkingDir())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.RemoveRemote("origin")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	remotes, err := runner.Remotes()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, remotes, 0)
 }
 
 func TestRunner_SetRemote(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	remotes, err := runner.Remotes()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{}, remotes)
 	origin := test.CreateRepo(t)
 	err = runner.AddRemote("origin", origin.WorkingDir())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	remotes, err = runner.Remotes()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"origin"}, remotes)
 }
 
 func TestRunner_ShaForCommit(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateCommit(git.Commit{Branch: "master", FileName: "foo", FileContent: "bar", Message: "commit"})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	sha, err := runner.ShaForCommit("commit")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, sha, 40)
 }
 
 func TestRunner_StageFile(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateFile("f1.txt", "one")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRunner_Stash(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	stashSize, err := runner.StashSize()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Zero(t, stashSize)
 	err = runner.CreateFile("f1.txt", "hello")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.Stash()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	stashSize, err = runner.StashSize()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, stashSize)
 }
 
 func TestRunner_UncommittedFiles(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
 	err := runner.CreateFile("f1.txt", "one")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = runner.CreateFile("f2.txt", "two")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	files, err := runner.UncommittedFiles()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{"f1.txt", "f2.txt"}, files)
 }
 
@@ -612,11 +612,11 @@ func TestRunner_UncommittedFiles(t *testing.T) {
 func CreateTestGitTownRepo(t *testing.T) test.Repo {
 	repo := test.CreateRepo(t)
 	err := repo.CreateBranch("main", "master")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = repo.RunMany([][]string{
 		{"git", "config", "git-town.main-branch-name", "main"},
 		{"git", "config", "git-town.perennial-branch-names", ""},
 	})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	return repo
 }

--- a/src/steps/run_state_test.go
+++ b/src/steps/run_state_test.go
@@ -22,9 +22,9 @@ func TestRunState_Marshal(t *testing.T) {
 		},
 	}
 	data, err := json.Marshal(runState)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	newRunState := &steps.RunState{}
 	err = json.Unmarshal(data, &newRunState)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, runState, newRunState)
 }


### PR DESCRIPTION

In case of error, it renders the url which fails, see:
```
Error Trace:github_test.go:146
Error:      Received unexpected error:
            GET https://api.github.com/repos/git-town/git-town/pulls?base=feature&state=open: 401 Bad credentials []
Test:       TestGitHubDriver_MergePullRequest
```