### PR TITLE
Check for interface returns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - gomnd # tests contain hard-coded test data that wouldn't make sense to extract into constants
     - ifshort
     - interfacer
-    - ireturn
     - lll # we aren't enforcing a line length at this point
     - maligned  # deprecated
     - nlreturn

--- a/src/drivers/core.go
+++ b/src/drivers/core.go
@@ -61,7 +61,7 @@ type MergePullRequestOptions struct {
 type logFn func(string, ...interface{})
 
 // Load returns the code hosting driver to use based on the git config.
-func Load(config config, git gitRunner, log logFn) CodeHostingDriver {
+func Load(config config, git gitRunner, log logFn) CodeHostingDriver { //nolint:ireturn
 	githubDriver := LoadGithub(config, log)
 	if githubDriver != nil {
 		return githubDriver

--- a/src/drivers/gitea_test.go
+++ b/src/drivers/gitea_test.go
@@ -19,7 +19,7 @@ const (
 
 func log(template string, messages ...interface{}) {}
 
-func setupGiteaDriver(t *testing.T, token string) (*drivers.GiteaCodeHostingDriver, func()) { //nolint:ireturn // apparent bug in ireturn
+func setupGiteaDriver(t *testing.T, token string) (*drivers.GiteaCodeHostingDriver, func()) {
 	t.Helper()
 	httpmock.Activate()
 	driver := drivers.LoadGitea(mockConfig{

--- a/src/drivers/gitea_test.go
+++ b/src/drivers/gitea_test.go
@@ -19,7 +19,7 @@ const (
 
 func log(template string, messages ...interface{}) {}
 
-func setupGiteaDriver(t *testing.T, token string) (drivers.CodeHostingDriver, func()) {
+func setupGiteaDriver(t *testing.T, token string) (*drivers.GiteaCodeHostingDriver, func()) {
 	t.Helper()
 	httpmock.Activate()
 	driver := drivers.LoadGitea(mockConfig{

--- a/src/drivers/gitea_test.go
+++ b/src/drivers/gitea_test.go
@@ -19,7 +19,7 @@ const (
 
 func log(template string, messages ...interface{}) {}
 
-func setupGiteaDriver(t *testing.T, token string) (*drivers.GiteaCodeHostingDriver, func()) {
+func setupGiteaDriver(t *testing.T, token string) (*drivers.GiteaCodeHostingDriver, func()) { //nolint:ireturn // apparent bug in ireturn
 	t.Helper()
 	httpmock.Activate()
 	driver := drivers.LoadGitea(mockConfig{

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -1,3 +1,4 @@
+//nolint:ireturn
 package steps
 
 import (

--- a/src/steps/delete_remote_branch_step.go
+++ b/src/steps/delete_remote_branch_step.go
@@ -15,7 +15,7 @@ type DeleteRemoteBranchStep struct {
 }
 
 // CreateUndoStep returns the undo step for this step.
-func (step *DeleteRemoteBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *DeleteRemoteBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	if step.IsTracking {
 		return &CreateTrackingBranchStep{BranchName: step.BranchName}, nil
 	}

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -1,3 +1,4 @@
+//nolint:ireturn
 package steps
 
 import (

--- a/src/steps/remove_from_perennial_branch.go
+++ b/src/steps/remove_from_perennial_branch.go
@@ -1,3 +1,4 @@
+//nolint:ireturn
 package steps
 
 import (

--- a/src/steps/restore_open_changes_step.go
+++ b/src/steps/restore_open_changes_step.go
@@ -1,3 +1,4 @@
+//nolint:ireturn
 package steps
 
 import (

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -1,3 +1,4 @@
+//nolint:ireturn
 package steps
 
 import (

--- a/src/steps/stash_open_changes_step.go
+++ b/src/steps/stash_open_changes_step.go
@@ -1,3 +1,4 @@
+//nolint:ireturn
 package steps
 
 import (


### PR DESCRIPTION
We got quite a lot of functions that return interfaces. This isn't idiomatic Go but it's the only thing we can do here. At least we should track the areas where we do this and enforce linting in other areas of the codebase.