### PR TITLE
Adopt more transparent, declarative and scalable golang ci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,16 @@
 linters:
   enable-all: true
   disable:
-    - dogsled             # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
-    - dupl                # I think that one creates too many false positives as well. Our tests are kind of repetitive, which is intentional. They are supposed to be simple, straightforward scripts.
+    - dogsled # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
+    - dupl # I think that one creates too many false positives as well. Our tests are kind of repetitive, which is intentional. They are supposed to be simple, straightforward scripts.
     # - exhaustive        TODO: enable after next release; current release at time of writing is v1.27
-    - gochecknoglobals    # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
-    - gochecknoinits      # I think the CLI framework we use requires them.
-    - goconst             # Our tests contain a ton of hard-coded test strings, for example branch names.
-    - goerr113            # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
-    - gomnd               # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
-    - lll                 # Following gofmt principles, we aren't enforcing a line length at this point.
-    - wsl                 # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
+    - gochecknoglobals # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
+    - gochecknoinits # I think the CLI framework we use requires them.
+    - goconst # Our tests contain a ton of hard-coded test strings, for example branch names.
+    - goerr113 # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
+    - gomnd # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
+    - lll # Following gofmt principles, we aren't enforcing a line length at this point.
+    - wsl # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,16 @@
 linters:
   enable-all: true
   disable:
-    - dogsled             # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
-    - dupl                # TODO: write rational for disabling here, brought over from Makefile
-    - exhaustive          # TODO: enable after next release; current release at time of writing is v1.27
-    - gochecknoglobals    # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
-    - gochecknoinits      # I think the CLI framework we use requires them.
-    - goconst             # Our tests contain a ton of hard-coded test strings, for example branch names.
-    - goerr113            # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
-    - gomnd               # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
-    - lll                 # Following gofmt principles, we aren't enforcing a line length at this point.
-    - wsl                 # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
+    - dogsled # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
+    - dupl # TODO: write rational for disabling here, brought over from Makefile
+    - exhaustive # TODO: enable after next release; current release at time of writing is v1.27
+    - gochecknoglobals # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
+    - gochecknoinits # I think the CLI framework we use requires them.
+    - goconst # Our tests contain a ton of hard-coded test strings, for example branch names.
+    - goerr113 # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
+    - gomnd # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
+    - lll # Following gofmt principles, we aren't enforcing a line length at this point.
+    - wsl # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,6 @@ issues:
   exclude:
     - Using the variable on range scope `(input|expected)` in function literal
   exclude-rules:
-      - linters:
-          - goerr113
-        text: "do not define dynamic errors"
+    - linters:
+        - goerr113
+      text: "do not define dynamic errors"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,16 @@
 linters:
   enable-all: true
   disable:
-    - dogsled # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
-    - dupl # TODO: write rational for disabling here, brought over from Makefile
-    - exhaustive # TODO: enable after next release; current release at time of writing is v1.27
-    - gochecknoglobals # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
-    - gochecknoinits # I think the CLI framework we use requires them.
-    - goconst # Our tests contain a ton of hard-coded test strings, for example branch names.
-    - goerr113 # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
-    - gomnd # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
-    - lll # Following gofmt principles, we aren't enforcing a line length at this point.
-    - wsl # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
+    - dogsled             # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
+    - dupl                # I think that one creates too many false positives as well. Our tests are kind of repetitive, which is intentional. They are supposed to be simple, straightforward scripts.
+    - exhaustive          # TODO: enable after next release; current release at time of writing is v1.27
+    - gochecknoglobals    # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
+    - gochecknoinits      # I think the CLI framework we use requires them.
+    - goconst             # Our tests contain a ton of hard-coded test strings, for example branch names.
+    - goerr113            # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
+    - gomnd               # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
+    - lll                 # Following gofmt principles, we aren't enforcing a line length at this point.
+    - wsl                 # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ linters:
   disable:
     - dogsled             # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
     - dupl                # I think that one creates too many false positives as well. Our tests are kind of repetitive, which is intentional. They are supposed to be simple, straightforward scripts.
