### PR TITLE
Add major version to Go API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TODAY=$(shell date +'%Y/%m/%d')
 .DEFAULT_GOAL := help
 
 build:  # builds for the current platform
-	go install -ldflags "-X github.com/git-town/git-town/src/cmd.version=v${VERSION}-dev -X github.com/git-town/git-town/src/cmd.buildDate=${TODAY}"
+	go install -ldflags "-X github.com/git-town/git-town/v7/src/cmd.version=v${VERSION}-dev -X github.com/git-town/git-town/v7/src/cmd.buildDate=${TODAY}"
 
 cuke: build   # runs the new Godog-based feature tests
 	@env GOGC=off go test . -v -count=1

--- a/documentation/development/release.md
+++ b/documentation/development/release.md
@@ -2,6 +2,11 @@
 
 This guide is for maintainers who make releases of Git Town.
 
+### bump the version
+
+- search-and-replace the old version with the new version
+- if bumping the major version, also update `/v7` in [go.mod](../../go.mod) with `/v8`
+
 ### create a GitHub release
 
 On a Linux machine:

--- a/documentation/development/release.md
+++ b/documentation/development/release.md
@@ -5,8 +5,8 @@ This guide is for maintainers who make releases of Git Town.
 ### bump the version
 
 - search-and-replace the old version with the new version
-- if bumping the major version, also update `github.com/git-town/git-town/v7/` with
-  `github.com/git-town/git-town/v8/`
+- if bumping the major version, also update `github.com/git-town/git-town/v7/`
+  with `github.com/git-town/git-town/v8/`
 
 ### create a GitHub release
 

--- a/documentation/development/release.md
+++ b/documentation/development/release.md
@@ -5,8 +5,8 @@ This guide is for maintainers who make releases of Git Town.
 ### bump the version
 
 - search-and-replace the old version with the new version
-- if bumping the major version, also update `/v7` in [go.mod](../../go.mod) with
-  `/v8`
+- if bumping the major version, also update `github.com/git-town/git-town/v7/` with
+  `github.com/git-town/git-town/v8/`
 
 ### create a GitHub release
 

--- a/documentation/development/release.md
+++ b/documentation/development/release.md
@@ -5,7 +5,8 @@ This guide is for maintainers who make releases of Git Town.
 ### bump the version
 
 - search-and-replace the old version with the new version
-- if bumping the major version, also update `/v7` in [go.mod](../../go.mod) with `/v8`
+- if bumping the major version, also update `/v7` in [go.mod](../../go.mod) with
+  `/v8`
 
 ### create a GitHub release
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/git-town/git-town
+module github.com/git-town/git-town/v7
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 // More information at https://github.com/git-town/git-town.
 package main
 
-import "github.com/git-town/git-town/src/cmd"
+import "github.com/git-town/git-town/v7/src/cmd"
 
 func main() {
 	cmd.Execute()

--- a/main_test.go
+++ b/main_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/cucumber/godog"
-	"github.com/git-town/git-town/test"
+	"github.com/git-town/git-town/v7/test"
 )
 
 func FeatureContext(suite *godog.Suite) {

--- a/src/browsers/browsers.go
+++ b/src/browsers/browsers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 )
 
 // OpenBrowserCommand returns the command to run on the console

--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/prompt"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/prompt"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/discard.go
+++ b/src/cmd/discard.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/main_branch.go
+++ b/src/cmd/main_branch.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/new_branch_push_flag.go
+++ b/src/cmd/new_branch_push_flag.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/offline.go
+++ b/src/cmd/offline.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/git-town/git-town/src/cli"
+	"github.com/git-town/git-town/v7/src/cli"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/perennial_branches.go
+++ b/src/cmd/perennial_branches.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/prompt"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/prompt"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/steps"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/pull_branch_strategy.go
+++ b/src/cmd/pull_branch_strategy.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
+	"github.com/git-town/git-town/v7/src/cli"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/steps"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/git-town/git-town/src/browsers"
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/drivers"
+	"github.com/git-town/git-town/v7/src/browsers"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/drivers"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/fatih/color"
-	"github.com/git-town/git-town/src/cli"
+	"github.com/git-town/git-town/v7/src/cli"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/root_test.go
+++ b/src/cmd/root_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/git-town/git-town/src/cmd"
+	"github.com/git-town/git-town/v7/src/cmd"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/cmd/set_parent_branch.go
+++ b/src/cmd/set_parent_branch.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"errors"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/prompt"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/prompt"
 	"github.com/spf13/cobra"
 )
 

