### PR TITLE
Explicit error checks

### DIFF
--- a/features/alias/alias.feature
+++ b/features/alias/alias.feature
@@ -46,7 +46,7 @@ Feature: git town: alias
 
   Scenario: no argument
     When I run "git-town alias"
-    Then it prints:
+    Then it prints the error:
       """
       accepts 1 arg(s), received 0
       """
@@ -62,7 +62,7 @@ Feature: git town: alias
 
   Scenario: too many arguments
     When I run "git-town alias true false"
-    Then it prints:
+    Then it prints the error:
       """
       accepts 1 arg(s), received 2
       """

--- a/features/config/prompt.feature
+++ b/features/config/prompt.feature
@@ -10,17 +10,11 @@ Feature: Automatically running the configuration wizard if Git Town is unconfigu
     When I run "<COMMAND>" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-      | Please specify perennial branches          | [ENTER] |
     Then it prints the initial configuration prompt
     And the main branch is now configured as "main"
     And my repo is now configured with no perennial branches
 
     Examples:
-      | COMMAND                   |
-      | git-town hack feature     |
-      | git-town kill             |
-      | git-town new-pull-request |
-      | git-town prune-branches   |
-      | git-town repo             |
-      | git-town ship             |
-      | git-town sync             |
+      | COMMAND       |
+      | git-town ship |
+      | git-town sync |

--- a/features/hack/unconfigured.feature
+++ b/features/hack/unconfigured.feature
@@ -1,4 +1,4 @@
-Feature: Ask for configuration
+Feature: Ask for missing configuration
 
   As a user having forgotten to configure Git Town
   I want to be prompted to configure it when I use it the first time

--- a/features/hack/unconfigured.feature
+++ b/features/hack/unconfigured.feature
@@ -1,0 +1,10 @@
+Feature: Ask for configuration
+
+  Scenario: running unconfigured
+    Given I haven't configured Git Town yet
+    When I run "git-town hack foo" and answer the prompts:
+      | PROMPT                                     | ANSWER  |
+      | Please specify the main development branch | [ENTER] |
+    Then it prints the initial configuration prompt
+    And the main branch is now configured as "main"
+    And my repo is now configured with no perennial branches

--- a/features/kill/current_branch/unconfigured.feature
+++ b/features/kill/current_branch/unconfigured.feature
@@ -1,0 +1,14 @@
+Feature: Ask for missing configuration
+
+  Scenario: run unconfigured
+    Given I haven't configured Git Town yet
+    When I run "git-town kill" and answer the prompts:
+      | PROMPT                                     | ANSWER  |
+      | Please specify the main development branch | [ENTER] |
+    Then it prints the initial configuration prompt
+    And the main branch is now configured as "main"
+    And my repo is now configured with no perennial branches
+    And it prints the error:
+      """
+      you can only kill feature branches
+      """

--- a/features/kill/current_branch/unconfigured.feature
+++ b/features/kill/current_branch/unconfigured.feature
@@ -1,5 +1,9 @@
 Feature: Ask for missing configuration
 
+  As a user having forgotten to configure Git Town
+  I want to be prompted to configure it when I use it the first time
+  So that I use a properly configured tool at all times.
+
   Scenario: run unconfigured
     Given I haven't configured Git Town yet
     When I run "git-town kill" and answer the prompts:

--- a/features/new-branch-push-flag/update.feature
+++ b/features/new-branch-push-flag/update.feature
@@ -28,7 +28,7 @@ Feature: set the new-branch-push-flag
 
   Scenario: multiple arguments
     When I run "git-town new-branch-push-flag true false"
-    Then it prints:
+    Then it prints the error:
       """
       accepts at most 1 arg(s), received 2
       """

--- a/features/new-pull-request/unconfigured.feature
+++ b/features/new-pull-request/unconfigured.feature
@@ -1,0 +1,16 @@
+Feature: Ask for missing configuration
+
+  Scenario: run unconfigured
+    Given I haven't configured Git Town yet
+    And my repo's origin is "https://github.com/git-town/git-town.git"
+    And my computer has the "open" tool installed
+    When I run "git-town new-pull-request" and answer the prompts:
+      | PROMPT                                     | ANSWER  |
+      | Please specify the main development branch | [ENTER] |
+    Then it prints the initial configuration prompt
+    And the main branch is now configured as "main"
+    And my repo is now configured with no perennial branches
+    And "open" launches a new pull request with this url in my browser:
+      """
+      https://github.com/git-town/git-town.github.com/compare/feature?expand=1 |
+      """

--- a/features/new-pull-request/unconfigured.feature
+++ b/features/new-pull-request/unconfigured.feature
@@ -1,5 +1,9 @@
 Feature: Ask for missing configuration
 
+  As a user having forgotten to configure Git Town
+  I want to be prompted to configure it when I use it the first time
+  So that I use a properly configured tool at all times.
+
   Scenario: run unconfigured
     Given I haven't configured Git Town yet
     And my repo's origin is "https://github.com/git-town/git-town.git"

