### PR TITLE
Format contributors table for new GitHub UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Kudos to our contributors!
     <td align="center" width="60">
       <a href="https://github.com/Iron-Ham">
         <img src="https://avatars1.githubusercontent.com/u/3388381?s=60" width="60px">
+        <br>
         <sup><b>@Iron-Ham</b></sup>
       </a>
     </td>

--- a/README.md
+++ b/README.md
@@ -210,14 +210,14 @@ Kudos to our contributors!
         <sup><b>@blaggacao</b></sup>
       </a>
     </td>
+  </tr>
+  <tr>
     <td align="center" width="60">
       <a href="https://github.com/aricahunter">
         <img src="https://avatars2.githubusercontent.com/u/5395515?s=60" width="60px">
         <sup><b>@aricahunter</b></sup>
       </a>
     </td>
-  </tr>
-  <tr>
     <td align="center" width="60">
       <a href="https://github.com/jiexi">
         <img src="https://avatars2.githubusercontent.com/u/918701?s=60" width="60px">
@@ -254,6 +254,8 @@ Kudos to our contributors!
         <sup><b>@seanstrom</b></sup>
       </a>
     </td>
+  </tr>
+  <tr>
     <td align="center" width="60">
       <a href="https://github.com/schneems">
         <img src="https://avatars2.githubusercontent.com/u/59744?s=60" width="60px">
@@ -266,8 +268,6 @@ Kudos to our contributors!
         <sup><b>@morrme</b></sup>
       </a>
     </td>
-  </tr>
-  <tr>
     <td align="center" width="60">
       <a href="https://github.com/mjhm">
         <img src="https://avatars0.githubusercontent.com/u/431925?s=60" width="60px">
@@ -298,6 +298,8 @@ Kudos to our contributors!
         <sup><b>@dgjnpr</b></sup>
       </a>
     </td>
+  </tr>
+  <tr>
     <td align="center" width="60">
       <a href="https://github.com/atilacamurca">
         <img src="https://avatars1.githubusercontent.com/u/508624?s=60" width="60px">
@@ -316,8 +318,6 @@ Kudos to our contributors!
         <sup><b>@TKAB</b></sup>
       </a>
     </td>
-  </tr>
-  <tr>
     <td align="center" width="60">
       <a href="https://github.com/Siilwyn">
         <img src="https://avatars2.githubusercontent.com/u/5701149?s=60" width="60px">
@@ -342,6 +342,8 @@ Kudos to our contributors!
         <sup><b>@cirego</b></sup>
       </a>
     </td>
+  </tr>
+  <tr>
     <td align="center" width="60">
       <a href="https://github.com/sheldonhull">
         <img src="https://avatars3.githubusercontent.com/u/3526320?s=60" width="60px">
@@ -366,8 +368,6 @@ Kudos to our contributors!
         <sup><b>@pattiereaves</b></sup>
       </a>
     </td>
-  </tr>
-  <tr>
     <td align="center" width="60">
       <a href="https://github.com/zenspider">
         <img src="https://avatars0.githubusercontent.com/u/9832?s=60" width="60px">
@@ -386,6 +386,8 @@ Kudos to our contributors!
         <sup><b>@grignaak</b></sup>
       </a>
     </td>
+  </tr>
+  <tr>
     <td align="center" width="60">
       <a href="https://github.com/ericyliu">
         <img src="https://avatars2.githubusercontent.com/u/8580080?s=60" width="60px">
@@ -410,14 +412,14 @@ Kudos to our contributors!
         <sup><b>@hmbrg</b></sup>
       </a>
     </td>
+  </tr>
+  <tr>
     <td align="center" width="60">
       <a href="https://github.com/qrevel">
         <img src="https://avatars2.githubusercontent.com/u/11804101?s=60" width="60px">
         <sup><b>@qrevel</b></sup>
       </a>
     </td>
-  </tr>
-  <tr>
     <td align="center" width="60">
       <a href="https://github.com/aeneasr">
         <img src="https://avatars1.githubusercontent.com/u/3372410?s=60" width="60px">

--- a/README.md
+++ b/README.md
@@ -412,8 +412,6 @@ Kudos to our contributors!
         <sup><b>@hmbrg</b></sup>
       </a>
     </td>
-  </tr>
-  <tr>
     <td align="center" width="60">
       <a href="https://github.com/qrevel">
         <img src="https://avatars2.githubusercontent.com/u/11804101?s=60" width="60px">
@@ -432,6 +430,8 @@ Kudos to our contributors!
         <sup><b>@martinjaime</b></sup>
       </a>
     </td>
+  </tr>
+  <tr>
     <td align="center" width="60">
       <a href="https://github.com/alexw10">
         <img src="https://avatars1.githubusercontent.com/u/9453636?s=60" width="60px">


### PR DESCRIPTION
GitHub's new UI provides less space and therefore breaks the old layout.