--- a/src/cmd/shared.go
+++ b/src/cmd/shared.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 )
 
 // These variables represent command-line flags.

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"os"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/steps"
 
 	"github.com/spf13/cobra"
 )

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/git-town/git-town/src/run"
-	"github.com/git-town/git-town/src/stringslice"
+	"github.com/git-town/git-town/v7/src/run"
+	"github.com/git-town/git-town/v7/src/stringslice"
 )
 
 // Config manages the Git Town configuration

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -3,7 +3,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/test"
+	"github.com/git-town/git-town/v7/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/drivers/bitbucket.go
+++ b/src/drivers/bitbucket.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/git-town/git-town/src/drivers/helpers"
+	"github.com/git-town/git-town/v7/src/drivers/helpers"
 )
 
 // bitbucketCodeHostingDriver provides access to the API of Bitbucket installations.

--- a/src/drivers/bitbucket_test.go
+++ b/src/drivers/bitbucket_test.go
@@ -3,7 +3,7 @@ package drivers_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/src/drivers"
+	"github.com/git-town/git-town/v7/src/drivers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/drivers/gitea.go
+++ b/src/drivers/gitea.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/git-town/git-town/src/drivers/helpers"
+	"github.com/git-town/git-town/v7/src/drivers/helpers"
 	"golang.org/x/oauth2"
 
 	"code.gitea.io/sdk/gitea"

--- a/src/drivers/gitea_test.go
+++ b/src/drivers/gitea_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/git-town/git-town/src/drivers"
+	"github.com/git-town/git-town/v7/src/drivers"
 	"github.com/stretchr/testify/assert"
 	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/git-town/git-town/src/drivers/helpers"
+	"github.com/git-town/git-town/v7/src/drivers/helpers"
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )

--- a/src/drivers/github_test.go
+++ b/src/drivers/github_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/git-town/git-town/src/drivers"
+	"github.com/git-town/git-town/v7/src/drivers"
 	"github.com/stretchr/testify/assert"
 	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )

--- a/src/drivers/gitlab.go
+++ b/src/drivers/gitlab.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/git-town/git-town/src/drivers/helpers"
+	"github.com/git-town/git-town/v7/src/drivers/helpers"
 )
 
 // gitlabCodeHostingDriver provides access to the API of GitLab installations.

--- a/src/drivers/gitlab_test.go
+++ b/src/drivers/gitlab_test.go
@@ -3,7 +3,7 @@ package drivers_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/src/drivers"
+	"github.com/git-town/git-town/v7/src/drivers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/git/cache_test.go
+++ b/src/git/cache_test.go
@@ -3,7 +3,7 @@ package git_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/git/logging_shell.go
+++ b/src/git/logging_shell.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 	"github.com/kballard/go-shellquote"
 )
 

--- a/src/git/main_first_test.go
+++ b/src/git/main_first_test.go
@@ -3,7 +3,7 @@ package git_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/git-town/git-town/src/config"
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/config"
+	"github.com/git-town/git-town/v7/src/run"
 )
 
 // ProdRepo is a Git Repo in production code.

--- a/src/git/prod_repo_test.go
+++ b/src/git/prod_repo_test.go
@@ -3,7 +3,7 @@ package git_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/git-town/git-town/src/config"
-	"github.com/git-town/git-town/src/run"
-	"github.com/git-town/git-town/src/stringslice"
+	"github.com/git-town/git-town/v7/src/config"
+	"github.com/git-town/git-town/v7/src/run"
+	"github.com/git-town/git-town/v7/src/stringslice"
 )
 
 // Runner executes Git commands.

--- a/src/git/runner_test.go
+++ b/src/git/runner_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/test"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // EnsureIsConfigured has the user to confgure the main branch and perennial branches if needed.

--- a/src/prompt/parent_branches.go
+++ b/src/prompt/parent_branches.go
@@ -3,8 +3,8 @@ package prompt
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // EnsureKnowsParentBranches asserts that the entire ancestry for all given branches

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/run"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 

--- a/src/run/result.go
+++ b/src/run/result.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/acarl005/stripansi"
-	"github.com/git-town/git-town/src/stringslice"
+	"github.com/git-town/git-town/v7/src/stringslice"
 )
 
 // Result contains the results of a command run in a subshell.

--- a/src/run/run.go
+++ b/src/run/run.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/git-town/git-town/src/cli"
+	"github.com/git-town/git-town/v7/src/cli"
 )
 
 // Options defines optional arguments for ShellRunner.RunWith().

--- a/src/run/run_test.go
+++ b/src/run/run_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/run/silent_shell_test.go
+++ b/src/run/silent_shell_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/steps/abort_merge_branch_step.go
+++ b/src/steps/abort_merge_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // AbortMergeBranchStep aborts the current merge conflict.

--- a/src/steps/abort_rebase_branch_step.go
+++ b/src/steps/abort_rebase_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // AbortRebaseBranchStep represents aborting on ongoing merge conflict.

--- a/src/steps/add_to_perennial_branch.go
+++ b/src/steps/add_to_perennial_branch.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // AddToPerennialBranches adds the branch with the given name as a perennial branch.

