### PR TITLE
make auto abort more clear

### DIFF
--- a/src/steps/run.go
+++ b/src/steps/run.go
@@ -44,6 +44,7 @@ func Run(runState *RunState, repo *git.ProdRepo, driver drivers.CodeHostingDrive
 		if runErr != nil {
 			runState.AbortStepList.Append(step.CreateAbortStep())
 			if step.ShouldAutomaticallyAbortOnError() {
+				cli.PrintError(fmt.Errorf(runErr.Error() + "\n" + "Auto-aborting..."))
 				abortRunState := runState.CreateAbortRunState()
 				err := Run(&abortRunState, repo, driver)
 				if err != nil {

--- a/src/steps/run.go
+++ b/src/steps/run.go
@@ -44,7 +44,7 @@ func Run(runState *RunState, repo *git.ProdRepo, driver drivers.CodeHostingDrive
 		if runErr != nil {
 			runState.AbortStepList.Append(step.CreateAbortStep())
 			if step.ShouldAutomaticallyAbortOnError() {
-				cli.PrintError(fmt.Errorf(runErr.Error() + "\n" + "Auto-aborting..."))
+				cli.PrintError(fmt.Errorf(runErr.Error() + "\nAuto-aborting..."))
 				abortRunState := runState.CreateAbortRunState()
 				err := Run(&abortRunState, repo, driver)
 				if err != nil {

--- a/src/steps/squash_merge_branch_step.go
+++ b/src/steps/squash_merge_branch_step.go
@@ -43,11 +43,11 @@ func (step *SquashMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHo
 	}
 	author, err := prompt.GetSquashCommitAuthor(step.BranchName, repo)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting squash commit author: %w", err)
 	}
 	repoAuthor, err := repo.Silent.Author()
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot determine repo author: %w", err)
 	}
 	if err = repo.Silent.CommentOutSquashCommitMessage(""); err != nil {
 		return fmt.Errorf("cannot comment out the squash commit message: %w", err)


### PR DESCRIPTION
To help debug #1634 

Running `godog features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature` with adding the debug tag:

Before change:
<img width="348" alt="Screen Shot 2020-08-23 at 7 02 01 PM" src="https://user-images.githubusercontent.com/1676758/90996428-9c082280-e573-11ea-85ad-d251f05a6904.png">

After change:
<img width="354" alt="Screen Shot 2020-08-23 at 7 01 20 PM" src="https://user-images.githubusercontent.com/1676758/90996423-98749b80-e573-11ea-99f7-6646a5a69ae5.png">

