### PR TITLE
Use local installation of mdBook

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,1 +1,2 @@
+bin
 book

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,20 +1,20 @@
 .DEFAULT_GOAL := help
 
 build:  # transpiles the website to HTML
-	./mdbook build
+	bin/mdbook build
 
 clean:  # removes all build artifacts
-	./mdbook clean
+	bin/mdbook clean
 	rm -rf bin
 
 help:  # prints available targets
 	@cat Makefile | grep '^[^ ]*:' | grep -v help | sed 's/:.*#/#/' | column -s "#" -t
 
 serve:  # runs a local development server of the website
-	./mdbook serve --open
+	bin/mdbook serve --open
 
 setup:  # installs the mdBook binary
-	./scripts/install_mdbook
+	scripts/install_mdbook
 
 test:  # tests the website
 	cd .. && make --no-print-dir docs

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,13 +1,23 @@
 .DEFAULT_GOAL := help
 
 build:  # transpiles the website to HTML
-	mdbook build
+	./mdbook build
 
 clean:  # removes all build artifacts
-	mdbook clean
+	./mdbook clean
+	rm -rf bin
 
 help:  # prints available targets
 	@cat Makefile | grep '^[^ ]*:' | grep -v help | sed 's/:.*#/#/' | column -s "#" -t
 
 serve:  # runs a local development server of the website
-	mdbook serve --open
+	./mdbook serve --open
+
+setup:  # installs the mdBook binary
+	./scripts/install_mdbook
+
+test:  # tests the website
+	cd .. && make --no-print-dir docs
+
+
+.SILENT:

--- a/website/scripts/install_mdbook
+++ b/website/scripts/install_mdbook
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+LINUX_URL=https://github.com/rust-lang/mdBook/releases/download/v0.4.15/mdbook-v0.4.15-x86_64-unknown-linux-gnu.tar.gz
+MACOS_URL=https://github.com/rust-lang/mdBook/releases/download/v0.4.15/mdbook-v0.4.15-x86_64-apple-darwin.tar.gz
+MSWIN_URL=https://github.com/rust-lang/mdBook/releases/download/v0.4.15/mdbook-v0.4.15-x86_64-pc-windows-msvc.zip
+
+
+function os_name {
+  case "$OSTYPE" in
+    darwin*)  echo "macos" ;;
+    linux*)   echo "linux" ;;
+    msys*)    echo "windows" ;;
+    cygwin*)  echo "windows" ;;
+    *)        echo "unknown" ;;
+  esac
+}
+
+function download_linux {
+	curl -L $LINUX_URL | tar xvz --directory bin
+}
+
+function download_macos {
+  echo Note: this is untested, please submit bug reports and fixes if it is broken
+	curl -L $MACOS_URL | tar xvz --directory bin
+}
+
+function download_win {
+  echo Note: this is untested, please submit bug reports and fixes if it is broken
+	curl -L $MSWIN_URL | tar xvz --directory bin
+}
+
+function download_unknown {
+  echo "Error: unsupported operating system."
+  echo "Please compile mdBook from source."
+  exit 1
+}
+
+mkdir -p bin
+download_"$(os_name)"


### PR DESCRIPTION
Relying on an external installation is too cumbersome and this is needed for deployment on Netlify anyways.