--- a/src/steps/checkout_branch_step.go
+++ b/src/steps/checkout_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // CheckoutBranchStep checks out a new branch.

--- a/src/steps/commit_open_changes_step.go
+++ b/src/steps/commit_open_changes_step.go
@@ -3,8 +3,8 @@ package steps
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // CommitOpenChangesStep commits all open changes as a new commit.

--- a/src/steps/continue_merge_branch_step.go
+++ b/src/steps/continue_merge_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // ContinueMergeBranchStep finishes an ongoing merge conflict

--- a/src/steps/continue_rebase_branch_step.go
+++ b/src/steps/continue_rebase_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // ContinueRebaseBranchStep finishes an ongoing rebase operation

--- a/src/steps/create_branch_step.go
+++ b/src/steps/create_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // CreateBranchStep creates a new branch

--- a/src/steps/create_pull_request_step.go
+++ b/src/steps/create_pull_request_step.go
@@ -1,9 +1,9 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/browsers"
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/browsers"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // CreatePullRequestStep creates a new pull request for the current branch.

--- a/src/steps/create_remote_branch_step.go
+++ b/src/steps/create_remote_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // CreateRemoteBranchStep pushes the current branch up to origin.

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // CreateTrackingBranchStep pushes the current branch up to origin

--- a/src/steps/delete_local_branch_step.go
+++ b/src/steps/delete_local_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // DeleteLocalBranchStep deletes the branch with the given name,

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // DeleteParentBranchStep removes the parent branch entry in the Git Town configuration.

--- a/src/steps/delete_remote_branch_step.go
+++ b/src/steps/delete_remote_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // DeleteRemoteBranchStep deletes the current branch from the origin remote.

--- a/src/steps/discard_open_changes_step.go
+++ b/src/steps/discard_open_changes_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // DiscardOpenChangesStep resets the branch to the last commit, discarding uncommitted changes.

--- a/src/steps/driver_merge_pull_request_step.go
+++ b/src/steps/driver_merge_pull_request_step.go
@@ -3,8 +3,8 @@ package steps
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // DriverMergePullRequestStep squash merges the branch with the given name into the current branch.

--- a/src/steps/ensure_has_shippable_changes_step.go
+++ b/src/steps/ensure_has_shippable_changes_step.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // EnsureHasShippableChangesStep asserts that the branch has unique changes not on the main branch.

--- a/src/steps/fetch_upstream_step.go
+++ b/src/steps/fetch_upstream_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // FetchUpstreamStep brings the Git history of the local repository

--- a/src/steps/merge_branch_step.go
+++ b/src/steps/merge_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // MergeBranchStep merges the branch with the given name into the current branch.

