### PR TITLE
print more information on command failure

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
@@ -329,10 +328,9 @@ func (c *Config) removeLocalConfigValue(key string) error {
 
 // RemoveLocalGitConfiguration removes all Git Town configuration.
 func (c *Config) RemoveLocalGitConfiguration() error {
-	_, err := c.shell.Run("git", "config", "--remove-section", "git-town")
+	result, err := c.shell.Run("git", "config", "--remove-section", "git-town")
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 {
+		if result.ExitCode() == 128 {
 			// Git returns exit code 128 when trying to delete a non-existing config section.
 			// This is not an error condition in this workflow so we can ignore it here.
 			return nil

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -578,11 +577,8 @@ func (r *Runner) HasFile(name, content string) (result bool, err error) {
 // HasGitTownConfigNow indicates whether this repository contain Git Town specific configuration.
 func (r *Runner) HasGitTownConfigNow() (result bool, err error) {
 	outcome, err := r.Run("git", "config", "--local", "--get-regex", "git-town")
-	if err != nil {
-		exitError := err.(*exec.ExitError)
-		if exitError.ExitCode() == 1 {
-			return false, nil
-		}
+	if outcome.ExitCode() == 1 {
+		return false, nil
 	}
 	return outcome.OutputSanitized() != "", err
 }

--- a/src/run/result.go
+++ b/src/run/result.go
@@ -10,9 +10,10 @@ import (
 
 // Result contains the results of a command run in a subshell.
 type Result struct {
-	command string   // the executed command
-	args    []string // arguments for the executed command
-	output  string   // the raw output of the command
+	command  string   // the executed command
+	args     []string // arguments for the executed command
+	output   string   // the raw output of the command
+	exitCode int      // the exit code of the command
 }
 
 // Args provides the arguments used when running the command.
@@ -23,6 +24,11 @@ func (c *Result) Args() []string {
 // Command provides the command run that led to this result.
 func (c *Result) Command() string {
 	return c.command
+}
+
+// ExitCode returns the exit code of the command
+func (c *Result) ExitCode() int {
+	return c.exitCode
 }
 
 // FullCmd provides the full command run.

--- a/src/run/result.go
+++ b/src/run/result.go
@@ -26,7 +26,7 @@ func (c *Result) Command() string {
 	return c.command
 }
 
-// ExitCode returns the exit code of the command
+// ExitCode returns the exit code of the command.
 func (c *Result) ExitCode() int {
 	return c.exitCode
 }

--- a/src/run/run.go
+++ b/src/run/run.go
@@ -76,5 +76,14 @@ func WithOptions(opts Options, cmd string, args ...string) (*Result, error) {
 	}
 	err = subProcess.Wait()
 	result.output = output.String()
+	result.exitCode = subProcess.ProcessState.ExitCode()
+	if err != nil {
+		err = fmt.Errorf(`Command failed.
+
+Command: %s %s
+Error: %w
+Output:
+%s`, cmd, strings.Join(args, " "), err, result.output)
+	}
 	return &result, err
 }

--- a/src/run/run.go
+++ b/src/run/run.go
@@ -86,8 +86,7 @@ Command: %s %s
 Error: %w
 Output:
 %s
-----------------------------------------
-`, cmd, strings.Join(args, " "), err, result.output)
+----------------------------------------`, cmd, strings.Join(args, " "), err, result.output)
 	}
 	return &result, err
 }

--- a/src/run/run.go
+++ b/src/run/run.go
@@ -78,12 +78,16 @@ func WithOptions(opts Options, cmd string, args ...string) (*Result, error) {
 	result.output = output.String()
 	result.exitCode = subProcess.ProcessState.ExitCode()
 	if err != nil {
-		err = fmt.Errorf(`Command failed.
+		err = fmt.Errorf(`
+----------------------------------------
+Diagnostic information of failed command
 
 Command: %s %s
 Error: %w
 Output:
-%s`, cmd, strings.Join(args, " "), err, result.output)
+%s
+----------------------------------------
+`, cmd, strings.Join(args, " "), err, result.output)
 	}
 	return &result, err
 }

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -26,10 +26,16 @@ func TestRun_Exec_UnknownExecutable(t *testing.T) {
 }
 
 func TestRun_Exec_ExitCode(t *testing.T) {
-	_, err := run.Exec("bash", "-c", "exit 2")
-	var execError *exec.ExitError
-	assert.True(t, errors.As(err, &execError))
-	assert.Equal(t, 2, execError.ExitCode())
+	result, err := run.Exec("bash", "-c", "echo 'hi' && exit 2")
+	assert.Equal(t, 2, result.ExitCode())
+	expectedError := `Command failed.
+
+Command: bash -c echo 'hi' && exit 2
+Error: exit status 2
+Output:
+hi
+`
+	assert.Equal(t, expectedError, err.Error())
 }
 
 func TestRun_InDir(t *testing.T) {

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -28,13 +28,16 @@ func TestRun_Exec_UnknownExecutable(t *testing.T) {
 func TestRun_Exec_ExitCode(t *testing.T) {
 	result, err := run.Exec("bash", "-c", "echo 'hi' && exit 2")
 	assert.Equal(t, 2, result.ExitCode())
-	expectedError := `Command failed.
+	expectedError := `
+----------------------------------------
+Diagnostic information of failed command
 
 Command: bash -c echo 'hi' && exit 2
 Error: exit status 2
 Output:
 hi
-`
+
+----------------------------------------`
 	assert.Equal(t, expectedError, err.Error())
 }
 

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -26,13 +26,13 @@ func TestRun_Exec_UnknownExecutable(t *testing.T) {
 }
 
 func TestRun_Exec_ExitCode(t *testing.T) {
-	result, err := run.Exec("bash", "-c", "echo 'hi' && exit 2")
+	result, err := run.Exec("bash", "-c", "echo hi && exit 2")
 	assert.Equal(t, 2, result.ExitCode())
 	expectedError := `
 ----------------------------------------
 Diagnostic information of failed command
 
-Command: bash -c echo 'hi' && exit 2
+Command: bash -c echo hi && exit 2
 Error: exit status 2
 Output:
 hi


### PR DESCRIPTION
Examples:

```
$ git town set-parent-branch
Feature branches can be branched directly off
master or from other feature branches.

The former allows to develop and ship features completely independent of each other.
The latter allows to build on top of currently unshipped features.


Error: 
----------------------------------------
Diagnostic information of failed command

Command: git branch2
Error: exit status 1
Output:
git: 'branch2' is not a git command. See 'git --help'.

The most similar command is
        branch

----------------------------------------


```

And

```
$ git hack test
[cr-diagnostic] git fetch --prune --tags

[cr-diagnostic] git add -A

[cr-diagnostic] git stash
Saved working directory and index state WIP on cr-diagnostic: 614b51eb update

[cr-diagnostic] git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

[master] git rebase origin/master
Current branch master is up to date.

[master] git branch test master

[master] git checkout test
Switched to branch 'test'

Error: cannot determine whether the local branch "master" exists: 
----------------------------------------
Diagnostic information of failed command

Command: git branch2
Error: exit status 1
Output:
git: 'branch2' is not a git command. See 'git --help'.

The most similar command is
        branch

----------------------------------------

To abort, run "git-town abort".
To continue after having resolved conflicts, run "git-town continue".

```