### PR TITLE
Draft releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,8 @@ nfpms:
       - git
 
 release:
-  ids:
-    - scoop
+  draft: true
+  ids: []
 
 scoop:
   bucket:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,8 @@ nfpms:
 
 release:
   draft: true
-  ids: []
+  ids:
+    - nothing
 
 scoop:
   bucket:

--- a/documentation/development/release.md
+++ b/documentation/development/release.md
@@ -13,6 +13,7 @@ On a Windows machine, in Git Bash:
 - `env GITHUB_TOKEN=<your Github token> make release`
   - or omit the Github token and enter your credentials when asked
 - this opens a release in the browser - review and publish it
+- it creates two releases right now, delete the one without attached files
 
 ### create a Homebrew release
 


### PR DESCRIPTION
I needed to enable releases via Goreleaser again in order for it to push the Scoop formula to https://github.com/git-town/scoop. This makes it create its own GitHub release. I can't use this one because it misses the `.msi` file and contains the assets in random order, which is annoying. This PR makes goreleaser create a draft release that we can easily delete.