### PR TITLE
Cross-platform installation of dev tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ setup: setup-go  # the setup steps necessary on developer machines
 	cd tools/text-runner && yarn install
 
 setup-go:
-	GO111MODULE=on go get github.com/cucumber/godog/cmd/godog@v0.9.0
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(shell go env GOPATH)/bin v1.27.0
+	@(cd .. && GO111MODULE=on go get github.com/cucumber/godog/cmd/godog@v0.9.0)
+	@(cd .. && GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0)
 
 stats:  # shows code statistics
 	@find . -type f | grep -v '\./node_modules/' | grep -v '\./vendor/' | grep -v '\./.git/' | xargs scc


### PR DESCRIPTION
This works on Windows and Linux. The `curl` solution suggested by golangci-lint errors out on Windows.