--- a/features/offline/set.feature
+++ b/features/offline/set.feature
@@ -1,6 +1,6 @@
 Feature: enabling offline mode
 
-    When developing on an airplane
+  When developing on an airplane
   I want to be able to use Git Town without interactions with remote origins
   So that I can work on my code even without internet connection.
 

--- a/features/offline/set.feature
+++ b/features/offline/set.feature
@@ -1,6 +1,6 @@
 Feature: enabling offline mode
 
-  When developing on an airplane
+    When developing on an airplane
   I want to be able to use Git Town without interactions with remote origins
   So that I can work on my code even without internet connection.
 
@@ -26,7 +26,7 @@ Feature: enabling offline mode
 
   Scenario: multiple values
     When I run "git-town offline true false"
-    Then it prints:
+    Then it prints the error:
       """
       accepts at most 1 arg(s), received 2
       """

--- a/features/prune-branches/unconfigured.feature
+++ b/features/prune-branches/unconfigured.feature
@@ -1,0 +1,10 @@
+Feature: Ask for missing configuration
+
+  Scenario: run unconfigured
+    Given I haven't configured Git Town yet
+    When I run "git-town prune-branches" and answer the prompts:
+      | PROMPT                                     | ANSWER  |
+      | Please specify the main development branch | [ENTER] |
+    Then it prints the initial configuration prompt
+    And the main branch is now configured as "main"
+    And my repo is now configured with no perennial branches

--- a/features/prune-branches/unconfigured.feature
+++ b/features/prune-branches/unconfigured.feature
@@ -1,5 +1,9 @@
 Feature: Ask for missing configuration
 
+  As a user having forgotten to configure Git Town
+  I want to be prompted to configure it when I use it the first time
+  So that I use a properly configured tool at all times.
+
   Scenario: run unconfigured
     Given I haven't configured Git Town yet
     When I run "git-town prune-branches" and answer the prompts:

--- a/features/repo/unconfigured.feature
+++ b/features/repo/unconfigured.feature
@@ -1,0 +1,12 @@
+Feature: Ask for missing configuration information
+
+  Scenario: run unconfigured
+    Given I haven't configured Git Town yet
+    And my repo's origin is "https://github.com/git-town/git-town.git"
+    And my computer has the "open" tool installed
+    When I run "git-town repo" and answer the prompts:
+      | PROMPT                                     | ANSWER  |
+      | Please specify the main development branch | [ENTER] |
+    Then it prints the initial configuration prompt
+    And the main branch is now configured as "main"
+    And my repo is now configured with no perennial branches

--- a/features/repo/unconfigured.feature
+++ b/features/repo/unconfigured.feature
@@ -1,5 +1,9 @@
 Feature: Ask for missing configuration information
 
+  As a user having forgotten to configure Git Town
+  I want to be prompted to configure it when I use it the first time
+  So that I use a properly configured tool at all times.
+
   Scenario: run unconfigured
     Given I haven't configured Git Town yet
     And my repo's origin is "https://github.com/git-town/git-town.git"

--- a/features/shared/strip_colors.feature
+++ b/features/shared/strip_colors.feature
@@ -12,7 +12,6 @@ Feature: Strip colors
     When I run "git-town hack new-feature" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-      | Please specify perennial branches          | [ENTER] |
     And Git Town is now aware of this branch hierarchy
       | BRANCH      | PARENT |
       | new-feature | main   |

--- a/features/ship/current_branch/unconfigured.feature
+++ b/features/ship/current_branch/unconfigured.feature
@@ -1,20 +1,18 @@
-Feature: Automatically running the configuration wizard if Git Town is unconfigured
+Feature: Ask for missing configuration information
 
   As a user having forgotten to configure Git Town
   I want to be prompted to configure it when I use it the first time
   So that I use a properly configured tool at all times.
 
-
-  Scenario Outline: All Git Town commands show the configuration prompt if running unconfigured
+  Scenario: running unconfigured
     Given I haven't configured Git Town yet
-    When I run "<COMMAND>" and answer the prompts:
+    When I run "git-town ship" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
     Then it prints the initial configuration prompt
     And the main branch is now configured as "main"
     And my repo is now configured with no perennial branches
-
-    Examples:
-      | COMMAND       |
-      | git-town ship |
-      | git-town sync |
+    And it prints the error:
+      """
+      the branch "main" is not a feature branch. Only feature branches can be shipped
+      """

--- a/features/sync/current_branch/main_branch/unconfigured.feature
+++ b/features/sync/current_branch/main_branch/unconfigured.feature
@@ -1,12 +1,12 @@
-Feature: Ask for configuration
+Feature: Ask for missing configuration information
 
   As a user having forgotten to configure Git Town
   I want to be prompted to configure it when I use it the first time
   So that I use a properly configured tool at all times.
 
-  Scenario: running unconfigured
+  Scenario: run unconfigured
     Given I haven't configured Git Town yet
-    When I run "git-town hack foo" and answer the prompts:
+    When I run "git-town sync" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
     Then it prints the initial configuration prompt

