### PR TITLE
Install Harp last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,9 @@ lint-md:   # lints the Markdown files
 	tools$/text-runner$/node_modules$/.bin$/text-run --offline
 
 setup: setup-go  # the setup steps necessary on developer machines
-	cd tools/harp && yarn install
 	cd tools/prettier && yarn install
 	cd tools/text-runner && yarn install
+	cd tools/harp && yarn install
 
 setup-go:
 	@(cd .. && GO111MODULE=on go get github.com/cucumber/godog/cmd/godog@v0.9.0)


### PR DESCRIPTION
Harp is usually not needed, problems installing it should not prevent installing Prettier and Text-Runner, which are far more frequently used.