### PR TITLE
Move comments for step methods into the interface

### DIFF
--- a/src/steps/abort_merge_branch_step.go
+++ b/src/steps/abort_merge_branch_step.go
@@ -10,7 +10,6 @@ type AbortMergeBranchStep struct {
 	NoOpStep
 }
 
-// Run executes this step.
 func (step *AbortMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.AbortMerge()
 }

--- a/src/steps/abort_rebase_branch_step.go
+++ b/src/steps/abort_rebase_branch_step.go
@@ -11,7 +11,6 @@ type AbortRebaseBranchStep struct {
 	NoOpStep
 }
 
-// Run executes this step.
 func (step *AbortRebaseBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.AbortRebase()
 }

--- a/src/steps/add_to_perennial_branch.go
+++ b/src/steps/add_to_perennial_branch.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -12,12 +11,10 @@ type AddToPerennialBranches struct {
 	BranchName string
 }
 
-// CreateUndoStep returns the undo step for this step.
-func (step *AddToPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *AddToPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &RemoveFromPerennialBranches{BranchName: step.BranchName}, nil
 }
 
-// Run executes this step.
 func (step *AddToPerennialBranches) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Config.AddToPerennialBranches(step.BranchName)
 }

--- a/src/steps/checkout_branch_step.go
+++ b/src/steps/checkout_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -14,12 +13,10 @@ type CheckoutBranchStep struct {
 	previousBranchName string
 }
 
-// CreateUndoStep returns the undo step for this step.
-func (step *CheckoutBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *CheckoutBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &CheckoutBranchStep{BranchName: step.previousBranchName}, nil
 }
 
