### PR TITLE
Convert util package to stringslice

### DIFF
--- a/documentation/development/architecture.md
+++ b/documentation/development/architecture.md
@@ -14,7 +14,8 @@ code is located in the [src](../../src) folder. It contains these packages:
 - [src/git](../../src/git) accesses the Git binary on the user's computer
 - [src/prompt](../../src/prompt) implements interactive wizards
 - [src/steps](../../src/steps) contains the building blocks of Git Town commands
-- [src/util](../../src/util) string helper functions
+- [src/stringslice](../../src/stringslice) functions for working with string
+  slices
 
 ## State files
 

--- a/documentation/development/architecture.md
+++ b/documentation/development/architecture.md
@@ -1,7 +1,7 @@
 # Architecture of the Git Town code base
 
-This mono-repo contains all Git Town related code. The source code is located in
-the [src](../../src) folder. It contains these packages:
+This mono-repo contains all Git Town related code. The [src](../../src) folder
+contains these packages:
 
 - [src/browsers](../../src/browsers) interacts with the local browser
 - [src/cli](../../src/cli) reads and writes data from and to Git Town's CLI
@@ -19,12 +19,10 @@ the [src](../../src) folder. It contains these packages:
 
 ## State files
 
-When a Git Town command finishes, a list of the steps to undo the command as
-well as optionally any remaining steps to be run (in case the command
-encountered conflicts) are stored in a state files in a temp folder on the
-machine. The struct that holds the state is in
-[src/steps/run_state.go](../../src/steps/run_state.go).
+When a Git Town command finishes, it stores the steps to undo or continue itself
+in a _state file_ located in the temp folder of the machine. The struct that
+holds the state is in [src/steps/run_state.go](../../src/steps/run_state.go).
 
 ## Tests
 
-The test architecture is described [separately](testing.md).
+See [testing.md](testing.md).

--- a/documentation/development/architecture.md
+++ b/documentation/development/architecture.md
@@ -1,12 +1,12 @@
 # Architecture of the Git Town code base
 