-    - exhaustive          # TODO: enable after next release; current release at time of writing is v1.27
+    # - exhaustive        TODO: enable after next release; current release at time of writing is v1.27
     - gochecknoglobals    # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
     - gochecknoinits      # I think the CLI framework we use requires them.
     - goconst             # Our tests contain a ton of hard-coded test strings, for example branch names.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,57 @@
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    # - dogsled (TODO: write rational for disabling here, brought over from Makefile)
+    # - dupl (TODO: write rational for disabling here, brought over from Makefile)
+    - errcheck
+    - exhaustive
+    - funlen
+    # - gochecknoglobals (TODO: write rational for disabling here, brought over from Makefile)
+    # - gochecknoinits (TODO: write rational for disabling here, brought over from Makefile)
+    - gocognit
+    # - goconst (TODO: write rational for disabling here, brought over from Makefile)
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    # - goerr113 (TODO: expose errors proerply, once/if approaching library use, as oposed to current cli-only use)
+    - gofmt
+    - goimports
+    - golint
+    # - gomnd (TODO: write rational for disabling here, brought over from Makefile)
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    # - lll (TODO: write rational for disabling here, brought over from Makefile)
+    - maligned
+    - misspell
+    - nakedret
+    - nestif
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - testpackage
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    # - wsl  (TODO: write rational for disabling here, brought over from Makefile)
+
 issues:
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
@@ -5,7 +59,3 @@ issues:
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - Using the variable on range scope `(input|expected)` in function literal
-  exclude-rules:
-    - linters:
-        - goerr113
-      text: "do not define dynamic errors"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,56 +1,16 @@
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
-  enable:
-    - asciicheck
-    - bodyclose
-    - deadcode
-    - depguard
-    # - dogsled (The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.)
-    # - dupl (TODO: write rational for disabling here, brought over from Makefile)
-    - errcheck
-    - exhaustive
-    - funlen
-    # - gochecknoglobals (We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.)
-    # - gochecknoinits (I think the CLI framework we use requires them.)
-    - gocognit
-    # - goconst (Our tests contain a ton of hard-coded test strings, for example branch names.)
-    - gocritic
-    - gocyclo
-    - godot
-    - godox
-    # - goerr113 (Expose errors properly, once/if approaching library use, as opposed to current cli-only use)
-    - gofmt
-    - goimports
-    - golint
-    # - gomnd (Our tests contain hard-coded test data that wouldn't make sense to extract into constants)
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - interfacer
-    # - lll (Following gofmt principles, we aren't enforcing a line length at this point.)
-    - maligned
-    - misspell
-    - nakedret
-    - nestif
-    - nolintlint
-    - prealloc
-    - rowserrcheck
-    - scopelint
-    - staticcheck
-    - structcheck
-    - stylecheck
-    - testpackage
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - varcheck
-    - whitespace
-    # - wsl (This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.)
+  enable-all: true
+  disable:
+    - dogsled             # The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.
+    - dupl                # TODO: write rational for disabling here, brought over from Makefile
+    - exhaustive          # TODO: enable after next release; current release at time of writing is v1.27
+    - gochecknoglobals    # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
+    - gochecknoinits      # I think the CLI framework we use requires them.
+    - goconst             # Our tests contain a ton of hard-coded test strings, for example branch names.
+    - goerr113            # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
+    - gomnd               # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
+    - lll                 # Following gofmt principles, we aren't enforcing a line length at this point.
+    - wsl                 # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - gochecknoglobals # We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.
     - gochecknoinits # I think the CLI framework we use requires them.
     - goconst # Our tests contain a ton of hard-coded test strings, for example branch names.
-    - goerr113 # Expose errors properly, once/if approaching library use, as opposed to current cli-only use
     - gomnd # Our tests contain hard-coded test data that wouldn't make sense to extract into constants
     - lll # Following gofmt principles, we aren't enforcing a line length at this point.
     - wsl # This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.
@@ -19,3 +18,7 @@ issues:
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - Using the variable on range scope `(input|expected)` in function literal
+  exclude-rules:
+      - linters:
+          - goerr113
+        text: "do not define dynamic errors"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,31 +7,31 @@ linters:
     - bodyclose
     - deadcode
     - depguard
-    # - dogsled (TODO: write rational for disabling here, brought over from Makefile)
+    # - dogsled (The rationale for disabling dogsled is that all the cases it flags have been false positives in test code that intentionally ignores many return values because they test only one thing.)
     # - dupl (TODO: write rational for disabling here, brought over from Makefile)
     - errcheck
     - exhaustive
     - funlen
-    # - gochecknoglobals (TODO: write rational for disabling here, brought over from Makefile)
-    # - gochecknoinits (TODO: write rational for disabling here, brought over from Makefile)
+    # - gochecknoglobals (We are currently using some globals. It's a lot more forgivable in a CLI tool than in a library.)
+    # - gochecknoinits (I think the CLI framework we use requires them.)
     - gocognit
-    # - goconst (TODO: write rational for disabling here, brought over from Makefile)
+    # - goconst (Our tests contain a ton of hard-coded test strings, for example branch names.)
     - gocritic
     - gocyclo
     - godot
     - godox
-    # - goerr113 (TODO: expose errors proerply, once/if approaching library use, as oposed to current cli-only use)
+    # - goerr113 (Expose errors properly, once/if approaching library use, as opposed to current cli-only use)
     - gofmt
     - goimports
     - golint
-    # - gomnd (TODO: write rational for disabling here, brought over from Makefile)
+    # - gomnd (Our tests contain hard-coded test data that wouldn't make sense to extract into constants)
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
     - interfacer
-    # - lll (TODO: write rational for disabling here, brought over from Makefile)
+    # - lll (Following gofmt principles, we aren't enforcing a line length at this point.)
     - maligned
     - misspell
     - nakedret
@@ -50,7 +50,7 @@ linters:
     - unused
     - varcheck
     - whitespace
-    # - wsl  (TODO: write rational for disabling here, brought over from Makefile)
+    # - wsl (This linter creates too many false positives. Our policy is to not have any empty lines in code blocks anyways.)
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:  # prints all make targets
 lint: lint-go lint-md   # lints all the source code
 
 lint-go:  # lints the Go files
-	golangci-lint run --enable-all -D dupl -D lll -D gochecknoglobals -D gochecknoinits -D goconst -D wsl -D gomnd -D dogsled src/... test/...
+	golangci-lint run src/... test/...
 
 lint-md:   # lints the Markdown files
 	tools/prettier/node_modules/.bin/prettier -l .


### PR DESCRIPTION
As recomended on: https://golangci-lint.run/usage/configuration/

Follow up on  #1496