-// Run executes this step.
 func (step *CheckoutBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) (err error) {
 	step.previousBranchName, err = repo.Silent.CurrentBranch()
 	if err != nil {

--- a/src/steps/commit_open_changes_step.go
+++ b/src/steps/commit_open_changes_step.go
@@ -16,12 +16,10 @@ type CommitOpenChangesStep struct {
 	previousSha string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *CommitOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &ResetToShaStep{Sha: step.previousSha}, nil
 }
 
-// Run executes this step.
 func (step *CommitOpenChangesStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) (err error) {
 	step.previousSha, err = repo.Silent.CurrentSha()
 	if err != nil {

--- a/src/steps/continue_merge_branch_step.go
+++ b/src/steps/continue_merge_branch_step.go
@@ -12,17 +12,14 @@ type ContinueMergeBranchStep struct {
 	NoOpStep
 }
 
-// CreateAbortStep returns the abort step for this step.
 func (step *ContinueMergeBranchStep) CreateAbortStep() Step {
 	return &NoOpStep{}
 }
 
-// CreateContinueStep returns the continue step for this step.
 func (step *ContinueMergeBranchStep) CreateContinueStep() Step {
 	return step
 }
 
-// Run executes this step.
 func (step *ContinueMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	hasMergeInprogress, err := repo.Silent.HasMergeInProgress()
 	if err != nil {

--- a/src/steps/continue_rebase_branch_step.go
+++ b/src/steps/continue_rebase_branch_step.go
@@ -12,17 +12,14 @@ type ContinueRebaseBranchStep struct {
 	NoOpStep
 }
 
-// CreateAbortStep returns the abort step for this step.
 func (step *ContinueRebaseBranchStep) CreateAbortStep() Step {
 	return &AbortRebaseBranchStep{}
 }
 
-// CreateContinueStep returns the continue step for this step.
 func (step *ContinueRebaseBranchStep) CreateContinueStep() Step {
 	return step
 }
 
-// Run executes this step.
 func (step *ContinueRebaseBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	hasRebaseInProgress, err := repo.Silent.HasRebaseInProgress()
 	if err != nil {

--- a/src/steps/create_branch_step.go
+++ b/src/steps/create_branch_step.go
@@ -14,12 +14,10 @@ type CreateBranchStep struct {
 	StartingPoint string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *CreateBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &DeleteLocalBranchStep{BranchName: step.BranchName}, nil
 }
 
-// Run executes this step.
 func (step *CreateBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.CreateBranch(step.BranchName, step.StartingPoint)
 }

--- a/src/steps/create_pull_request_step.go
+++ b/src/steps/create_pull_request_step.go
@@ -12,7 +12,6 @@ type CreatePullRequestStep struct {
 	BranchName string
 }
 
-// Run executes this step.
 func (step *CreatePullRequestStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	parentBranch := repo.Config.ParentBranch(step.BranchName)
 	prURL, err := driver.NewPullRequestURL(step.BranchName, parentBranch)

--- a/src/steps/create_remote_branch_step.go
+++ b/src/steps/create_remote_branch_step.go
@@ -12,7 +12,6 @@ type CreateRemoteBranchStep struct {
 	Sha        string
 }
 
-// Run executes this step.
 func (step *CreateRemoteBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.CreateRemoteBranch(step.Sha, step.BranchName)
 }

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -13,12 +13,10 @@ type CreateTrackingBranchStep struct {
 	BranchName string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *CreateTrackingBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &DeleteRemoteBranchStep{BranchName: step.BranchName}, nil
 }
 
-// Run executes this step.
 func (step *CreateTrackingBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.CreateTrackingBranch(step.BranchName)
 }

--- a/src/steps/delete_local_branch_step.go
+++ b/src/steps/delete_local_branch_step.go
@@ -16,12 +16,10 @@ type DeleteLocalBranchStep struct {
 	branchSha string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *DeleteLocalBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &CreateBranchStep{BranchName: step.BranchName, StartingPoint: step.branchSha}, nil
 }
 
-// Run executes this step.
 func (step *DeleteLocalBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) (err error) {
 	step.branchSha, err = repo.Silent.ShaForBranch(step.BranchName)
 	if err != nil {

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -14,7 +14,6 @@ type DeleteParentBranchStep struct {
 	previousParent string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *DeleteParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	if step.previousParent == "" {
 		return &NoOpStep{}, nil
@@ -22,7 +21,6 @@ func (step *DeleteParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, er
 	return &SetParentBranchStep{BranchName: step.BranchName, ParentBranchName: step.previousParent}, nil
 }
 
-// Run executes this step.
 func (step *DeleteParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	step.previousParent = repo.Config.ParentBranch(step.BranchName)
 	return repo.Config.DeleteParentBranch(step.BranchName)

--- a/src/steps/delete_remote_branch_step.go
+++ b/src/steps/delete_remote_branch_step.go
@@ -14,7 +14,6 @@ type DeleteRemoteBranchStep struct {
 	branchSha string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *DeleteRemoteBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	if step.IsTracking {
 		return &CreateTrackingBranchStep{BranchName: step.BranchName}, nil
@@ -22,7 +21,6 @@ func (step *DeleteRemoteBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, er
 	return &CreateRemoteBranchStep{BranchName: step.BranchName, Sha: step.branchSha}, nil
 }
 
-// Run executes this step.
 func (step *DeleteRemoteBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) (err error) {
 	if !step.IsTracking {
 		trackingBranchName := repo.Silent.TrackingBranchName(step.BranchName)

--- a/src/steps/discard_open_changes_step.go
+++ b/src/steps/discard_open_changes_step.go
@@ -10,7 +10,6 @@ type DiscardOpenChangesStep struct {
 	NoOpStep
 }
 
-// Run executes this step.
 func (step *DiscardOpenChangesStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.DiscardOpenChanges()
 }

--- a/src/steps/driver_merge_pull_request_step.go
+++ b/src/steps/driver_merge_pull_request_step.go
@@ -20,7 +20,6 @@ type DriverMergePullRequestStep struct {
 	mergeSha                  string
 }
 
-// CreateAbortStep returns the abort step for this step.
 func (step *DriverMergePullRequestStep) CreateAbortStep() Step {
 	if step.enteredEmptyCommitMessage {
 		return &DiscardOpenChangesStep{}
@@ -28,13 +27,10 @@ func (step *DriverMergePullRequestStep) CreateAbortStep() Step {
 	return nil
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *DriverMergePullRequestStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &RevertCommitStep{Sha: step.mergeSha}, nil
 }
 
-// CreateAutomaticAbortError returns the error message to display when this step
-// cause the command to automatically abort.
 func (step *DriverMergePullRequestStep) CreateAutomaticAbortError() error {
 	if step.enteredEmptyCommitMessage {
 		return fmt.Errorf("aborted because commit exited with error")
@@ -42,7 +38,6 @@ func (step *DriverMergePullRequestStep) CreateAutomaticAbortError() error {
 	return step.mergeError
 }
 
-// Run executes this step.
 func (step *DriverMergePullRequestStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	commitMessage := step.CommitMessage
 	//nolint:nestif

--- a/src/steps/ensure_has_shippable_changes_step.go
+++ b/src/steps/ensure_has_shippable_changes_step.go
@@ -14,13 +14,10 @@ type EnsureHasShippableChangesStep struct {
 	BranchName string
 }
 
-// CreateAutomaticAbortError returns the error message to display when this step
-// cause the command to automatically abort.
 func (step *EnsureHasShippableChangesStep) CreateAutomaticAbortError() error {
 	return fmt.Errorf("the branch %q has no shippable changes", step.BranchName)
 }
 
-// Run executes this step.
 func (step *EnsureHasShippableChangesStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	hasShippableChanges, err := repo.Silent.HasShippableChanges(step.BranchName)
 	if err != nil {
@@ -32,8 +29,6 @@ func (step *EnsureHasShippableChangesStep) Run(repo *git.ProdRepo, driver driver
 	return nil
 }
 
-// ShouldAutomaticallyAbortOnError returns whether this step should cause the command to
-// automatically abort if it errors.
 func (step *EnsureHasShippableChangesStep) ShouldAutomaticallyAbortOnError() bool {
 	return true
 }

--- a/src/steps/fetch_upstream_step.go
+++ b/src/steps/fetch_upstream_step.go
@@ -12,7 +12,6 @@ type FetchUpstreamStep struct {
 	BranchName string
 }
 
-// Run executes this step.
 func (step *FetchUpstreamStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.FetchUpstream(step.BranchName)
 }

--- a/src/steps/merge_branch_step.go
+++ b/src/steps/merge_branch_step.go
@@ -14,22 +14,18 @@ type MergeBranchStep struct {
 	previousSha string
 }
 
-// CreateAbortStep returns the abort step for this step.
 func (step *MergeBranchStep) CreateAbortStep() Step {
 	return &AbortMergeBranchStep{}
 }
 
-// CreateContinueStep returns the continue step for this step.
 func (step *MergeBranchStep) CreateContinueStep() Step {
 	return &ContinueMergeBranchStep{}
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *MergeBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &ResetToShaStep{Hard: true, Sha: step.previousSha}, nil
 }
 
-// Run executes this step.
 func (step *MergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) (err error) {
 	step.previousSha, err = repo.Silent.CurrentSha()
 	if err != nil {

--- a/src/steps/no_op_step.go
+++ b/src/steps/no_op_step.go
@@ -12,34 +12,26 @@ import (
 // It is used for steps that have no undo or abort steps.
 type NoOpStep struct{}
 
-// CreateAbortStep returns the abort step for this step.
 func (step *NoOpStep) CreateAbortStep() Step {
 	return &NoOpStep{}
 }
 
-// CreateContinueStep returns the continue step for this step.
 func (step *NoOpStep) CreateContinueStep() Step {
 	return &NoOpStep{}
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *NoOpStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &NoOpStep{}, nil
 }
 
-// CreateAutomaticAbortError returns the error message to display when this step
-// cause the command to automatically abort.
 func (step *NoOpStep) CreateAutomaticAbortError() error {
 	return errors.New("")
 }
 
-// Run executes this step.
 func (step *NoOpStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return nil
 }
 
-// ShouldAutomaticallyAbortOnError returns whether this step should cause the command to
-// automatically abort if it errors.
 func (step *NoOpStep) ShouldAutomaticallyAbortOnError() bool {
 	return false
 }

--- a/src/steps/preserve_checkout_history_step.go
+++ b/src/steps/preserve_checkout_history_step.go
@@ -12,7 +12,6 @@ type PreserveCheckoutHistoryStep struct {
 	InitialPreviouslyCheckedOutBranch string
 }
 
-// Run executes this step.
 func (step *PreserveCheckoutHistoryStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	expectedPreviouslyCheckedOutBranch, err := repo.Silent.ExpectedPreviouslyCheckedOutBranch(step.InitialPreviouslyCheckedOutBranch, step.InitialBranch)
 	if err != nil {

--- a/src/steps/pull_branch_step.go
+++ b/src/steps/pull_branch_step.go
@@ -11,7 +11,6 @@ type PullBranchStep struct {
 	BranchName string
 }
 
-// Run executes this step.
 func (step *PullBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.Pull()
 }

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -15,7 +15,6 @@ type PushBranchStep struct {
 	Undoable   bool
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *PushBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	if step.Undoable {
 		return &PushBranchAfterCurrentBranchSteps{}, nil
@@ -23,7 +22,6 @@ func (step *PushBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &SkipCurrentBranchSteps{}, nil
 }
 
-// Run executes this step.
 func (step *PushBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	shouldPush, err := repo.Silent.ShouldPushBranch(step.BranchName)
 	if err != nil {

--- a/src/steps/push_tags_step.go
+++ b/src/steps/push_tags_step.go
@@ -10,7 +10,6 @@ type PushTagsStep struct {
 	NoOpStep
 }
 
-// Run executes this step.
 func (step *PushTagsStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.PushTags()
 }

--- a/src/steps/rebase_branch_step.go
+++ b/src/steps/rebase_branch_step.go
@@ -15,22 +15,18 @@ type RebaseBranchStep struct {
 	previousSha string
 }
 
-// CreateAbortStep returns the abort step for this step.
 func (step *RebaseBranchStep) CreateAbortStep() Step {
 	return &AbortRebaseBranchStep{}
 }
 
-// CreateContinueStep returns the continue step for this step.
 func (step *RebaseBranchStep) CreateContinueStep() Step {
 	return &ContinueRebaseBranchStep{}
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *RebaseBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &ResetToShaStep{Hard: true, Sha: step.previousSha}, nil
 }
 
-// Run executes this step.
 func (step *RebaseBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) (err error) {
 	step.previousSha, err = repo.Silent.CurrentSha()
 	if err != nil {

--- a/src/steps/remove_from_perennial_branch.go
+++ b/src/steps/remove_from_perennial_branch.go
@@ -12,12 +12,10 @@ type RemoveFromPerennialBranches struct {
 	BranchName string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *RemoveFromPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &AddToPerennialBranches{BranchName: step.BranchName}, nil
 }
 
-// Run executes this step.
 func (step *RemoveFromPerennialBranches) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Config.RemoveFromPerennialBranches(step.BranchName)
 }

--- a/src/steps/reset_to_sha_step.go
+++ b/src/steps/reset_to_sha_step.go
@@ -13,7 +13,6 @@ type ResetToShaStep struct {
 	Sha  string
 }
 
-// Run executes this step.
 func (step *ResetToShaStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) (err error) {
 	currentSha, err := repo.Silent.CurrentSha()
 	if err != nil {

--- a/src/steps/restore_open_changes_step.go
+++ b/src/steps/restore_open_changes_step.go
@@ -13,12 +13,10 @@ type RestoreOpenChangesStep struct {
 	NoOpStep
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *RestoreOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &StashOpenChangesStep{}, nil
 }
 
-// Run executes this step.
 func (step *RestoreOpenChangesStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	err := repo.Logging.PopStash()
 	if err != nil {

--- a/src/steps/revert_commit_step.go
+++ b/src/steps/revert_commit_step.go
@@ -11,7 +11,6 @@ type RevertCommitStep struct {
 	Sha string
 }
 
-// Run executes this step.
 func (step *RevertCommitStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.RevertCommit(step.Sha)
 }

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -16,7 +16,6 @@ type SetParentBranchStep struct {
 	previousParent string
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *SetParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	if step.previousParent == "" {
 		return &DeleteParentBranchStep{BranchName: step.BranchName}, nil
@@ -24,7 +23,6 @@ func (step *SetParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error
 	return &SetParentBranchStep{BranchName: step.BranchName, ParentBranchName: step.previousParent}, nil
 }
 
-// Run executes this step.
 func (step *SetParentBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	step.previousParent = repo.Config.ParentBranch(step.BranchName)
 	return repo.Config.SetParentBranch(step.BranchName, step.ParentBranchName)

--- a/src/steps/squash_merge_branch_step.go
+++ b/src/steps/squash_merge_branch_step.go
@@ -16,12 +16,10 @@ type SquashMergeBranchStep struct {
 	CommitMessage string
 }
 
-// CreateAbortStep returns the abort step for this step.
 func (step *SquashMergeBranchStep) CreateAbortStep() Step {
 	return &DiscardOpenChangesStep{}
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *SquashMergeBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	currentSHA, err := repo.Silent.CurrentSha()
 	if err != nil {
@@ -30,13 +28,10 @@ func (step *SquashMergeBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, err
 	return &RevertCommitStep{Sha: currentSHA}, nil
 }
 
-// CreateAutomaticAbortError returns the error message to display when this step
-// cause the command to automatically abort.
 func (step *SquashMergeBranchStep) CreateAutomaticAbortError() error {
 	return fmt.Errorf("aborted because commit exited with error")
 }
 
-// Run executes this step.
 func (step *SquashMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	err := repo.Logging.SquashMerge(step.BranchName)
 	if err != nil {
@@ -63,8 +58,6 @@ func (step *SquashMergeBranchStep) Run(repo *git.ProdRepo, driver drivers.CodeHo
 	}
 }
 
-// ShouldAutomaticallyAbortOnError returns whether this step should cause the command to
-// automatically abort if it errors.
 func (step *SquashMergeBranchStep) ShouldAutomaticallyAbortOnError() bool {
 	return true
 }

--- a/src/steps/stash_open_changes_step.go
+++ b/src/steps/stash_open_changes_step.go
@@ -6,17 +6,14 @@ import (
 	"github.com/git-town/git-town/v7/src/git"
 )
 
-// StashOpenChangesStep stores all uncommitted changes on the Git stash.
 type StashOpenChangesStep struct {
 	NoOpStep
 }
 
-// CreateUndoStep returns the undo step for this step.
 func (step *StashOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
 	return &RestoreOpenChangesStep{}, nil
 }
 
-// Run executes this step.
 func (step *StashOpenChangesStep) Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error {
 	return repo.Logging.Stash()
 }

--- a/src/steps/step.go
+++ b/src/steps/step.go
@@ -10,8 +10,12 @@ import (
 type Step interface {
 	CreateAbortStep() Step
 	CreateContinueStep() Step
+
+	// CreateUndoStep returns the undo step for this step.
 	CreateUndoStep(*git.ProdRepo) (Step, error)
 	CreateAutomaticAbortError() error
+
+	// Run executes this step.
 	Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error
 	ShouldAutomaticallyAbortOnError() bool
 }

--- a/src/steps/step.go
+++ b/src/steps/step.go
@@ -8,14 +8,23 @@ import (
 // Step represents a dedicated activity within a Git Town command.
 // Git Town commands are comprised of a number of steps that need to be executed.
 type Step interface {
+	// CreateAbortStep returns the abort step for this step.
 	CreateAbortStep() Step
+
+	// CreateContinueStep returns the continue step for this step.
 	CreateContinueStep() Step
 
 	// CreateUndoStep returns the undo step for this step.
 	CreateUndoStep(*git.ProdRepo) (Step, error)
+
+	// CreateAutomaticAbortError returns the error message to display when this step
+	// cause the command to automatically abort.
 	CreateAutomaticAbortError() error
 
 	// Run executes this step.
 	Run(repo *git.ProdRepo, driver drivers.CodeHostingDriver) error
+
+	// ShouldAutomaticallyAbortOnError returns whether this step should cause the command to
+	// automatically abort if it errors.
 	ShouldAutomaticallyAbortOnError() bool
 }


### PR DESCRIPTION
We only added these comments to satisfy `golint`, which we assumed was an official part of the Go toolchain. This tool is not [deprecated](https://github.com/golang/go/issues/38968), allowing us to clean up this smell.