--- a/src/steps/no_op_step.go
+++ b/src/steps/no_op_step.go
@@ -3,8 +3,8 @@ package steps
 import (
 	"errors"
 
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // NoOpStep does nothing.

--- a/src/steps/preserve_checkout_history_step.go
+++ b/src/steps/preserve_checkout_history_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // PreserveCheckoutHistoryStep does stuff.

--- a/src/steps/pull_branch_step.go
+++ b/src/steps/pull_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // PullBranchStep pulls the branch with the given name from the origin remote.

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // PushBranchStep pushes the branch with the given name to the origin remote.

--- a/src/steps/push_tags_step.go
+++ b/src/steps/push_tags_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // PushTagsStep pushes newly created Git tags to the remote.

--- a/src/steps/rebase_branch_step.go
+++ b/src/steps/rebase_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // RebaseBranchStep rebases the current branch

--- a/src/steps/remove_from_perennial_branch.go
+++ b/src/steps/remove_from_perennial_branch.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // RemoveFromPerennialBranches removes the branch with the given name as a perennial branch.

--- a/src/steps/reset_to_sha_step.go
+++ b/src/steps/reset_to_sha_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // ResetToShaStep undoes all commits on the current branch

--- a/src/steps/restore_open_changes_step.go
+++ b/src/steps/restore_open_changes_step.go
@@ -3,8 +3,8 @@ package steps
 import (
 	"errors"
 
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // RestoreOpenChangesStep restores stashed away changes into the workspace.

--- a/src/steps/revert_commit_step.go
+++ b/src/steps/revert_commit_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // RevertCommitStep reverts the commit with the given sha.

--- a/src/steps/run.go
+++ b/src/steps/run.go
@@ -3,9 +3,9 @@ package steps
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // Run runs the Git Town command described by the given state.

--- a/src/steps/run_state.go
+++ b/src/steps/run_state.go
@@ -3,7 +3,7 @@ package steps
 import (
 	"time"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // UnfinishedRunStateDetails has details about an unfinished run state.

--- a/src/steps/run_state_test.go
+++ b/src/steps/run_state_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/git-town/git-town/src/steps"
+	"github.com/git-town/git-town/v7/src/steps"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/steps/run_state_to_disk.go
+++ b/src/steps/run_state_to_disk.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // LoadPreviousRunState loads the run state from disk if it exists or creates a new run state.

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // SetParentBranchStep registers the branch with the given name as a parent

--- a/src/steps/squash_merge_branch_step.go
+++ b/src/steps/squash_merge_branch_step.go
@@ -3,9 +3,9 @@ package steps
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/prompt"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/prompt"
 )
 
 // SquashMergeBranchStep squash merges the branch with the given name into the current branch.

--- a/src/steps/stash_open_changes_step.go
+++ b/src/steps/stash_open_changes_step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // StashOpenChangesStep stores all uncommitted changes on the Git stash.

--- a/src/steps/step.go
+++ b/src/steps/step.go
@@ -1,8 +1,8 @@
 package steps
 
 import (
-	"github.com/git-town/git-town/src/drivers"
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/drivers"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // Step represents a dedicated activity within a Git Town command.

--- a/src/steps/step_list.go
+++ b/src/steps/step_list.go
@@ -3,7 +3,7 @@ package steps
 import (
 	"encoding/json"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // StepList is a list of steps

--- a/src/steps/sync_steps.go
+++ b/src/steps/sync_steps.go
@@ -3,7 +3,7 @@ package steps
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 )
 
 // GetSyncBranchSteps returns the steps to sync the branch with the given name.

--- a/test/assert.go
+++ b/test/assert.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/commit_table_builder.go
+++ b/test/commit_table_builder.go
@@ -4,8 +4,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/test/helpers"
 )
 
 // CommitTableBuilder collects data about commits in Git repositories

--- a/test/commit_table_builder_test.go
+++ b/test/commit_table_builder_test.go
@@ -3,8 +3,8 @@ package test_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/test"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/commit_tools.go
+++ b/test/commit_tools.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/cucumber/messages-go/v10"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/test/helpers"
 )
 
 // DefaultCommit provides a new Commit instance populated with the default values used in the absence of value specified by the test.

--- a/test/data_table.go
+++ b/test/data_table.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/cucumber/messages-go/v10"
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 

--- a/test/data_table_test.go
+++ b/test/data_table_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/git-town/git-town/test"
+	"github.com/git-town/git-town/v7/test"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/assert"
 )

--- a/test/git_environment.go
+++ b/test/git_environment.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/cucumber/messages-go/v10"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/test/helpers"
 )
 
 // GitEnvironment is the complete Git environment for a test scenario.

--- a/test/git_environment_test.go
+++ b/test/git_environment_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/git-town/git-town/src/git"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/git_manager.go
+++ b/test/git_manager.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 )
 
 /*

--- a/test/helpers/folder_name_test.go
+++ b/test/helpers/folder_name_test.go
@@ -3,7 +3,7 @@ package helpers_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/helpers/longest_string_length_test.go
+++ b/test/helpers/longest_string_length_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/helpers/ordered_string_set_test.go
+++ b/test/helpers/ordered_string_set_test.go
@@ -3,7 +3,7 @@ package helpers_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/helpers/unique_string_test.go
+++ b/test/helpers/unique_string_test.go
@@ -3,7 +3,7 @@ package helpers_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/mocking_shell.go
+++ b/test/mocking_shell.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 	"github.com/kballard/go-shellquote"
 )
 

--- a/test/mocking_shell_test.go
+++ b/test/mocking_shell_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/repo.go
+++ b/test/repo.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/git-town/git-town/src/config"
-	"github.com/git-town/git-town/src/git"
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/config"
+	"github.com/git-town/git-town/v7/src/git"
+	"github.com/git-town/git-town/v7/src/run"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/test/scenario_state.go
+++ b/test/scenario_state.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"github.com/cucumber/messages-go/v10"
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/run"
 )
 
 // ScenarioState constains the state that is shared by all steps within a scenario.

--- a/test/step_helpers.go
+++ b/test/step_helpers.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/cucumber/messages-go/v10"
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 )
 
 // compareExistingCommits compares the commits in the Git environment of the given FeatureState

--- a/test/steps.go
+++ b/test/steps.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
-	"github.com/git-town/git-town/src/cli"
-	"github.com/git-town/git-town/src/run"
+	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/run"
 )
 
 // beforeSuiteMux ensures that we run BeforeSuite only once globally.

--- a/test/tag_table_builder.go
+++ b/test/tag_table_builder.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/git-town/git-town/test/helpers"
+	"github.com/git-town/git-town/v7/test/helpers"
 )
 
 // TagTableBuilder collects data about tags in Git repositories


### PR DESCRIPTION
This enables proper handling by Go's indexing servers, which is needed for example for FreeBSD ports.

resolves #1675 

@charlierudolph since this adds complexity on our end, I'd like your approval before merging this