### PR TITLE
extract configuration into its own package

### DIFF
--- a/documentation/development/architecture.md
+++ b/documentation/development/architecture.md
@@ -8,6 +8,7 @@ code is located in the [src](../../src) folder. It contains these packages:
 - [src/cmd](../../src/cmd) defines Git Town's
   [Cobra](https://github.com/spf13/cobra)-based subcommands
 - [src/command](../../src/command) runs commands in subshells
+- [src/config](../../src/config) accesses the Git Town configuration
 - [src/drivers](../../src/drivers) interacts with external Git hosting providers
 - [src/dryrun](../../src/dryrun) manages dry-runs
 - [src/git](../../src/git) accesses the Git binary on the user's computer

--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -20,7 +20,7 @@ var abortCmd = &cobra.Command{
 			cli.Exit("Nothing to abort")
 		}
 		abortRunState := runState.CreateAbortRunState()
-		err = steps.Run(&abortRunState, prodRepo, drivers.Load(prodRepo.Configuration, &prodRepo.Silent))
+		err = steps.Run(&abortRunState, prodRepo, drivers.Load(prodRepo.Config, &prodRepo.Silent))
 		if err != nil {
 			cli.Exit(err)
 		}

--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -55,7 +55,7 @@ This can conflict with other tools that also define Git aliases.`,
 }
 
 func addAlias(command string, repo *git.ProdRepo) error {
-	result, err := repo.AddGitAlias(command)
+	result, err := repo.Config.AddGitAlias(command)
 	if err != nil {
 		return fmt.Errorf("cannot create alias for %q: %w", command, err)
 	}
@@ -63,9 +63,9 @@ func addAlias(command string, repo *git.ProdRepo) error {
 }
 
 func removeAlias(command string, repo *git.ProdRepo) error {
-	existingAlias := repo.GetGitAlias(command)
+	existingAlias := repo.Config.GetGitAlias(command)
 	if existingAlias == "town "+command {
-		result, err := repo.RemoveGitAlias(command)
+		result, err := repo.Config.RemoveGitAlias(command)
 		if err != nil {
 			return fmt.Errorf("cannot remove alias for %q: %w", command, err)
 		}

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -67,7 +67,7 @@ func getAppendConfig(args []string, repo *git.ProdRepo) (result appendConfig, er
 	if err != nil {
 		return result, err
 	}
-	if result.hasOrigin && !repo.IsOffline() {
+	if result.hasOrigin && !repo.Config.IsOffline() {
 		err := repo.Logging.Fetch()
 		if err != nil {
 			return result, err
@@ -84,9 +84,9 @@ func getAppendConfig(args []string, repo *git.ProdRepo) (result appendConfig, er
 	if err != nil {
 		return result, err
 	}
-	result.ancestorBranches = repo.GetAncestorBranches(result.parentBranch)
-	result.shouldNewBranchPush = repo.ShouldNewBranchPush()
-	result.isOffline = repo.IsOffline()
+	result.ancestorBranches = repo.Config.GetAncestorBranches(result.parentBranch)
+	result.shouldNewBranchPush = repo.Config.ShouldNewBranchPush()
+	result.isOffline = repo.Config.IsOffline()
 	return result, err
 }
 

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -67,7 +67,7 @@ func getAppendConfig(args []string, repo *git.ProdRepo) (result appendConfig, er
 	if err != nil {
 		return result, err
 	}
-	if result.hasOrigin && !git.Config().IsOffline() {
+	if result.hasOrigin && !repo.IsOffline() {
 		err := repo.Logging.Fetch()
 		if err != nil {
 			return result, err
@@ -84,9 +84,9 @@ func getAppendConfig(args []string, repo *git.ProdRepo) (result appendConfig, er
 	if err != nil {
 		return result, err
 	}
-	result.ancestorBranches = git.Config().GetAncestorBranches(result.parentBranch)
-	result.shouldNewBranchPush = git.Config().ShouldNewBranchPush()
-	result.isOffline = git.Config().IsOffline()
+	result.ancestorBranches = repo.GetAncestorBranches(result.parentBranch)
+	result.shouldNewBranchPush = repo.ShouldNewBranchPush()
+	result.isOffline = repo.IsOffline()
 	return result, err
 }
 

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
 	"github.com/git-town/git-town/src/prompt"
 	"github.com/spf13/cobra"
 )
@@ -16,11 +15,11 @@ var configCommand = &cobra.Command{
 		fmt.Println()
 		cli.PrintLabelAndValue("Main branch", cli.PrintableMainBranch(prodRepo.GetMainBranch()))
 		cli.PrintLabelAndValue("Perennial branches", cli.PrintablePerennialBranches(prodRepo.GetPerennialBranches()))
-		mainBranch := git.Config().GetMainBranch()
+		mainBranch := prodRepo.GetMainBranch()
 		if mainBranch != "" {
 			cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(prodRepo.Configuration))
 		}
-		cli.PrintLabelAndValue("Pull branch strategy", git.Config().GetPullBranchStrategy())
+		cli.PrintLabelAndValue("Pull branch strategy", prodRepo.GetPullBranchStrategy())
 		cli.PrintLabelAndValue("New Branch Push Flag", cli.PrintableNewBranchPushFlag(prodRepo.ShouldNewBranchPush()))
 	},
 	Args: cobra.NoArgs,
@@ -33,7 +32,7 @@ var resetConfigCommand = &cobra.Command{
 	Use:   "reset",
 	Short: "Resets your Git Town configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := git.Config().RemoveLocalGitConfiguration()
+		err := prodRepo.RemoveLocalGitConfiguration()
 		if err != nil {
 			cli.Exit(err)
 		}

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -13,14 +13,14 @@ var configCommand = &cobra.Command{
 	Short: "Displays your Git Town configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println()
-		cli.PrintLabelAndValue("Main branch", cli.PrintableMainBranch(prodRepo.GetMainBranch()))
-		cli.PrintLabelAndValue("Perennial branches", cli.PrintablePerennialBranches(prodRepo.GetPerennialBranches()))
-		mainBranch := prodRepo.GetMainBranch()
+		cli.PrintLabelAndValue("Main branch", cli.PrintableMainBranch(prodRepo.Config.GetMainBranch()))
+		cli.PrintLabelAndValue("Perennial branches", cli.PrintablePerennialBranches(prodRepo.Config.GetPerennialBranches()))
+		mainBranch := prodRepo.Config.GetMainBranch()
 		if mainBranch != "" {
 			cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(prodRepo.Config))
 		}
-		cli.PrintLabelAndValue("Pull branch strategy", prodRepo.GetPullBranchStrategy())
-		cli.PrintLabelAndValue("New Branch Push Flag", cli.PrintableNewBranchPushFlag(prodRepo.ShouldNewBranchPush()))
+		cli.PrintLabelAndValue("Pull branch strategy", prodRepo.Config.GetPullBranchStrategy())
+		cli.PrintLabelAndValue("New Branch Push Flag", cli.PrintableNewBranchPushFlag(prodRepo.Config.ShouldNewBranchPush()))
 	},
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -32,7 +32,7 @@ var resetConfigCommand = &cobra.Command{
 	Use:   "reset",
 	Short: "Resets your Git Town configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := prodRepo.RemoveLocalGitConfiguration()
+		err := prodRepo.Config.RemoveLocalGitConfiguration()
 		if err != nil {
 			cli.Exit(err)
 		}

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -17,7 +17,7 @@ var configCommand = &cobra.Command{
 		cli.PrintLabelAndValue("Perennial branches", cli.PrintablePerennialBranches(prodRepo.GetPerennialBranches()))
 		mainBranch := prodRepo.GetMainBranch()
 		if mainBranch != "" {
-			cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(prodRepo.Configuration))
+			cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(prodRepo.Config))
 		}
 		cli.PrintLabelAndValue("Pull branch strategy", prodRepo.GetPullBranchStrategy())
 		cli.PrintLabelAndValue("New Branch Push Flag", cli.PrintableNewBranchPushFlag(prodRepo.ShouldNewBranchPush()))

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -28,7 +28,7 @@ var continueCmd = &cobra.Command{
 		if hasConflicts {
 			cli.Exit(fmt.Errorf("you must resolve the conflicts before continuing"))
 		}
-		err = steps.Run(runState, prodRepo, drivers.Load(prodRepo.Configuration, &prodRepo.Silent))
+		err = steps.Run(runState, prodRepo, drivers.Load(prodRepo.Config, &prodRepo.Silent))
 		if err != nil {
 			cli.Exit(err)
 		}

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -61,14 +61,14 @@ func getDiffParentConfig(args []string, repo *git.ProdRepo) (config diffParentCo
 			return config, fmt.Errorf("there is no local branch named %q", config.branch)
 		}
 	}
-	if !prodRepo.IsFeatureBranch(config.branch) {
+	if !prodRepo.Config.IsFeatureBranch(config.branch) {
 		return config, fmt.Errorf("you can only diff-parent feature branches")
 	}
 	err = prompt.EnsureKnowsParentBranches([]string{config.branch}, repo)
 	if err != nil {
 		return config, err
 	}
-	config.parentBranch = repo.GetParentBranch(config.branch)
+	config.parentBranch = repo.Config.GetParentBranch(config.branch)
 	return config, nil
 }
 

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -61,14 +61,14 @@ func getDiffParentConfig(args []string, repo *git.ProdRepo) (config diffParentCo
 			return config, fmt.Errorf("there is no local branch named %q", config.branch)
 		}
 	}
-	if !git.Config().IsFeatureBranch(config.branch) {
+	if !prodRepo.IsFeatureBranch(config.branch) {
 		return config, fmt.Errorf("you can only diff-parent feature branches")
 	}
 	err = prompt.EnsureKnowsParentBranches([]string{config.branch}, repo)
 	if err != nil {
 		return config, err
 	}
-	config.parentBranch = git.Config().GetParentBranch(config.branch)
+	config.parentBranch = repo.GetParentBranch(config.branch)
 	return config, nil
 }
 

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -51,7 +51,7 @@ See "sync" for information regarding remote upstream.`,
 
 func getParentBranch(targetBranch string, repo *git.ProdRepo) (string, error) {
 	if promptForParent {
-		parentBranch, err := prompt.AskForBranchParent(targetBranch, git.Config().GetMainBranch(), repo)
+		parentBranch, err := prompt.AskForBranchParent(targetBranch, repo.GetMainBranch(), repo)
 		if err != nil {
 			return "", err
 		}
@@ -61,7 +61,7 @@ func getParentBranch(targetBranch string, repo *git.ProdRepo) (string, error) {
 		}
 		return parentBranch, nil
 	}
-	return git.Config().GetMainBranch(), nil
+	return repo.GetMainBranch(), nil
 }
 
 func getHackConfig(args []string, repo *git.ProdRepo) (result appendConfig, err error) {
@@ -74,9 +74,9 @@ func getHackConfig(args []string, repo *git.ProdRepo) (result appendConfig, err 
 	if err != nil {
 		return result, err
 	}
-	result.shouldNewBranchPush = git.Config().ShouldNewBranchPush()
-	result.isOffline = git.Config().IsOffline()
-	if result.hasOrigin && !git.Config().IsOffline() {
+	result.shouldNewBranchPush = repo.ShouldNewBranchPush()
+	result.isOffline = repo.IsOffline()
+	if result.hasOrigin && !repo.IsOffline() {
 		err := repo.Logging.Fetch()
 		if err != nil {
 			return result, err

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -51,7 +51,7 @@ See "sync" for information regarding remote upstream.`,
 
 func getParentBranch(targetBranch string, repo *git.ProdRepo) (string, error) {
 	if promptForParent {
-		parentBranch, err := prompt.AskForBranchParent(targetBranch, repo.GetMainBranch(), repo)
+		parentBranch, err := prompt.AskForBranchParent(targetBranch, repo.Config.GetMainBranch(), repo)
 		if err != nil {
 			return "", err
 		}
@@ -61,7 +61,7 @@ func getParentBranch(targetBranch string, repo *git.ProdRepo) (string, error) {
 		}
 		return parentBranch, nil
 	}
-	return repo.GetMainBranch(), nil
+	return repo.Config.GetMainBranch(), nil
 }
 
 func getHackConfig(args []string, repo *git.ProdRepo) (result appendConfig, err error) {
@@ -74,9 +74,9 @@ func getHackConfig(args []string, repo *git.ProdRepo) (result appendConfig, err 
 	if err != nil {
 		return result, err
 	}
-	result.shouldNewBranchPush = repo.ShouldNewBranchPush()
-	result.isOffline = repo.IsOffline()
-	if result.hasOrigin && !repo.IsOffline() {
+	result.shouldNewBranchPush = repo.Config.ShouldNewBranchPush()
+	result.isOffline = repo.Config.IsOffline()
+	if result.hasOrigin && !repo.Config.IsOffline() {
 		err := repo.Logging.Fetch()
 		if err != nil {
 			return result, err

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -64,7 +64,7 @@ func getKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err er
 	} else {
 		result.targetBranch = args[0]
 	}
-	if !repo.IsFeatureBranch(result.targetBranch) {
+	if !repo.Config.IsFeatureBranch(result.targetBranch) {
 		return result, fmt.Errorf("you can only kill feature branches")
 	}
 	result.isTargetBranchLocal, err = repo.Silent.HasLocalBranch(result.targetBranch)
@@ -82,7 +82,7 @@ func getKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err er
 	if err != nil {
 		return result, err
 	}
-	result.isOffline = repo.IsOffline()
+	result.isOffline = repo.Config.IsOffline()
 	if hasOrigin && !result.isOffline {
 		err := repo.Logging.Fetch()
 		if err != nil {
@@ -102,7 +102,7 @@ func getKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err er
 	if err != nil {
 		return result, err
 	}
-	result.targetBranchParent = repo.GetParentBranch(result.targetBranch)
+	result.targetBranchParent = repo.Config.GetParentBranch(result.targetBranch)
 	result.previousBranch, err = repo.Silent.PreviouslyCheckedOutBranch()
 	if err != nil {
 		return result, err
@@ -111,7 +111,7 @@ func getKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err er
 	if err != nil {
 		return result, err
 	}
-	result.childBranches = repo.GetChildBranches(result.targetBranch)
+	result.childBranches = repo.Config.GetChildBranches(result.targetBranch)
 	return result, nil
 }
 
@@ -132,7 +132,7 @@ func getKillStepList(config killConfig, repo *git.ProdRepo) (result steps.StepLi
 			result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: config.targetBranchParent})
 		}
 		result.Append(&steps.DeleteParentBranchStep{BranchName: config.targetBranch})
-	case !repo.IsOffline():
+	case !repo.Config.IsOffline():
 		result.Append(&steps.DeleteRemoteBranchStep{BranchName: config.targetBranch, IsTracking: false})
 	default:
 		return result, fmt.Errorf("cannot delete remote branch %q in offline mode", config.targetBranch)

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -76,7 +76,7 @@ func getKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err er
 		if err != nil {
 			return result, err
 		}
-		repo.Configuration.Reload()
+		repo.Config.Reload()
 	}
 	hasOrigin, err := repo.Silent.HasRemote("origin")
 	if err != nil {

--- a/src/cmd/main_branch.go
+++ b/src/cmd/main_branch.go
@@ -42,7 +42,7 @@ func setMainBranch(branchName string, repo *git.ProdRepo) error {
 	if !hasBranch {
 		return fmt.Errorf("there is no branch named %q", branchName)
 	}
-	return git.Config().SetMainBranch(branchName)
+	return repo.SetMainBranch(branchName)
 }
 
 func init() {

--- a/src/cmd/main_branch.go
+++ b/src/cmd/main_branch.go
@@ -31,7 +31,7 @@ The main branch is the Git branch from which new feature branches are cut.`,
 }
 
 func printMainBranch() {
-	cli.Println(cli.PrintableMainBranch(prodRepo.GetMainBranch()))
+	cli.Println(cli.PrintableMainBranch(prodRepo.Config.GetMainBranch()))
 }
 
 func setMainBranch(branchName string, repo *git.ProdRepo) error {
@@ -42,7 +42,7 @@ func setMainBranch(branchName string, repo *git.ProdRepo) error {
 	if !hasBranch {
 		return fmt.Errorf("there is no branch named %q", branchName)
 	}
-	return repo.SetMainBranch(branchName)
+	return repo.Config.SetMainBranch(branchName)
 }
 
 func init() {

--- a/src/cmd/new_branch_push_flag.go
+++ b/src/cmd/new_branch_push_flag.go
@@ -38,14 +38,14 @@ hack / append / prepend on creation. Defaults to false.`,
 
 func printNewBranchPushFlag(repo *git.ProdRepo) {
 	if globalFlag {
-		cli.Println(strconv.FormatBool(repo.ShouldNewBranchPushGlobal()))
+		cli.Println(strconv.FormatBool(repo.Config.ShouldNewBranchPushGlobal()))
 	} else {
-		cli.Println(cli.PrintableNewBranchPushFlag(prodRepo.ShouldNewBranchPush()))
+		cli.Println(cli.PrintableNewBranchPushFlag(prodRepo.Config.ShouldNewBranchPush()))
 	}
 }
 
 func setNewBranchPushFlag(value bool, repo *git.ProdRepo) error {
-	return repo.SetNewBranchPush(value, globalFlag)
+	return repo.Config.SetNewBranchPush(value, globalFlag)
 }
 
 func init() {

--- a/src/cmd/new_branch_push_flag.go
+++ b/src/cmd/new_branch_push_flag.go
@@ -18,13 +18,13 @@ If "new-branch-push-flag" is true, Git Town pushes branches created with
 hack / append / prepend on creation. Defaults to false.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			printNewBranchPushFlag()
+			printNewBranchPushFlag(prodRepo)
 		} else {
 			value, err := strconv.ParseBool(args[0])
 			if err != nil {
 				cli.Exit(fmt.Errorf(`invalid argument: %q. Please provide either "true" or "false"`, args[0]))
 			}
-			err = setNewBranchPushFlag(value)
+			err = setNewBranchPushFlag(value, prodRepo)
 			if err != nil {
 				cli.Exit(err)
 			}
@@ -36,16 +36,16 @@ hack / append / prepend on creation. Defaults to false.`,
 	},
 }
 
-func printNewBranchPushFlag() {
+func printNewBranchPushFlag(repo *git.ProdRepo) {
 	if globalFlag {
-		cli.Println(strconv.FormatBool(git.Config().ShouldNewBranchPushGlobal()))
+		cli.Println(strconv.FormatBool(repo.ShouldNewBranchPushGlobal()))
 	} else {
 		cli.Println(cli.PrintableNewBranchPushFlag(prodRepo.ShouldNewBranchPush()))
 	}
 }
 
-func setNewBranchPushFlag(value bool) error {
-	return git.Config().SetNewBranchPush(value, globalFlag)
+func setNewBranchPushFlag(value bool, repo *git.ProdRepo) error {
+	return repo.SetNewBranchPush(value, globalFlag)
 }
 
 func init() {

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -60,7 +60,7 @@ where hostname matches what is in your ssh config file.`,
 		if err := validateIsConfigured(prodRepo); err != nil {
 			return err
 		}
-		if err := prodRepo.ValidateIsOnline(); err != nil {
+		if err := prodRepo.Config.ValidateIsOnline(); err != nil {
 			return err
 		}
 		return nil
@@ -86,7 +86,7 @@ func getNewPullRequestConfig(repo *git.ProdRepo) (result newPullRequestConfig, e
 	if err != nil {
 		return result, err
 	}
-	result.BranchesToSync = append(repo.GetAncestorBranches(result.InitialBranch), result.InitialBranch)
+	result.BranchesToSync = append(repo.Config.GetAncestorBranches(result.InitialBranch), result.InitialBranch)
 	return
 }
 

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -60,7 +60,7 @@ where hostname matches what is in your ssh config file.`,
 		if err := validateIsConfigured(prodRepo); err != nil {
 			return err
 		}
-		if err := git.Config().ValidateIsOnline(); err != nil {
+		if err := prodRepo.ValidateIsOnline(); err != nil {
 			return err
 		}
 		return nil
@@ -86,7 +86,7 @@ func getNewPullRequestConfig(repo *git.ProdRepo) (result newPullRequestConfig, e
 	if err != nil {
 		return result, err
 	}
-	result.BranchesToSync = append(git.Config().GetAncestorBranches(result.InitialBranch), result.InitialBranch)
+	result.BranchesToSync = append(repo.GetAncestorBranches(result.InitialBranch), result.InitialBranch)
 	return
 }
 

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -38,7 +38,7 @@ where hostname matches what is in your ssh config file.`,
 		if err != nil {
 			cli.Exit(err)
 		}
-		driver := drivers.Load(prodRepo.Configuration, &prodRepo.Silent)
+		driver := drivers.Load(prodRepo.Config, &prodRepo.Silent)
 		if driver == nil {
 			cli.Exit(drivers.UnsupportedHostingError())
 		}

--- a/src/cmd/offline.go
+++ b/src/cmd/offline.go
@@ -16,13 +16,13 @@ var offlineCommand = &cobra.Command{
 Git Town avoids network operations in offline mode.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cli.Println(cli.PrintableOfflineFlag(prodRepo.IsOffline()))
+			cli.Println(cli.PrintableOfflineFlag(prodRepo.Config.IsOffline()))
 		} else {
 			value, err := strconv.ParseBool(args[0])
 			if err != nil {
 				cli.Exit(fmt.Errorf(`invalid argument: %q. Please provide either "true" or "false".\n`, args[0]))
 			}
-			err = prodRepo.SetOffline(value)
+			err = prodRepo.Config.SetOffline(value)
 			if err != nil {
 				cli.Exit(err)
 			}

--- a/src/cmd/offline.go
+++ b/src/cmd/offline.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
 	"github.com/spf13/cobra"
 )
 
@@ -17,27 +16,19 @@ var offlineCommand = &cobra.Command{
 Git Town avoids network operations in offline mode.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			printOfflineFlag()
+			cli.Println(cli.PrintableOfflineFlag(prodRepo.IsOffline()))
 		} else {
 			value, err := strconv.ParseBool(args[0])
 			if err != nil {
 				cli.Exit(fmt.Errorf(`invalid argument: %q. Please provide either "true" or "false".\n`, args[0]))
 			}
-			err = setOfflineFlag(value)
+			err = prodRepo.SetOffline(value)
 			if err != nil {
 				cli.Exit(err)
 			}
 		}
 	},
 	Args: cobra.MaximumNArgs(1),
-}
-
-func printOfflineFlag() {
-	cli.Println(cli.PrintableOfflineFlag(prodRepo.IsOffline()))
-}
-
-func setOfflineFlag(value bool) error {
-	return git.Config().SetOffline(value)
 }
 
 func init() {

--- a/src/cmd/perennial_branches.go
+++ b/src/cmd/perennial_branches.go
@@ -14,7 +14,7 @@ var perennialBranchesCommand = &cobra.Command{
 Perennial branches are long-lived branches.
 They cannot be shipped.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cli.Println(cli.PrintablePerennialBranches(prodRepo.GetPerennialBranches()))
+		cli.Println(cli.PrintablePerennialBranches(prodRepo.Config.GetPerennialBranches()))
 	},
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -70,8 +70,8 @@ func getPrependConfig(args []string, repo *git.ProdRepo) (result prependConfig, 
 	if err != nil {
 		return result, err
 	}
-	result.shouldNewBranchPush = git.Config().ShouldNewBranchPush()
-	result.isOffline = git.Config().IsOffline()
+	result.shouldNewBranchPush = repo.ShouldNewBranchPush()
+	result.isOffline = repo.IsOffline()
 	if result.hasOrigin && !result.isOffline {
 		err := repo.Logging.Fetch()
 		if err != nil {
@@ -85,15 +85,15 @@ func getPrependConfig(args []string, repo *git.ProdRepo) (result prependConfig, 
 	if hasBranch {
 		return result, fmt.Errorf("a branch named %q already exists", result.targetBranch)
 	}
-	if !git.Config().IsFeatureBranch(result.initialBranch) {
+	if !repo.IsFeatureBranch(result.initialBranch) {
 		return result, fmt.Errorf("the branch %q is not a feature branch. Only feature branches can have parent branches", result.initialBranch)
 	}
 	err = prompt.EnsureKnowsParentBranches([]string{result.initialBranch}, repo)
 	if err != nil {
 		return result, err
 	}
-	result.parentBranch = git.Config().GetParentBranch(result.initialBranch)
-	result.ancestorBranches = git.Config().GetAncestorBranches(result.initialBranch)
+	result.parentBranch = repo.GetParentBranch(result.initialBranch)
+	result.ancestorBranches = repo.GetAncestorBranches(result.initialBranch)
 	return result, nil
 }
 

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -70,8 +70,8 @@ func getPrependConfig(args []string, repo *git.ProdRepo) (result prependConfig, 
 	if err != nil {
 		return result, err
 	}
-	result.shouldNewBranchPush = repo.ShouldNewBranchPush()
-	result.isOffline = repo.IsOffline()
+	result.shouldNewBranchPush = repo.Config.ShouldNewBranchPush()
+	result.isOffline = repo.Config.IsOffline()
 	if result.hasOrigin && !result.isOffline {
 		err := repo.Logging.Fetch()
 		if err != nil {
@@ -85,15 +85,15 @@ func getPrependConfig(args []string, repo *git.ProdRepo) (result prependConfig, 
 	if hasBranch {
 		return result, fmt.Errorf("a branch named %q already exists", result.targetBranch)
 	}
-	if !repo.IsFeatureBranch(result.initialBranch) {
+	if !repo.Config.IsFeatureBranch(result.initialBranch) {
 		return result, fmt.Errorf("the branch %q is not a feature branch. Only feature branches can have parent branches", result.initialBranch)
 	}
 	err = prompt.EnsureKnowsParentBranches([]string{result.initialBranch}, repo)
 	if err != nil {
 		return result, err
 	}
-	result.parentBranch = repo.GetParentBranch(result.initialBranch)
-	result.ancestorBranches = repo.GetAncestorBranches(result.initialBranch)
+	result.parentBranch = repo.Config.GetParentBranch(result.initialBranch)
+	result.ancestorBranches = repo.Config.GetAncestorBranches(result.initialBranch)
 	return result, nil
 }
 

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -43,7 +43,7 @@ This usually means the branch was shipped or killed on another machine.`,
 		if err := validateIsConfigured(prodRepo); err != nil {
 			return err
 		}
-		return prodRepo.ValidateIsOnline()
+		return prodRepo.Config.ValidateIsOnline()
 	},
 }
 
@@ -58,7 +58,7 @@ func getPruneBranchesConfig(repo *git.ProdRepo) (result pruneBranchesConfig, err
 			return result, err
 		}
 	}
-	result.mainBranch = repo.GetMainBranch()
+	result.mainBranch = repo.Config.GetMainBranch()
 	result.initialBranchName, err = repo.Silent.CurrentBranch()
 	if err != nil {
 		return result, err
@@ -73,14 +73,14 @@ func getPruneBranchesStepList(config pruneBranchesConfig, repo *git.ProdRepo) (r
 		if initialBranchName == branchName {
 			result.Append(&steps.CheckoutBranchStep{BranchName: config.mainBranch})
 		}
-		parent := repo.GetParentBranch(branchName)
+		parent := repo.Config.GetParentBranch(branchName)
 		if parent != "" {
-			for _, child := range repo.GetChildBranches(branchName) {
+			for _, child := range repo.Config.GetChildBranches(branchName) {
 				result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: parent})
 			}
 			result.Append(&steps.DeleteParentBranchStep{BranchName: branchName})
 		}
-		if repo.IsPerennialBranch(branchName) {
+		if repo.Config.IsPerennialBranch(branchName) {
 			result.Append(&steps.RemoveFromPerennialBranches{BranchName: branchName})
 		}
 		result.Append(&steps.DeleteLocalBranchStep{BranchName: branchName})

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -43,7 +43,7 @@ This usually means the branch was shipped or killed on another machine.`,
 		if err := validateIsConfigured(prodRepo); err != nil {
 			return err
 		}
-		return git.Config().ValidateIsOnline()
+		return prodRepo.ValidateIsOnline()
 	},
 }
 
@@ -58,7 +58,7 @@ func getPruneBranchesConfig(repo *git.ProdRepo) (result pruneBranchesConfig, err
 			return result, err
 		}
 	}
-	result.mainBranch = git.Config().GetMainBranch()
+	result.mainBranch = repo.GetMainBranch()
 	result.initialBranchName, err = repo.Silent.CurrentBranch()
 	if err != nil {
 		return result, err
@@ -73,14 +73,14 @@ func getPruneBranchesStepList(config pruneBranchesConfig, repo *git.ProdRepo) (r
 		if initialBranchName == branchName {
 			result.Append(&steps.CheckoutBranchStep{BranchName: config.mainBranch})
 		}
-		parent := git.Config().GetParentBranch(branchName)
+		parent := repo.GetParentBranch(branchName)
 		if parent != "" {
-			for _, child := range git.Config().GetChildBranches(branchName) {
+			for _, child := range repo.GetChildBranches(branchName) {
 				result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: parent})
 			}
 			result.Append(&steps.DeleteParentBranchStep{BranchName: branchName})
 		}
-		if git.Config().IsPerennialBranch(branchName) {
+		if repo.IsPerennialBranch(branchName) {
 			result.Append(&steps.RemoveFromPerennialBranches{BranchName: branchName})
 		}
 		result.Append(&steps.DeleteLocalBranchStep{BranchName: branchName})

--- a/src/cmd/pull_branch_strategy.go
+++ b/src/cmd/pull_branch_strategy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
 	"github.com/spf13/cobra"
 )
 
@@ -18,9 +17,9 @@ when merging remote tracking branches into local branches
 for the main branch and perennial branches.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			printPullBranchStrategy()
+			cli.Println(prodRepo.GetPullBranchStrategy())
 		} else {
-			err := setPullBranchStrategy(args[0])
+			err := prodRepo.SetPullBranchStrategy(args[0])
 			if err != nil {
 				cli.Exit(err)
 			}
@@ -35,14 +34,6 @@ for the main branch and perennial branches.`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return ValidateIsRepository(prodRepo)
 	},
-}
-
-func printPullBranchStrategy() {
-	cli.Println(git.Config().GetPullBranchStrategy())
-}
-
-func setPullBranchStrategy(value string) error {
-	return git.Config().SetPullBranchStrategy(value)
 }
 
 func init() {

--- a/src/cmd/pull_branch_strategy.go
+++ b/src/cmd/pull_branch_strategy.go
@@ -17,9 +17,9 @@ when merging remote tracking branches into local branches
 for the main branch and perennial branches.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cli.Println(prodRepo.GetPullBranchStrategy())
+			cli.Println(prodRepo.Config.GetPullBranchStrategy())
 		} else {
-			err := prodRepo.SetPullBranchStrategy(args[0])
+			err := prodRepo.Config.SetPullBranchStrategy(args[0])
 			if err != nil {
 				cli.Exit(err)
 			}

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -71,8 +71,8 @@ func getRenameBranchConfig(args []string, repo *git.ProdRepo) (result renameBran
 	if err != nil {
 		return result, err
 	}
-	result.isInitialBranchPerennial = repo.IsPerennialBranch(result.initialBranch)
-	result.isOffline = repo.IsOffline()
+	result.isInitialBranchPerennial = repo.Config.IsPerennialBranch(result.initialBranch)
+	result.isOffline = repo.Config.IsOffline()
 	if len(args) == 1 {
 		result.oldBranchName = result.initialBranch
 		result.newBranchName = args[0]
@@ -80,11 +80,11 @@ func getRenameBranchConfig(args []string, repo *git.ProdRepo) (result renameBran
 		result.oldBranchName = args[0]
 		result.newBranchName = args[1]
 	}
-	if repo.IsMainBranch(result.oldBranchName) {
+	if repo.Config.IsMainBranch(result.oldBranchName) {
 		return result, fmt.Errorf("the main branch cannot be renamed")
 	}
 	if !forceFlag {
-		if repo.IsPerennialBranch(result.oldBranchName) {
+		if repo.Config.IsPerennialBranch(result.oldBranchName) {
 			return result, fmt.Errorf("%q is a perennial branch. Renaming a perennial branch typically requires other updates. If you are sure you want to do this, use '--force'", result.oldBranchName)
 		}
 	}
@@ -118,7 +118,7 @@ func getRenameBranchConfig(args []string, repo *git.ProdRepo) (result renameBran
 	if hasNewBranch {
 		return result, fmt.Errorf("a branch named %q already exists", result.newBranchName)
 	}
-	result.oldBranchChildren = repo.GetChildBranches(result.oldBranchName)
+	result.oldBranchChildren = repo.Config.GetChildBranches(result.oldBranchName)
 	result.oldBranchHasTrackingBranch, err = repo.Silent.HasTrackingBranch(result.oldBranchName)
 	return result, err
 }
@@ -133,7 +133,7 @@ func getRenameBranchStepList(config renameBranchConfig, repo *git.ProdRepo) (res
 		result.Append(&steps.AddToPerennialBranches{BranchName: config.newBranchName})
 	} else {
 		result.Append(&steps.DeleteParentBranchStep{BranchName: config.oldBranchName})
-		result.Append(&steps.SetParentBranchStep{BranchName: config.newBranchName, ParentBranchName: repo.GetParentBranch(config.oldBranchName)})
+		result.Append(&steps.SetParentBranchStep{BranchName: config.newBranchName, ParentBranchName: repo.Config.GetParentBranch(config.oldBranchName)})
 	}
 	for _, child := range config.oldBranchChildren {
 		result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: config.newBranchName})

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -71,8 +71,8 @@ func getRenameBranchConfig(args []string, repo *git.ProdRepo) (result renameBran
 	if err != nil {
 		return result, err
 	}
-	result.isInitialBranchPerennial = git.Config().IsPerennialBranch(result.initialBranch)
-	result.isOffline = git.Config().IsOffline()
+	result.isInitialBranchPerennial = repo.IsPerennialBranch(result.initialBranch)
+	result.isOffline = repo.IsOffline()
 	if len(args) == 1 {
 		result.oldBranchName = result.initialBranch
 		result.newBranchName = args[0]
@@ -80,11 +80,11 @@ func getRenameBranchConfig(args []string, repo *git.ProdRepo) (result renameBran
 		result.oldBranchName = args[0]
 		result.newBranchName = args[1]
 	}
-	if git.Config().IsMainBranch(result.oldBranchName) {
+	if repo.IsMainBranch(result.oldBranchName) {
 		return result, fmt.Errorf("the main branch cannot be renamed")
 	}
 	if !forceFlag {
-		if git.Config().IsPerennialBranch(result.oldBranchName) {
+		if repo.IsPerennialBranch(result.oldBranchName) {
 			return result, fmt.Errorf("%q is a perennial branch. Renaming a perennial branch typically requires other updates. If you are sure you want to do this, use '--force'", result.oldBranchName)
 		}
 	}
@@ -118,7 +118,7 @@ func getRenameBranchConfig(args []string, repo *git.ProdRepo) (result renameBran
 	if hasNewBranch {
 		return result, fmt.Errorf("a branch named %q already exists", result.newBranchName)
 	}
-	result.oldBranchChildren = git.Config().GetChildBranches(result.oldBranchName)
+	result.oldBranchChildren = repo.GetChildBranches(result.oldBranchName)
 	result.oldBranchHasTrackingBranch, err = repo.Silent.HasTrackingBranch(result.oldBranchName)
 	return result, err
 }
@@ -133,7 +133,7 @@ func getRenameBranchStepList(config renameBranchConfig, repo *git.ProdRepo) (res
 		result.Append(&steps.AddToPerennialBranches{BranchName: config.newBranchName})
 	} else {
 		result.Append(&steps.DeleteParentBranchStep{BranchName: config.oldBranchName})
-		result.Append(&steps.SetParentBranchStep{BranchName: config.newBranchName, ParentBranchName: git.Config().GetParentBranch(config.oldBranchName)})
+		result.Append(&steps.SetParentBranchStep{BranchName: config.newBranchName, ParentBranchName: repo.GetParentBranch(config.oldBranchName)})
 	}
 	for _, child := range config.oldBranchChildren {
 		result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: config.newBranchName})

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -22,7 +22,7 @@ When using SSH identities, run
 "git config git-town.code-hosting-origin-hostname <HOSTNAME>"
 where HOSTNAME matches what is in your ssh config file.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		driver := drivers.Load(prodRepo.Configuration, &prodRepo.Silent)
+		driver := drivers.Load(prodRepo.Config, &prodRepo.Silent)
 		if driver == nil {
 			cli.Exit(drivers.UnsupportedHostingError())
 		}

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -4,7 +4,6 @@ import (
 	"github.com/git-town/git-town/src/browsers"
 	"github.com/git-town/git-town/src/cli"
 	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ where HOSTNAME matches what is in your ssh config file.`,
 		if err := validateIsConfigured(prodRepo); err != nil {
 			return err
 		}
-		if err := git.Config().ValidateIsOnline(); err != nil {
+		if err := prodRepo.ValidateIsOnline(); err != nil {
 			return err
 		}
 		return nil

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -36,7 +36,7 @@ where HOSTNAME matches what is in your ssh config file.`,
 		if err := validateIsConfigured(prodRepo); err != nil {
 			return err
 		}
-		if err := prodRepo.ValidateIsOnline(); err != nil {
+		if err := prodRepo.Config.ValidateIsOnline(); err != nil {
 			return err
 		}
 		return nil

--- a/src/cmd/set_parent_branch.go
+++ b/src/cmd/set_parent_branch.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
 	"github.com/git-town/git-town/src/prompt"
 	"github.com/spf13/cobra"
 )
@@ -18,14 +17,14 @@ var setParentBranchCommand = &cobra.Command{
 		if err != nil {
 			cli.Exit(err)
 		}
-		if !git.Config().IsFeatureBranch(branchName) {
+		if !prodRepo.IsFeatureBranch(branchName) {
 			cli.Exit(errors.New("only feature branches can have parent branches"))
 		}
-		defaultParentBranch := git.Config().GetParentBranch(branchName)
+		defaultParentBranch := prodRepo.GetParentBranch(branchName)
 		if defaultParentBranch == "" {
-			defaultParentBranch = git.Config().GetMainBranch()
+			defaultParentBranch = prodRepo.GetMainBranch()
 		}
-		err = git.Config().DeleteParentBranch(branchName)
+		err = prodRepo.DeleteParentBranch(branchName)
 		if err != nil {
 			cli.Exit(err)
 		}

--- a/src/cmd/set_parent_branch.go
+++ b/src/cmd/set_parent_branch.go
@@ -17,14 +17,14 @@ var setParentBranchCommand = &cobra.Command{
 		if err != nil {
 			cli.Exit(err)
 		}
-		if !prodRepo.IsFeatureBranch(branchName) {
+		if !prodRepo.Config.IsFeatureBranch(branchName) {
 			cli.Exit(errors.New("only feature branches can have parent branches"))
 		}
-		defaultParentBranch := prodRepo.GetParentBranch(branchName)
+		defaultParentBranch := prodRepo.Config.GetParentBranch(branchName)
 		if defaultParentBranch == "" {
-			defaultParentBranch = prodRepo.GetMainBranch()
+			defaultParentBranch = prodRepo.Config.GetMainBranch()
 		}
-		err = prodRepo.DeleteParentBranch(branchName)
+		err = prodRepo.Config.DeleteParentBranch(branchName)
 		if err != nil {
 			cli.Exit(err)
 		}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -109,7 +109,7 @@ func gitShipConfig(args []string, driver drivers.CodeHostingDriver, repo *git.Pr
 	if err != nil {
 		return result, err
 	}
-	if result.hasOrigin && !git.Config().IsOffline() {
+	if result.hasOrigin && !repo.IsOffline() {
 		err := repo.Logging.Fetch()
 		if err != nil {
 			return result, err
@@ -124,7 +124,7 @@ func gitShipConfig(args []string, driver drivers.CodeHostingDriver, repo *git.Pr
 			return result, fmt.Errorf("there is no branch named %q", result.branchToShip)
 		}
 	}
-	if !git.Config().IsFeatureBranch(result.branchToShip) {
+	if !repo.IsFeatureBranch(result.branchToShip) {
 		return result, fmt.Errorf("the branch %q is not a feature branch. Only feature branches can be shipped", result.branchToShip)
 	}
 	err = prompt.EnsureKnowsParentBranches([]string{result.branchToShip}, repo)
@@ -136,22 +136,22 @@ func gitShipConfig(args []string, driver drivers.CodeHostingDriver, repo *git.Pr
 	if err != nil {
 		return result, err
 	}
-	result.isOffline = git.Config().IsOffline()
+	result.isOffline = repo.IsOffline()
 	result.isShippingInitialBranch = result.branchToShip == result.initialBranch
-	result.branchToMergeInto = git.Config().GetParentBranch(result.branchToShip)
+	result.branchToMergeInto = repo.GetParentBranch(result.branchToShip)
 	prInfo, err := getCanShipWithDriver(result.branchToShip, result.branchToMergeInto, driver)
 	result.canShipWithDriver = prInfo.CanMergeWithAPI
 	result.defaultCommitMessage = prInfo.DefaultCommitMessage
 	result.pullRequestNumber = prInfo.PullRequestNumber
-	result.childBranches = git.Config().GetChildBranches(result.branchToShip)
-	result.shouldShipDeleteRemoteBranch = git.Config().ShouldShipDeleteRemoteBranch()
+	result.childBranches = repo.GetChildBranches(result.branchToShip)
+	result.shouldShipDeleteRemoteBranch = prodRepo.ShouldShipDeleteRemoteBranch()
 	return result, err
 }
 
 func ensureParentBranchIsMainOrPerennialBranch(branchName string) {
-	parentBranch := git.Config().GetParentBranch(branchName)
-	if !git.Config().IsMainBranch(parentBranch) && !git.Config().IsPerennialBranch(parentBranch) {
-		ancestors := git.Config().GetAncestorBranches(branchName)
+	parentBranch := prodRepo.GetParentBranch(branchName)
+	if !prodRepo.IsMainBranch(parentBranch) && !prodRepo.IsPerennialBranch(parentBranch) {
+		ancestors := prodRepo.GetAncestorBranches(branchName)
 		ancestorsWithoutMainOrPerennial := ancestors[1:]
 		oldestAncestor := ancestorsWithoutMainOrPerennial[0]
 		cli.Exit(
@@ -218,7 +218,7 @@ func getCanShipWithDriver(branch, parentBranch string, driver drivers.CodeHostin
 	if !hasOrigin {
 		return result, nil
 	}
-	if git.Config().IsOffline() {
+	if prodRepo.IsOffline() {
 		return result, nil
 	}
 	if driver == nil {

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -61,7 +61,7 @@ GitHub's feature to automatically delete head branches,
 run "git config git-town.ship-delete-remote-branch false"
 and Git Town will leave it up to your origin server to delete the remote branch.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		driver := drivers.Load(prodRepo.Configuration, &prodRepo.Silent)
+		driver := drivers.Load(prodRepo.Config, &prodRepo.Silent)
 		config, err := gitShipConfig(args, driver, prodRepo)
 		if err != nil {
 			cli.Exit(err)

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -86,7 +86,7 @@ func getSyncConfig(repo *git.ProdRepo) (result syncConfig, err error) {
 	if err != nil {
 		return result, err
 	}
-	result.isOffline = prodRepo.IsOffline()
+	result.isOffline = prodRepo.Config.IsOffline()
 	if result.hasOrigin && !result.isOffline {
 		err := repo.Logging.Fetch()
 		if err != nil {
@@ -113,8 +113,8 @@ func getSyncConfig(repo *git.ProdRepo) (result syncConfig, err error) {
 		if err != nil {
 			return result, err
 		}
-		result.branchesToSync = append(prodRepo.GetAncestorBranches(result.initialBranch), result.initialBranch)
-		result.shouldPushTags = !prodRepo.IsFeatureBranch(result.initialBranch)
+		result.branchesToSync = append(prodRepo.Config.GetAncestorBranches(result.initialBranch), result.initialBranch)
+		result.shouldPushTags = !prodRepo.Config.IsFeatureBranch(result.initialBranch)
 	}
 	return result, nil
 }

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -86,7 +86,7 @@ func getSyncConfig(repo *git.ProdRepo) (result syncConfig, err error) {
 	if err != nil {
 		return result, err
 	}
-	result.isOffline = git.Config().IsOffline()
+	result.isOffline = prodRepo.IsOffline()
 	if result.hasOrigin && !result.isOffline {
 		err := repo.Logging.Fetch()
 		if err != nil {
@@ -113,8 +113,8 @@ func getSyncConfig(repo *git.ProdRepo) (result syncConfig, err error) {
 		if err != nil {
 			return result, err
 		}
-		result.branchesToSync = append(git.Config().GetAncestorBranches(result.initialBranch), result.initialBranch)
-		result.shouldPushTags = !git.Config().IsFeatureBranch(result.initialBranch)
+		result.branchesToSync = append(prodRepo.GetAncestorBranches(result.initialBranch), result.initialBranch)
+		result.shouldPushTags = !prodRepo.IsFeatureBranch(result.initialBranch)
 	}
 	return result, nil
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,9 +1,4 @@
-/*
-This file contains functionality around storing configuration settings
-inside Git's metadata storage for the repository.
-*/
-
-package git
+package config
 
 import (
 	"errors"
@@ -33,20 +28,6 @@ type Configuration struct {
 	// for running shell commands
 	shell command.Shell
 }
-
-// Config provides the current configuration.
-// This is used in the Git Town business logic, which runs in the current directory.
-// The configuration is lazy-loaded this way to allow using some Git Town commands outside of Git repositories.
-func Config() *Configuration {
-	if currentDirConfig == nil {
-		shell := command.SilentShell{}
-		currentDirConfig = NewConfiguration(&shell)
-	}
-	return currentDirConfig
-}
-
-// currentDirConfig contains the Git Town configuration in the current working directory.
-var currentDirConfig *Configuration
 
 // NewConfiguration provides a Configuration instance reflecting the configuration values in the given directory.
 func NewConfiguration(shell command.Shell) *Configuration {

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,13 +1,14 @@
-package git_test
+package config_test
 
 import (
 	"testing"
 
+	"github.com/git-town/git-town/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRunner_SetOffline(t *testing.T) {
-	repo := CreateTestGitTownRepo(t)
+	repo := test.CreateTestGitTownRepo(t)
 	err := repo.SetOffline(true)
 	assert.NoError(t, err)
 	offline := repo.IsOffline()

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestRunner_SetOffline(t *testing.T) {
 	repo := test.CreateTestGitTownRepo(t)
-	err := repo.SetOffline(true)
+	err := repo.Config.SetOffline(true)
 	assert.NoError(t, err)
-	offline := repo.IsOffline()
+	offline := repo.Config.IsOffline()
 	assert.True(t, offline)
-	err = repo.SetOffline(false)
+	err = repo.Config.SetOffline(false)
 	assert.NoError(t, err)
-	offline = repo.IsOffline()
+	offline = repo.Config.IsOffline()
 	assert.False(t, offline)
 }

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -1,19 +1,22 @@
 package git
 
-import "github.com/git-town/git-town/src/command"
+import (
+	"github.com/git-town/git-town/src/command"
+	"github.com/git-town/git-town/src/config"
+)
 
 // ProdRepo is a Git Repo in production code.
 type ProdRepo struct {
-	Silent         Runner        // the Runner instance for silent Git operations
-	Logging        Runner        // the Runner instance to Git operations that show up in the output
-	LoggingShell   *LoggingShell // the LoggingShell instance used
-	*Configuration               // the git.Configuration instance for this repo
+	Silent                Runner        // the Runner instance for silent Git operations
+	Logging               Runner        // the Runner instance to Git operations that show up in the output
+	LoggingShell          *LoggingShell // the LoggingShell instance used
+	*config.Configuration               // the git.Configuration instance for this repo
 }
 
 // NewProdRepo provides a Repo instance in the current working directory.
 func NewProdRepo() *ProdRepo {
 	silentShell := command.SilentShell{}
-	config := Config()
+	config := config.NewConfiguration(silentShell)
 	currentBranchTracker := StringCache{}
 	isRepoCache := BoolCache{}
 	remoteBranchCache := StringSliceCache{}

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -7,10 +7,10 @@ import (
 
 // ProdRepo is a Git Repo in production code.
 type ProdRepo struct {
-	Silent                Runner        // the Runner instance for silent Git operations
-	Logging               Runner        // the Runner instance to Git operations that show up in the output
-	LoggingShell          *LoggingShell // the LoggingShell instance used
-	*config.Configuration               // the git.Configuration instance for this repo
+	Silent         Runner        // the Runner instance for silent Git operations
+	Logging        Runner        // the Runner instance to Git operations that show up in the output
+	LoggingShell   *LoggingShell // the LoggingShell instance used
+	*config.Config               // the git.Configuration instance for this repo
 }
 
 // NewProdRepo provides a Repo instance in the current working directory.
@@ -23,7 +23,7 @@ func NewProdRepo() *ProdRepo {
 	remotesCache := StringSliceCache{}
 	silentRunner := Runner{
 		Shell:              silentShell,
-		Configuration:      config,
+		Config:             config,
 		CurrentBranchCache: &currentBranchTracker,
 		IsRepoCache:        &isRepoCache,
 		RemotesCache:       &remotesCache,
@@ -33,7 +33,7 @@ func NewProdRepo() *ProdRepo {
 	loggingShell := NewLoggingShell(&silentRunner)
 	loggingRunner := Runner{
 		Shell:              loggingShell,
-		Configuration:      config,
+		Config:             config,
 		CurrentBranchCache: &currentBranchTracker,
 		IsRepoCache:        &isRepoCache,
 		RemotesCache:       &remotesCache,
@@ -41,10 +41,10 @@ func NewProdRepo() *ProdRepo {
 		RootDirCache:       &StringCache{},
 	}
 	return &ProdRepo{
-		Silent:        silentRunner,
-		Logging:       loggingRunner,
-		LoggingShell:  loggingShell,
-		Configuration: config,
+		Silent:       silentRunner,
+		Logging:      loggingRunner,
+		LoggingShell: loggingShell,
+		Config:       config,
 	}
 }
 
@@ -60,7 +60,7 @@ func (r *ProdRepo) RemoveOutdatedConfiguration() error {
 			return err
 		}
 		if !hasChildBranch || !hasParentBranch {
-			return r.Configuration.DeleteParentBranch(child)
+			return r.DeleteParentBranch(child)
 		}
 	}
 	return nil

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -7,10 +7,10 @@ import (
 
 // ProdRepo is a Git Repo in production code.
 type ProdRepo struct {
-	Silent         Runner        // the Runner instance for silent Git operations
-	Logging        Runner        // the Runner instance to Git operations that show up in the output
-	LoggingShell   *LoggingShell // the LoggingShell instance used
-	*config.Config               // the git.Configuration instance for this repo
+	Silent       Runner         // the Runner instance for silent Git operations
+	Logging      Runner         // the Runner instance to Git operations that show up in the output
+	LoggingShell *LoggingShell  // the LoggingShell instance used
+	Config       *config.Config // the git.Configuration instance for this repo
 }
 
 // NewProdRepo provides a Repo instance in the current working directory.
@@ -50,7 +50,7 @@ func NewProdRepo() *ProdRepo {
 
 // RemoveOutdatedConfiguration removes outdated Git Town configuration.
 func (r *ProdRepo) RemoveOutdatedConfiguration() error {
-	for child, parent := range r.GetParentBranchMap() {
+	for child, parent := range r.Config.GetParentBranchMap() {
 		hasChildBranch, err := r.Silent.HasLocalOrRemoteBranch(child)
 		if err != nil {
 			return err
@@ -60,7 +60,7 @@ func (r *ProdRepo) RemoveOutdatedConfiguration() error {
 			return err
 		}
 		if !hasChildBranch || !hasParentBranch {
-			return r.DeleteParentBranch(child)
+			return r.Config.DeleteParentBranch(child)
 		}
 	}
 	return nil

--- a/src/git/prod_repo_test.go
+++ b/src/git/prod_repo_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestNewProdRepo(t *testing.T) {
 	repo := git.NewProdRepo()
-	assert.Equal(t, repo.Configuration, repo.Silent.Configuration)
+	assert.Equal(t, repo.Config, repo.Silent.Config)
 }

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -12,19 +12,20 @@ import (
 	"strings"
 
 	"github.com/git-town/git-town/src/command"
+	"github.com/git-town/git-town/src/config"
 	"github.com/git-town/git-town/src/dryrun"
 	"github.com/git-town/git-town/src/util"
 )
 
 // Runner executes Git commands.
 type Runner struct {
-	command.Shell                        // for running console commands
-	*Configuration                       // caches Git configuration settings
-	CurrentBranchCache *StringCache      // caches the currently checked out Git branch
-	IsRepoCache        *BoolCache        // caches whether the current directory is a Git repo
-	RemoteBranchCache  *StringSliceCache // caches the remote branches of this Git repo
-	RemotesCache       *StringSliceCache // caches Git remotes
-	RootDirCache       *StringCache      // caches the base of the Git directory
+	command.Shell                           // for running console commands
+	*config.Configuration                   // caches Git configuration settings
+	CurrentBranchCache    *StringCache      // caches the currently checked out Git branch
+	IsRepoCache           *BoolCache        // caches whether the current directory is a Git repo
+	RemoteBranchCache     *StringSliceCache // caches the remote branches of this Git repo
+	RemotesCache          *StringSliceCache // caches Git remotes
+	RootDirCache          *StringCache      // caches the base of the Git directory
 }
 
 // AbortMerge cancels a currently ongoing Git merge operation.
@@ -484,7 +485,7 @@ func (r *Runner) ExpectedPreviouslyCheckedOutBranch(initialPreviouslyCheckedOutB
 		}
 		return initialBranch, nil
 	}
-	return Config().GetMainBranch(), nil
+	return r.GetMainBranch(), nil
 }
 
 // Fetch retrieves the updates from the remote repo.

--- a/src/git/runner_test.go
+++ b/src/git/runner_test.go
@@ -67,9 +67,9 @@ func TestRunner_Commits(t *testing.T) {
 
 func TestRunner_Configuration(t *testing.T) {
 	runner := test.CreateRepo(t).Runner
-	config := runner.Configuration
+	config := runner.Config
 	assert.NotNil(t, config, "first path: new config")
-	config = runner.Configuration
+	config = runner.Config
 	assert.NotNil(t, config, "second path: cached config")
 }
 
@@ -157,18 +157,18 @@ func TestRunner_CreateFeatureBranch(t *testing.T) {
 	runner := test.CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranch("f1")
 	assert.NoError(t, err)
-	runner.Configuration.Reload()
-	assert.True(t, runner.Configuration.IsFeatureBranch("f1"))
-	assert.Equal(t, []string{"main"}, runner.Configuration.GetAncestorBranches("f1"))
+	runner.Config.Reload()
+	assert.True(t, runner.Config.IsFeatureBranch("f1"))
+	assert.Equal(t, []string{"main"}, runner.Config.GetAncestorBranches("f1"))
 }
 
 func TestRunner_CreateFeatureBranchNoParent(t *testing.T) {
 	runner := test.CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranchNoParent("f1")
 	assert.NoError(t, err)
-	runner.Configuration.Reload()
-	assert.True(t, runner.Configuration.IsFeatureBranch("f1"))
-	assert.Equal(t, []string(nil), runner.Configuration.GetAncestorBranches("f1"))
+	runner.Config.Reload()
+	assert.True(t, runner.Config.IsFeatureBranch("f1"))
+	assert.Equal(t, []string(nil), runner.Config.GetAncestorBranches("f1"))
 }
 
 func TestRunner_CreateFile(t *testing.T) {
@@ -196,9 +196,9 @@ func TestRunner_CreatePerennialBranches(t *testing.T) {
 	branches, err := runner.LocalBranchesMainFirst()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"main", "master", "p1", "p2"}, branches)
-	runner.Configuration.Reload()
-	assert.True(t, runner.Configuration.IsPerennialBranch("p1"))
-	assert.True(t, runner.Configuration.IsPerennialBranch("p2"))
+	runner.Config.Reload()
+	assert.True(t, runner.Config.IsPerennialBranch("p1"))
+	assert.True(t, runner.Config.IsPerennialBranch("p2"))
 }
 
 func TestRunner_CurrentBranch(t *testing.T) {

--- a/src/git/runner_test.go
+++ b/src/git/runner_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRunner_AddRemote(t *testing.T) {
-	runner := CreateTestGitTownRepo(t).Runner
+	runner := test.CreateTestGitTownRepo(t).Runner
 	err := runner.AddRemote("foo", "bar")
 	assert.NoError(t, err)
 	remotes, err := runner.Remotes()
@@ -104,7 +104,7 @@ func TestRunner_CreateBranch(t *testing.T) {
 }
 
 func TestRunner_CreateChildFeatureBranch(t *testing.T) {
-	runner := CreateTestGitTownRepo(t).Runner
+	runner := test.CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranch("f1")
 	assert.NoError(t, err)
 	err = runner.CreateChildFeatureBranch("f1a", "f1")
@@ -154,7 +154,7 @@ func TestRunner_CreateCommit_Author(t *testing.T) {
 }
 
 func TestRunner_CreateFeatureBranch(t *testing.T) {
-	runner := CreateTestGitTownRepo(t).Runner
+	runner := test.CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranch("f1")
 	assert.NoError(t, err)
 	runner.Configuration.Reload()
@@ -163,7 +163,7 @@ func TestRunner_CreateFeatureBranch(t *testing.T) {
 }
 
 func TestRunner_CreateFeatureBranchNoParent(t *testing.T) {
-	runner := CreateTestGitTownRepo(t).Runner
+	runner := test.CreateTestGitTownRepo(t).Runner
 	err := runner.CreateFeatureBranchNoParent("f1")
 	assert.NoError(t, err)
 	runner.Configuration.Reload()
@@ -190,7 +190,7 @@ func TestRunner_CreateFile_InSubFolder(t *testing.T) {
 }
 
 func TestRunner_CreatePerennialBranches(t *testing.T) {
-	runner := CreateTestGitTownRepo(t).Runner
+	runner := test.CreateTestGitTownRepo(t).Runner
 	err := runner.CreatePerennialBranches("p1", "p2")
 	assert.NoError(t, err)
 	branches, err := runner.LocalBranchesMainFirst()
@@ -605,18 +605,4 @@ func TestRunner_UncommittedFiles(t *testing.T) {
 	files, err := runner.UncommittedFiles()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"f1.txt", "f2.txt"}, files)
-}
-
-// CreateTestGitTownRepo creates a GitRepo for use in tests, with a main branch and
-// initial git town configuration.
-func CreateTestGitTownRepo(t *testing.T) test.Repo {
-	repo := test.CreateRepo(t)
-	err := repo.CreateBranch("main", "master")
-	assert.NoError(t, err)
-	err = repo.RunMany([][]string{
-		{"git", "config", "git-town.main-branch-name", "main"},
-		{"git", "config", "git-town.perennial-branch-names", ""},
-	})
-	assert.NoError(t, err)
-	return repo
 }

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -10,7 +10,7 @@ import (
 
 // EnsureIsConfigured has the user to confgure the main branch and perennial branches if needed.
 func EnsureIsConfigured(repo *git.ProdRepo) error {
-	if git.Config().GetMainBranch() == "" {
+	if repo.GetMainBranch() == "" {
 		fmt.Println("Git Town needs to be configured")
 		fmt.Println()
 		err := ConfigureMainBranch(repo)
@@ -30,10 +30,10 @@ func ConfigureMainBranch(repo *git.ProdRepo) error {
 	}
 	newMainBranch := askForBranch(askForBranchOptions{
 		branchNames:       localBranches,
-		prompt:            getMainBranchPrompt(),
-		defaultBranchName: git.Config().GetMainBranch(),
+		prompt:            getMainBranchPrompt(repo),
+		defaultBranchName: repo.GetMainBranch(),
 	})
-	return git.Config().SetMainBranch(newMainBranch)
+	return repo.SetMainBranch(newMainBranch)
 }
 
 // ConfigurePerennialBranches has the user to confgure the perennial branches.
@@ -47,17 +47,17 @@ func ConfigurePerennialBranches(repo *git.ProdRepo) error {
 	}
 	newPerennialBranches := askForBranches(askForBranchesOptions{
 		branchNames:        branchNames,
-		prompt:             getPerennialBranchesPrompt(),
-		defaultBranchNames: git.Config().GetPerennialBranches(),
+		prompt:             getPerennialBranchesPrompt(repo),
+		defaultBranchNames: repo.GetPerennialBranches(),
 	})
-	return git.Config().SetPerennialBranches(newPerennialBranches)
+	return repo.SetPerennialBranches(newPerennialBranches)
 }
 
 // Helpers
 
-func getMainBranchPrompt() (result string) {
+func getMainBranchPrompt(repo *git.ProdRepo) (result string) {
 	result += "Please specify the main development branch:"
-	currentMainBranch := git.Config().GetMainBranch()
+	currentMainBranch := repo.GetMainBranch()
 	if currentMainBranch != "" {
 		coloredBranchName := color.New(color.Bold).Add(color.FgCyan).Sprintf(currentMainBranch)
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchName)
@@ -65,9 +65,9 @@ func getMainBranchPrompt() (result string) {
 	return
 }
 
-func getPerennialBranchesPrompt() (result string) {
+func getPerennialBranchesPrompt(repo *git.ProdRepo) (result string) {
 	result += "Please specify perennial branches:"
-	currentPerennialBranches := git.Config().GetPerennialBranches()
+	currentPerennialBranches := repo.GetPerennialBranches()
 	if len(currentPerennialBranches) > 0 {
 		coloredBranchNames := color.New(color.Bold).Add(color.FgCyan).Sprintf(strings.Join(currentPerennialBranches, ", "))
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchNames)

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -10,7 +10,7 @@ import (
 
 // EnsureIsConfigured has the user to confgure the main branch and perennial branches if needed.
 func EnsureIsConfigured(repo *git.ProdRepo) error {
-	if repo.GetMainBranch() == "" {
+	if repo.Config.GetMainBranch() == "" {
 		fmt.Println("Git Town needs to be configured")
 		fmt.Println()
 		err := ConfigureMainBranch(repo)
@@ -31,9 +31,9 @@ func ConfigureMainBranch(repo *git.ProdRepo) error {
 	newMainBranch := askForBranch(askForBranchOptions{
 		branchNames:       localBranches,
 		prompt:            getMainBranchPrompt(repo),
-		defaultBranchName: repo.GetMainBranch(),
+		defaultBranchName: repo.Config.GetMainBranch(),
 	})
-	return repo.SetMainBranch(newMainBranch)
+	return repo.Config.SetMainBranch(newMainBranch)
 }
 
 // ConfigurePerennialBranches has the user to confgure the perennial branches.
@@ -48,16 +48,16 @@ func ConfigurePerennialBranches(repo *git.ProdRepo) error {
 	newPerennialBranches := askForBranches(askForBranchesOptions{
 		branchNames:        branchNames,
 		prompt:             getPerennialBranchesPrompt(repo),
-		defaultBranchNames: repo.GetPerennialBranches(),
+		defaultBranchNames: repo.Config.GetPerennialBranches(),
 	})
-	return repo.SetPerennialBranches(newPerennialBranches)
+	return repo.Config.SetPerennialBranches(newPerennialBranches)
 }
 
 // Helpers
 
 func getMainBranchPrompt(repo *git.ProdRepo) (result string) {
 	result += "Please specify the main development branch:"
-	currentMainBranch := repo.GetMainBranch()
+	currentMainBranch := repo.Config.GetMainBranch()
 	if currentMainBranch != "" {
 		coloredBranchName := color.New(color.Bold).Add(color.FgCyan).Sprintf(currentMainBranch)
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchName)
@@ -67,7 +67,7 @@ func getMainBranchPrompt(repo *git.ProdRepo) (result string) {
 
 func getPerennialBranchesPrompt(repo *git.ProdRepo) (result string) {
 	result += "Please specify perennial branches:"
-	currentPerennialBranches := repo.GetPerennialBranches()
+	currentPerennialBranches := repo.Config.GetPerennialBranches()
 	if len(currentPerennialBranches) > 0 {
 		coloredBranchNames := color.New(color.Bold).Add(color.FgCyan).Sprintf(strings.Join(currentPerennialBranches, ", "))
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchNames)

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -12,8 +12,8 @@ import (
 
 // GetSquashCommitAuthor gets the author of the supplied branch.
 // If the branch has more than one author, the author is queried from the user.
-func GetSquashCommitAuthor(branchName string) (string, error) {
-	authors, err := getBranchAuthors(branchName)
+func GetSquashCommitAuthor(branchName string, repo *git.ProdRepo) (string, error) {
+	authors, err := getBranchAuthors(branchName, repo)
 	if err != nil {
 		return "", err
 	}
@@ -42,9 +42,9 @@ func askForAuthor(authors []string) string {
 	return result
 }
 
-func getBranchAuthors(branchName string) (result []string, err error) {
+func getBranchAuthors(branchName string, repo *git.ProdRepo) (result []string, err error) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	lines, err := command.Run("git", "shortlog", "-s", "-n", "-e", git.Config().GetMainBranch()+".."+branchName)
+	lines, err := command.Run("git", "shortlog", "-s", "-n", "-e", repo.GetMainBranch()+".."+branchName)
 	if err != nil {
 		return result, err
 	}

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -44,7 +44,7 @@ func askForAuthor(authors []string) string {
 
 func getBranchAuthors(branchName string, repo *git.ProdRepo) (result []string, err error) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	lines, err := command.Run("git", "shortlog", "-s", "-n", "-e", repo.GetMainBranch()+".."+branchName)
+	lines, err := command.Run("git", "shortlog", "-s", "-n", "-e", repo.Config.GetMainBranch()+".."+branchName)
 	if err != nil {
 		return result, err
 	}

--- a/src/steps/add_to_perennial_branch.go
+++ b/src/steps/add_to_perennial_branch.go
@@ -18,5 +18,5 @@ func (step *AddToPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Step, er
 
 // Run executes this step.
 func (step *AddToPerennialBranches) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	return repo.AddToPerennialBranches(step.BranchName)
+	return repo.Config.AddToPerennialBranches(step.BranchName)
 }

--- a/src/steps/create_pull_request_step.go
+++ b/src/steps/create_pull_request_step.go
@@ -14,7 +14,7 @@ type CreatePullRequestStep struct {
 
 // Run executes this step.
 func (step *CreatePullRequestStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	parentBranch := repo.GetParentBranch(step.BranchName)
+	parentBranch := repo.Config.GetParentBranch(step.BranchName)
 	prURL, err := driver.NewPullRequestURL(step.BranchName, parentBranch)
 	if err != nil {
 		return err

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -23,6 +23,6 @@ func (step *DeleteParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, er
 
 // Run executes this step.
 func (step *DeleteParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	step.previousParent = repo.GetParentBranch(step.BranchName)
-	return repo.DeleteParentBranch(step.BranchName)
+	step.previousParent = repo.Config.GetParentBranch(step.BranchName)
+	return repo.Config.DeleteParentBranch(step.BranchName)
 }

--- a/src/steps/remove_from_perennial_branch.go
+++ b/src/steps/remove_from_perennial_branch.go
@@ -18,5 +18,5 @@ func (step *RemoveFromPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Ste
 
 // Run executes this step.
 func (step *RemoveFromPerennialBranches) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	return repo.RemoveFromPerennialBranches(step.BranchName)
+	return repo.Config.RemoveFromPerennialBranches(step.BranchName)
 }

--- a/src/steps/run.go
+++ b/src/steps/run.go
@@ -64,7 +64,7 @@ func Run(runState *RunState, repo *git.ProdRepo, driver drivers.CodeHostingDrive
 				if err != nil {
 					return err
 				}
-				if runState.Command == "sync" && !(rebasing && git.Config().IsMainBranch(currentBranch)) {
+				if runState.Command == "sync" && !(rebasing && repo.IsMainBranch(currentBranch)) {
 					runState.UnfinishedDetails.CanSkip = true
 				}
 				err = SaveRunState(runState, repo)

--- a/src/steps/run.go
+++ b/src/steps/run.go
@@ -64,7 +64,7 @@ func Run(runState *RunState, repo *git.ProdRepo, driver drivers.CodeHostingDrive
 				if err != nil {
 					return err
 				}
-				if runState.Command == "sync" && !(rebasing && repo.IsMainBranch(currentBranch)) {
+				if runState.Command == "sync" && !(rebasing && repo.Config.IsMainBranch(currentBranch)) {
 					runState.UnfinishedDetails.CanSkip = true
 				}
 				err = SaveRunState(runState, repo)

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -25,6 +25,6 @@ func (step *SetParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error
 
 // Run executes this step.
 func (step *SetParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	step.previousParent = repo.GetParentBranch(step.BranchName)
-	return repo.SetParentBranch(step.BranchName, step.ParentBranchName)
+	step.previousParent = repo.Config.GetParentBranch(step.BranchName)
+	return repo.Config.SetParentBranch(step.BranchName, step.ParentBranchName)
 }

--- a/src/steps/squash_merge_branch_step.go
+++ b/src/steps/squash_merge_branch_step.go
@@ -41,7 +41,7 @@ func (step *SquashMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHo
 	if err != nil {
 		return err
 	}
-	author, err := prompt.GetSquashCommitAuthor(step.BranchName)
+	author, err := prompt.GetSquashCommitAuthor(step.BranchName, repo)
 	if err != nil {
 		return err
 	}

--- a/test/repo.go
+++ b/test/repo.go
@@ -53,7 +53,7 @@ func NewRepo(workingDir, homeDir, binDir string) Repo {
 	shell := NewMockingShell(workingDir, homeDir, binDir)
 	runner := git.Runner{
 		Shell:              shell,
-		Configuration:      config.NewConfiguration(shell),
+		Config:             config.NewConfiguration(shell),
 		IsRepoCache:        &git.BoolCache{},
 		RemoteBranchCache:  &git.StringSliceCache{},
 		RemotesCache:       &git.StringSliceCache{},

--- a/test/repo.go
+++ b/test/repo.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/src/command"
+	"github.com/git-town/git-town/src/config"
 	"github.com/git-town/git-town/src/git"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,7 +53,7 @@ func NewRepo(workingDir, homeDir, binDir string) Repo {
 	shell := NewMockingShell(workingDir, homeDir, binDir)
 	runner := git.Runner{
 		Shell:              shell,
-		Configuration:      git.NewConfiguration(shell),
+		Configuration:      config.NewConfiguration(shell),
 		IsRepoCache:        &git.BoolCache{},
 		RemoteBranchCache:  &git.StringSliceCache{},
 		RemotesCache:       &git.StringSliceCache{},
@@ -93,4 +94,18 @@ func (repo *Repo) FilesInBranches() (result DataTable, err error) {
 		}
 	}
 	return result, err
+}
+
+// CreateTestGitTownRepo creates a GitRepo for use in tests, with a main branch and
+// initial git town configuration.
+func CreateTestGitTownRepo(t *testing.T) Repo {
+	repo := CreateRepo(t)
+	err := repo.CreateBranch("main", "master")
+	assert.NoError(t, err)
+	err = repo.RunMany([][]string{
+		{"git", "config", "git-town.main-branch-name", "main"},
+		{"git", "config", "git-town.perennial-branch-names", ""},
+	})
+	assert.NoError(t, err)
+	return repo
 }

--- a/test/steps.go
+++ b/test/steps.go
@@ -82,7 +82,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^Git Town is in offline mode$`, func() error {
-		return state.gitEnv.DevRepo.SetOffline(true)
+		return state.gitEnv.DevRepo.Config.SetOffline(true)
 	})
 
 	suite.Step(`^Git Town is no longer configured for this repo$`, func() error {
@@ -101,8 +101,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		table.AddRow("BRANCH", "PARENT")
 		for _, row := range input.Rows[1:] {
 			branch := row.Cells[0].Value
-			state.gitEnv.DevRepo.Configuration.Reload()
-			parentBranch := state.gitEnv.DevRepo.Configuration.GetParentBranch(branch)
+			state.gitEnv.DevRepo.Config.Reload()
+			parentBranch := state.gitEnv.DevRepo.Config.GetParentBranch(branch)
 			table.AddRow(branch, parentBranch)
 		}
 		diff, errCount := table.EqualGherkin(input)
@@ -115,8 +115,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^Git Town now has no branch hierarchy information$`, func() error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		if state.gitEnv.DevRepo.Configuration.HasBranchInformation() {
+		state.gitEnv.DevRepo.Config.Reload()
+		if state.gitEnv.DevRepo.Config.HasBranchInformation() {
 			return fmt.Errorf("unexpected Git Town branch hierarchy information")
 		}
 		return nil
@@ -175,7 +175,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^I haven't configured Git Town yet$`, func() error {
-		err := state.gitEnv.DevRepo.DeletePerennialBranchConfiguration()
+		err := state.gitEnv.DevRepo.Config.DeletePerennialBranchConfiguration()
 		if err != nil {
 			return err
 		}
@@ -367,7 +367,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my coworker sets the parent branch of "([^"]*)" as "([^"]*)"$`, func(childBranch, parentBranch string) error {
-		_ = state.gitEnv.CoworkerRepo.Configuration.SetParentBranch(childBranch, parentBranch)
+		_ = state.gitEnv.CoworkerRepo.Config.SetParentBranch(childBranch, parentBranch)
 		return nil
 	})
 
@@ -428,15 +428,15 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my repo has "color\.ui" set to "([^"]*)"$`, func(value string) error {
-		return state.gitEnv.DevRepo.SetColorUI(value)
+		return state.gitEnv.DevRepo.Config.SetColorUI(value)
 	})
 
 	suite.Step(`^my repo has "git-town.code-hosting-driver" set to "([^"]*)"$`, func(value string) error {
-		return state.gitEnv.DevRepo.SetCodeHostingDriver(value)
+		return state.gitEnv.DevRepo.Config.SetCodeHostingDriver(value)
 	})
 
 	suite.Step(`^my repo has "git-town.code-hosting-origin-hostname" set to "([^"]*)"$`, func(value string) error {
-		return state.gitEnv.DevRepo.SetCodeHostingOriginHostname(value)
+		return state.gitEnv.DevRepo.Config.SetCodeHostingOriginHostname(value)
 	})
 
 	suite.Step(`^my repo has "git-town.ship-delete-remote-branch" set to "(true|false)"$`, func(value string) error {
@@ -444,7 +444,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		_ = state.gitEnv.DevRepo.SetShouldShipDeleteRemoteBranch(parsed)
+		_ = state.gitEnv.DevRepo.Config.SetShouldShipDeleteRemoteBranch(parsed)
 		return nil
 	})
 
@@ -453,7 +453,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		_ = state.gitEnv.DevRepo.SetShouldSyncUpstream(value)
+		_ = state.gitEnv.DevRepo.Config.SetShouldSyncUpstream(value)
 		return nil
 	})
 
@@ -518,8 +518,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my repo is now configured with no perennial branches$`, func() error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		branches := state.gitEnv.DevRepo.GetPerennialBranches()
+		state.gitEnv.DevRepo.Config.Reload()
+		branches := state.gitEnv.DevRepo.Config.GetPerennialBranches()
 		if len(branches) > 0 {
 			return fmt.Errorf("expected no perennial branches, got %q", branches)
 		}
@@ -681,16 +681,16 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^offline mode is disabled$`, func() error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		if state.gitEnv.DevRepo.IsOffline() {
+		state.gitEnv.DevRepo.Config.Reload()
+		if state.gitEnv.DevRepo.Config.IsOffline() {
 			return fmt.Errorf("expected to not be offline but am")
 		}
 		return nil
 	})
 
 	suite.Step(`^offline mode is enabled$`, func() error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		if !state.gitEnv.DevRepo.IsOffline() {
+		state.gitEnv.DevRepo.Config.Reload()
+		if !state.gitEnv.DevRepo.Config.IsOffline() {
 			return fmt.Errorf("expected to be offline but am not")
 		}
 		return nil
@@ -731,12 +731,12 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		_ = state.gitEnv.DevRepo.SetNewBranchPush(b, true)
+		_ = state.gitEnv.DevRepo.Config.SetNewBranchPush(b, true)
 		return nil
 	})
 
 	suite.Step(`^the main branch is configured as "([^"]+)"$`, func(name string) error {
-		return state.gitEnv.DevRepo.SetMainBranch(name)
+		return state.gitEnv.DevRepo.Config.SetMainBranch(name)
 	})
 
 	suite.Step(`^the main branch name is not configured$`, func() error {
@@ -744,8 +744,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the main branch is now configured as "([^"]+)"$`, func(name string) error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		actual := state.gitEnv.DevRepo.GetMainBranch()
+		state.gitEnv.DevRepo.Config.Reload()
+		actual := state.gitEnv.DevRepo.Config.GetMainBranch()
 		if actual != name {
 			return fmt.Errorf("expected %q, got %q", name, actual)
 		}
@@ -757,11 +757,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		return state.gitEnv.DevRepo.SetNewBranchPush(b, false)
+		return state.gitEnv.DevRepo.Config.SetNewBranchPush(b, false)
 	})
 
 	suite.Step(`^the new-branch-push-flag configuration is "([^"]*)"$`, func(value string) error {
-		_, err := state.gitEnv.DevRepo.Configuration.SetLocalConfigValue("git-town.new-branch-push-flag", value)
+		_, err := state.gitEnv.DevRepo.Config.SetLocalConfigValue("git-town.new-branch-push-flag", value)
 		return err
 	})
 
@@ -770,8 +770,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		state.gitEnv.DevRepo.Configuration.Reload()
-		have := state.gitEnv.DevRepo.ShouldNewBranchPush()
+		state.gitEnv.DevRepo.Config.Reload()
+		have := state.gitEnv.DevRepo.Config.ShouldNewBranchPush()
 		if have != want {
 			return fmt.Errorf("expected global new-branch-push-flag to be %t, but was %t", want, have)
 		}
@@ -779,21 +779,21 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the offline configuration is accidentally set to "([^"]*)"$`, func(value string) error {
-		_, err := state.gitEnv.DevRepo.Configuration.SetGlobalConfigValue("git-town.offline", value)
+		_, err := state.gitEnv.DevRepo.Config.SetGlobalConfigValue("git-town.offline", value)
 		return err
 	})
 
 	suite.Step(`^the perennial branches are configured as "([^"]+)"$`, func(name string) error {
-		return state.gitEnv.DevRepo.AddToPerennialBranches(name)
+		return state.gitEnv.DevRepo.Config.AddToPerennialBranches(name)
 	})
 
 	suite.Step(`^the perennial branches are configured as "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
-		return state.gitEnv.DevRepo.AddToPerennialBranches(branch1, branch2)
+		return state.gitEnv.DevRepo.Config.AddToPerennialBranches(branch1, branch2)
 	})
 
 	suite.Step(`^the perennial branches are now configured as "([^"]+)"$`, func(name string) error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		actual := state.gitEnv.DevRepo.GetPerennialBranches()
+		state.gitEnv.DevRepo.Config.Reload()
+		actual := state.gitEnv.DevRepo.Config.GetPerennialBranches()
 		if len(actual) != 1 {
 			return fmt.Errorf("expected 1 perennial branch, got %q", actual)
 		}
@@ -804,8 +804,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the perennial branches are now configured as "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		actual := state.gitEnv.DevRepo.GetPerennialBranches()
+		state.gitEnv.DevRepo.Config.Reload()
+		actual := state.gitEnv.DevRepo.Config.GetPerennialBranches()
 		if len(actual) != 2 {
 			return fmt.Errorf("expected 2 perennial branches, got %q", actual)
 		}
@@ -816,7 +816,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the perennial branches are not configured$`, func() error {
-		return state.gitEnv.DevRepo.DeletePerennialBranchConfiguration()
+		return state.gitEnv.DevRepo.Config.DeletePerennialBranchConfiguration()
 	})
 
 	suite.Step(`^the previous Git branch is (?:now|still) "([^"]*)"$`, func(want string) error {
@@ -835,12 +835,12 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the pull-branch-strategy configuration is "(merge|rebase)"$`, func(value string) error {
-		return state.gitEnv.DevRepo.SetPullBranchStrategy(value)
+		return state.gitEnv.DevRepo.Config.SetPullBranchStrategy(value)
 	})
 
 	suite.Step(`^the pull-branch-strategy configuration is now "(merge|rebase)"$`, func(want string) error {
-		state.gitEnv.DevRepo.Configuration.Reload()
-		have := state.gitEnv.DevRepo.GetPullBranchStrategy()
+		state.gitEnv.DevRepo.Config.Reload()
+		have := state.gitEnv.DevRepo.Config.GetPullBranchStrategy()
 		if have != want {
 			return fmt.Errorf("expected pull-branch-strategy to be %q but was %q", want, have)
 		}


### PR DESCRIPTION
As we have discussed, the configuration moves from the `git` package into its own `config` package.
I also shorten the name of the main class to `Config` and remove the global access function. Configuration is now accessed through the `git.ProdRepo` instance used. I also separate Git operations from config operations now to make this distinction more clear.