### PR TITLE
Make shows help by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION ?= 0.0.0
 TODAY=$(shell date +'%Y/%m/%d')
 
-.DEFAULT_GOAL := spec
+.DEFAULT_GOAL := help
 
 build:  # builds for the current platform
 	go install -ldflags "-X github.com/git-town/git-town/src/cmd.version=v${VERSION}-dev -X github.com/git-town/git-town/src/cmd.buildDate=${TODAY}"


### PR DESCRIPTION
It's more intuitive if running just `make` shows all available commands by default.