### PR TITLE
More idiomatic Getter functions

### DIFF
--- a/src/cli/printable.go
+++ b/src/cli/printable.go
@@ -9,7 +9,7 @@ import (
 // BranchAncestryConfig defines the configuration values needed by the `cli` package.
 type BranchAncestryConfig interface {
 	BranchAncestryRoots() []string
-	GetChildBranches(string) []string
+	ChildBranches(string) []string
 }
 
 // PrintableBranchAncestry provides the branch ancestry in CLI printable format.
@@ -25,7 +25,7 @@ func PrintableBranchAncestry(config BranchAncestryConfig) string {
 // PrintableBranchTree returns a user printable branch tree.
 func PrintableBranchTree(branchName string, config BranchAncestryConfig) (result string) {
 	result += branchName
-	childBranches := config.GetChildBranches(branchName)
+	childBranches := config.ChildBranches(branchName)
 	sort.Strings(childBranches)
 	for _, childBranch := range childBranches {
 		result += "\n" + Indent(PrintableBranchTree(childBranch, config))

--- a/src/cli/printable.go
+++ b/src/cli/printable.go
@@ -8,13 +8,13 @@ import (
 
 // BranchAncestryConfig defines the configuration values needed by the `cli` package.
 type BranchAncestryConfig interface {
-	GetBranchAncestryRoots() []string
+	BranchAncestryRoots() []string
 	GetChildBranches(string) []string
 }
 
 // PrintableBranchAncestry provides the branch ancestry in CLI printable format.
 func PrintableBranchAncestry(config BranchAncestryConfig) string {
-	roots := config.GetBranchAncestryRoots()
+	roots := config.BranchAncestryRoots()
 	trees := make([]string, len(roots))
 	for r := range roots {
 		trees[r] = PrintableBranchTree(roots[r], config)

--- a/src/cmd/alias.go
+++ b/src/cmd/alias.go
@@ -63,7 +63,7 @@ func addAlias(command string, repo *git.ProdRepo) error {
 }
 
 func removeAlias(command string, repo *git.ProdRepo) error {
-	existingAlias := repo.Config.GetGitAlias(command)
+	existingAlias := repo.Config.GitAlias(command)
 	if existingAlias == "town "+command {
 		result, err := repo.Config.RemoveGitAlias(command)
 		if err != nil {

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -83,7 +83,7 @@ func getAppendConfig(args []string, repo *git.ProdRepo) (result appendConfig, er
 	if err != nil {
 		return result, err
 	}
-	result.ancestorBranches = repo.Config.GetAncestorBranches(result.parentBranch)
+	result.ancestorBranches = repo.Config.AncestorBranches(result.parentBranch)
 	result.shouldNewBranchPush = repo.Config.ShouldNewBranchPush()
 	result.isOffline = repo.Config.IsOffline()
 	return result, err

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -14,12 +14,12 @@ var configCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println()
 		cli.PrintLabelAndValue("Main branch", cli.PrintableMainBranch(prodRepo.Config.MainBranch()))
-		cli.PrintLabelAndValue("Perennial branches", cli.PrintablePerennialBranches(prodRepo.Config.GetPerennialBranches()))
+		cli.PrintLabelAndValue("Perennial branches", cli.PrintablePerennialBranches(prodRepo.Config.PerennialBranches()))
 		mainBranch := prodRepo.Config.MainBranch()
 		if mainBranch != "" {
 			cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(prodRepo.Config))
 		}
-		cli.PrintLabelAndValue("Pull branch strategy", prodRepo.Config.GetPullBranchStrategy())
+		cli.PrintLabelAndValue("Pull branch strategy", prodRepo.Config.PullBranchStrategy())
 		cli.PrintLabelAndValue("New Branch Push Flag", cli.PrintableNewBranchPushFlag(prodRepo.Config.ShouldNewBranchPush()))
 	},
 	Args: cobra.NoArgs,

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -13,9 +13,9 @@ var configCommand = &cobra.Command{
 	Short: "Displays your Git Town configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println()
-		cli.PrintLabelAndValue("Main branch", cli.PrintableMainBranch(prodRepo.Config.GetMainBranch()))
+		cli.PrintLabelAndValue("Main branch", cli.PrintableMainBranch(prodRepo.Config.MainBranch()))
 		cli.PrintLabelAndValue("Perennial branches", cli.PrintablePerennialBranches(prodRepo.Config.GetPerennialBranches()))
-		mainBranch := prodRepo.Config.GetMainBranch()
+		mainBranch := prodRepo.Config.MainBranch()
 		if mainBranch != "" {
 			cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(prodRepo.Config))
 		}

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -68,7 +68,7 @@ func getDiffParentConfig(args []string, repo *git.ProdRepo) (config diffParentCo
 	if err != nil {
 		return config, err
 	}
-	config.parentBranch = repo.Config.GetParentBranch(config.branch)
+	config.parentBranch = repo.Config.ParentBranch(config.branch)
 	return config, nil
 }
 

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -50,7 +50,7 @@ See "sync" for information regarding remote upstream.`,
 
 func getParentBranch(targetBranch string, repo *git.ProdRepo) (string, error) {
 	if promptForParent {
-		parentBranch, err := prompt.AskForBranchParent(targetBranch, repo.Config.GetMainBranch(), repo)
+		parentBranch, err := prompt.AskForBranchParent(targetBranch, repo.Config.MainBranch(), repo)
 		if err != nil {
 			return "", err
 		}
@@ -60,7 +60,7 @@ func getParentBranch(targetBranch string, repo *git.ProdRepo) (string, error) {
 		}
 		return parentBranch, nil
 	}
-	return repo.Config.GetMainBranch(), nil
+	return repo.Config.MainBranch(), nil
 }
 
 func getHackConfig(args []string, repo *git.ProdRepo) (result appendConfig, err error) {

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -111,7 +111,7 @@ func getKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err er
 	if err != nil {
 		return result, err
 	}
-	result.childBranches = repo.Config.GetChildBranches(result.targetBranch)
+	result.childBranches = repo.Config.ChildBranches(result.targetBranch)
 	return result, nil
 }
 

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -102,7 +102,7 @@ func getKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err er
 	if err != nil {
 		return result, err
 	}
-	result.targetBranchParent = repo.Config.GetParentBranch(result.targetBranch)
+	result.targetBranchParent = repo.Config.ParentBranch(result.targetBranch)
 	result.previousBranch, err = repo.Silent.PreviouslyCheckedOutBranch()
 	if err != nil {
 		return result, err

--- a/src/cmd/main_branch.go
+++ b/src/cmd/main_branch.go
@@ -31,7 +31,7 @@ The main branch is the Git branch from which new feature branches are cut.`,
 }
 
 func printMainBranch() {
-	cli.Println(cli.PrintableMainBranch(prodRepo.Config.GetMainBranch()))
+	cli.Println(cli.PrintableMainBranch(prodRepo.Config.MainBranch()))
 }
 
 func setMainBranch(branchName string, repo *git.ProdRepo) error {

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -86,7 +86,7 @@ func getNewPullRequestConfig(repo *git.ProdRepo) (result newPullRequestConfig, e
 	if err != nil {
 		return result, err
 	}
-	result.BranchesToSync = append(repo.Config.GetAncestorBranches(result.InitialBranch), result.InitialBranch)
+	result.BranchesToSync = append(repo.Config.AncestorBranches(result.InitialBranch), result.InitialBranch)
 	return
 }
 

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -92,7 +92,7 @@ func getNewPullRequestConfig(repo *git.ProdRepo) (result newPullRequestConfig, e
 
 func getNewPullRequestStepList(config newPullRequestConfig, repo *git.ProdRepo) (result steps.StepList, err error) {
 	for _, branchName := range config.BranchesToSync {
-		steps, err := steps.GetSyncBranchSteps(branchName, true, repo)
+		steps, err := steps.SyncBranchSteps(branchName, true, repo)
 		if err != nil {
 			return result, err
 		}

--- a/src/cmd/perennial_branches.go
+++ b/src/cmd/perennial_branches.go
@@ -14,7 +14,7 @@ var perennialBranchesCommand = &cobra.Command{
 Perennial branches are long-lived branches.
 They cannot be shipped.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cli.Println(cli.PrintablePerennialBranches(prodRepo.Config.GetPerennialBranches()))
+		cli.Println(cli.PrintablePerennialBranches(prodRepo.Config.PerennialBranches()))
 	},
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -92,7 +92,7 @@ func getPrependConfig(args []string, repo *git.ProdRepo) (result prependConfig, 
 		return result, err
 	}
 	result.parentBranch = repo.Config.GetParentBranch(result.initialBranch)
-	result.ancestorBranches = repo.Config.GetAncestorBranches(result.initialBranch)
+	result.ancestorBranches = repo.Config.AncestorBranches(result.initialBranch)
 	return result, nil
 }
 

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -91,7 +91,7 @@ func getPrependConfig(args []string, repo *git.ProdRepo) (result prependConfig, 
 	if err != nil {
 		return result, err
 	}
-	result.parentBranch = repo.Config.GetParentBranch(result.initialBranch)
+	result.parentBranch = repo.Config.ParentBranch(result.initialBranch)
 	result.ancestorBranches = repo.Config.AncestorBranches(result.initialBranch)
 	return result, nil
 }

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -98,7 +98,7 @@ func getPrependConfig(args []string, repo *git.ProdRepo) (result prependConfig, 
 
 func getPrependStepList(config prependConfig, repo *git.ProdRepo) (result steps.StepList, err error) {
 	for _, branchName := range config.ancestorBranches {
-		steps, err := steps.GetSyncBranchSteps(branchName, true, repo)
+		steps, err := steps.SyncBranchSteps(branchName, true, repo)
 		if err != nil {
 			return result, err
 		}

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -58,7 +58,7 @@ func getPruneBranchesConfig(repo *git.ProdRepo) (result pruneBranchesConfig, err
 			return result, err
 		}
 	}
-	result.mainBranch = repo.Config.GetMainBranch()
+	result.mainBranch = repo.Config.MainBranch()
 	result.initialBranchName, err = repo.Silent.CurrentBranch()
 	if err != nil {
 		return result, err

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -75,7 +75,7 @@ func getPruneBranchesStepList(config pruneBranchesConfig, repo *git.ProdRepo) (r
 		}
 		parent := repo.Config.GetParentBranch(branchName)
 		if parent != "" {
-			for _, child := range repo.Config.GetChildBranches(branchName) {
+			for _, child := range repo.Config.ChildBranches(branchName) {
 				result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: parent})
 			}
 			result.Append(&steps.DeleteParentBranchStep{BranchName: branchName})

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -73,7 +73,7 @@ func getPruneBranchesStepList(config pruneBranchesConfig, repo *git.ProdRepo) (r
 		if initialBranchName == branchName {
 			result.Append(&steps.CheckoutBranchStep{BranchName: config.mainBranch})
 		}
-		parent := repo.Config.GetParentBranch(branchName)
+		parent := repo.Config.ParentBranch(branchName)
 		if parent != "" {
 			for _, child := range repo.Config.ChildBranches(branchName) {
 				result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: parent})

--- a/src/cmd/pull_branch_strategy.go
+++ b/src/cmd/pull_branch_strategy.go
@@ -17,7 +17,7 @@ when merging remote tracking branches into local branches
 for the main branch and perennial branches.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cli.Println(prodRepo.Config.GetPullBranchStrategy())
+			cli.Println(prodRepo.Config.PullBranchStrategy())
 		} else {
 			err := prodRepo.Config.SetPullBranchStrategy(args[0])
 			if err != nil {

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -118,7 +118,7 @@ func getRenameBranchConfig(args []string, repo *git.ProdRepo) (result renameBran
 	if hasNewBranch {
 		return result, fmt.Errorf("a branch named %q already exists", result.newBranchName)
 	}
-	result.oldBranchChildren = repo.Config.GetChildBranches(result.oldBranchName)
+	result.oldBranchChildren = repo.Config.ChildBranches(result.oldBranchName)
 	result.oldBranchHasTrackingBranch, err = repo.Silent.HasTrackingBranch(result.oldBranchName)
 	return result, err
 }

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -133,7 +133,7 @@ func getRenameBranchStepList(config renameBranchConfig, repo *git.ProdRepo) (res
 		result.Append(&steps.AddToPerennialBranches{BranchName: config.newBranchName})
 	} else {
 		result.Append(&steps.DeleteParentBranchStep{BranchName: config.oldBranchName})
-		result.Append(&steps.SetParentBranchStep{BranchName: config.newBranchName, ParentBranchName: repo.Config.GetParentBranch(config.oldBranchName)})
+		result.Append(&steps.SetParentBranchStep{BranchName: config.newBranchName, ParentBranchName: repo.Config.ParentBranch(config.oldBranchName)})
 	}
 	for _, child := range config.oldBranchChildren {
 		result.Append(&steps.SetParentBranchStep{BranchName: child, ParentBranchName: config.newBranchName})

--- a/src/cmd/set_parent_branch.go
+++ b/src/cmd/set_parent_branch.go
@@ -22,7 +22,7 @@ var setParentBranchCommand = &cobra.Command{
 		}
 		defaultParentBranch := prodRepo.Config.GetParentBranch(branchName)
 		if defaultParentBranch == "" {
-			defaultParentBranch = prodRepo.Config.GetMainBranch()
+			defaultParentBranch = prodRepo.Config.MainBranch()
 		}
 		err = prodRepo.Config.DeleteParentBranch(branchName)
 		if err != nil {

--- a/src/cmd/set_parent_branch.go
+++ b/src/cmd/set_parent_branch.go
@@ -20,7 +20,7 @@ var setParentBranchCommand = &cobra.Command{
 		if !prodRepo.Config.IsFeatureBranch(branchName) {
 			cli.Exit(errors.New("only feature branches can have parent branches"))
 		}
-		defaultParentBranch := prodRepo.Config.GetParentBranch(branchName)
+		defaultParentBranch := prodRepo.Config.ParentBranch(branchName)
 		if defaultParentBranch == "" {
 			defaultParentBranch = prodRepo.Config.MainBranch()
 		}

--- a/src/cmd/shared.go
+++ b/src/cmd/shared.go
@@ -46,7 +46,7 @@ func ValidateIsRepository(repo *git.ProdRepo) error {
 
 func getAppendStepList(config appendConfig, repo *git.ProdRepo) (result steps.StepList, err error) {
 	for _, branchName := range append(config.ancestorBranches, config.parentBranch) {
-		steps, err := steps.GetSyncBranchSteps(branchName, true, repo)
+		steps, err := steps.SyncBranchSteps(branchName, true, repo)
 		if err != nil {
 			return result, err
 		}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -159,12 +159,12 @@ please ship %q first`, strings.Join(ancestorsWithoutMainOrPerennial, ", "), olde
 }
 
 func getShipStepList(config shipConfig, repo *git.ProdRepo) (result steps.StepList, err error) {
-	syncSteps, err := steps.GetSyncBranchSteps(config.branchToMergeInto, true, repo)
+	syncSteps, err := steps.SyncBranchSteps(config.branchToMergeInto, true, repo)
 	if err != nil {
 		return result, err
 	}
 	result.AppendList(syncSteps)
-	syncSteps, err = steps.GetSyncBranchSteps(config.branchToShip, false, repo)
+	syncSteps, err = steps.SyncBranchSteps(config.branchToShip, false, repo)
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -150,7 +150,7 @@ func gitShipConfig(args []string, driver drivers.CodeHostingDriver, repo *git.Pr
 func ensureParentBranchIsMainOrPerennialBranch(branchName string) {
 	parentBranch := prodRepo.Config.GetParentBranch(branchName)
 	if !prodRepo.Config.IsMainBranch(parentBranch) && !prodRepo.Config.IsPerennialBranch(parentBranch) {
-		ancestors := prodRepo.Config.GetAncestorBranches(branchName)
+		ancestors := prodRepo.Config.AncestorBranches(branchName)
 		ancestorsWithoutMainOrPerennial := ancestors[1:]
 		oldestAncestor := ancestorsWithoutMainOrPerennial[0]
 		cli.Exit(fmt.Errorf(`shipping this branch would ship %q as well,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -142,7 +142,7 @@ func gitShipConfig(args []string, driver drivers.CodeHostingDriver, repo *git.Pr
 	result.canShipWithDriver = prInfo.CanMergeWithAPI
 	result.defaultCommitMessage = prInfo.DefaultCommitMessage
 	result.pullRequestNumber = prInfo.PullRequestNumber
-	result.childBranches = repo.Config.GetChildBranches(result.branchToShip)
+	result.childBranches = repo.Config.ChildBranches(result.branchToShip)
 	result.shouldShipDeleteRemoteBranch = prodRepo.Config.ShouldShipDeleteRemoteBranch()
 	return result, err
 }

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -137,7 +137,7 @@ func gitShipConfig(args []string, driver drivers.CodeHostingDriver, repo *git.Pr
 	}
 	result.isOffline = repo.Config.IsOffline()
 	result.isShippingInitialBranch = result.branchToShip == result.initialBranch
-	result.branchToMergeInto = repo.Config.GetParentBranch(result.branchToShip)
+	result.branchToMergeInto = repo.Config.ParentBranch(result.branchToShip)
 	prInfo, err := getCanShipWithDriver(result.branchToShip, result.branchToMergeInto, driver)
 	result.canShipWithDriver = prInfo.CanMergeWithAPI
 	result.defaultCommitMessage = prInfo.DefaultCommitMessage
@@ -148,7 +148,7 @@ func gitShipConfig(args []string, driver drivers.CodeHostingDriver, repo *git.Pr
 }
 
 func ensureParentBranchIsMainOrPerennialBranch(branchName string) {
-	parentBranch := prodRepo.Config.GetParentBranch(branchName)
+	parentBranch := prodRepo.Config.ParentBranch(branchName)
 	if !prodRepo.Config.IsMainBranch(parentBranch) && !prodRepo.Config.IsPerennialBranch(parentBranch) {
 		ancestors := prodRepo.Config.AncestorBranches(branchName)
 		ancestorsWithoutMainOrPerennial := ancestors[1:]

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -119,7 +119,7 @@ func getSyncConfig(repo *git.ProdRepo) (result syncConfig, err error) {
 
 func getSyncStepList(config syncConfig, repo *git.ProdRepo) (result steps.StepList, err error) {
 	for _, branchName := range config.branchesToSync {
-		steps, err := steps.GetSyncBranchSteps(branchName, true, repo)
+		steps, err := steps.SyncBranchSteps(branchName, true, repo)
 		if err != nil {
 			return result, err
 		}

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -111,7 +111,7 @@ func getSyncConfig(repo *git.ProdRepo) (result syncConfig, err error) {
 		if err != nil {
 			return result, err
 		}
-		result.branchesToSync = append(prodRepo.Config.GetAncestorBranches(result.initialBranch), result.initialBranch)
+		result.branchesToSync = append(prodRepo.Config.AncestorBranches(result.initialBranch), result.initialBranch)
 		result.shouldPushTags = !prodRepo.Config.IsFeatureBranch(result.initialBranch)
 	}
 	return result, nil

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -183,8 +183,8 @@ func (c *Config) GetGitAlias(command string) string {
 	return c.getGlobalConfigValue("alias." + command)
 }
 
-// GetGitHubToken provides the content of the GitHub API token stored in the local or global Git Town configuration.
-func (c *Config) GetGitHubToken() string {
+// GitHubToken provides the content of the GitHub API token stored in the local or global Git Town configuration.
+func (c *Config) GitHubToken() string {
 	return c.getLocalOrGlobalConfigValue("git-town.github-token")
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -193,8 +193,8 @@ func (c *Config) GiteaToken() string {
 	return c.getLocalOrGlobalConfigValue("git-town.gitea-token")
 }
 
-// GetMainBranch returns the name of the main branch.
-func (c *Config) GetMainBranch() string {
+// MainBranch returns the name of the main branch.
+func (c *Config) MainBranch() string {
 	return c.getLocalOrGlobalConfigValue("git-town.main-branch-name")
 }
 
@@ -262,7 +262,7 @@ func (c *Config) IsFeatureBranch(branchName string) bool {
 // IsMainBranch indicates whether the branch with the given name
 // is the main branch of the repository.
 func (c *Config) IsMainBranch(branchName string) bool {
-	return branchName == c.GetMainBranch()
+	return branchName == c.MainBranch()
 }
 
 // IsOffline indicates whether Git Town is currently in offline mode.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -188,8 +188,8 @@ func (c *Config) GitHubToken() string {
 	return c.getLocalOrGlobalConfigValue("git-town.github-token")
 }
 
-// GetGiteaToken provides the content of the Gitea API token stored in the local or global Git Town configuration.
-func (c *Config) GetGiteaToken() string {
+// GiteaToken provides the content of the Gitea API token stored in the local or global Git Town configuration.
+func (c *Config) GiteaToken() string {
 	return c.getLocalOrGlobalConfigValue("git-town.gitea-token")
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -221,9 +221,9 @@ func (c *Config) GetPullBranchStrategy() string {
 	return "rebase"
 }
 
-// GetRemoteOriginURL returns the URL for the "origin" remote.
+// RemoteOriginURL returns the URL for the "origin" remote.
 // In tests this value can be stubbed.
-func (c *Config) GetRemoteOriginURL() string {
+func (c *Config) RemoteOriginURL() string {
 	remote := os.Getenv("GIT_TOWN_REMOTE")
 	if remote != "" {
 		return remote

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -137,13 +137,13 @@ func (c *Config) GetChildBranches(branchName string) (result []string) {
 	return
 }
 
-// GetCodeHostingDriverName provides the name of the code hosting driver to use.
-func (c *Config) GetCodeHostingDriverName() string {
+// CodeHostingDriverName provides the name of the code hosting driver to use.
+func (c *Config) CodeHostingDriverName() string {
 	return c.getLocalOrGlobalConfigValue("git-town.code-hosting-driver")
 }
 
-// GetCodeHostingOriginHostname provides the host name of the code hosting server.
-func (c *Config) GetCodeHostingOriginHostname() string {
+// CodeHostingOriginHostname provides the host name of the code hosting server.
+func (c *Config) CodeHostingOriginHostname() string {
 	return c.getLocalConfigValue("git-town.code-hosting-origin-hostname")
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -124,9 +124,9 @@ func (c *Config) BranchAncestryRoots() []string {
 	return roots
 }
 
-// GetChildBranches returns the names of all branches for which the given branch
+// ChildBranches returns the names of all branches for which the given branch
 // is a parent.
-func (c *Config) GetChildBranches(branchName string) (result []string) {
+func (c *Config) ChildBranches(branchName string) (result []string) {
 	for _, key := range c.localConfigKeysMatching(`^git-town-branch\..*\.parent$`) {
 		parent := c.getLocalConfigValue(key)
 		if parent == branchName {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -92,10 +92,10 @@ func (c *Config) DeletePerennialBranchConfiguration() error {
 	return c.removeLocalConfigValue("git-town.perennial-branch-names")
 }
 
-// GetAncestorBranches returns the names of all parent branches for the given branch,
+// AncestorBranches returns the names of all parent branches for the given branch,
 // This information is read from the cache in the Git config,
 // so might be out of date when the branch hierarchy has been modified.
-func (c *Config) GetAncestorBranches(branchName string) (result []string) {
+func (c *Config) AncestorBranches(branchName string) (result []string) {
 	parentBranchMap := c.GetParentBranchMap()
 	current := branchName
 	for {
@@ -249,7 +249,7 @@ func (c *Config) HasParentBranch(branchName string) bool {
 
 // IsAncestorBranch indicates whether the given branch is an ancestor of the other given branch.
 func (c *Config) IsAncestorBranch(branchName, ancestorBranchName string) bool {
-	ancestorBranches := c.GetAncestorBranches(branchName)
+	ancestorBranches := c.AncestorBranches(branchName)
 	return stringslice.Contains(ancestorBranches, ancestorBranchName)
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -68,7 +68,7 @@ func loadGitConfig(shell run.Shell, global bool) map[string]string {
 // AddToPerennialBranches registers the given branch names as perennial branches.
 // The branches must exist.
 func (c *Config) AddToPerennialBranches(branchNames ...string) error {
-	return c.SetPerennialBranches(append(c.GetPerennialBranches(), branchNames...))
+	return c.SetPerennialBranches(append(c.PerennialBranches(), branchNames...))
 }
 
 // AddGitAlias sets the given Git alias.
@@ -203,8 +203,8 @@ func (c *Config) GetParentBranch(branchName string) string {
 	return c.getLocalConfigValue("git-town-branch." + branchName + ".parent")
 }
 
-// GetPerennialBranches returns all branches that are marked as perennial.
-func (c *Config) GetPerennialBranches() []string {
+// PerennialBranches returns all branches that are marked as perennial.
+func (c *Config) PerennialBranches() []string {
 	result := c.getLocalOrGlobalConfigValue("git-town.perennial-branch-names")
 	if result == "" {
 		return []string{}
@@ -212,8 +212,8 @@ func (c *Config) GetPerennialBranches() []string {
 	return strings.Split(result, " ")
 }
 
-// GetPullBranchStrategy returns the currently configured pull branch strategy.
-func (c *Config) GetPullBranchStrategy() string {
+// PullBranchStrategy returns the currently configured pull branch strategy.
+func (c *Config) PullBranchStrategy() string {
 	config := c.getLocalOrGlobalConfigValue("git-town.pull-branch-strategy")
 	if config != "" {
 		return config
@@ -283,7 +283,7 @@ func (c *Config) IsOffline() bool {
 // IsPerennialBranch indicates whether the branch with the given name is
 // a perennial branch.
 func (c *Config) IsPerennialBranch(branchName string) bool {
-	perennialBranches := c.GetPerennialBranches()
+	perennialBranches := c.PerennialBranches()
 	return stringslice.Contains(perennialBranches, branchName)
 }
 
@@ -306,7 +306,7 @@ func (c *Config) Reload() {
 
 // RemoveFromPerennialBranches removes the given branch as a perennial branch.
 func (c *Config) RemoveFromPerennialBranches(branchName string) error {
-	return c.SetPerennialBranches(stringslice.Remove(c.GetPerennialBranches(), branchName))
+	return c.SetPerennialBranches(stringslice.Remove(c.PerennialBranches(), branchName))
 }
 
 // RemoveGitAlias removes the given Git alias.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -96,7 +96,7 @@ func (c *Config) DeletePerennialBranchConfiguration() error {
 // This information is read from the cache in the Git config,
 // so might be out of date when the branch hierarchy has been modified.
 func (c *Config) AncestorBranches(branchName string) (result []string) {
-	parentBranchMap := c.GetParentBranchMap()
+	parentBranchMap := c.ParentBranchMap()
 	current := branchName
 	for {
 		if c.IsMainBranch(current) || c.IsPerennialBranch(current) {
@@ -113,7 +113,7 @@ func (c *Config) AncestorBranches(branchName string) (result []string) {
 
 // BranchAncestryRoots provides the branches with children and no parents.
 func (c *Config) BranchAncestryRoots() []string {
-	parentMap := c.GetParentBranchMap()
+	parentMap := c.ParentBranchMap()
 	roots := []string{}
 	for _, parent := range parentMap {
 		if _, ok := parentMap[parent]; !ok && !stringslice.Contains(roots, parent) {
@@ -167,8 +167,8 @@ func (c *Config) getLocalOrGlobalConfigValue(key string) string {
 	return c.getGlobalConfigValue(key)
 }
 
-// GetParentBranchMap returns a map from branch name to its parent branch.
-func (c *Config) GetParentBranchMap() map[string]string {
+// ParentBranchMap returns a map from branch name to its parent branch.
+func (c *Config) ParentBranchMap() map[string]string {
 	result := map[string]string{}
 	for _, key := range c.localConfigKeysMatching(`^git-town-branch\..*\.parent$`) {
 		child := strings.TrimSuffix(strings.TrimPrefix(key, "git-town-branch."), ".parent")
@@ -198,8 +198,8 @@ func (c *Config) MainBranch() string {
 	return c.getLocalOrGlobalConfigValue("git-town.main-branch-name")
 }
 
-// GetParentBranch returns the name of the parent branch of the given branch.
-func (c *Config) GetParentBranch(branchName string) string {
+// ParentBranch returns the name of the parent branch of the given branch.
+func (c *Config) ParentBranch(branchName string) string {
 	return c.getLocalConfigValue("git-town-branch." + branchName + ".parent")
 }
 
@@ -244,7 +244,7 @@ func (c *Config) HasBranchInformation() bool {
 
 // HasParentBranch returns whether or not the given branch has a parent.
 func (c *Config) HasParentBranch(branchName string) bool {
-	return c.GetParentBranch(branchName) != ""
+	return c.ParentBranch(branchName) != ""
 }
 
 // IsAncestorBranch indicates whether the given branch is an ancestor of the other given branch.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -111,8 +111,8 @@ func (c *Config) GetAncestorBranches(branchName string) (result []string) {
 	}
 }
 
-// GetBranchAncestryRoots provides the branches with children and no parents.
-func (c *Config) GetBranchAncestryRoots() []string {
+// BranchAncestryRoots provides the branches with children and no parents.
+func (c *Config) BranchAncestryRoots() []string {
 	parentMap := c.GetParentBranchMap()
 	roots := []string{}
 	for _, parent := range parentMap {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -178,8 +178,8 @@ func (c *Config) ParentBranchMap() map[string]string {
 	return result
 }
 
-// GetGitAlias provides the currently set alias for the given Git Town command.
-func (c *Config) GetGitAlias(command string) string {
+// GitAlias provides the currently set alias for the given Git Town command.
+func (c *Config) GitAlias(command string) string {
 	return c.getGlobalConfigValue("alias." + command)
 }
 

--- a/src/drivers/bitbucket.go
+++ b/src/drivers/bitbucket.go
@@ -34,7 +34,7 @@ func LoadBitbucket(config config, git gitRunner) *BitbucketCodeHostingDriver {
 		git:        git,
 		hostname:   hostname,
 		originURL:  originURL,
-		repository: helpers.GetURLRepositoryName(originURL),
+		repository: helpers.URLRepositoryName(originURL),
 	}
 }
 

--- a/src/drivers/bitbucket.go
+++ b/src/drivers/bitbucket.go
@@ -22,7 +22,7 @@ type BitbucketCodeHostingDriver struct {
 func LoadBitbucket(config config, git gitRunner) *BitbucketCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
 	originURL := config.RemoteOriginURL()
-	hostname := helpers.GetURLHostname(originURL)
+	hostname := helpers.URLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName

--- a/src/drivers/bitbucket.go
+++ b/src/drivers/bitbucket.go
@@ -21,7 +21,7 @@ type BitbucketCodeHostingDriver struct {
 // otherwise nil.
 func LoadBitbucket(config config, git gitRunner) *BitbucketCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
-	originURL := config.GetRemoteOriginURL()
+	originURL := config.RemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {

--- a/src/drivers/bitbucket.go
+++ b/src/drivers/bitbucket.go
@@ -20,10 +20,10 @@ type BitbucketCodeHostingDriver struct {
 // LoadBitbucket provides a Bitbucket driver instance if the given repo configuration is for a Bitbucket repo,
 // otherwise nil.
 func LoadBitbucket(config config, git gitRunner) *BitbucketCodeHostingDriver {
-	driverType := config.GetCodeHostingDriverName()
+	driverType := config.CodeHostingDriverName()
 	originURL := config.GetRemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
-	manualHostName := config.GetCodeHostingOriginHostname()
+	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName
 	}

--- a/src/drivers/core.go
+++ b/src/drivers/core.go
@@ -33,7 +33,7 @@ type config interface {
 	GiteaToken() string
 	GitHubToken() string
 	MainBranch() string
-	GetRemoteOriginURL() string
+	RemoteOriginURL() string
 }
 
 // runner defines the runner methods used by the driver package.

--- a/src/drivers/core.go
+++ b/src/drivers/core.go
@@ -28,8 +28,8 @@ type CodeHostingDriver interface {
 
 // config defines the configuration data needed by the driver package.
 type config interface {
-	GetCodeHostingOriginHostname() string
-	GetCodeHostingDriverName() string
+	CodeHostingOriginHostname() string
+	CodeHostingDriverName() string
 	GetGiteaToken() string
 	GetGitHubToken() string
 	GetMainBranch() string

--- a/src/drivers/core.go
+++ b/src/drivers/core.go
@@ -31,7 +31,7 @@ type config interface {
 	CodeHostingOriginHostname() string
 	CodeHostingDriverName() string
 	GetGiteaToken() string
-	GetGitHubToken() string
+	GitHubToken() string
 	GetMainBranch() string
 	GetRemoteOriginURL() string
 }

--- a/src/drivers/core.go
+++ b/src/drivers/core.go
@@ -30,7 +30,7 @@ type CodeHostingDriver interface {
 type config interface {
 	CodeHostingOriginHostname() string
 	CodeHostingDriverName() string
-	GetGiteaToken() string
+	GiteaToken() string
 	GitHubToken() string
 	GetMainBranch() string
 	GetRemoteOriginURL() string

--- a/src/drivers/core.go
+++ b/src/drivers/core.go
@@ -32,7 +32,7 @@ type config interface {
 	CodeHostingDriverName() string
 	GiteaToken() string
 	GitHubToken() string
-	GetMainBranch() string
+	MainBranch() string
 	GetRemoteOriginURL() string
 }
 

--- a/src/drivers/core_test.go
+++ b/src/drivers/core_test.go
@@ -17,7 +17,7 @@ func (mc mockConfig) CodeHostingDriverName() string {
 	return mc.codeHostingDriverName
 }
 
-func (mc mockConfig) GetGitHubToken() string {
+func (mc mockConfig) GitHubToken() string {
 	return mc.gitHubToken
 }
 

--- a/src/drivers/core_test.go
+++ b/src/drivers/core_test.go
@@ -29,6 +29,6 @@ func (mc mockConfig) MainBranch() string {
 	return mc.mainBranch
 }
 
-func (mc mockConfig) GetRemoteOriginURL() string {
+func (mc mockConfig) RemoteOriginURL() string {
 	return mc.remoteOriginURL
 }

--- a/src/drivers/core_test.go
+++ b/src/drivers/core_test.go
@@ -21,7 +21,7 @@ func (mc mockConfig) GitHubToken() string {
 	return mc.gitHubToken
 }
 
-func (mc mockConfig) GetGiteaToken() string {
+func (mc mockConfig) GiteaToken() string {
 	return mc.giteaToken
 }
 

--- a/src/drivers/core_test.go
+++ b/src/drivers/core_test.go
@@ -25,7 +25,7 @@ func (mc mockConfig) GiteaToken() string {
 	return mc.giteaToken
 }
 
-func (mc mockConfig) GetMainBranch() string {
+func (mc mockConfig) MainBranch() string {
 	return mc.mainBranch
 }
 

--- a/src/drivers/core_test.go
+++ b/src/drivers/core_test.go
@@ -9,11 +9,11 @@ type mockConfig struct {
 	remoteOriginURL       string
 }
 
-func (mc mockConfig) GetCodeHostingOriginHostname() string {
+func (mc mockConfig) CodeHostingOriginHostname() string {
 	return mc.manualHostName
 }
 
-func (mc mockConfig) GetCodeHostingDriverName() string {
+func (mc mockConfig) CodeHostingDriverName() string {
 	return mc.codeHostingDriverName
 }
 

--- a/src/drivers/gitea.go
+++ b/src/drivers/gitea.go
@@ -25,10 +25,10 @@ type GiteaCodeHostingDriver struct {
 // LoadGitea provides a Gitea driver instance if the given repo configuration is for a Gitea repo,
 // otherwise nil.
 func LoadGitea(config config, log logFn) *GiteaCodeHostingDriver {
-	driverType := config.GetCodeHostingDriverName()
+	driverType := config.CodeHostingDriverName()
 	originURL := config.GetRemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
-	manualHostName := config.GetCodeHostingOriginHostname()
+	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName
 	}

--- a/src/drivers/gitea.go
+++ b/src/drivers/gitea.go
@@ -27,7 +27,7 @@ type GiteaCodeHostingDriver struct {
 func LoadGitea(config config, log logFn) *GiteaCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
 	originURL := config.RemoteOriginURL()
-	hostname := helpers.GetURLHostname(originURL)
+	hostname := helpers.URLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName

--- a/src/drivers/gitea.go
+++ b/src/drivers/gitea.go
@@ -26,7 +26,7 @@ type GiteaCodeHostingDriver struct {
 // otherwise nil.
 func LoadGitea(config config, log logFn) *GiteaCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
-	originURL := config.GetRemoteOriginURL()
+	originURL := config.RemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {

--- a/src/drivers/gitea.go
+++ b/src/drivers/gitea.go
@@ -35,7 +35,7 @@ func LoadGitea(config config, log logFn) *GiteaCodeHostingDriver {
 	if driverType != "gitea" && hostname != "gitea.com" {
 		return nil
 	}
-	repositoryParts := strings.SplitN(helpers.GetURLRepositoryName(originURL), "/", 2)
+	repositoryParts := strings.SplitN(helpers.URLRepositoryName(originURL), "/", 2)
 	if len(repositoryParts) != 2 {
 		return nil
 	}

--- a/src/drivers/gitea.go
+++ b/src/drivers/gitea.go
@@ -44,7 +44,7 @@ func LoadGitea(config config, log logFn) *GiteaCodeHostingDriver {
 	return &GiteaCodeHostingDriver{
 		originURL:  originURL,
 		hostname:   hostname,
-		apiToken:   config.GetGiteaToken(),
+		apiToken:   config.GiteaToken(),
 		log:        log,
 		owner:      owner,
 		repository: repository,

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -36,7 +36,7 @@ func LoadGithub(config config, log logFn) *GithubCodeHostingDriver {
 	if driverType != "github" && hostname != "github.com" {
 		return nil
 	}
-	repositoryParts := strings.SplitN(helpers.GetURLRepositoryName(originURL), "/", 2)
+	repositoryParts := strings.SplitN(helpers.URLRepositoryName(originURL), "/", 2)
 	if len(repositoryParts) != 2 {
 		return nil
 	}

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -43,7 +43,7 @@ func LoadGithub(config config, log logFn) *GithubCodeHostingDriver {
 	owner := repositoryParts[0]
 	repository := repositoryParts[1]
 	return &GithubCodeHostingDriver{
-		apiToken:   config.GetGitHubToken(),
+		apiToken:   config.GitHubToken(),
 		config:     config,
 		hostname:   hostname,
 		log:        log,

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -73,7 +73,7 @@ func (d *GithubCodeHostingDriver) LoadPullRequestInfo(branch, parentBranch strin
 
 func (d *GithubCodeHostingDriver) NewPullRequestURL(branch string, parentBranch string) (string, error) {
 	toCompare := branch
-	if parentBranch != d.config.GetMainBranch() {
+	if parentBranch != d.config.MainBranch() {
 		toCompare = parentBranch + "..." + branch
 	}
 	return fmt.Sprintf("%s/compare/%s?expand=1", d.RepositoryURL(), url.PathEscape(toCompare)), nil

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -27,7 +27,7 @@ type GithubCodeHostingDriver struct {
 // otherwise nil.
 func LoadGithub(config config, log logFn) *GithubCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
-	originURL := config.GetRemoteOriginURL()
+	originURL := config.RemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -28,7 +28,7 @@ type GithubCodeHostingDriver struct {
 func LoadGithub(config config, log logFn) *GithubCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
 	originURL := config.RemoteOriginURL()
-	hostname := helpers.GetURLHostname(originURL)
+	hostname := helpers.URLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName

--- a/src/drivers/github.go
+++ b/src/drivers/github.go
@@ -26,10 +26,10 @@ type GithubCodeHostingDriver struct {
 // LoadGithub provides a GitHub driver instance if the given repo configuration is for a Github repo,
 // otherwise nil.
 func LoadGithub(config config, log logFn) *GithubCodeHostingDriver {
-	driverType := config.GetCodeHostingDriverName()
+	driverType := config.CodeHostingDriverName()
 	originURL := config.GetRemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
-	manualHostName := config.GetCodeHostingOriginHostname()
+	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName
 	}

--- a/src/drivers/gitlab.go
+++ b/src/drivers/gitlab.go
@@ -19,7 +19,7 @@ type GitlabCodeHostingDriver struct {
 // otherwise nil.
 func LoadGitlab(config config) *GitlabCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
-	originURL := config.GetRemoteOriginURL()
+	originURL := config.RemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {

--- a/src/drivers/gitlab.go
+++ b/src/drivers/gitlab.go
@@ -18,10 +18,10 @@ type GitlabCodeHostingDriver struct {
 // LoadGitlab provides a GitLab driver instance if the given repo configuration is for a GitLab repo,
 // otherwise nil.
 func LoadGitlab(config config) *GitlabCodeHostingDriver {
-	driverType := config.GetCodeHostingDriverName()
+	driverType := config.CodeHostingDriverName()
 	originURL := config.GetRemoteOriginURL()
 	hostname := helpers.GetURLHostname(originURL)
-	manualHostName := config.GetCodeHostingOriginHostname()
+	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName
 	}

--- a/src/drivers/gitlab.go
+++ b/src/drivers/gitlab.go
@@ -31,7 +31,7 @@ func LoadGitlab(config config) *GitlabCodeHostingDriver {
 	return &GitlabCodeHostingDriver{
 		originURL:  originURL,
 		hostname:   hostname,
-		repository: helpers.GetURLRepositoryName(originURL),
+		repository: helpers.URLRepositoryName(originURL),
 	}
 }
 

--- a/src/drivers/gitlab.go
+++ b/src/drivers/gitlab.go
@@ -20,7 +20,7 @@ type GitlabCodeHostingDriver struct {
 func LoadGitlab(config config) *GitlabCodeHostingDriver {
 	driverType := config.CodeHostingDriverName()
 	originURL := config.RemoteOriginURL()
-	hostname := helpers.GetURLHostname(originURL)
+	hostname := helpers.URLHostname(originURL)
 	manualHostName := config.CodeHostingOriginHostname()
 	if manualHostName != "" {
 		hostname = manualHostName

--- a/src/drivers/helpers/url-hostname.go
+++ b/src/drivers/helpers/url-hostname.go
@@ -2,8 +2,8 @@ package helpers
 
 import "regexp"
 
-// GetURLHostname returns the hostname contained within the given Git URL.
-func GetURLHostname(url string) string {
+// URLHostname returns the hostname contained within the given Git URL.
+func URLHostname(url string) string {
 	hostnameRegex := regexp.MustCompile("(^[^:]*://([^@]*@)?|git@)([^/:]+).*")
 	matches := hostnameRegex.FindStringSubmatch(url)
 	if matches == nil {

--- a/src/drivers/helpers/url-repo-name.go
+++ b/src/drivers/helpers/url-repo-name.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// GetURLRepositoryName returns the repository name contains within the given Git URL.
-func GetURLRepositoryName(url string) string {
+// URLRepositoryName returns the repository name contains within the given Git URL.
+func URLRepositoryName(url string) string {
 	hostname := URLHostname(url)
 	repositoryNameRegex := regexp.MustCompile(".*" + hostname + "[/:](.+)")
 	matches := repositoryNameRegex.FindStringSubmatch(url)

--- a/src/drivers/helpers/url-repo-name.go
+++ b/src/drivers/helpers/url-repo-name.go
@@ -7,7 +7,7 @@ import (
 
 // GetURLRepositoryName returns the repository name contains within the given Git URL.
 func GetURLRepositoryName(url string) string {
-	hostname := GetURLHostname(url)
+	hostname := URLHostname(url)
 	repositoryNameRegex := regexp.MustCompile(".*" + hostname + "[/:](.+)")
 	matches := repositoryNameRegex.FindStringSubmatch(url)
 	if matches == nil {

--- a/src/git/prod_repo.go
+++ b/src/git/prod_repo.go
@@ -58,7 +58,7 @@ func NewProdRepo() *ProdRepo {
 
 // RemoveOutdatedConfiguration removes outdated Git Town configuration.
 func (r *ProdRepo) RemoveOutdatedConfiguration() error {
-	for child, parent := range r.Config.GetParentBranchMap() {
+	for child, parent := range r.Config.ParentBranchMap() {
 		hasChildBranch, err := r.Silent.HasLocalOrRemoteBranch(child)
 		if err != nil {
 			return err

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -73,7 +73,7 @@ func (r *Runner) Author() (author string, err error) {
 // BranchHasUnmergedCommits indicates whether the branch with the given name
 // contains commits that are not merged into the main branch.
 func (r *Runner) BranchHasUnmergedCommits(branch string) (bool, error) {
-	out, err := r.Run("git", "log", r.Config.GetMainBranch()+".."+branch)
+	out, err := r.Run("git", "log", r.Config.MainBranch()+".."+branch)
 	if err != nil {
 		return false, fmt.Errorf("cannot determine if branch %q has unmerged commits: %w", branch, err)
 	}
@@ -483,7 +483,7 @@ func (r *Runner) ExpectedPreviouslyCheckedOutBranch(initialPreviouslyCheckedOutB
 		}
 		return initialBranch, nil
 	}
-	return r.Config.GetMainBranch(), nil
+	return r.Config.MainBranch(), nil
 }
 
 // Fetch retrieves the updates from the remote repo.
@@ -644,7 +644,7 @@ func (r *Runner) HasRemote(name string) (result bool, err error) {
 // HasShippableChanges indicates whether the given branch has changes
 // not currently in the main branch.
 func (r *Runner) HasShippableChanges(branch string) (bool, error) {
-	out, err := r.Run("git", "diff", r.Config.GetMainBranch()+".."+branch)
+	out, err := r.Run("git", "diff", r.Config.MainBranch()+".."+branch)
 	if err != nil {
 		return false, fmt.Errorf("cannot determine whether branch %q has shippable changes: %w", branch, err)
 	}
@@ -770,7 +770,7 @@ func (r *Runner) LocalBranchesWithDeletedTrackingBranches() (result []string, er
 // LocalBranchesWithoutMain returns the names of all branches in the local repository,
 // ordered alphabetically without the main branch.
 func (r *Runner) LocalBranchesWithoutMain() (result []string, err error) {
-	mainBranch := r.Config.GetMainBranch()
+	mainBranch := r.Config.MainBranch()
 	branches, err := r.LocalBranches()
 	if err != nil {
 		return result, err

--- a/src/git/runner_test.go
+++ b/src/git/runner_test.go
@@ -169,7 +169,7 @@ func TestRunner_CreateFeatureBranch(t *testing.T) {
 	assert.NoError(t, err)
 	runner.Config.Reload()
 	assert.True(t, runner.Config.IsFeatureBranch("f1"))
-	assert.Equal(t, []string{"main"}, runner.Config.GetAncestorBranches("f1"))
+	assert.Equal(t, []string{"main"}, runner.Config.AncestorBranches("f1"))
 }
 
 func TestRunner_CreateFeatureBranchNoParent(t *testing.T) {
@@ -179,7 +179,7 @@ func TestRunner_CreateFeatureBranchNoParent(t *testing.T) {
 	assert.NoError(t, err)
 	runner.Config.Reload()
 	assert.True(t, runner.Config.IsFeatureBranch("f1"))
-	assert.Equal(t, []string(nil), runner.Config.GetAncestorBranches("f1"))
+	assert.Equal(t, []string(nil), runner.Config.AncestorBranches("f1"))
 }
 
 func TestRunner_CreateFile(t *testing.T) {

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -10,7 +10,7 @@ import (
 
 // EnsureIsConfigured has the user to confgure the main branch and perennial branches if needed.
 func EnsureIsConfigured(repo *git.ProdRepo) error {
-	if repo.Config.GetMainBranch() == "" {
+	if repo.Config.MainBranch() == "" {
 		fmt.Println("Git Town needs to be configured")
 		fmt.Println()
 		err := ConfigureMainBranch(repo)
@@ -31,7 +31,7 @@ func ConfigureMainBranch(repo *git.ProdRepo) error {
 	newMainBranch, err := askForBranch(askForBranchOptions{
 		branchNames:       localBranches,
 		prompt:            getMainBranchPrompt(repo),
-		defaultBranchName: repo.Config.GetMainBranch(),
+		defaultBranchName: repo.Config.MainBranch(),
 	})
 	if err != nil {
 		return err
@@ -63,7 +63,7 @@ func ConfigurePerennialBranches(repo *git.ProdRepo) error {
 
 func getMainBranchPrompt(repo *git.ProdRepo) (result string) {
 	result += "Please specify the main development branch:"
-	currentMainBranch := repo.Config.GetMainBranch()
+	currentMainBranch := repo.Config.MainBranch()
 	if currentMainBranch != "" {
 		coloredBranchName := color.New(color.Bold).Add(color.FgCyan).Sprintf(currentMainBranch)
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchName)

--- a/src/prompt/config.go
+++ b/src/prompt/config.go
@@ -51,7 +51,7 @@ func ConfigurePerennialBranches(repo *git.ProdRepo) error {
 	newPerennialBranches, err := askForBranches(askForBranchesOptions{
 		branchNames:        branchNames,
 		prompt:             getPerennialBranchesPrompt(repo),
-		defaultBranchNames: repo.Config.GetPerennialBranches(),
+		defaultBranchNames: repo.Config.PerennialBranches(),
 	})
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func getMainBranchPrompt(repo *git.ProdRepo) (result string) {
 
 func getPerennialBranchesPrompt(repo *git.ProdRepo) (result string) {
 	result += "Please specify perennial branches:"
-	currentPerennialBranches := repo.Config.GetPerennialBranches()
+	currentPerennialBranches := repo.Config.PerennialBranches()
 	if len(currentPerennialBranches) > 0 {
 		coloredBranchNames := color.New(color.Bold).Add(color.FgCyan).Sprintf(strings.Join(currentPerennialBranches, ", "))
 		result += fmt.Sprintf(" (current value: %s)", coloredBranchNames)

--- a/src/prompt/parent_branches.go
+++ b/src/prompt/parent_branches.go
@@ -30,7 +30,7 @@ func EnsureKnowsParentBranches(branchNames []string, repo *git.ProdRepo) error {
 func AskForBranchAncestry(branchName, defaultBranchName string, repo *git.ProdRepo) (err error) {
 	current := branchName
 	for {
-		parent := repo.Config.GetParentBranch(current)
+		parent := repo.Config.ParentBranch(current)
 		if parent == "" { //nolint:nestif
 			printParentBranchHeader(repo)
 			parent, err = AskForBranchParent(current, defaultBranchName, repo)

--- a/src/prompt/parent_branches.go
+++ b/src/prompt/parent_branches.go
@@ -15,7 +15,7 @@ func EnsureKnowsParentBranches(branchNames []string, repo *git.ProdRepo) error {
 		if repo.Config.IsMainBranch(branchName) || repo.Config.IsPerennialBranch(branchName) || repo.Config.HasParentBranch(branchName) {
 			continue
 		}
-		err := AskForBranchAncestry(branchName, repo.Config.GetMainBranch(), repo)
+		err := AskForBranchAncestry(branchName, repo.Config.MainBranch(), repo)
 		if err != nil {
 			return err
 		}
@@ -49,7 +49,7 @@ func AskForBranchAncestry(branchName, defaultBranchName string, repo *git.ProdRe
 				return err
 			}
 		}
-		if parent == repo.Config.GetMainBranch() || repo.Config.IsPerennialBranch(parent) {
+		if parent == repo.Config.MainBranch() || repo.Config.IsPerennialBranch(parent) {
 			break
 		}
 		current = parent
@@ -103,6 +103,6 @@ func filterOutSelfAndDescendants(branchName string, choices []string, repo *git.
 func printParentBranchHeader(repo *git.ProdRepo) {
 	if !parentBranchHeaderShown {
 		parentBranchHeaderShown = true
-		cli.Printf(parentBranchHeaderTemplate, repo.Config.GetMainBranch())
+		cli.Printf(parentBranchHeaderTemplate, repo.Config.MainBranch())
 	}
 }

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -10,9 +10,9 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
-// GetSquashCommitAuthor gets the author of the supplied branch.
+// DetermineSquashCommitAuthor gets the author of the supplied branch.
 // If the branch has more than one author, the author is queried from the user.
-func GetSquashCommitAuthor(branchName string, repo *git.ProdRepo) (string, error) {
+func DetermineSquashCommitAuthor(branchName string, repo *git.ProdRepo) (string, error) {
 	authors, err := getBranchAuthors(branchName, repo)
 	if err != nil {
 		return "", err

--- a/src/prompt/squash_commit_author.go
+++ b/src/prompt/squash_commit_author.go
@@ -44,7 +44,7 @@ func askForAuthor(authors []string) (string, error) {
 
 func getBranchAuthors(branchName string, repo *git.ProdRepo) (result []string, err error) {
 	// Returns lines of "<number of commits>\t<name and email>"
-	lines, err := run.Exec("git", "shortlog", "-s", "-n", "-e", repo.Config.GetMainBranch()+".."+branchName)
+	lines, err := run.Exec("git", "shortlog", "-s", "-n", "-e", repo.Config.MainBranch()+".."+branchName)
 	if err != nil {
 		return result, err
 	}

--- a/src/steps/create_pull_request_step.go
+++ b/src/steps/create_pull_request_step.go
@@ -14,7 +14,7 @@ type CreatePullRequestStep struct {
 
 // Run executes this step.
 func (step *CreatePullRequestStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	parentBranch := repo.Config.GetParentBranch(step.BranchName)
+	parentBranch := repo.Config.ParentBranch(step.BranchName)
 	prURL, err := driver.NewPullRequestURL(step.BranchName, parentBranch)
 	if err != nil {
 		return err

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -24,6 +24,6 @@ func (step *DeleteParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, er
 
 // Run executes this step.
 func (step *DeleteParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	step.previousParent = repo.Config.GetParentBranch(step.BranchName)
+	step.previousParent = repo.Config.ParentBranch(step.BranchName)
 	return repo.Config.DeleteParentBranch(step.BranchName)
 }

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -26,6 +26,6 @@ func (step *SetParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error
 
 // Run executes this step.
 func (step *SetParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
-	step.previousParent = repo.Config.GetParentBranch(step.BranchName)
+	step.previousParent = repo.Config.ParentBranch(step.BranchName)
 	return repo.Config.SetParentBranch(step.BranchName, step.ParentBranchName)
 }

--- a/src/steps/squash_merge_branch_step.go
+++ b/src/steps/squash_merge_branch_step.go
@@ -42,7 +42,7 @@ func (step *SquashMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHo
 	if err != nil {
 		return err
 	}
-	author, err := prompt.GetSquashCommitAuthor(step.BranchName, repo)
+	author, err := prompt.DetermineSquashCommitAuthor(step.BranchName, repo)
 	if err != nil {
 		return fmt.Errorf("error getting squash commit author: %w", err)
 	}

--- a/src/steps/sync_steps.go
+++ b/src/steps/sync_steps.go
@@ -64,7 +64,7 @@ func getSyncNonFeatureBranchSteps(branchName string, repo *git.ProdRepo) (result
 		return result, err
 	}
 	if hasTrackingBranch {
-		if repo.Config.GetPullBranchStrategy() == "rebase" {
+		if repo.Config.PullBranchStrategy() == "rebase" {
 			result.Append(&RebaseBranchStep{BranchName: repo.Silent.TrackingBranchName(branchName)})
 		} else {
 			result.Append(&MergeBranchStep{BranchName: repo.Silent.TrackingBranchName(branchName)})

--- a/src/steps/sync_steps.go
+++ b/src/steps/sync_steps.go
@@ -6,8 +6,8 @@ import (
 	"github.com/git-town/git-town/v7/src/git"
 )
 
-// GetSyncBranchSteps returns the steps to sync the branch with the given name.
-func GetSyncBranchSteps(branchName string, pushBranch bool, repo *git.ProdRepo) (result StepList, err error) {
+// SyncBranchSteps returns the steps to sync the branch with the given name.
+func SyncBranchSteps(branchName string, pushBranch bool, repo *git.ProdRepo) (result StepList, err error) {
 	isFeature := repo.Config.IsFeatureBranch(branchName)
 	hasRemoteOrigin, err := repo.Silent.HasRemote("origin")
 	if err != nil {

--- a/src/steps/sync_steps.go
+++ b/src/steps/sync_steps.go
@@ -54,7 +54,7 @@ func getSyncFeatureBranchSteps(branchName string, repo *git.ProdRepo) (result St
 	if hasTrackingBranch {
 		result.Append(&MergeBranchStep{BranchName: repo.Silent.TrackingBranchName(branchName)})
 	}
-	result.Append(&MergeBranchStep{BranchName: repo.Config.GetParentBranch(branchName)})
+	result.Append(&MergeBranchStep{BranchName: repo.Config.ParentBranch(branchName)})
 	return
 }
 

--- a/src/steps/sync_steps.go
+++ b/src/steps/sync_steps.go
@@ -18,7 +18,7 @@ func SyncBranchSteps(branchName string, pushBranch bool, repo *git.ProdRepo) (re
 	}
 	result.Append(&CheckoutBranchStep{BranchName: branchName})
 	if isFeature {
-		steps, err := getSyncFeatureBranchSteps(branchName, repo)
+		steps, err := syncFeatureBranchSteps(branchName, repo)
 		if err != nil {
 			return result, err
 		}
@@ -46,7 +46,7 @@ func SyncBranchSteps(branchName string, pushBranch bool, repo *git.ProdRepo) (re
 
 // Helpers
 
-func getSyncFeatureBranchSteps(branchName string, repo *git.ProdRepo) (result StepList, err error) {
+func syncFeatureBranchSteps(branchName string, repo *git.ProdRepo) (result StepList, err error) {
 	hasTrackingBranch, err := repo.Silent.HasTrackingBranch(branchName)
 	if err != nil {
 		return result, err

--- a/src/steps/sync_steps.go
+++ b/src/steps/sync_steps.go
@@ -71,7 +71,7 @@ func getSyncNonFeatureBranchSteps(branchName string, repo *git.ProdRepo) (result
 		}
 	}
 
-	mainBranchName := repo.Config.GetMainBranch()
+	mainBranchName := repo.Config.MainBranch()
 	hasUpstream, err := repo.Silent.HasRemote("upstream")
 	if err != nil {
 		return result, err

--- a/test/steps.go
+++ b/test/steps.go
@@ -524,7 +524,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^my repo is now configured with no perennial branches$`, func() error {
 		state.gitEnv.DevRepo.Config.Reload()
-		branches := state.gitEnv.DevRepo.Config.GetPerennialBranches()
+		branches := state.gitEnv.DevRepo.Config.PerennialBranches()
 		if len(branches) > 0 {
 			return fmt.Errorf("expected no perennial branches, got %q", branches)
 		}
@@ -809,7 +809,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^the perennial branches are now configured as "([^"]+)"$`, func(name string) error {
 		state.gitEnv.DevRepo.Config.Reload()
-		actual := state.gitEnv.DevRepo.Config.GetPerennialBranches()
+		actual := state.gitEnv.DevRepo.Config.PerennialBranches()
 		if len(actual) != 1 {
 			return fmt.Errorf("expected 1 perennial branch, got %q", actual)
 		}
@@ -821,7 +821,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^the perennial branches are now configured as "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
 		state.gitEnv.DevRepo.Config.Reload()
-		actual := state.gitEnv.DevRepo.Config.GetPerennialBranches()
+		actual := state.gitEnv.DevRepo.Config.PerennialBranches()
 		if len(actual) != 2 {
 			return fmt.Errorf("expected 2 perennial branches, got %q", actual)
 		}
@@ -856,7 +856,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^the pull-branch-strategy configuration is now "(merge|rebase)"$`, func(want string) error {
 		state.gitEnv.DevRepo.Config.Reload()
-		have := state.gitEnv.DevRepo.Config.GetPullBranchStrategy()
+		have := state.gitEnv.DevRepo.Config.PullBranchStrategy()
 		if have != want {
 			return fmt.Errorf("expected pull-branch-strategy to be %q but was %q", want, have)
 		}

--- a/test/steps.go
+++ b/test/steps.go
@@ -107,7 +107,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		table.AddRow("BRANCH", "PARENT")
 		state.gitEnv.DevRepo.Config.Reload()
 		// Table sorted by child branch name
-		parentBranchMap := state.gitEnv.DevRepo.Config.GetParentBranchMap()
+		parentBranchMap := state.gitEnv.DevRepo.Config.ParentBranchMap()
 		childBranches := make([]string, 0, len(parentBranchMap))
 		for child := range parentBranchMap {
 			childBranches = append(childBranches, child)

--- a/test/steps.go
+++ b/test/steps.go
@@ -761,7 +761,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^the main branch is now configured as "([^"]+)"$`, func(name string) error {
 		state.gitEnv.DevRepo.Config.Reload()
-		actual := state.gitEnv.DevRepo.Config.GetMainBranch()
+		actual := state.gitEnv.DevRepo.Config.MainBranch()
 		if actual != name {
 			return fmt.Errorf("expected %q, got %q", name, actual)
 		}


### PR DESCRIPTION
Makes the code follow the guidelines at https://go.dev/doc/effective_go#Getters, i.e. remove the pointless `Get` in getter methods. Setters keep the `Set` prefix. The idea is that most data should be immutable and read accesses far exceed write accesses to attributes. So the syntax should make read access short and it's okay to make mutability explicit with the `Set` prefix.