### PR TITLE
Dedicated "make docs" task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ deploy:  # deploys the website
 	git push
 	git checkout master
 
+docs:  # tests the documentation
+	tools$/text-runner$/node_modules$/.bin$/text-run --offline
+
 fix: fix-go fix-md  # auto-fixes lint issues in all languages
 
 fix-go:  # auto-fixes all Go lint issues
@@ -46,14 +49,13 @@ fix-md:  # auto-fixes all Markdown lint issues
 help:  # prints all make targets
 	@cat Makefile | grep '^[^ ]*:' | grep -v '.PHONY' | grep -v help | sed 's/:.*#/#/' | column -s "#" -t
 
-lint: lint-go lint-md   # lints all the source code
+lint: lint-go lint-md  # lints all the source code
 
 lint-go:  # lints the Go files
 	golangci-lint run src/... test/...
 
 lint-md:   # lints the Markdown files
 	tools$/prettier$/node_modules$/.bin$/prettier -l .
-	tools$/text-runner$/node_modules$/.bin$/text-run --offline
 
 setup: setup-go  # the setup steps necessary on developer machines
 	cd tools/prettier && yarn install
@@ -67,7 +69,7 @@ setup-go:
 stats:  # shows code statistics
 	@find . -type f | grep -v '\./node_modules/' | grep -v '\./vendor/' | grep -v '\./.git/' | xargs scc
 
-test: lint unit cuke  # runs all the tests
+test: lint docs unit cuke  # runs all the tests
 .PHONY: test
 
 test-go: build u lint-go cuke  # runs all tests for Golang


### PR DESCRIPTION
Text-Runner is run a lot more often than Prettier (which should auto-run via IDE plugins), so a dedicated make task to test the documentation is in order.