--- a/features/sync/folder_does_not_exist_on_main_branch/conflict.feature
+++ b/features/sync/folder_does_not_exist_on_main_branch/conflict.feature
@@ -32,6 +32,10 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And I am still on the "current-feature" branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
+    And it prints the error:
+      """
+      exit status 1
+      """
 
 
   Scenario: aborting

--- a/src/steps/step_list.go
+++ b/src/steps/step_list.go
@@ -66,18 +66,17 @@ type WrapOptions struct {
 // Wrap wraps the list with steps that
 // change to the Git root directory or stash away open changes.
 func (stepList *StepList) Wrap(options WrapOptions, repo *git.ProdRepo) error {
-	previousBranch, err := repo.Silent.PreviouslyCheckedOutBranch()
-	if err != nil {
-		return err
+	previousBranch, errPrev := repo.Silent.PreviouslyCheckedOutBranch()
+	currentBranch, errCurr := repo.Silent.CurrentBranch()
+	if errCurr != nil {
+		return errCurr
 	}
-	currentBranch, err := repo.Silent.CurrentBranch()
-	if err != nil {
-		return err
+	if errPrev == nil {
+		stepList.Append(&PreserveCheckoutHistoryStep{
+			InitialBranch:                     currentBranch,
+			InitialPreviouslyCheckedOutBranch: previousBranch,
+		})
 	}
-	stepList.Append(&PreserveCheckoutHistoryStep{
-		InitialBranch:                     currentBranch,
-		InitialPreviouslyCheckedOutBranch: previousBranch,
-	})
 	hasOpenChanges, err := repo.Silent.HasOpenChanges()
 	if err != nil {
 		return err

--- a/test/scenario_state.go
+++ b/test/scenario_state.go
@@ -13,6 +13,9 @@ type ScenarioState struct {
 	// the error of the last run of Git Town
 	runErr error
 
+	// indicates whether the scenario has verified the error
+	runErrChecked bool
+
 	// the outcome of the last run of Git Town
 	runRes *run.Result
 
@@ -32,6 +35,7 @@ func (state *ScenarioState) Reset(gitEnv *GitEnvironment) {
 	state.initialCommits = nil
 	state.runRes = nil
 	state.runErr = nil
+	state.runErrChecked = false
 	state.uncommittedFileName = ""
 	state.uncommittedContent = ""
 }

--- a/test/steps.go
+++ b/test/steps.go
@@ -250,7 +250,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^it exits with an error$`, func() error {
 		if state.runErr == nil {
-			return fmt.Errorf("Expected error but previous command finished successfully")
+			return fmt.Errorf("expected error but previous command finished successfully")
 		}
 		state.runErrChecked = true
 		return nil

--- a/test/steps.go
+++ b/test/steps.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
+	"github.com/git-town/git-town/src/cli"
 	"github.com/git-town/git-town/src/run"
 )
 
@@ -68,6 +69,10 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	suite.AfterScenario(func(scenario *messages.Pickle, e error) {
 		if e != nil {
 			fmt.Printf("failed scenario, investigate state in %q\n", state.gitEnv.Dir)
+		}
+		if state.runErr != nil && !state.runErrChecked {
+			cli.PrintError(fmt.Errorf("%s - scenario %q doesn't document error %v", scenario.GetUri(), scenario.GetName(), state.runErr))
+			os.Exit(1)
 		}
 	})
 	suite.Step(`^all branches are now synchronized$`, func() error {
@@ -240,6 +245,14 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if strings.Contains(state.runRes.OutputSanitized(), text) {
 			return fmt.Errorf("text found: %q", text)
 		}
+		return nil
+	})
+
+	suite.Step(`^it exits with an error$`, func() error {
+		if state.runErr == nil {
+			return fmt.Errorf("Expected error but previous command finished successfully")
+		}
+		state.runErrChecked = true
 		return nil
 	})
 

--- a/test/steps.go
+++ b/test/steps.go
@@ -265,6 +265,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if state.runErr == nil {
 			return fmt.Errorf("expected error")
 		}
+		state.runErrChecked = true
 		return nil
 	})
 

--- a/test/steps.go
+++ b/test/steps.go
@@ -248,14 +248,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^it exits with an error$`, func() error {
-		if state.runErr == nil {
-			return fmt.Errorf("expected error but previous command finished successfully")
-		}
-		state.runErrChecked = true
-		return nil
-	})
-
 	suite.Step(`^it prints:$`, func(expected *messages.PickleStepArgument_PickleDocString) error {
 		if !strings.Contains(state.runRes.OutputSanitized(), expected.Content) {
 			return fmt.Errorf("text not found:\n\nEXPECTED: %q\n\nACTUAL:\n\n%q", expected.Content, state.runRes.OutputSanitized())


### PR DESCRIPTION
resolves #1549

@charlierudolph would be great to get your 👀 on this

To fix this bug, I have added stricter error checking. Feature specs now check for unexpected exit codes when running Git Town. They can signal an unexpected error via a `And it prints the error:` step.
