### PR TITLE
Use Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
   # which the "go-s" job tests in parallel
   go:
     docker:
-      - image: circleci/golang:1.14.2
+      - image: circleci/golang:1.16.8
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -36,7 +36,7 @@ jobs:
   # runs the Cucumber tests for ship and sync in parallel to the other ones
   go-s:
     docker:
-      - image: circleci/golang:1.14.2
+      - image: circleci/golang:1.16.8
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/features/sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
+++ b/features/sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
@@ -39,11 +39,11 @@ Feature: git-sync: on a feature branch with merge pull branch strategy
       | BRANCH  | LOCATION      | MESSAGE                                                    | FILE NAME           |
       | main    | local, remote | local main commit                                          | local_main_file     |
       |         |               | remote main commit                                         | remote_main_file    |
-      |         |               | Merge remote-tracking branch 'origin/main' into main       |                     |
+      |         |               | Merge remote-tracking branch 'origin/main'                 |                     |
       | feature | local, remote | local feature commit                                       | local_feature_file  |
       |         |               | remote feature commit                                      | remote_feature_file |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |                     |
       |         |               | local main commit                                          | local_main_file     |
       |         |               | remote main commit                                         | remote_main_file    |
-      |         |               | Merge remote-tracking branch 'origin/main' into main       |                     |
+      |         |               | Merge remote-tracking branch 'origin/main'                 |                     |
       |         |               | Merge branch 'main' into feature                           |                     |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-town/git-town
 
-go 1.14
+go 1.16
 
 require (
 	code.gitea.io/sdk/gitea v0.12.0


### PR DESCRIPTION
This also seems to use a Git version newer than 2.29 on CI. Starting with this version, certain branches are no longer listed in merge commits. For background, see https://github.com/git/git/blob/master/Documentation/RelNotes/2.29.0.txt and search for `merge.suppressDest`.