### PR TITLE
Move all opening browsers code into the "browsers" package

### DIFF
--- a/src/browsers/browsers.go
+++ b/src/browsers/browsers.go
@@ -1,6 +1,7 @@
 package browsers
 
 import (
+	"fmt"
 	"runtime"
 
 	"github.com/git-town/git-town/src/command"
@@ -35,4 +36,18 @@ func GetOpenBrowserCommand() string {
 		}
 	}
 	return ""
+}
+
+// OpenBrowser opens the default browser with the given URL.
+// If no browser is found, prints the URL.
+func OpenBrowser(url string, shell command.Shell) {
+	command := GetOpenBrowserCommand()
+	if command == "" {
+		fmt.Println("Please open in a browser: " + url)
+		return
+	}
+	_, err := shell.Run(command, url)
+	if err != nil {
+		fmt.Println("Please open in a browser: " + url)
+	}
 }

--- a/src/browsers/browsers.go
+++ b/src/browsers/browsers.go
@@ -7,9 +7,9 @@ import (
 	"github.com/git-town/git-town/src/command"
 )
 
-// GetOpenBrowserCommand returns the command to run on the console
+// OpenBrowserCommand returns the command to run on the console
 // to open the default browser.
-func GetOpenBrowserCommand() string {
+func OpenBrowserCommand() string {
 	if runtime.GOOS == "windows" {
 		// NOTE: the "explorer" command cannot handle special characters
 		//       like "?" and "=".
@@ -38,10 +38,10 @@ func GetOpenBrowserCommand() string {
 	return ""
 }
 
-// OpenBrowser opens the default browser with the given URL.
+// Open opens the default browser with the given URL.
 // If no browser is found, prints the URL.
-func OpenBrowser(url string, shell command.Shell) {
-	command := GetOpenBrowserCommand()
+func Open(url string, shell command.Shell) {
+	command := OpenBrowserCommand()
 	if command == "" {
 		fmt.Println("Please open in a browser: " + url)
 		return

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/git-town/git-town/src/browsers"
 	"github.com/git-town/git-town/src/drivers"
 	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/script"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +31,7 @@ where HOSTNAME matches what is in your ssh config file.`,
 			fmt.Println(drivers.UnsupportedHostingError())
 			os.Exit(1)
 		}
-		script.OpenBrowser(driver.RepositoryURL())
+		browsers.OpenBrowser(driver.RepositoryURL(), repo.LoggingShell)
 	},
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -31,7 +31,7 @@ where HOSTNAME matches what is in your ssh config file.`,
 			fmt.Println(drivers.UnsupportedHostingError())
 			os.Exit(1)
 		}
-		browsers.OpenBrowser(driver.RepositoryURL(), repo.LoggingShell)
+		browsers.Open(driver.RepositoryURL(), repo.LoggingShell)
 	},
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/src/script/script.go
+++ b/src/script/script.go
@@ -1,13 +1,6 @@
 package script
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
-	"strings"
-
-	"github.com/git-town/git-town/src/browsers"
 	"github.com/git-town/git-town/src/dryrun"
 	"github.com/git-town/git-town/src/git"
 
@@ -28,63 +21,4 @@ func ActivateDryRun() {
 		panic(err)
 	}
 	dryrun.Activate(git.GetCurrentBranchName())
-}
-
-// OpenBrowser opens the default browser with the given URL.
-// If no browser is found, prints the URL.
-func OpenBrowser(url string) {
-	command := browsers.GetOpenBrowserCommand()
-	if command == "" {
-		fmt.Println("Please open in a browser: " + url)
-		return
-	}
-	err := RunCommand(command, url)
-	fmt.Println(err)
-	if err != nil {
-		fmt.Println("Please open in a browser: " + url)
-	}
-}
-
-// PrintCommand prints the given command-line operation on the console.
-func PrintCommand(cmd string, args ...string) {
-	header := cmd + " "
-	for index, part := range args {
-		if strings.Contains(part, " ") {
-			part = "\"" + strings.Replace(part, "\"", "\\\"", -1) + "\""
-		}
-		if index != 0 {
-			header += " "
-		}
-		header += part
-	}
-	if cmd == "git" && git.IsRepository() {
-		header = fmt.Sprintf("[%s] %s", git.GetCurrentBranchName(), header)
-	}
-	fmt.Println()
-	_, err := color.New(color.Bold).Println(header)
-	if err != nil {
-		panic(err)
-	}
-}
-
-// RunCommand executes the given command-line operation.
-func RunCommand(cmd string, args ...string) error {
-	PrintCommand(cmd, args...)
-	if dryrun.IsActive() {
-		if len(args) == 2 && cmd == "git" && args[0] == "checkout" {
-			dryrun.SetCurrentBranchName(args[1])
-		}
-		return nil
-	}
-	// Windows commands run inside CMD
-	// because opening browsers is done via "start"
-	if runtime.GOOS == "windows" {
-		args = append([]string{"/C", cmd}, args...)
-		cmd = "cmd"
-	}
-	subProcess := exec.Command(cmd, args...) // #nosec
-	subProcess.Stderr = os.Stderr
-	subProcess.Stdin = os.Stdin
-	subProcess.Stdout = os.Stdout
-	return subProcess.Run()
 }

--- a/src/steps/create_pull_request_step.go
+++ b/src/steps/create_pull_request_step.go
@@ -15,6 +15,6 @@ type CreatePullRequestStep struct {
 // Run executes this step.
 func (step *CreatePullRequestStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	parentBranch := repo.GetParentBranch(step.BranchName)
-	browsers.OpenBrowser(driver.NewPullRequestURL(step.BranchName, parentBranch), repo.LoggingShell)
+	browsers.Open(driver.NewPullRequestURL(step.BranchName, parentBranch), repo.LoggingShell)
 	return nil
 }

--- a/src/steps/create_pull_request_step.go
+++ b/src/steps/create_pull_request_step.go
@@ -1,9 +1,9 @@
 package steps
 
 import (
+	"github.com/git-town/git-town/src/browsers"
 	"github.com/git-town/git-town/src/drivers"
 	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/script"
 )
 
 // CreatePullRequestStep creates a new pull request for the current branch.
@@ -15,6 +15,6 @@ type CreatePullRequestStep struct {
 // Run executes this step.
 func (step *CreatePullRequestStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	parentBranch := repo.GetParentBranch(step.BranchName)
-	script.OpenBrowser(driver.NewPullRequestURL(step.BranchName, parentBranch))
+	browsers.OpenBrowser(driver.NewPullRequestURL(step.BranchName, parentBranch), repo.LoggingShell)
 	return nil
 }


### PR DESCRIPTION
- it belongs there
- the browser package uses a LoggingShell to open the browser
- this eliminates the last usage of `script.RunCommand` so that gets cleaned up as well