### PR TITLE
Remove MustRun

### DIFF
--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -57,7 +57,10 @@ This can conflict with other tools that also define Git aliases.`,
 }
 
 func addAlias(command string, repo *git.ProdRepo) error {
-	result := repo.AddGitAlias(command)
+	result, err := repo.AddGitAlias(command)
+	if err != nil {
+		return fmt.Errorf("cannot create alias for %q: %w", command, err)
+	}
 	return repo.LoggingShell.PrintCommand(result.Command(), result.Args()...)
 }
 

--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -64,7 +64,10 @@ func addAlias(command string, repo *git.ProdRepo) error {
 func removeAlias(command string, repo *git.ProdRepo) error {
 	existingAlias := repo.GetGitAlias(command)
 	if existingAlias == "town "+command {
-		result := repo.RemoveGitAlias(command)
+		result, err := repo.RemoveGitAlias(command)
+		if err != nil {
+			return fmt.Errorf("cannot remove alias for %q: %w", command, err)
+		}
 		return repo.LoggingShell.PrintCommand(result.Command(), result.Args()...)
 	}
 	return nil

--- a/src/cmd/main_branch.go
+++ b/src/cmd/main_branch.go
@@ -44,8 +44,7 @@ func setMainBranch(branchName string, repo *git.ProdRepo) error {
 	if !hasBranch {
 		return fmt.Errorf("there is no branch named %q", branchName)
 	}
-	git.Config().SetMainBranch(branchName)
-	return nil
+	return git.Config().SetMainBranch(branchName)
 }
 
 func init() {

--- a/src/cmd/new_branch_push_flag.go
+++ b/src/cmd/new_branch_push_flag.go
@@ -26,7 +26,10 @@ hack / append / prepend on creation. Defaults to false.`,
 				fmt.Printf(`Error: invalid argument: %q. Please provide either "true" or "false".\n`, args[0])
 				os.Exit(1)
 			}
-			setNewBranchPushFlag(value)
+			err = setNewBranchPushFlag(value)
+			if err != nil {
+				cli.Exit(err)
+			}
 		}
 	},
 	Args: cobra.MaximumNArgs(1),
@@ -43,8 +46,8 @@ func printNewBranchPushFlag() {
 	}
 }
 
