### PR TITLE
Remove support for BSD

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,10 +25,7 @@ builds:
       - 7
     goos:
       - darwin
-      - freebsd
       - linux
-      - netbsd
-      - openbsd
       - windows
 
 changelog:


### PR DESCRIPTION
BSD causes many dozen files in each release. BSD is mostly used on servers these days, little chance of using Git Town there. 99.99% of our users are on Windows, Linux, Mac. Happy to add it back on user demand.