### PR TITLE
Narrow linter exceptions

### DIFF
--- a/src/steps/commit_open_changes_step.go
+++ b/src/steps/commit_open_changes_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -16,7 +15,7 @@ type CommitOpenChangesStep struct {
 	previousSha string
 }
 
-func (step *CommitOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *CommitOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &ResetToShaStep{Sha: step.previousSha}, nil
 }
 

--- a/src/steps/continue_merge_branch_step.go
+++ b/src/steps/continue_merge_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -12,11 +11,11 @@ type ContinueMergeBranchStep struct {
 	NoOpStep
 }
 
-func (step *ContinueMergeBranchStep) CreateAbortStep() Step {
+func (step *ContinueMergeBranchStep) CreateAbortStep() Step { //nolint:ireturn
 	return &NoOpStep{}
 }
 
-func (step *ContinueMergeBranchStep) CreateContinueStep() Step {
+func (step *ContinueMergeBranchStep) CreateContinueStep() Step { //nolint:ireturn
 	return step
 }
 

--- a/src/steps/continue_rebase_branch_step.go
+++ b/src/steps/continue_rebase_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -12,11 +11,11 @@ type ContinueRebaseBranchStep struct {
 	NoOpStep
 }
 
-func (step *ContinueRebaseBranchStep) CreateAbortStep() Step {
+func (step *ContinueRebaseBranchStep) CreateAbortStep() Step { //nolint:ireturn
 	return &AbortRebaseBranchStep{}
 }
 
-func (step *ContinueRebaseBranchStep) CreateContinueStep() Step {
+func (step *ContinueRebaseBranchStep) CreateContinueStep() Step { //nolint:ireturn
 	return step
 }
 

--- a/src/steps/create_branch_step.go
+++ b/src/steps/create_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -14,7 +13,7 @@ type CreateBranchStep struct {
 	StartingPoint string
 }
 
-func (step *CreateBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *CreateBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &DeleteLocalBranchStep{BranchName: step.BranchName}, nil
 }
 

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -13,7 +12,7 @@ type CreateTrackingBranchStep struct {
 	BranchName string
 }
 
-func (step *CreateTrackingBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *CreateTrackingBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &DeleteRemoteBranchStep{BranchName: step.BranchName}, nil
 }
 

--- a/src/steps/delete_local_branch_step.go
+++ b/src/steps/delete_local_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -16,7 +15,7 @@ type DeleteLocalBranchStep struct {
 	branchSha string
 }
 
-func (step *DeleteLocalBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *DeleteLocalBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &CreateBranchStep{BranchName: step.BranchName, StartingPoint: step.branchSha}, nil
 }
 

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -14,7 +13,7 @@ type DeleteParentBranchStep struct {
 	previousParent string
 }
 
-func (step *DeleteParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *DeleteParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	if step.previousParent == "" {
 		return &NoOpStep{}, nil
 	}

--- a/src/steps/driver_merge_pull_request_step.go
+++ b/src/steps/driver_merge_pull_request_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -20,14 +19,14 @@ type DriverMergePullRequestStep struct {
 	mergeSha                  string
 }
 
-func (step *DriverMergePullRequestStep) CreateAbortStep() Step {
+func (step *DriverMergePullRequestStep) CreateAbortStep() Step { //nolint:ireturn
 	if step.enteredEmptyCommitMessage {
 		return &DiscardOpenChangesStep{}
 	}
 	return nil
 }
 
-func (step *DriverMergePullRequestStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *DriverMergePullRequestStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &RevertCommitStep{Sha: step.mergeSha}, nil
 }
 

--- a/src/steps/json_step.go
+++ b/src/steps/json_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -37,7 +36,7 @@ func (j *JSONStep) UnmarshalJSON(b []byte) error {
 }
 
 //nolint:gocyclo,funlen
-func determineStep(stepType string) Step {
+func determineStep(stepType string) Step { //nolint:ireturn
 	switch stepType {
 	case "*AbortMergeBranchStep":
 		return &AbortMergeBranchStep{}

--- a/src/steps/merge_branch_step.go
+++ b/src/steps/merge_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -14,15 +13,15 @@ type MergeBranchStep struct {
 	previousSha string
 }
 
-func (step *MergeBranchStep) CreateAbortStep() Step {
+func (step *MergeBranchStep) CreateAbortStep() Step { //nolint:ireturn
 	return &AbortMergeBranchStep{}
 }
 
-func (step *MergeBranchStep) CreateContinueStep() Step {
+func (step *MergeBranchStep) CreateContinueStep() Step { //nolint:ireturn
 	return &ContinueMergeBranchStep{}
 }
 
-func (step *MergeBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *MergeBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &ResetToShaStep{Hard: true, Sha: step.previousSha}, nil
 }
 

--- a/src/steps/no_op_step.go
+++ b/src/steps/no_op_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -12,15 +11,15 @@ import (
 // It is used for steps that have no undo or abort steps.
 type NoOpStep struct{}
 
-func (step *NoOpStep) CreateAbortStep() Step {
+func (step *NoOpStep) CreateAbortStep() Step { //nolint:ireturn
 	return &NoOpStep{}
 }
 
-func (step *NoOpStep) CreateContinueStep() Step {
+func (step *NoOpStep) CreateContinueStep() Step { //nolint:ireturn
 	return &NoOpStep{}
 }
 
-func (step *NoOpStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *NoOpStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &NoOpStep{}, nil
 }
 

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -15,7 +14,7 @@ type PushBranchStep struct {
 	Undoable   bool
 }
 
-func (step *PushBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *PushBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	if step.Undoable {
 		return &PushBranchAfterCurrentBranchSteps{}, nil
 	}

--- a/src/steps/rebase_branch_step.go
+++ b/src/steps/rebase_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -15,15 +14,15 @@ type RebaseBranchStep struct {
 	previousSha string
 }
 
-func (step *RebaseBranchStep) CreateAbortStep() Step {
+func (step *RebaseBranchStep) CreateAbortStep() Step { //nolint:ireturn
 	return &AbortRebaseBranchStep{}
 }
 
-func (step *RebaseBranchStep) CreateContinueStep() Step {
+func (step *RebaseBranchStep) CreateContinueStep() Step { //nolint:ireturn
 	return &ContinueRebaseBranchStep{}
 }
 
-func (step *RebaseBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *RebaseBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &ResetToShaStep{Hard: true, Sha: step.previousSha}, nil
 }
 

--- a/src/steps/remove_from_perennial_branch.go
+++ b/src/steps/remove_from_perennial_branch.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -12,7 +11,7 @@ type RemoveFromPerennialBranches struct {
 	BranchName string
 }
 
-func (step *RemoveFromPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *RemoveFromPerennialBranches) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &AddToPerennialBranches{BranchName: step.BranchName}, nil
 }
 

--- a/src/steps/restore_open_changes_step.go
+++ b/src/steps/restore_open_changes_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -13,7 +12,7 @@ type RestoreOpenChangesStep struct {
 	NoOpStep
 }
 
-func (step *RestoreOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *RestoreOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &StashOpenChangesStep{}, nil
 }
 

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -16,7 +15,7 @@ type SetParentBranchStep struct {
 	previousParent string
 }
 
-func (step *SetParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *SetParentBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	if step.previousParent == "" {
 		return &DeleteParentBranchStep{BranchName: step.BranchName}, nil
 	}

--- a/src/steps/squash_merge_branch_step.go
+++ b/src/steps/squash_merge_branch_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -16,11 +15,11 @@ type SquashMergeBranchStep struct {
 	CommitMessage string
 }
 
-func (step *SquashMergeBranchStep) CreateAbortStep() Step {
+func (step *SquashMergeBranchStep) CreateAbortStep() Step { //nolint:ireturn
 	return &DiscardOpenChangesStep{}
 }
 
-func (step *SquashMergeBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *SquashMergeBranchStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	currentSHA, err := repo.Silent.CurrentSha()
 	if err != nil {
 		return nil, err

--- a/src/steps/stash_open_changes_step.go
+++ b/src/steps/stash_open_changes_step.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -10,7 +9,7 @@ type StashOpenChangesStep struct {
 	NoOpStep
 }
 
-func (step *StashOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) {
+func (step *StashOpenChangesStep) CreateUndoStep(repo *git.ProdRepo) (Step, error) { //nolint:ireturn
 	return &RestoreOpenChangesStep{}, nil
 }
 

--- a/src/steps/step_list.go
+++ b/src/steps/step_list.go
@@ -1,4 +1,3 @@
-//nolint:ireturn
 package steps
 
 import (
@@ -29,7 +28,7 @@ func (stepList *StepList) isEmpty() bool {
 }
 
 // Peek returns the first element of this StepList.
-func (stepList *StepList) Peek() (result Step) {
+func (stepList *StepList) Peek() (result Step) { //nolint:ireturn
 	if stepList.isEmpty() {
 		return nil
 	}
@@ -37,7 +36,7 @@ func (stepList *StepList) Peek() (result Step) {
 }
 
 // Pop removes and returns the first element of this StepList.
-func (stepList *StepList) Pop() (result Step) {
+func (stepList *StepList) Pop() (result Step) { //nolint:ireturn
 	if stepList.isEmpty() {
 		return nil
 	}


### PR DESCRIPTION
No need to disable linters for the entire file when we want to only disable them for the methods that really need them.