-All Git Town code is stored as a mono-repo. The [Go](https://golang.org) source
-code is located in the [src](../../src) folder. It contains these packages:
+This mono-repo contains all Git Town related code. The source code is located in
+the [src](../../src) folder. It contains these packages:
 
 - [src/browsers](../../src/browsers) interacts with the local browser
 - [src/cli](../../src/cli) reads and writes data from and to Git Town's CLI
 - [src/cmd](../../src/cmd) defines Git Town's
-  [Cobra](https://github.com/spf13/cobra)-based subcommands
+  [Cobra](https://github.com/spf13/cobra) subcommands
 - [src/command](../../src/command) runs commands in subshells
 - [src/config](../../src/config) accesses the Git Town configuration
 - [src/drivers](../../src/drivers) interacts with external Git hosting providers

--- a/src/cli/helpers.go
+++ b/src/cli/helpers.go
@@ -1,4 +1,4 @@
-package util
+package cli
 
 import "strings"
 

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/git-town/git-town/src/util"
 )
 
 // Printf prints the given text using fmt.Printf
@@ -52,6 +51,6 @@ func PrintError(messages ...interface{}) {
 func PrintLabelAndValue(label, value string) {
 	labelFmt := color.New(color.Bold).Add(color.Underline)
 	PrintlnColor(labelFmt, label+":")
-	Println(util.Indent(value))
+	Println(Indent(value))
 	fmt.Println()
 }

--- a/src/cli/printable.go
+++ b/src/cli/printable.go
@@ -4,8 +4,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/git-town/git-town/src/util"
 )
 
 // BranchAncestryConfig defines the configuration values needed by the `cli` package.
@@ -30,7 +28,7 @@ func PrintableBranchTree(branchName string, config BranchAncestryConfig) (result
 	childBranches := config.GetChildBranches(branchName)
 	sort.Strings(childBranches)
 	for _, childBranch := range childBranches {
-		result += "\n" + util.Indent(PrintableBranchTree(childBranch, config))
+		result += "\n" + Indent(PrintableBranchTree(childBranch, config))
 	}
 	return
 }

--- a/src/command/result.go
+++ b/src/command/result.go
@@ -50,7 +50,7 @@ func (c *Result) OutputSanitized() string {
 // OutputContainsLine returns whether the output of this command
 // contains the given line.
 func (c *Result) OutputContainsLine(line string) bool {
-	return stringslice.DoesStringArrayContain(c.OutputLines(), line)
+	return stringslice.Contains(c.OutputLines(), line)
 }
 
 // OutputContainsText returns whether the output of this command

--- a/src/command/result.go
+++ b/src/command/result.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/acarl005/stripansi"
-	"github.com/git-town/git-town/src/util"
+	"github.com/git-town/git-town/src/stringslice"
 )
 
 // Result contains the results of a command run in a subshell.
@@ -50,7 +50,7 @@ func (c *Result) OutputSanitized() string {
 // OutputContainsLine returns whether the output of this command
 // contains the given line.
 func (c *Result) OutputContainsLine(line string) bool {
-	return util.DoesStringArrayContain(c.OutputLines(), line)
+	return stringslice.DoesStringArrayContain(c.OutputLines(), line)
 }
 
 // OutputContainsText returns whether the output of this command

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -117,7 +117,7 @@ func (c *Config) GetBranchAncestryRoots() []string {
 	parentMap := c.GetParentBranchMap()
 	roots := []string{}
 	for _, parent := range parentMap {
-		if _, ok := parentMap[parent]; !ok && !stringslice.DoesStringArrayContain(roots, parent) {
+		if _, ok := parentMap[parent]; !ok && !stringslice.Contains(roots, parent) {
 			roots = append(roots, parent)
 		}
 	}
@@ -251,7 +251,7 @@ func (c *Config) HasParentBranch(branchName string) bool {
 // IsAncestorBranch indicates whether the given branch is an ancestor of the other given branch.
 func (c *Config) IsAncestorBranch(branchName, ancestorBranchName string) bool {
 	ancestorBranches := c.GetAncestorBranches(branchName)
-	return stringslice.DoesStringArrayContain(ancestorBranches, ancestorBranchName)
+	return stringslice.Contains(ancestorBranches, ancestorBranchName)
 }
 
 // IsFeatureBranch indicates whether the branch with the given name is
@@ -285,7 +285,7 @@ func (c *Config) IsOffline() bool {
 // a perennial branch.
 func (c *Config) IsPerennialBranch(branchName string) bool {
 	perennialBranches := c.GetPerennialBranches()
-	return stringslice.DoesStringArrayContain(perennialBranches, branchName)
+	return stringslice.Contains(perennialBranches, branchName)
 }
 
 // localConfigKeysMatching provides the names of the Git Town configuration keys matching the given RegExp string.
@@ -307,7 +307,7 @@ func (c *Config) Reload() {
 
 // RemoveFromPerennialBranches removes the given branch as a perennial branch.
 func (c *Config) RemoveFromPerennialBranches(branchName string) error {
-	return c.SetPerennialBranches(stringslice.RemoveStringFromSlice(c.GetPerennialBranches(), branchName))
+	return c.SetPerennialBranches(stringslice.Remove(c.GetPerennialBranches(), branchName))
 }
 
 // RemoveGitAlias removes the given Git alias.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/git-town/git-town/src/command"
-	"github.com/git-town/git-town/src/util"
+	"github.com/git-town/git-town/src/stringslice"
 )
 
 // Config manages the Git Town configuration
@@ -117,7 +117,7 @@ func (c *Config) GetBranchAncestryRoots() []string {
 	parentMap := c.GetParentBranchMap()
 	roots := []string{}
 	for _, parent := range parentMap {
-		if _, ok := parentMap[parent]; !ok && !util.DoesStringArrayContain(roots, parent) {
+		if _, ok := parentMap[parent]; !ok && !stringslice.DoesStringArrayContain(roots, parent) {
 			roots = append(roots, parent)
 		}
 	}
@@ -251,7 +251,7 @@ func (c *Config) HasParentBranch(branchName string) bool {
 // IsAncestorBranch indicates whether the given branch is an ancestor of the other given branch.
 func (c *Config) IsAncestorBranch(branchName, ancestorBranchName string) bool {
 	ancestorBranches := c.GetAncestorBranches(branchName)
-	return util.DoesStringArrayContain(ancestorBranches, ancestorBranchName)
+	return stringslice.DoesStringArrayContain(ancestorBranches, ancestorBranchName)
 }
 
 // IsFeatureBranch indicates whether the branch with the given name is
@@ -285,7 +285,7 @@ func (c *Config) IsOffline() bool {
 // a perennial branch.
 func (c *Config) IsPerennialBranch(branchName string) bool {
 	perennialBranches := c.GetPerennialBranches()
-	return util.DoesStringArrayContain(perennialBranches, branchName)
+	return stringslice.DoesStringArrayContain(perennialBranches, branchName)
 }
 
 // localConfigKeysMatching provides the names of the Git Town configuration keys matching the given RegExp string.
@@ -307,7 +307,7 @@ func (c *Config) Reload() {
 
 // RemoveFromPerennialBranches removes the given branch as a perennial branch.
 func (c *Config) RemoveFromPerennialBranches(branchName string) error {
-	return c.SetPerennialBranches(util.RemoveStringFromSlice(c.GetPerennialBranches(), branchName))
+	return c.SetPerennialBranches(stringslice.RemoveStringFromSlice(c.GetPerennialBranches(), branchName))
 }
 
 // RemoveGitAlias removes the given Git alias.

--- a/src/config/helpers.go
+++ b/src/config/helpers.go
@@ -1,1 +1,0 @@
-package config

--- a/src/config/helpers.go
+++ b/src/config/helpers.go
@@ -1,0 +1,1 @@
+package config

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -14,7 +14,7 @@ import (
 	"github.com/git-town/git-town/src/command"
 	"github.com/git-town/git-town/src/config"
 	"github.com/git-town/git-town/src/dryrun"
-	"github.com/git-town/git-town/src/util"
+	"github.com/git-town/git-town/src/stringslice"
 )
 
 // Runner executes Git commands.
@@ -148,14 +148,14 @@ func (r *Runner) CommitsInBranch(branch string, fields []string) (result []Commi
 		if strings.EqualFold(commit.Message, "initial commit") {
 			continue
 		}
-		if util.DoesStringArrayContain(fields, "FILE NAME") {
+		if stringslice.DoesStringArrayContain(fields, "FILE NAME") {
 			filenames, err := r.FilesInCommit(commit.SHA)
 			if err != nil {
 				return result, fmt.Errorf("cannot determine file name for commit %q in branch %q: %w", commit.SHA, branch, err)
 			}
 			commit.FileName = strings.Join(filenames, ", ")
 		}
-		if util.DoesStringArrayContain(fields, "FILE CONTENT") {
+		if stringslice.DoesStringArrayContain(fields, "FILE CONTENT") {
 			filecontent, err := r.FileContentInCommit(commit.SHA, commit.FileName)
 			if err != nil {
 				return result, fmt.Errorf("cannot determine file content for commit %q in branch %q: %w", commit.SHA, branch, err)
@@ -597,7 +597,7 @@ func (r *Runner) HasLocalBranch(name string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("cannot determine whether the local branch %q exists: %w", name, err)
 	}
-	return util.DoesStringArrayContain(branches, name), nil
+	return stringslice.DoesStringArrayContain(branches, name), nil
 }
 
 // HasLocalOrRemoteBranch indicates whether this repo has a local or remote branch with the given name.
@@ -606,7 +606,7 @@ func (r *Runner) HasLocalOrRemoteBranch(name string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("cannot determine whether the local or remote branch %q exists: %w", name, err)
 	}
-	return util.DoesStringArrayContain(branches, name), nil
+	return stringslice.DoesStringArrayContain(branches, name), nil
 }
 
 // HasMergeInProgress indicates whether this Git repository currently has a merge in progress.
@@ -646,7 +646,7 @@ func (r *Runner) HasRemote(name string) (result bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("cannot determine if remote %q exists: %w", name, err)
 	}
-	return util.DoesStringArrayContain(remotes, name), nil
+	return stringslice.DoesStringArrayContain(remotes, name), nil
 }
 
 // HasShippableChanges indicates whether the given branch has changes

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -148,14 +148,14 @@ func (r *Runner) CommitsInBranch(branch string, fields []string) (result []Commi
 		if strings.EqualFold(commit.Message, "initial commit") {
 			continue
 		}
-		if stringslice.DoesStringArrayContain(fields, "FILE NAME") {
+		if stringslice.Contains(fields, "FILE NAME") {
 			filenames, err := r.FilesInCommit(commit.SHA)
 			if err != nil {
 				return result, fmt.Errorf("cannot determine file name for commit %q in branch %q: %w", commit.SHA, branch, err)
 			}
 			commit.FileName = strings.Join(filenames, ", ")
 		}
-		if stringslice.DoesStringArrayContain(fields, "FILE CONTENT") {
+		if stringslice.Contains(fields, "FILE CONTENT") {
 			filecontent, err := r.FileContentInCommit(commit.SHA, commit.FileName)
 			if err != nil {
 				return result, fmt.Errorf("cannot determine file content for commit %q in branch %q: %w", commit.SHA, branch, err)
@@ -597,7 +597,7 @@ func (r *Runner) HasLocalBranch(name string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("cannot determine whether the local branch %q exists: %w", name, err)
 	}
-	return stringslice.DoesStringArrayContain(branches, name), nil
+	return stringslice.Contains(branches, name), nil
 }
 
 // HasLocalOrRemoteBranch indicates whether this repo has a local or remote branch with the given name.
@@ -606,7 +606,7 @@ func (r *Runner) HasLocalOrRemoteBranch(name string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("cannot determine whether the local or remote branch %q exists: %w", name, err)
 	}
-	return stringslice.DoesStringArrayContain(branches, name), nil
+	return stringslice.Contains(branches, name), nil
 }
 
 // HasMergeInProgress indicates whether this Git repository currently has a merge in progress.
@@ -646,7 +646,7 @@ func (r *Runner) HasRemote(name string) (result bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("cannot determine if remote %q exists: %w", name, err)
 	}
-	return stringslice.DoesStringArrayContain(remotes, name), nil
+	return stringslice.Contains(remotes, name), nil
 }
 
 // HasShippableChanges indicates whether the given branch has changes

--- a/src/stringslice/stringslice.go
+++ b/src/stringslice/stringslice.go
@@ -1,4 +1,4 @@
-package util
+package stringslice
 
 // DoesStringArrayContain returns whether the given string slice
 // contains the given string.

--- a/src/stringslice/stringslice.go
+++ b/src/stringslice/stringslice.go
@@ -1,8 +1,8 @@
 package stringslice
 
-// DoesStringArrayContain returns whether the given string slice
+// Contains returns whether the given string slice
 // contains the given string.
-func DoesStringArrayContain(list []string, value string) bool {
+func Contains(list []string, value string) bool {
 	for _, element := range list {
 		if element == value {
 			return true
@@ -11,9 +11,9 @@ func DoesStringArrayContain(list []string, value string) bool {
 	return false
 }
 
-// RemoveStringFromSlice returns a new string slice which is the given string slice
+// Remove returns a new string slice which is the given string slice
 // with the given string removed.
-func RemoveStringFromSlice(list []string, value string) (result []string) {
+func Remove(list []string, value string) (result []string) {
 	for _, element := range list {
 		if element != value {
 			result = append(result, element)


### PR DESCRIPTION
`util` is a discouraged name for packages since it doesn't say much and leads to "trash can" packages that can contain all sorts of things. Packages better have names like `stringslice` that indicate that they provide features for working with string slices. This also helps with naming of functions: rather than `util.DoesStringArrayContain`, we now have `stringslice.Contains`, and instead of `util.RemoveStringFromSlice` we now have `stringslice.Remove`.