### PR TITLE
Extract helpers from Config

### DIFF
--- a/src/drivers/bitbucket.go
+++ b/src/drivers/bitbucket.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/git-town/git-town/src/drivers/helpers"
 	"github.com/git-town/git-town/src/git"
 )
 
@@ -44,8 +45,8 @@ func (d *bitbucketCodeHostingDriver) HostingServiceName() string {
 
 func (d *bitbucketCodeHostingDriver) SetOriginURL(originURL string) {
 	d.originURL = originURL
-	d.hostname = git.Config().GetURLHostname(originURL)
-	d.repository = git.Config().GetURLRepositoryName(originURL)
+	d.hostname = helpers.GetURLHostname(originURL)
+	d.repository = helpers.GetURLRepositoryName(originURL)
 }
 
 func (d *bitbucketCodeHostingDriver) SetOriginHostname(originHostname string) {

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/git-town/git-town/src/drivers/helpers"
 	"github.com/git-town/git-town/src/git"
 	"github.com/google/go-github/github"
 )
@@ -67,9 +68,9 @@ func (d *githubCodeHostingDriver) HostingServiceName() string {
 
 func (d *githubCodeHostingDriver) SetOriginURL(originURL string) {
 	d.originURL = originURL
-	d.hostname = git.Config().GetURLHostname(originURL)
+	d.hostname = helpers.GetURLHostname(originURL)
 	d.client = nil
-	repositoryParts := strings.SplitN(git.Config().GetURLRepositoryName(originURL), "/", 2)
+	repositoryParts := strings.SplitN(helpers.GetURLRepositoryName(originURL), "/", 2)
 	if len(repositoryParts) == 2 {
 		d.owner = repositoryParts[0]
 		d.repository = repositoryParts[1]

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -123,7 +123,7 @@ func (d *githubCodeHostingDriver) mergePullRequest(options MergePullRequestOptio
 		return "", fmt.Errorf("cannot merge via Github since there is no pull request")
 	}
 	if options.LogRequests {
-		printLog(fmt.Sprintf("GitHub API: Merging PR #%d", options.PullRequestNumber))
+		helpers.PrintLog(fmt.Sprintf("GitHub API: Merging PR #%d", options.PullRequestNumber))
 	}
 	commitMessageParts := strings.SplitN(options.CommitMessage, "\n", 2)
 	githubCommitTitle := commitMessageParts[0]
@@ -151,7 +151,7 @@ func (d *githubCodeHostingDriver) updatePullRequestsAgainst(options MergePullReq
 	}
 	for _, pullRequest := range pullRequests {
 		if options.LogRequests {
-			printLog(fmt.Sprintf("GitHub API: Updating base branch for PR #%d", *pullRequest.Number))
+			helpers.PrintLog(fmt.Sprintf("GitHub API: Updating base branch for PR #%d", *pullRequest.Number))
 		}
 		_, _, err = d.client.PullRequests.Edit(context.Background(), d.owner, d.repository, *pullRequest.Number, &github.PullRequest{
 			Base: &github.PullRequestBranch{

--- a/src/drivers/gitlab.go
+++ b/src/drivers/gitlab.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/src/drivers/helpers"
 )
 
 type gitlabCodeHostingDriver struct {
@@ -43,8 +43,8 @@ func (d *gitlabCodeHostingDriver) HostingServiceName() string {
 
 func (d *gitlabCodeHostingDriver) SetOriginURL(originURL string) {
 	d.originURL = originURL
-	d.hostname = git.Config().GetURLHostname(originURL)
-	d.repository = git.Config().GetURLRepositoryName(originURL)
+	d.hostname = helpers.GetURLHostname(originURL)
+	d.repository = helpers.GetURLRepositoryName(originURL)
 }
 
 func (d *gitlabCodeHostingDriver) SetOriginHostname(originHostname string) {

--- a/src/drivers/helpers/print-log.go
+++ b/src/drivers/helpers/print-log.go
@@ -1,4 +1,4 @@
-package drivers
+package helpers
 
 import (
 	"fmt"
@@ -6,7 +6,8 @@ import (
 	"github.com/fatih/color"
 )
 
-func printLog(message string) {
+// PrintLog prints the given log message in bold.
+func PrintLog(message string) {
 	fmt.Println()
 	_, err := color.New(color.Bold).Println(message)
 	if err != nil {

--- a/src/drivers/helpers/url-hostname.go
+++ b/src/drivers/helpers/url-hostname.go
@@ -1,0 +1,13 @@
+package helpers
+
+import "regexp"
+
+// GetURLHostname returns the hostname contained within the given Git URL.
+func GetURLHostname(url string) string {
+	hostnameRegex := regexp.MustCompile("(^[^:]*://([^@]*@)?|git@)([^/:]+).*")
+	matches := hostnameRegex.FindStringSubmatch(url)
+	if matches == nil {
+		return ""
+	}
+	return matches[3]
+}

--- a/src/drivers/helpers/url-repo-name.go
+++ b/src/drivers/helpers/url-repo-name.go
@@ -1,0 +1,17 @@
+package helpers
+
+import (
+	"regexp"
+	"strings"
+)
+
+// GetURLRepositoryName returns the repository name contains within the given Git URL.
+func GetURLRepositoryName(url string) string {
+	hostname := GetURLHostname(url)
+	repositoryNameRegex := regexp.MustCompile(".*" + hostname + "[/:](.+)")
+	matches := repositoryNameRegex.FindStringSubmatch(url)
+	if matches == nil {
+		return ""
+	}
+	return strings.TrimSuffix(matches[1], ".git")
+}

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -237,27 +237,6 @@ func (c *Configuration) GetRemoteOriginURL() string {
 	return c.shell.MustRun("git", "remote", "get-url", "origin").OutputSanitized()
 }
 
-// GetURLHostname returns the hostname contained within the given Git URL.
-func (c *Configuration) GetURLHostname(url string) string {
-	hostnameRegex := regexp.MustCompile("(^[^:]*://([^@]*@)?|git@)([^/:]+).*")
-	matches := hostnameRegex.FindStringSubmatch(url)
-	if matches == nil {
-		return ""
-	}
-	return matches[3]
-}
-
-// GetURLRepositoryName returns the repository name contains within the given Git URL.
-func (c *Configuration) GetURLRepositoryName(url string) string {
-	hostname := c.GetURLHostname(url)
-	repositoryNameRegex := regexp.MustCompile(".*" + hostname + "[/:](.+)")
-	matches := repositoryNameRegex.FindStringSubmatch(url)
-	if matches == nil {
-		return ""
-	}
-	return strings.TrimSuffix(matches[1], ".git")
-}
-
 // HasBranchInformation indicates whether this configuration contains any branch hierarchy entries.
 func (c *Configuration) HasBranchInformation() bool {
 	for key := range c.localConfigCache {


### PR DESCRIPTION
First step in the driver architecture refactoring: extract helper functions from `git.Configuration` into the `drivers` package, as suggested by @blaggacao.