### PR TITLE
Install Vim on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,10 @@ jobs:
       - run: mv ./git-town /go/bin/
       - run: mv ./godog /go/bin/
       - run: mv ./golangci-lint /go/bin/
+      - run: echo 'export PATH=$PATH:/go/bin:/usr/local/go/bin' >> $BASH_ENV
       - run: make unit
       - run: make lint-go
+      - run: echo $PATH
       - run:
           find features -type f -name '*.feature' | grep -v features/s | xargs
           godog --concurrency=$(nproc --all) --format=progress --strict
@@ -47,6 +49,8 @@ jobs:
       - run: mv ./git-town /go/bin/
       - run: mv ./godog /go/bin/
       - run: mv ./golangci-lint /go/bin/
+      - run: echo 'export PATH=$PATH:/go/bin:/usr/local/go/bin' >> $BASH_ENV
+      - run: echo $PATH
       - run:
           find features -type f -name '*.feature' | grep features/s | xargs
           godog --concurrency=$(nproc --all) --format=progress --strict

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install vi
+      - run: sudo apt-get update && sudo apt-get install vim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/
@@ -43,7 +43,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install vi
+      - run: sudo apt-get update && sudo apt-get install vim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install vim
+      - run: sudo apt-get update && sudo apt-get install neovim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/
@@ -43,7 +43,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install vim
+      - run: sudo apt-get update && sudo apt-get install neovim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
       - run: mv ./git-town /go/bin/
       - run: mv ./godog /go/bin/
       - run: mv ./golangci-lint /go/bin/
+      - run: godog features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
       - run: echo 'export PATH=$PATH:/go/bin:/usr/local/go/bin' >> $BASH_ENV
       - run: echo $PATH
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
       - run: echo 'export PATH=$PATH:/go/bin:/usr/local/go/bin' >> $BASH_ENV
       - run: make unit
       - run: make lint-go
-      - run: echo $PATH
       - run:
           find features -type f -name '*.feature' | grep -v features/s | xargs
           godog --concurrency=$(nproc --all) --format=progress --strict
@@ -49,9 +48,8 @@ jobs:
       - run: mv ./git-town /go/bin/
       - run: mv ./godog /go/bin/
       - run: mv ./golangci-lint /go/bin/
-      - run: godog features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
+      - run: bash -c "godog features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature"
       - run: echo 'export PATH=$PATH:/go/bin:/usr/local/go/bin' >> $BASH_ENV
-      - run: echo $PATH
       - run:
           find features -type f -name '*.feature' | grep features/s | xargs
           godog --concurrency=$(nproc --all) --format=progress --strict

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
     docker:
       - image: circleci/golang:1.16.8
     steps:
+      # install vim for tests that require entering a commit message with an editor
+      - run: sudo apt-get update && sudo apt-get install vim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/
@@ -38,6 +40,8 @@ jobs:
     docker:
       - image: circleci/golang:1.16.8
     steps:
+      # install vim for tests that require entering a commit message with an editor
+      - run: sudo apt-get update && sudo apt-get install vim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install vim
+      - run: sudo apt-get update && sudo apt-get install vi
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/
@@ -43,7 +43,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install vim
+      - run: sudo apt-get update && sudo apt-get install vi
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run: mv ./git-town /go/bin/
       - run: mv ./godog /go/bin/
       - run: mv ./golangci-lint /go/bin/
-      - run: bash -c "godog features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature"
+      - run: godog features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
       - run: echo 'export PATH=$PATH:/go/bin:/usr/local/go/bin' >> $BASH_ENV
       - run:
           find features -type f -name '*.feature' | grep features/s | xargs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install neovim
+      - run: sudo apt-get update && sudo apt-get install vim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/
@@ -43,7 +43,7 @@ jobs:
       - image: circleci/golang:1.16.8
     steps:
       # install vim for tests that require entering a commit message with an editor
-      - run: sudo apt-get update && sudo apt-get install neovim
+      - run: sudo apt-get update && sudo apt-get install vim
       - attach_workspace:
           at: /home/circleci
       - run: mv ./git-town /go/bin/

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
@@ -33,7 +33,7 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
       | main    | git checkout feature               |
     And it prints the error:
       """
-      aborted because commit exited with error
+      Aborting commit due to empty commit message.
       """
     And I am still on the "feature" branch
     And my repo is left with my original commits

--- a/features/ship/supplied_branch/feature_branch/empty_commit_message.feature
+++ b/features/ship/supplied_branch/feature_branch/empty_commit_message.feature
@@ -37,7 +37,7 @@ Feature: git town-ship: aborting the ship of the supplied feature branch by ente
       | other-feature | git stash pop                               |
     And it prints the error:
       """
-      aborted because commit exited with error
+      Aborting commit due to empty commit message.
       """
     And I am still on the "other-feature" branch
     And my workspace still contains my uncommitted file

--- a/test/steps.go
+++ b/test/steps.go
@@ -219,7 +219,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^I run "([^"]*)" and enter an empty commit message$`, func(cmd string) error {
-		state.runRes, state.runErr = state.gitEnv.DevShell.RunStringWith(cmd, run.Options{Input: []string{"dGZZ"}})
+		state.runRes, state.runErr = state.gitEnv.DevShell.RunStringWith(cmd, run.Options{Input: []string{"ZZ"}})
 		return nil
 	})
 


### PR DESCRIPTION
Extracted from #1686 to help investigate test failures

- This always ran locally where Vim was installed.
- This works when SSHing into CircleCI and running the exact command that runs on CI manually: `find features -type f -name '*.feature' | grep features/s | xargs godog --concurrency=$(nproc --all) --format=progress --strict`
- This works when SSHing into CircleCI and running `make cuke`
- This works when SSHing into CircleCI and running `godog features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature`
- The regular CI run fails