### PR TITLE
Use current gopath bin for local testing

### DIFF
--- a/text-run/command-description.js
+++ b/text-run/command-description.js
@@ -54,7 +54,9 @@ function getMd(activity) {
 
 function getCliDesc(activity) {
   const command = getCommand(activity.file)
-  const output = child_process.execSync(`git-town help ${command}`).toString()
+  const output = child_process
+    .execSync(`$GOPATH/bin/git-town help ${command}`)
+    .toString()
   const matches = output.match(/^.*\n\n([\s\S]*)\n\nUsage:\n/m)
   return normalize(
     matches[1]

--- a/text-run/command-flags.js
+++ b/text-run/command-flags.js
@@ -14,7 +14,7 @@ function getMdFlags(activity) {
 
 function getCliFlags(activity) {
   return child_process
-    .execSync(`git-town help ${getCommand(activity.file)}`)
+    .execSync(`$GOPATH/bin/git-town help ${getCommand(activity.file)}`)
     .toString()
     .match(/\nFlags:\n([\s\S]*)\nGlobal Flags:\n/)[1]
     .split("\n")

--- a/text-run/command-subcommands.js
+++ b/text-run/command-subcommands.js
@@ -12,7 +12,7 @@ function getCliCommands(activity) {
   const result = []
   const command = getCommand(activity.file)
   const cliOutput = child_process
-    .execSync(`git-town help ${command}`)
+    .execSync(`$GOPATH/bin/git-town help ${command}`)
     .toString()
   const matches = cliOutput.match(/\nAvailable Commands:\n([\s\S]*?)\n\n/)
   const text = matches[1]

--- a/text-run/command-summary.js
+++ b/text-run/command-summary.js
@@ -11,7 +11,7 @@ module.exports = async function (activity) {
 function getCliDescription(activity) {
   const command = getCommand(activity.file)
   const cliOutput = child_process
-    .execSync(`git-town help ${command}`)
+    .execSync(`$GOPATH/bin/git-town help ${command}`)
     .toString()
   const matches = cliOutput.match(/^(.*)/)
   return matches[1].trim()

--- a/text-run/command-usage.js
+++ b/text-run/command-usage.js
@@ -15,7 +15,7 @@ module.exports = async function (activity) {
 function getCliUsage(activity) {
   const command = getCommand(activity.file)
   const cliOutput = child_process
-    .execSync(`git-town help ${command}`)
+    .execSync(`$GOPATH/bin/git-town help ${command}`)
     .toString()
   const matches = cliOutput.match(/\nUsage:\n([\s\S]*?)\n\n/)
   return matches[1]


### PR DESCRIPTION
This is why my tests where always c=failing locally.
Look's like the godog also suffers from this problem, bu couldn't find yet where to direct it to the gopath binary.