### PR TITLE
Normalize file paths on Windows

### DIFF
--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -967,7 +967,7 @@ func (r *Runner) RootDirectory() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("cannot determine root directory: %w", err)
 		}
-		r.RootDirCache.Set(res.OutputSanitized())
+		r.RootDirCache.Set(filepath.Clean(res.OutputSanitized()))
 	}
 	return r.RootDirCache.Value(), nil
 }

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -967,7 +967,7 @@ func (r *Runner) RootDirectory() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("cannot determine root directory: %w", err)
 		}
-		r.RootDirCache.Set(filepath.Clean(res.OutputSanitized()))
+		r.RootDirCache.Set(filepath.FromSlash(res.OutputSanitized()))
 	}
 	return r.RootDirCache.Value(), nil
 }


### PR DESCRIPTION
Git returns filepaths with forward slashes but we want to use proper Windows paths with backslashes.