-func setNewBranchPushFlag(value bool) {
-	git.Config().SetNewBranchPush(value, globalFlag)
+func setNewBranchPushFlag(value bool) error {
+	return git.Config().SetNewBranchPush(value, globalFlag)
 }
 
 func init() {

--- a/src/cmd/offline.go
+++ b/src/cmd/offline.go
@@ -25,7 +25,10 @@ Git Town avoids network operations in offline mode.`,
 				fmt.Printf(`Error: invalid argument: %q. Please provide either "true" or "false".\n`, args[0])
 				os.Exit(1)
 			}
-			setOfflineFlag(value)
+			err = setOfflineFlag(value)
+			if err != nil {
+				cli.Exit(err)
+			}
 		}
 	},
 	Args: cobra.MaximumNArgs(1),
@@ -35,8 +38,8 @@ func printOfflineFlag() {
 	cli.Println(cli.PrintableOfflineFlag(prodRepo.IsOffline()))
 }
 
-func setOfflineFlag(value bool) {
-	git.Config().SetOffline(value)
+func setOfflineFlag(value bool) error {
+	return git.Config().SetOffline(value)
 }
 
 func init() {

--- a/src/cmd/pull_branch_strategy.go
+++ b/src/cmd/pull_branch_strategy.go
@@ -20,7 +20,10 @@ for the main branch and perennial branches.`,
 		if len(args) == 0 {
 			printPullBranchStrategy()
 		} else {
-			setPullBranchStrategy(args[0])
+			err := setPullBranchStrategy(args[0])
+			if err != nil {
+				cli.Exit(err)
+			}
 		}
 	},
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -38,8 +41,8 @@ func printPullBranchStrategy() {
 	cli.Println(git.Config().GetPullBranchStrategy())
 }
 
-func setPullBranchStrategy(value string) {
-	git.Config().SetPullBranchStrategy(value)
+func setPullBranchStrategy(value string) error {
+	return git.Config().SetPullBranchStrategy(value)
 }
 
 func init() {

--- a/src/cmd/set_parent_branch.go
+++ b/src/cmd/set_parent_branch.go
@@ -27,7 +27,10 @@ var setParentBranchCommand = &cobra.Command{
 		if defaultParentBranch == "" {
 			defaultParentBranch = git.Config().GetMainBranch()
 		}
-		git.Config().DeleteParentBranch(branchName)
+		err = git.Config().DeleteParentBranch(branchName)
+		if err != nil {
+			cli.Exit(err)
+		}
 		err = prompt.AskForBranchAncestry(branchName, defaultParentBranch, prodRepo)
 		if err != nil {
 			cli.Exit(err)

--- a/src/command/run.go
+++ b/src/command/run.go
@@ -42,14 +42,6 @@ func MustRun(cmd string, args ...string) *Result {
 	return result
 }
 
-// MustRunInDir executes an essential subshell command given in argv notation.
-// Essential subshell commands are essential for the functioning of Git Town.
-// If they fail, Git Town ends right there.
-func MustRunInDir(dir string, cmd string, args ...string) *Result {
-	result, _ := RunWith(Options{Dir: dir, Essential: true}, cmd, args...)
-	return result
-}
-
 // Run executes the command given in argv notation.
 func Run(cmd string, args ...string) (*Result, error) {
 	return RunWith(Options{}, cmd, args...)

--- a/src/command/run.go
+++ b/src/command/run.go
@@ -34,14 +34,6 @@ type Options struct {
 // InputDelay defines how long to wait before writing the next input string into the subprocess.
 const InputDelay = 500 * time.Millisecond
 
-// MustRun executes an essential subshell command given in argv notation.
-// Essential subshell commands are essential for the functioning of Git Town.
-// If they fail, Git Town ends right there.
-func MustRun(cmd string, args ...string) *Result {
-	result, _ := RunWith(Options{Essential: true}, cmd, args...)
-	return result
-}
-
 // Run executes the command given in argv notation.
 func Run(cmd string, args ...string) (*Result, error) {
 	return RunWith(Options{}, cmd, args...)

--- a/src/command/shell.go
+++ b/src/command/shell.go
@@ -2,7 +2,6 @@ package command
 
 // Shell allows running commands in a subshell.
 type Shell interface {
-	MustRun(string, ...string) *Result
 	Run(string, ...string) (*Result, error)
 	RunMany([][]string) error
 	RunString(string) (*Result, error)

--- a/src/command/silent_shell.go
+++ b/src/command/silent_shell.go
@@ -15,11 +15,6 @@ func (shell SilentShell) WorkingDir() string {
 	return "."
 }
 
-// MustRun runs the given command and returns the result. Panics on error.
-func (shell SilentShell) MustRun(cmd string, args ...string) *Result {
-	return MustRun(cmd, args...)
-}
-
 // Run runs the given command in this ShellRunner's directory.
 func (shell SilentShell) Run(cmd string, args ...string) (*Result, error) {
 	return Run(cmd, args...)

--- a/src/command/silent_shell_test.go
+++ b/src/command/silent_shell_test.go
@@ -9,12 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSilentShell_MustRun(t *testing.T) {
-	shell := command.SilentShell{}
-	res := shell.MustRun("echo", "hello", "world")
-	assert.Equal(t, "hello world", res.OutputSanitized())
-}
-
 func TestSilentShell_Run_arguments(t *testing.T) {
 	shell := command.SilentShell{}
 	res, err := shell.Run("echo", "hello", "world")

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -362,10 +362,11 @@ func (c *Configuration) RemoveLocalGitConfiguration() {
 }
 
 // SetCodeHostingDriver sets the "github.code-hosting-driver" setting.
-func (c *Configuration) SetCodeHostingDriver(value string) *command.Result {
+func (c *Configuration) SetCodeHostingDriver(value string) error {
 	const key = "git-town.code-hosting-driver"
 	c.localConfigCache[key] = value
-	return c.shell.MustRun("git", "config", key, value)
+	_, err := c.shell.Run("git", "config", key, value)
+	return err
 }
 
 // SetCodeHostingOriginHostname sets the "github.code-hosting-driver" setting.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -378,8 +378,9 @@ func (c *Configuration) SetCodeHostingOriginHostname(value string) error {
 }
 
 // SetColorUI configures whether Git output contains color codes.
-func (c *Configuration) SetColorUI(value string) *command.Result {
-	return c.shell.MustRun("git", "config", "color.ui", value)
+func (c *Configuration) SetColorUI(value string) error {
+	_, err := c.shell.Run("git", "config", "color.ui", value)
+	return err
 }
 
 // SetGlobalConfigValue sets the given configuration setting in the global Git configuration.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -370,10 +370,11 @@ func (c *Configuration) SetCodeHostingDriver(value string) error {
 }
 
 // SetCodeHostingOriginHostname sets the "github.code-hosting-driver" setting.
-func (c *Configuration) SetCodeHostingOriginHostname(value string) *command.Result {
+func (c *Configuration) SetCodeHostingOriginHostname(value string) error {
 	const key = "git-town.code-hosting-origin-hostname"
 	c.localConfigCache[key] = value
-	return c.shell.MustRun("git", "config", key, value)
+	_, err := c.shell.Run("git", "config", key, value)
+	return err
 }
 
 // SetColorUI configures whether Git output contains color codes.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -330,13 +330,13 @@ func (c *Configuration) RemoveFromPerennialBranches(branchName string) {
 }
 
 // RemoveGitAlias removes the given Git alias.
-func (c *Configuration) RemoveGitAlias(command string) *command.Result {
+func (c *Configuration) RemoveGitAlias(command string) (*command.Result, error) {
 	return c.removeGlobalConfigValue("alias." + command)
 }
 
-func (c *Configuration) removeGlobalConfigValue(key string) *command.Result {
+func (c *Configuration) removeGlobalConfigValue(key string) (*command.Result, error) {
 	delete(c.globalConfigCache, key)
-	return c.shell.MustRun("git", "config", "--global", "--unset", key)
+	return c.shell.Run("git", "config", "--global", "--unset", key)
 }
 
 // removeLocalConfigurationValue deletes the configuration value with the given key from the local Git Town configuration.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -87,7 +87,7 @@ func loadGitConfig(shell command.Shell, global bool) map[string]string {
 
 // AddToPerennialBranches registers the given branch names as perennial branches.
 // The branches must exist.
-func (c *Configuration) AddToPerennialBranches(branchNames ...string) *command.Result {
+func (c *Configuration) AddToPerennialBranches(branchNames ...string) error {
 	return c.SetPerennialBranches(append(c.GetPerennialBranches(), branchNames...))
 }
 
@@ -325,8 +325,8 @@ func (c *Configuration) Reload() {
 }
 
 // RemoveFromPerennialBranches removes the given branch as a perennial branch.
-func (c *Configuration) RemoveFromPerennialBranches(branchName string) {
-	c.SetPerennialBranches(util.RemoveStringFromSlice(c.GetPerennialBranches(), branchName))
+func (c *Configuration) RemoveFromPerennialBranches(branchName string) error {
+	return c.SetPerennialBranches(util.RemoveStringFromSlice(c.GetPerennialBranches(), branchName))
 }
 
 // RemoveGitAlias removes the given Git alias.
@@ -390,15 +390,16 @@ func (c *Configuration) SetGlobalConfigValue(key, value string) (*command.Result
 }
 
 // SetLocalConfigValue sets the local configuration with the given key to the given value.
-func (c *Configuration) SetLocalConfigValue(key, value string) *command.Result {
+func (c *Configuration) SetLocalConfigValue(key, value string) (*command.Result, error) {
 	c.localConfigCache[key] = value
-	return c.shell.MustRun("git", "config", key, value)
+	return c.shell.Run("git", "config", key, value)
 }
 
 // SetMainBranch marks the given branch as the main branch
 // in the Git Town configuration.
-func (c *Configuration) SetMainBranch(branchName string) *command.Result {
-	return c.SetLocalConfigValue("git-town.main-branch-name", branchName)
+func (c *Configuration) SetMainBranch(branchName string) error {
+	_, err := c.SetLocalConfigValue("git-town.main-branch-name", branchName)
+	return err
 }
 
 // SetNewBranchPush updates whether the current repository is configured to push
@@ -408,8 +409,8 @@ func (c *Configuration) SetNewBranchPush(value bool, global bool) error {
 		_, err := c.SetGlobalConfigValue("git-town.new-branch-push-flag", strconv.FormatBool(value))
 		return err
 	}
-	c.SetLocalConfigValue("git-town.new-branch-push-flag", strconv.FormatBool(value))
-	return nil
+	_, err := c.SetLocalConfigValue("git-town.new-branch-push-flag", strconv.FormatBool(value))
+	return err
 }
 
 // SetOffline updates whether Git Town is in offline mode.
@@ -419,34 +420,40 @@ func (c *Configuration) SetOffline(value bool) error {
 }
 
 // SetTestOrigin sets the origin to be used for testing.
-func (c *Configuration) SetTestOrigin(value string) {
-	_ = c.SetLocalConfigValue("git-town.testing.remote-url", value)
+func (c *Configuration) SetTestOrigin(value string) error {
+	_, err := c.SetLocalConfigValue("git-town.testing.remote-url", value)
+	return err
 }
 
 // SetParentBranch marks the given branch as the direct parent of the other given branch
 // in the Git Town configuration.
-func (c *Configuration) SetParentBranch(branchName, parentBranchName string) *command.Result {
-	return c.SetLocalConfigValue("git-town-branch."+branchName+".parent", parentBranchName)
+func (c *Configuration) SetParentBranch(branchName, parentBranchName string) error {
+	_, err := c.SetLocalConfigValue("git-town-branch."+branchName+".parent", parentBranchName)
+	return err
 }
 
 // SetPerennialBranches marks the given branches as perennial branches.
-func (c *Configuration) SetPerennialBranches(branchNames []string) *command.Result {
-	return c.SetLocalConfigValue("git-town.perennial-branch-names", strings.Join(branchNames, " "))
+func (c *Configuration) SetPerennialBranches(branchNames []string) error {
+	_, err := c.SetLocalConfigValue("git-town.perennial-branch-names", strings.Join(branchNames, " "))
+	return err
 }
 
 // SetPullBranchStrategy updates the configured pull branch strategy.
-func (c *Configuration) SetPullBranchStrategy(strategy string) *command.Result {
-	return c.SetLocalConfigValue("git-town.pull-branch-strategy", strategy)
+func (c *Configuration) SetPullBranchStrategy(strategy string) error {
+	_, err := c.SetLocalConfigValue("git-town.pull-branch-strategy", strategy)
+	return err
 }
 
 // SetShouldShipDeleteRemoteBranch updates the configured pull branch strategy.
-func (c *Configuration) SetShouldShipDeleteRemoteBranch(value bool) *command.Result {
-	return c.SetLocalConfigValue("git-town.ship-delete-remote-branch", strconv.FormatBool(value))
+func (c *Configuration) SetShouldShipDeleteRemoteBranch(value bool) error {
+	_, err := c.SetLocalConfigValue("git-town.ship-delete-remote-branch", strconv.FormatBool(value))
+	return err
 }
 
 // SetShouldSyncUpstream updates the configured pull branch strategy.
-func (c *Configuration) SetShouldSyncUpstream(value bool) *command.Result {
-	return c.SetLocalConfigValue("git-town.sync-upstream", strconv.FormatBool(value))
+func (c *Configuration) SetShouldSyncUpstream(value bool) error {
+	_, err := c.SetLocalConfigValue("git-town.sync-upstream", strconv.FormatBool(value))
+	return err
 }
 
 // ShouldNewBranchPush indicates whether the current repository is configured to push

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -97,19 +97,19 @@ func (c *Configuration) AddGitAlias(command string) *command.Result {
 }
 
 // DeleteMainBranchConfiguration removes the configuration entry for the main branch name.
-func (c *Configuration) DeleteMainBranchConfiguration() {
-	c.removeLocalConfigValue("git-town.main-branch-name")
+func (c *Configuration) DeleteMainBranchConfiguration() error {
+	return c.removeLocalConfigValue("git-town.main-branch-name")
 }
 
 // DeleteParentBranch removes the parent branch entry for the given branch
 // from the Git configuration.
-func (c *Configuration) DeleteParentBranch(branchName string) {
-	c.removeLocalConfigValue("git-town-branch." + branchName + ".parent")
+func (c *Configuration) DeleteParentBranch(branchName string) error {
+	return c.removeLocalConfigValue("git-town-branch." + branchName + ".parent")
 }
 
 // DeletePerennialBranchConfiguration removes the configuration entry for the perennial branches.
-func (c *Configuration) DeletePerennialBranchConfiguration() {
-	c.removeLocalConfigValue("git-town.perennial-branch-names")
+func (c *Configuration) DeletePerennialBranchConfiguration() error {
+	return c.removeLocalConfigValue("git-town.perennial-branch-names")
 }
 
 // GetAncestorBranches returns the names of all parent branches for the given branch,
@@ -340,9 +340,10 @@ func (c *Configuration) removeGlobalConfigValue(key string) (*command.Result, er
 }
 
 // removeLocalConfigurationValue deletes the configuration value with the given key from the local Git Town configuration.
-func (c *Configuration) removeLocalConfigValue(key string) {
+func (c *Configuration) removeLocalConfigValue(key string) error {
 	delete(c.localConfigCache, key)
-	c.shell.MustRun("git", "config", "--unset", key)
+	_, err := c.shell.Run("git", "config", "--unset", key)
+	return err
 }
 
 // RemoveLocalGitConfiguration removes all Git Town configuration.

--- a/src/git/config.go
+++ b/src/git/config.go
@@ -92,7 +92,7 @@ func (c *Configuration) AddToPerennialBranches(branchNames ...string) *command.R
 }
 
 // AddGitAlias sets the given Git alias.
-func (c *Configuration) AddGitAlias(command string) *command.Result {
+func (c *Configuration) AddGitAlias(command string) (*command.Result, error) {
 	return c.SetGlobalConfigValue("alias."+command, "town "+command)
 }
 
@@ -384,9 +384,9 @@ func (c *Configuration) SetColorUI(value string) error {
 }
 
 // SetGlobalConfigValue sets the given configuration setting in the global Git configuration.
-func (c *Configuration) SetGlobalConfigValue(key, value string) *command.Result {
+func (c *Configuration) SetGlobalConfigValue(key, value string) (*command.Result, error) {
 	c.globalConfigCache[key] = value
-	return c.shell.MustRun("git", "config", "--global", key, value)
+	return c.shell.Run("git", "config", "--global", key, value)
 }
 
 // SetLocalConfigValue sets the local configuration with the given key to the given value.
@@ -403,16 +403,19 @@ func (c *Configuration) SetMainBranch(branchName string) *command.Result {
 
 // SetNewBranchPush updates whether the current repository is configured to push
 // freshly created branches up to the origin remote.
-func (c *Configuration) SetNewBranchPush(value bool, global bool) *command.Result {
+func (c *Configuration) SetNewBranchPush(value bool, global bool) error {
 	if global {
-		return c.SetGlobalConfigValue("git-town.new-branch-push-flag", strconv.FormatBool(value))
+		_, err := c.SetGlobalConfigValue("git-town.new-branch-push-flag", strconv.FormatBool(value))
+		return err
 	}
-	return c.SetLocalConfigValue("git-town.new-branch-push-flag", strconv.FormatBool(value))
+	c.SetLocalConfigValue("git-town.new-branch-push-flag", strconv.FormatBool(value))
+	return nil
 }
 
 // SetOffline updates whether Git Town is in offline mode.
-func (c *Configuration) SetOffline(value bool) *command.Result {
-	return c.SetGlobalConfigValue("git-town.offline", strconv.FormatBool(value))
+func (c *Configuration) SetOffline(value bool) error {
+	_, err := c.SetGlobalConfigValue("git-town.offline", strconv.FormatBool(value))
+	return err
 }
 
 // SetTestOrigin sets the origin to be used for testing.

--- a/src/git/config_test.go
+++ b/src/git/config_test.go
@@ -8,10 +8,12 @@ import (
 
 func TestRunner_SetOffline(t *testing.T) {
 	repo := CreateTestGitTownRepo(t)
-	_ = repo.SetOffline(true)
+	err := repo.SetOffline(true)
+	assert.NoError(t, err)
 	offline := repo.IsOffline()
 	assert.True(t, offline)
-	_ = repo.SetOffline(false)
+	err = repo.SetOffline(false)
+	assert.NoError(t, err)
 	offline = repo.IsOffline()
 	assert.False(t, offline)
 }

--- a/src/git/logging_shell.go
+++ b/src/git/logging_shell.go
@@ -31,11 +31,6 @@ func (shell LoggingShell) WorkingDir() string {
 	return "."
 }
 
-// MustRun runs the given command and returns the result. Panics on error.
-func (shell LoggingShell) MustRun(cmd string, args ...string) *command.Result {
-	return command.MustRun(cmd, args...)
-}
-
 // Run runs the given command in this ShellRunner's directory.
 func (shell LoggingShell) Run(cmd string, args ...string) (*command.Result, error) {
 	err := shell.PrintCommand(cmd, args...)

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -57,7 +57,7 @@ func (r *ProdRepo) RemoveOutdatedConfiguration() error {
 			return err
 		}
 		if !hasChildBranch || !hasParentBranch {
-			r.Configuration.DeleteParentBranch(child)
+			return r.Configuration.DeleteParentBranch(child)
 		}
 	}
 	return nil

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -315,8 +315,7 @@ func (r *Runner) CreatePerennialBranches(names ...string) error {
 			return fmt.Errorf("cannot create perennial branch %q in repo %q: %w", name, r.WorkingDir(), err)
 		}
 	}
-	r.AddToPerennialBranches(names...)
-	return nil
+	return r.AddToPerennialBranches(names...)
 }
 
 // CreateRemoteBranch creates a remote branch from the given local SHA.

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -33,8 +33,7 @@ func ConfigureMainBranch(repo *git.ProdRepo) error {
 		prompt:            getMainBranchPrompt(),
 		defaultBranchName: git.Config().GetMainBranch(),
 	})
-	git.Config().SetMainBranch(newMainBranch)
-	return nil
+	return git.Config().SetMainBranch(newMainBranch)
 }
 
 // ConfigurePerennialBranches has the user to confgure the perennial branches.
@@ -51,8 +50,7 @@ func ConfigurePerennialBranches(repo *git.ProdRepo) error {
 		prompt:             getPerennialBranchesPrompt(),
 		defaultBranchNames: git.Config().GetPerennialBranches(),
 	})
-	git.Config().SetPerennialBranches(newPerennialBranches)
-	return nil
+	return git.Config().SetPerennialBranches(newPerennialBranches)
 }
 
 // Helpers

--- a/src/prompt/parent_branches.go
+++ b/src/prompt/parent_branches.go
@@ -31,17 +31,23 @@ func AskForBranchAncestry(branchName, defaultBranchName string, repo *git.ProdRe
 	current := branchName
 	for {
 		parent := git.Config().GetParentBranch(current)
-		if parent == "" {
+		if parent == "" { // nolint: nestif
 			printParentBranchHeader()
 			parent, err = AskForBranchParent(current, defaultBranchName, repo)
 			if err != nil {
 				return err
 			}
 			if parent == perennialBranchOption {
-				git.Config().AddToPerennialBranches(current)
+				err = git.Config().AddToPerennialBranches(current)
+				if err != nil {
+					return err
+				}
 				break
 			}
-			git.Config().SetParentBranch(current, parent)
+			err = git.Config().SetParentBranch(current, parent)
+			if err != nil {
+				return err
+			}
 		}
 		if parent == git.Config().GetMainBranch() || git.Config().IsPerennialBranch(parent) {
 			break

--- a/src/steps/add_to_perennial_branch.go
+++ b/src/steps/add_to_perennial_branch.go
@@ -18,6 +18,5 @@ func (step *AddToPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Step, er
 
 // Run executes this step.
 func (step *AddToPerennialBranches) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	repo.AddToPerennialBranches(step.BranchName)
-	return nil
+	return repo.AddToPerennialBranches(step.BranchName)
 }

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -24,6 +24,5 @@ func (step *DeleteParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, er
 // Run executes this step.
 func (step *DeleteParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	step.previousParent = repo.GetParentBranch(step.BranchName)
-	repo.DeleteParentBranch(step.BranchName)
-	return nil
+	return repo.DeleteParentBranch(step.BranchName)
 }

--- a/src/steps/remove_from_perennial_branch.go
+++ b/src/steps/remove_from_perennial_branch.go
@@ -18,6 +18,5 @@ func (step *RemoveFromPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Ste
 
 // Run executes this step.
 func (step *RemoveFromPerennialBranches) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	repo.RemoveFromPerennialBranches(step.BranchName)
-	return nil
+	return repo.RemoveFromPerennialBranches(step.BranchName)
 }

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -26,6 +26,5 @@ func (step *SetParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error
 // Run executes this step.
 func (step *SetParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	step.previousParent = repo.GetParentBranch(step.BranchName)
-	repo.SetParentBranch(step.BranchName, step.ParentBranchName)
-	return nil
+	return repo.SetParentBranch(step.BranchName, step.ParentBranchName)
 }

--- a/src/steps/squash_merge_branch_step.go
+++ b/src/steps/squash_merge_branch_step.go
@@ -41,7 +41,10 @@ func (step *SquashMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHo
 	if err != nil {
 		return err
 	}
-	author := prompt.GetSquashCommitAuthor(step.BranchName)
+	author, err := prompt.GetSquashCommitAuthor(step.BranchName)
+	if err != nil {
+		return err
+	}
 	repoAuthor, err := repo.Silent.Author()
 	if err != nil {
 		return err

--- a/test/mocking_shell.go
+++ b/test/mocking_shell.go
@@ -114,15 +114,6 @@ func (ms *MockingShell) MockNoCommandsInstalled() error {
 	return nil
 }
 
-// MustRun runs the given command and returns the result. Panics on error.
-func (ms *MockingShell) MustRun(cmd string, args ...string) *command.Result {
-	res, err := ms.RunWith(command.Options{Essential: true}, cmd, args...)
-	if err != nil {
-		panic(err)
-	}
-	return res
-}
-
 // Run runs the given command with the given arguments
 // in this ShellRunner's directory.
 // Shell overrides will be used and removed when done.

--- a/test/steps.go
+++ b/test/steps.go
@@ -438,8 +438,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my repo has "git-town.code-hosting-origin-hostname" set to "([^"]*)"$`, func(value string) error {
-		_ = state.gitEnv.DevRepo.SetCodeHostingOriginHostname(value)
-		return nil
+		return state.gitEnv.DevRepo.SetCodeHostingOriginHostname(value)
 	})
 
 	suite.Step(`^my repo has "git-town.ship-delete-remote-branch" set to "(true|false)"$`, func(value string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -434,8 +434,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my repo has "git-town.code-hosting-driver" set to "([^"]*)"$`, func(value string) error {
-		_ = state.gitEnv.DevRepo.SetCodeHostingDriver(value)
-		return nil
+		return state.gitEnv.DevRepo.SetCodeHostingDriver(value)
 	})
 
 	suite.Step(`^my repo has "git-town.code-hosting-origin-hostname" set to "([^"]*)"$`, func(value string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -429,8 +429,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my repo has "color\.ui" set to "([^"]*)"$`, func(value string) error {
-		_ = state.gitEnv.DevRepo.SetColorUI(value)
-		return nil
+		return state.gitEnv.DevRepo.SetColorUI(value)
 	})
 
 	suite.Step(`^my repo has "git-town.code-hosting-driver" set to "([^"]*)"$`, func(value string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -736,8 +736,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the main branch is configured as "([^"]+)"$`, func(name string) error {
-		state.gitEnv.DevRepo.SetMainBranch(name)
-		return nil
+		return state.gitEnv.DevRepo.SetMainBranch(name)
 	})
 
 	suite.Step(`^the main branch name is not configured$`, func() error {
@@ -762,8 +761,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the new-branch-push-flag configuration is "([^"]*)"$`, func(value string) error {
-		_ = state.gitEnv.DevRepo.Configuration.SetLocalConfigValue("git-town.new-branch-push-flag", value)
-		return nil
+		_, err := state.gitEnv.DevRepo.Configuration.SetLocalConfigValue("git-town.new-branch-push-flag", value)
+		return err
 	})
 
 	suite.Step(`^the new-branch-push-flag configuration is now (true|false)$`, func(text string) error {
@@ -785,13 +784,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the perennial branches are configured as "([^"]+)"$`, func(name string) error {
-		state.gitEnv.DevRepo.AddToPerennialBranches(name)
-		return nil
+		return state.gitEnv.DevRepo.AddToPerennialBranches(name)
 	})
 
 	suite.Step(`^the perennial branches are configured as "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
-		state.gitEnv.DevRepo.AddToPerennialBranches(branch1, branch2)
-		return nil
+		return state.gitEnv.DevRepo.AddToPerennialBranches(branch1, branch2)
 	})
 
 	suite.Step(`^the perennial branches are now configured as "([^"]+)"$`, func(name string) error {
@@ -838,8 +835,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the pull-branch-strategy configuration is "(merge|rebase)"$`, func(value string) error {
-		state.gitEnv.DevRepo.SetPullBranchStrategy(value)
-		return nil
+		return state.gitEnv.DevRepo.SetPullBranchStrategy(value)
 	})
 
 	suite.Step(`^the pull-branch-strategy configuration is now "(merge|rebase)"$`, func(want string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -176,7 +176,10 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^I haven't configured Git Town yet$`, func() error {
-		state.gitEnv.DevRepo.DeletePerennialBranchConfiguration()
+		err := state.gitEnv.DevRepo.DeletePerennialBranchConfiguration()
+		if err != nil {
+			return err
+		}
 		return state.gitEnv.DevRepo.DeleteMainBranchConfiguration()
 	})
 
@@ -821,8 +824,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the perennial branches are not configured$`, func() error {
-		state.gitEnv.DevRepo.DeletePerennialBranchConfiguration()
-		return nil
+		return state.gitEnv.DevRepo.DeletePerennialBranchConfiguration()
 	})
 
 	suite.Step(`^the previous Git branch is (?:now|still) "([^"]*)"$`, func(want string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -82,8 +82,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^Git Town is in offline mode$`, func() error {
-		state.gitEnv.DevRepo.SetOffline(true)
-		return nil
+		return state.gitEnv.DevRepo.SetOffline(true)
 	})
 
 	suite.Step(`^Git Town is no longer configured for this repo$`, func() error {
@@ -759,8 +758,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		state.gitEnv.DevRepo.SetNewBranchPush(b, false)
-		return nil
+		return state.gitEnv.DevRepo.SetNewBranchPush(b, false)
 	})
 
 	suite.Step(`^the new-branch-push-flag configuration is "([^"]*)"$`, func(value string) error {
@@ -782,8 +780,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the offline configuration is accidentally set to "([^"]*)"$`, func(value string) error {
-		_ = state.gitEnv.DevRepo.Configuration.SetGlobalConfigValue("git-town.offline", value)
-		return nil
+		_, err := state.gitEnv.DevRepo.Configuration.SetGlobalConfigValue("git-town.offline", value)
+		return err
 	})
 
 	suite.Step(`^the perennial branches are configured as "([^"]+)"$`, func(name string) error {


### PR DESCRIPTION
All errors now bubble to the outer shell where they are properly logged and the program cleanly terminates running all defer blocks.