### PR TITLE
Use variables in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 .DEFAULT_GOAL := spec
 
 build:  # builds for the current platform
-	go install -ldflags "-X github.com/git-town/git-town/src/cmd.version=v${VERSION}-dev -X github.com/git-town/git-town/src/cmd.buildDate=${TODAY}"
+	go install -ldflags "-X github.com/git-town/git-town/src/cmd.version=v${VERSION}-test -X github.com/git-town/git-town/src/cmd.buildDate=${TODAY}"
 
 cuke: build   # runs the new Godog-based feature tests
 	@env GOGC=off go test . -v -count=1

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+VERSION=7.4.0
+TODAY=$(shell date +'%Y/%m/%d')
+
 # platform-specificity
 ifdef COMSPEC
 	/ := $(strip \)
@@ -8,7 +11,7 @@ endif
 .DEFAULT_GOAL := spec
 
 build:  # builds for the current platform
-	go install -ldflags "-X github.com/git-town/git-town/src/cmd.version=v0.0.0-test -X github.com/git-town/git-town/src/cmd.buildDate=today"
+	go install -ldflags "-X github.com/git-town/git-town/src/cmd.version=v${VERSION}-dev -X github.com/git-town/git-town/src/cmd.buildDate=${TODAY}"
 
 cuke: build   # runs the new Godog-based feature tests
 	@env GOGC=off go test . -v -count=1
@@ -49,8 +52,8 @@ help:  # prints all make targets
 .PHONY: installer
 installer:  # compiles the MSI installer for Windows
 	rm -f git-town.msi
-	go build -ldflags "-X github.com/git-town/git-town/src/cmd.version=v7.3.0 -X github.com/git-town/git-town/src/cmd.buildDate=2020-07-02"
-	go-msi make --msi git-town.msi --version 7.3.0 --src installer/templates/ --path installer/wix.json
+	go build -ldflags "-X github.com/git-town/git-town/src/cmd.version=v${VERSION} -X github.com/git-town/git-town/src/cmd.buildDate=${TODAY}"
+	go-msi make --msi git-town.msi --version ${VERSION} --src installer/templates/ --path installer/wix.json
 	@rm git-town.exe
 
 lint: lint-go lint-md  # lints all the source code

--- a/documentation/development/release.md
+++ b/documentation/development/release.md
@@ -24,13 +24,13 @@ This guide is for maintainers who make releases of Git Town.
 
 ### create the Windows installer
 
-On a Windows machine:
+On a Windows machine, in Git Bash:
 
 ```
 make installer
 ```
 
-Add the installer to the GitHub release.
+Manually add the generated `.msi` file to the GitHub release.
 
 ### Arch Linux
 

--- a/features/version/version.feature
+++ b/features/version/version.feature
@@ -9,7 +9,7 @@ Feature: git town: show the current Git Town version
     When I run "git-town version"
     Then it prints:
       """
-      Git Town v0.0.0-test (today)
+      Git Town v7.4.0-test
       """
 
 
@@ -18,5 +18,5 @@ Feature: git town: show the current Git Town version
     When I run "git-town version"
     Then it prints:
       """
-      Git Town v0.0.0-test (today)
+      Git Town v7.4.0-test
       """


### PR DESCRIPTION
Removes redundancy, uses the current date instead of a hard-coded date.