### PR TITLE
Live without exhaustive struct checking for now

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ linters:
   disable:
     - cyclop
     - exhaustivestruct  # not applicable at the moment
-    - forbidigo
+    - forbidigo  # Git Town prints a lot to the CLI
     - gochecknoglobals # Cobra requires globals
     - gochecknoinits # Cobra requires init blocks
     - goconst # tests contain a ton of hard-coded test strings, for example branch names

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,12 +9,12 @@ linters:
     - goconst # tests contain a ton of hard-coded test strings, for example branch names
     - golint  # deprecated
     - gomnd # tests contain hard-coded test data that wouldn't make sense to extract into constants
-    - ifshort
+    - ifshort  # this enforces less readable code
     - interfacer  # deprecated
     - ireturn
     - lll # we aren't enforcing a line length at this point
     - maligned  # deprecated
-    - nlreturn
+    - nlreturn  # this forces unnecessary empty lines in function bodies
     - scopelint  # deprecated
     - wrapcheck
     - wsl # this linter creates too many false positives, our policy is to not have any empty lines in code blocks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   enable-all: true
   disable:
-    - cyclop
+    - cyclop  # we keep a tab on function length ourselves
     - exhaustivestruct  # not applicable at the moment
     - forbidigo  # Git Town prints a lot to the CLI
     - gochecknoglobals # Cobra requires globals

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,10 +7,10 @@ linters:
     - gochecknoglobals # Cobra requires globals
     - gochecknoinits # Cobra requires init blocks
     - goconst # tests contain a ton of hard-coded test strings, for example branch names
-    - golint
+    - golint  # deprecated
     - gomnd # tests contain hard-coded test data that wouldn't make sense to extract into constants
     - ifshort
-    - interfacer
+    - interfacer  # deprecated
     - ireturn
     - lll # we aren't enforcing a line length at this point
     - maligned  # deprecated

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ linters:
   enable-all: true
   disable:
     - cyclop
-    - exhaustivestruct  # TODO: activate
+    - exhaustivestruct  # not applicable at the moment
     - forbidigo
     - gochecknoglobals # Cobra requires globals
     - gochecknoinits # Cobra requires init blocks


### PR DESCRIPTION
Many Go APIs aren't built with it in mind.