### PR TITLE
Gherkin cleanup #1: Remove double empty lines

### DIFF
--- a/features/alias/alias.feature
+++ b/features/alias/alias.feature
@@ -15,7 +15,6 @@ Feature: git town: alias
       | git config --global alias.ship "town ship"                         |
       | git config --global alias.sync "town sync"                         |
 
-
   Scenario: remove alias
     Given I run "git-town alias true"
     When I run "git-town alias false"
@@ -32,12 +31,10 @@ Feature: git town: alias
       | git config --global --unset alias.ship             |
       | git config --global --unset alias.sync             |
 
-
   Scenario: remove alias does not remove unrelated aliases
     Given I run "git config --global alias.hack checkout"
     When I run "git-town alias false"
     Then it runs no commands
-
 
   Scenario: works outside of a Git repository
     Given my workspace is currently not a Git repo

--- a/features/append/hack-push-flag.feature
+++ b/features/append/hack-push-flag.feature
@@ -2,7 +2,6 @@ Feature: push branch to remote upon creation
 
   (see ../git-town-hack/hack_push_flag.feature)
 
-
   Background:
     Given the new-branch-push-flag configuration is true
     And the following commits exist in my repo
@@ -11,7 +10,6 @@ Feature: push branch to remote upon creation
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town append new-child"
-
 
   Scenario: inserting a branch into the branch ancestry
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: push branch to remote upon creation
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT |
       | new-child | main   |
-
 
   Scenario: Undo
     When I run "git-town undo"

--- a/features/append/offline.feature
+++ b/features/append/offline.feature
@@ -4,7 +4,6 @@ Feature: git append: offline mode
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 
-
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "existing-feature"
@@ -13,7 +12,6 @@ Feature: git append: offline mode
       | existing-feature | local, remote | existing feature commit |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
-
 
   Scenario: appending a branch in offline mode
     When I run "git-town append new-feature"
@@ -34,7 +32,6 @@ Feature: git append: offline mode
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing feature commit |
       | new-feature      | local         | existing feature commit |
-
 
   Scenario: Undo
     Given I run "git-town append new-feature"

--- a/features/append/on-child-branch.feature
+++ b/features/append/on-child-branch.feature
@@ -4,7 +4,6 @@ Feature: Appending a branch to a feature branch
   I want to be able to create a feature branch as the direct child of my current feature branch
   So that I can review and commit the changes separately without losing access to the other changes in my feature branch.
 
-
   Background:
     Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: Appending a branch to a feature branch
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
-
 
   Scenario: inserting a branch into the branch ancestry
     When I run "git-town append new-child"
@@ -39,7 +37,6 @@ Feature: Appending a branch to a feature branch
       | BRANCH           | PARENT           |
       | existing-feature | main             |
       | new-child        | existing-feature |
-
 
   Scenario: Undo
     Given I run "git-town append new-child"

--- a/features/append/on-feature-branch.feature
+++ b/features/append/on-feature-branch.feature
@@ -4,7 +4,6 @@ Feature: Appending a branch to a feature branch
   I want to be able to create a feature branch as the direct child of my current feature branch
   So that I can review and commit the changes separately without losing access to the other changes in my feature branch.
 
-
   Background:
     Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: Appending a branch to a feature branch
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
-
 
   Scenario: inserting a branch into the branch ancestry
     When I run "git-town append new-child"
@@ -39,7 +37,6 @@ Feature: Appending a branch to a feature branch
       | BRANCH           | PARENT           |
       | existing-feature | main             |
       | new-child        | existing-feature |
-
 
   Scenario: Undo
     Given I run "git-town append new-child"

--- a/features/append/on-main-branch.feature
+++ b/features/append/on-main-branch.feature
@@ -4,7 +4,6 @@ Feature: Appending a branch to a feature branch
   I want to be able to create a feature branch as the direct child of my current feature branch
   So that I can review and commit the changes separately without losing access to the other changes in my feature branch.
 
-
   Background:
     Given the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     |
@@ -12,7 +11,6 @@ Feature: Appending a branch to a feature branch
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town append new-child"
-
 
   Scenario: inserting a branch into the branch ancestry
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: Appending a branch to a feature branch
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT |
       | new-child | main   |
-
 
   Scenario: Undo
     When I run "git-town undo"

--- a/features/append/on-perennial-branch.feature
+++ b/features/append/on-perennial-branch.feature
@@ -4,7 +4,6 @@ Feature: Appending a branch to a perennial branch
   I want to be able to create a feature branch as the direct child of the perennial branch
   So that I can review and commit the changes separately without losing access to the other changes in my feature branch.
 
-
   Background:
     Given my repo has the perennial branches "qa" and "production"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: Appending a branch to a perennial branch
     And I am on the "production" branch
     And my workspace has an uncommitted file
     When I run "git-town append new-child"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: Appending a branch to a perennial branch
     And Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT     |
       | new-child | production |
-
 
   Scenario: Undo
     When I run "git-town undo"

--- a/features/config/already_set.feature
+++ b/features/config/already_set.feature
@@ -4,7 +4,6 @@ Feature: listing the configuration
   I want to see the existing configuration values
   So that I can change it more effectively
 
-
   @skipWindows
   Scenario: everything is configured
     Given my repo has the feature branches "production" and "qa"

--- a/features/config/reset.feature
+++ b/features/config/reset.feature
@@ -4,13 +4,11 @@ Feature: resetting the configuration
   I want to be able to cleanly remove all Git Town configuration from my git town-repo
   So that my repository is left in a clean state after the uninstallation.
 
-
   Scenario: everything is configured
     Given the main branch is configured as "main"
     And the perennial branches are configured as "qa" and "staging"
     When I run "git-town config reset"
     Then Git Town is no longer configured for this repo
-
 
   Scenario: the main branch is configured but the perennial branches are not
     Given the main branch is configured as "main"
@@ -18,13 +16,11 @@ Feature: resetting the configuration
     When I run "git-town config reset"
     Then Git Town is no longer configured for this repo
 
-
   Scenario: the main branch is not configured but the perennial branches are
     Given the main branch name is not configured
     And the perennial branches are configured as "qa"
     When I run "git-town config reset"
     Then Git Town is no longer configured for this repo
-
 
   Scenario: nothing is configured yet
     Given I haven't configured Git Town yet

--- a/features/config/setup.feature
+++ b/features/config/setup.feature
@@ -5,7 +5,6 @@ Feature: Initial configuration
   I want to have a simple, dedicated setup command
   So that I can configure it safely before using any Git Town command
 
-
   Scenario: succeeds on valid main branch and perennial branch names
     Given my repo has the feature branches "production" and "dev"
     And I haven't configured Git Town yet
@@ -15,7 +14,6 @@ Feature: Initial configuration
       | Please specify perennial branches          | [SPACE][DOWN][SPACE][ENTER] |
     Then the main branch is now configured as "main"
     And the perennial branches are now configured as "dev" and "production"
-
 
   Scenario: does not prompt for perennial branches if there is only the main branch
     Given I haven't configured Git Town yet

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -39,7 +39,7 @@ Feature: listing the configuration
           parent-feature
             child-feature
           stand-alone-feature
-
+        
         qa
           qa-hotfix
       """

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -4,7 +4,6 @@ Feature: listing the configuration
   I want to be able to see the complete Git Town configuration with one command
   So that I can configure Git Town efficiently and have more time for actual work.
 
-
   Scenario: everything is configured
     Given the main branch is configured as "main"
     And the perennial branches are configured as "qa" and "staging"
@@ -18,7 +17,6 @@ Feature: listing the configuration
         qa
         staging
       """
-
 
   Scenario: everything is configured and there are nested branches
     Given the main branch is configured as "main"
@@ -41,11 +39,10 @@ Feature: listing the configuration
           parent-feature
             child-feature
           stand-alone-feature
-        
+
         qa
           qa-hotfix
       """
-
 
   Scenario: the main branch is configured but the perennial branches are not
     Given the main branch is configured as "main"
@@ -60,7 +57,6 @@ Feature: listing the configuration
         [none]
       """
 
-
   Scenario: the main branch is not configured but the perennial branches are
     Given the main branch name is not configured
     And the perennial branches are configured as "qa" and "staging"
@@ -74,7 +70,6 @@ Feature: listing the configuration
         qa
         staging
       """
-
 
   Scenario: nothing is configured yet
     Given I haven't configured Git Town yet

--- a/features/diff-parent/current_branch/on_feature_branch/no_parent_branch.feature
+++ b/features/diff-parent/current_branch/on_feature_branch/no_parent_branch.feature
@@ -6,7 +6,6 @@ Feature: git town-parent-diff: diffing the current feature branch
   I should see a prompt to supply a parent branch
   So that the command can work as I expect
 
-
   @skipWindows
   Scenario: result
     Given my repo has a feature branch named "feature" with no parent

--- a/features/diff-parent/current_branch/on_feature_branch/with_parent_branch.feature
+++ b/features/diff-parent/current_branch/on_feature_branch/with_parent_branch.feature
@@ -5,7 +5,6 @@ Feature: git town-parent-diff: diffing the current feature branch
     So that I know what work is left to do
     And which work will be merged into the parent branch
 
-
   Scenario: result
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"

--- a/features/diff-parent/current_branch/on_main_branch.feature
+++ b/features/diff-parent/current_branch/on_main_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-diff-parent: errors when trying to diff the main branch
   I should see an error that I cannot diff the main branch
   Because the master branch cannot have a parent branch
 
-
   Scenario: result
     Given my repo has a feature branch named "feature"
     And I am on the "main" branch

--- a/features/diff-parent/current_branch/on_non_feature_branch.feature
+++ b/features/diff-parent/current_branch/on_non_feature_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-diff-parent: errors when trying to diff a perennial branch
   I should see an error that I cannot diff perennial branches
   Because perennial branches cannot have parent branches
 
-
   Scenario: result
     Given my repo has the perennial branch "qa"
     And I am on the "qa" branch

--- a/features/diff-parent/supplied_branch/feature_branch/on_main_branch.feature
+++ b/features/diff-parent/supplied_branch/feature_branch/on_main_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-diff-parent: diffing a given feature branch
 
   (see ../../current_branch/on_feature_branch/with_parent_branches.feature)
 
-
   Scenario: result
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"

--- a/features/diff-parent/supplied_branch/feature_branch/on_main_branch_no_parent.feature
+++ b/features/diff-parent/supplied_branch/feature_branch/on_main_branch_no_parent.feature
@@ -6,7 +6,6 @@ Feature: git town-parent-diff: diffing the current feature branch
   I should see a prompt to identify a parent branch
   So that the command can work as I expect
 
-
   @skipWindows
   Scenario: result
     Given my repo has a feature branch named "feature" with no parent

--- a/features/diff-parent/supplied_branch/feature_branch/on_parent_branch.feature
+++ b/features/diff-parent/supplied_branch/feature_branch/on_parent_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-diff-parent: diffing a given feature branch
 
   (see ../../current_branch/on_feature_branch/with_parent_branches.feature)
 
-
   Scenario: result
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"

--- a/features/diff-parent/supplied_branch/main_branch.feature
+++ b/features/diff-parent/supplied_branch/main_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-diff-parent: errors when trying to diff the main branch
 
   (see ../current_branch/on_main_branch.feature)
 
-
   Scenario: result
     Given my repo has a feature branch named "feature"
     And I am on the "feature" branch

--- a/features/diff-parent/supplied_branch/on_supplied_feature_branch/has_parent.feature
+++ b/features/diff-parent/supplied_branch/on_supplied_feature_branch/has_parent.feature
@@ -2,7 +2,6 @@ Feature: git town-diff-parent: diffing a given feature branch
 
   (see ../../current_branch/on_feature_branch/with_parent_branch.feature)
 
-
   Scenario: result
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"

--- a/features/diff-parent/supplied_branch/on_supplied_feature_branch/no_parent_branch.feature
+++ b/features/diff-parent/supplied_branch/on_supplied_feature_branch/no_parent_branch.feature
@@ -6,7 +6,6 @@ Feature: git town-parent-diff: diffing the current feature branch
   I should see a prompt to supply a parent branch
   So that the command can work as I expect
 
-
   @skipWindows
   Scenario: result
     Given my repo has a feature branch named "feature" with no parent

--- a/features/diff-parent/supplied_branch/perennial_branch.feature
+++ b/features/diff-parent/supplied_branch/perennial_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-diff-parent: errors when trying to diff a perennial branch
 
   (see ../current_branch/on_perennial_branch.feature)
 
-
   Scenario: result
     Given my repo has a feature branch named "feature"
     And my repo has the perennial branch "qa"

--- a/features/git-town/minimum_git_version.feature
+++ b/features/git-town/minimum_git_version.feature
@@ -7,7 +7,6 @@ Feature: git town: show an error message when minimum Git version is not satisfi
   Reasoning: Using `git remote get-url <name>` which was added in 2.7.0
   https://github.com/git/git/blob/1eb437020a2c098a7c12da4c05082fbea10d98c9/Documentation/RelNotes/2.7.0.txt
 
-
   Scenario: using an unsupported Git Version
     Given my computer has Git "2.6.2" installed
     When I run "git-town config"

--- a/features/hack/branch_exists_locally.feature
+++ b/features/hack/branch_exists_locally.feature
@@ -4,13 +4,11 @@ Feature: git town-hack: errors when the branch exists locally
   I should see an error telling me that a branch with that name already exists
   So that my new feature branch is unique.
 
-
   Background:
     Given my repo has a feature branch named "existing-feature"
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack existing-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/branch_exists_remotely.feature
+++ b/features/hack/branch_exists_remotely.feature
@@ -2,13 +2,11 @@ Feature: git town-hack: errors when the branch exists remotely
 
   (see ./branch_exists_locally.feature)
 
-
   Background:
     Given my coworker has a feature branch named "existing-feature"
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack existing-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/branch_name_with_slash.feature
+++ b/features/hack/branch_name_with_slash.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: does not error when branch name contains a forward slash
   I don't want to see a warning about an invalid key
   So that the tool doesn't get in my way
 
-
   Scenario: result
     Given I am on the "main" branch
     When I run "git-town hack my/feature"

--- a/features/hack/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/hack/main_branch_rebase_tracking_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature"
-
 
   Scenario: result
     Then it runs the commands
@@ -32,7 +30,6 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -45,7 +42,6 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
     And there is no rebase in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it prints the error:
@@ -54,7 +50,6 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
       """
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -74,7 +69,6 @@ Feature: git town-hack: resolving conflicts between main branch and its tracking
       |             |               | conflicting local commit  | conflicting_file |
       | new-feature | local         | conflicting remote commit | conflicting_file |
       |             |               | conflicting local commit  | conflicting_file |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/hack/new_branch_push_flag.feature
+++ b/features/hack/new_branch_push_flag.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: push branch to remote upon creation
   I want it to be pushed to the CI server right away
   So that I can push and pull from the remote branch right away without having to run "git sync" first
 
-
   Background:
     Given the new-branch-push-flag configuration is true
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-hack: push branch to remote upon creation
       | main   | remote   | remote commit |
     And I am on the "main" branch
     When I run "git-town hack feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/offline.feature
+++ b/features/hack/offline.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: offline mode
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 
-
   Background:
     Given Git Town is in offline mode
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-hack: offline mode
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/on_feature_branch/in_committed_subfolder.feature
+++ b/features/hack/on_feature_branch/in_committed_subfolder.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
   I want to be able to extract my open changes into a new feature branch
   So that I can get them reviewed separately from the changes on this branch.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature" in the "new_folder" folder
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/on_feature_branch/in_uncommitted_subfolder.feature
+++ b/features/hack/on_feature_branch/in_uncommitted_subfolder.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
   I want to be able to extract my open changes into a new feature branch
   So that I can get them reviewed separately from the changes on this branch.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-hack: starting a new feature from a new subfolder on the main 
     And I am on the "feature" branch
     And my workspace has an uncommitted file in folder "new_folder"
     When I run "git-town hack new-feature" in the "new_folder" folder
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/on_feature_branch/uncommitted_conflicts_with_main.feature
+++ b/features/hack/on_feature_branch/uncommitted_conflicts_with_main.feature
@@ -9,7 +9,6 @@ Feature: git town-hack: resolving conflicts between uncommitted changes and the 
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town hack new-feature"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH           | COMMAND                     |
@@ -27,14 +26,12 @@ Feature: git town-hack: resolving conflicts between uncommitted changes and the 
       """
     And the file "conflicting_file" contains unresolved conflicts
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it prints the error:
       """
       you must resolve the conflicts before continuing
       """
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"

--- a/features/hack/on_feature_branch/with_remote_origin.feature
+++ b/features/hack/on_feature_branch/with_remote_origin.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: starting a new feature from a feature branch (with remot
   I want to be able to create a new up-to-date feature branch and continue my work there
   So that my work can exist on its own branch, code reviews remain effective, and my team productive.
 
-
   Background:
     Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-hack: starting a new feature from a feature branch (with remot
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/on_feature_branch/without_remote_origin.feature
+++ b/features/hack/on_feature_branch/without_remote_origin.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: starting a new feature from a feature branch (without re
   I want to be able to create a new up-to-date feature branch and continue my work there
   So that my work can exist on its own branch, code reviews remain effective, and my team productive.
 
-
   Background:
     Given my repo has a feature branch named "existing-feature"
     And my repo does not have a remote origin
@@ -15,7 +14,6 @@ Feature: git town-hack: starting a new feature from a feature branch (without re
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/on_main_branch/in_subfolder.feature
+++ b/features/hack/on_main_branch/in_subfolder.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: starting a new feature from a subfolder on the main bran
   I want to be able to extract my open changes into a feature branch
   So that I can get them reviewed.
 
-
   Background:
     Given the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE       | FILE NAME        |
@@ -12,7 +11,6 @@ Feature: git town-hack: starting a new feature from a subfolder on the main bran
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature" in the "new_folder" folder
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/on_main_branch/with_remote_origin.feature
+++ b/features/hack/on_main_branch/with_remote_origin.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: starting a new feature from the main branch (with remote
   I want to be able to create a new up-to-date feature branch and continue my work there
   So that my work can exist on its own branch, code reviews remain effective, and my team productive.
 
-
   Background:
     Given the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     |
@@ -12,7 +11,6 @@ Feature: git town-hack: starting a new feature from the main branch (with remote
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/on_main_branch/with_upstream.feature
+++ b/features/hack/on_main_branch/with_upstream.feature
@@ -9,7 +9,6 @@ Feature: git-hack: on the main branch with a upstream remote
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH      | COMMAND                     |

--- a/features/hack/on_main_branch/without_remote_origin.feature
+++ b/features/hack/on_main_branch/without_remote_origin.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: starting a new feature from the main branch (without rem
   I want to be able to create a new up-to-date feature branch and continue my work there
   So that my work can exist on its own branch, code reviews remain effective, and my team productive.
 
-
   Background:
     Given my repo does not have a remote origin
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-hack: starting a new feature from the main branch (without rem
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/hack/prompt_for_parent.feature
+++ b/features/hack/prompt_for_parent.feature
@@ -4,7 +4,6 @@ Feature: git town-hack: prompt for parent branch
   I want to be able to create a new up-to-date branch without checking out the parent
   So that I have a unified way for creating new branches
 
-
   @skipWindows
   Scenario: selecting the default branch (the main development branch)
     Given the following commits exist in my repo
@@ -30,7 +29,6 @@ Feature: git town-hack: prompt for parent branch
       | BRANCH      | LOCATION      | MESSAGE     |
       | main        | local, remote | main_commit |
       | new-feature | local         | main_commit |
-
 
   @skipWindows
   Scenario: selecting another branch

--- a/features/help/help_configured.feature
+++ b/features/help/help_configured.feature
@@ -4,7 +4,6 @@ Feature: show help screen when Git Town is configured
   I want to see a helpful list of all commands
   So that I can refresh my memory quickly and move on to what I actually wanted to do.
 
-
   Scenario Outline:
     When I run "<COMMAND>"
     Then it prints:

--- a/features/help/help_outside_git_repo.feature
+++ b/features/help/help_outside_git_repo.feature
@@ -2,7 +2,6 @@ Feature: show help screen even outside of a Git repository
 
   (see ./help_configured.feature)
 
-
   Scenario Outline: Running outside of a Git repository
     Given my workspace is currently not a Git repo
     When I run "<COMMAND>"

--- a/features/kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
+++ b/features/kill/current_branch/on_feature_branch/with_deleted_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing the current feature branch with a deleted tracki
   I want the command to succeed anyways
   So that killing branches is robust and reliable.
 
-
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git town-kill: killing the current feature branch with a deleted tracki
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: git town-kill: killing the current feature branch with a deleted tracki
     And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
+++ b/features/kill/current_branch/on_feature_branch/with_parent_and_child_branches.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing the current feature branch with child branches
   I want that the current branch is cleanly removed from the branch hierarchy metadata
   So that killing branches is robust and reliable.
 
-
   Background:
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
@@ -17,7 +16,6 @@ Feature: git town-kill: killing the current feature branch with child branches
     And I am on the "feature-2" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
-
 
   Scenario: result
     Then it runs the commands
@@ -42,7 +40,6 @@ Feature: git town-kill: killing the current feature branch with child branches
       | BRANCH    | PARENT    |
       | feature-1 | main      |
       | feature-3 | feature-1 |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/current_branch/on_feature_branch/with_tracking_branch.feature
+++ b/features/kill/current_branch/on_feature_branch/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing the current feature branch with a tracking branc
   I want to be able to cleanly delete the current branch including all open changes
   So that my workspace doesn't contain irrelevant branches and my productivity remains high.
 
-
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-kill: killing the current feature branch with a tracking branc
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: git town-kill: killing the current feature branch with a tracking branc
     And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/current_branch/on_feature_branch/without_remote_origin.feature
+++ b/features/kill/current_branch/on_feature_branch/without_remote_origin.feature
@@ -2,7 +2,6 @@ Feature: git town-kill: killing the current feature branch without a tracking br
 
   (see ../without_tracking_branch/with_open_changes.feature)
 
-
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "current-feature" and "other-feature"
@@ -13,7 +12,6 @@ Feature: git town-kill: killing the current feature branch without a tracking br
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
-
 
   Scenario: result
     Then it runs the commands
@@ -29,7 +27,6 @@ Feature: git town-kill: killing the current feature branch without a tracking br
     And my repo now has the following commits
       | BRANCH        | LOCATION | MESSAGE              |
       | other-feature | local    | other feature commit |
-
 
   Scenario: Undoing a kill of a local feature branch
     When I run "git-town undo"

--- a/features/kill/current_branch/on_feature_branch/without_tracking_branch.feature
+++ b/features/kill/current_branch/on_feature_branch/without_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing the current feature branch without a tracking br
   I want to be able to remove the current branch including all open changes
   So that my workspace doesn't contain irrelevant branches and my productivity remains high.
 
-
   Background:
     Given my repo has a feature branch named "other-feature"
     And my repo has a local feature branch named "current-feature"
@@ -15,7 +14,6 @@ Feature: git town-kill: killing the current feature branch without a tracking br
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
-
 
   Scenario: result
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: git town-kill: killing the current feature branch without a tracking br
     And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
-
 
   Scenario: Undoing a kill of a local feature branch
     When I run "git-town undo"

--- a/features/kill/current_branch/on_main_branch.feature
+++ b/features/kill/current_branch/on_main_branch.feature
@@ -4,14 +4,12 @@ Feature: git town-kill: errors when trying to kill the main branch
   I should see an error that I cannot delete the main branch
   So that my main development line remains intact and my project stays shippable.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |
     And I am on the "main" branch
-
 
   Scenario: result
     Given my workspace has an uncommitted file

--- a/features/kill/current_branch/on_non_feature_branch.feature
+++ b/features/kill/current_branch/on_non_feature_branch.feature
@@ -4,14 +4,12 @@ Feature: git town-kill: errors when trying to kill a perennial branch
   I should see an error that I cannot delete perennial branches
   So that my release infrastructure remains intact and my project stays shippable.
 
-
   Background:
     Given my repo has the perennial branch "qa"
     And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE   |
       | qa     | local, remote | qa commit |
     And I am on the "qa" branch
-
 
   Scenario: result
     Given my workspace has an uncommitted file

--- a/features/kill/supplied_branch/branch_does_not_exist.feature
+++ b/features/kill/supplied_branch/branch_does_not_exist.feature
@@ -4,10 +4,8 @@ Feature: git town-kill: errors if supplied branch does not exist
   I should get an error that the given branch does not exist
   So that I can delete the correct branch
 
-
   Background:
     Given I am on the "main" branch
-
 
   Scenario: result
     When I run "git-town kill non-existing-feature"

--- a/features/kill/supplied_branch/feature_branch/remote_branch.feature
+++ b/features/kill/supplied_branch/feature_branch/remote_branch.feature
@@ -9,7 +9,6 @@ Feature: git town-kill: killing a remote only branch
     And I run "git-town sync"
     When I run "git-town kill feature"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |
@@ -19,7 +18,6 @@ Feature: git town-kill: killing a remote only branch
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/kill/supplied_branch/feature_branch/with_child_branches.feature
@@ -2,7 +2,6 @@ Feature: git town-kill: killing the given branch with child branches
 
   (see ../../current_branch/on_feature_branch/with_child_branches.feature)
 
-
   Background:
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
@@ -15,7 +14,6 @@ Feature: git town-kill: killing the given branch with child branches
     And I am on the "feature-3" branch
     And my workspace has an uncommitted file
     When I run "git-town kill feature-2"
-
 
   Scenario: result
     Then it runs the commands
@@ -37,7 +35,6 @@ Feature: git town-kill: killing the given branch with child branches
       | BRANCH    | PARENT    |
       | feature-1 | main      |
       | feature-3 | feature-1 |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/kill/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing the given feature branch
   I want to be able to cleanly delete another dead-end feature branch without leaving my ongoing work
   So that I keep the repository lean and my team's productivity remains high.
 
-
   Background:
     Given my repo has the feature branches "good-feature" and "dead-feature"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git town-kill: killing the given feature branch
     And I am on the "good-feature" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town kill dead-feature"
-
 
   Scenario: result
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: git town-kill: killing the given feature branch
       | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
       | main         | local, remote | conflicting with uncommitted changes | conflicting_file |
       | good-feature | local, remote | good commit                          | good_file        |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/kill/supplied_branch/feature_branch/without_remote_origin.feature
@@ -2,7 +2,6 @@ Feature: git town-kill: killing the given feature branch (without remote repo)
 
   (see ../with_tracking_branch/with_open_changes.feature)
 
-
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "current-feature" and "other-feature"
@@ -14,7 +13,6 @@ Feature: git town-kill: killing the given feature branch (without remote repo)
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town kill other-feature"
-
 
   Scenario: result
     Then it runs the commands
@@ -32,7 +30,6 @@ Feature: git town-kill: killing the given feature branch (without remote repo)
       | BRANCH          | LOCATION | MESSAGE                | FILE NAME            |
       | main            | local    | main commit            | conflicting_file     |
       | current-feature | local    | current feature commit | current_feature_file |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/supplied_branch/main_branch.feature
+++ b/features/kill/supplied_branch/main_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-kill: errors when trying to kill the main branch
 
   (see ../current_branch/on_main_branch.feature)
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -10,7 +9,6 @@ Feature: git town-kill: errors when trying to kill the main branch
       | main    | local, remote | main commit |
       | feature | local, remote | good commit |
     And I am on the "feature" branch
-
 
   Scenario: result
     Given my workspace has an uncommitted file

--- a/features/kill/supplied_branch/offline/local_branch.feature
+++ b/features/kill/supplied_branch/offline/local_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing a local branch in offline mode
   I want to be able to still delete the current branch including all open changes
   So that I can work as much as possible despite no internet connection.
 
-
   Background:
     Given Git Town is in offline mode
     And my repo has the feature branches "current-feature" and "other-feature"
@@ -15,7 +14,6 @@ Feature: git town-kill: killing a local branch in offline mode
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: git town-kill: killing a local branch in offline mode
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | remote        | current feature commit |
       | other-feature   | local, remote | other feature commit   |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/supplied_branch/offline/remote_branch.feature
+++ b/features/kill/supplied_branch/offline/remote_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing a remote branch in offline mode
   I want to be notified that this operation is not possible
   So that I know about my mistake and can do more appropriate actions instead.
 
-
   Background:
     Given Git Town is in offline mode
     And my origin has a feature branch named "feature"
@@ -14,7 +13,6 @@ Feature: git town-kill: killing a remote branch in offline mode
     And my repo knows about the remote branch
     And I am on the "main" branch
     When I run "git-town kill feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
+++ b/features/kill/supplied_branch/on_supplied_feature_branch/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-kill: killing the given feature branch when on it
   I want to be able to kill it by name
   So that cleaning out branches is easy and robust.
 
-
   Background:
     Given my repo has the feature branches "other-feature" and "current-feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-kill: killing the given feature branch when on it
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill current-feature"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: git town-kill: killing the given feature branch when on it
     And my repo now has the following commits
       | BRANCH        | LOCATION      | MESSAGE              |
       | other-feature | local, remote | other feature commit |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
+++ b/features/kill/supplied_branch/on_supplied_feature_branch/without_remote_origin.feature
@@ -2,7 +2,6 @@ Feature: git town-kill: killing the given feature branch when on it (without rem
 
   (see ../with_tracking_branch/with_open_changes.feature)
 
-
   Background:
     Given my repo does not have a remote origin
     And my repo has the local feature branches "current-feature" and "other-feature"
@@ -13,7 +12,6 @@ Feature: git town-kill: killing the given feature branch when on it (without rem
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill current-feature"
-
 
   Scenario: result
     Then it runs the commands
@@ -30,7 +28,6 @@ Feature: git town-kill: killing the given feature branch when on it (without rem
     And my repo now has the following commits
       | BRANCH        | LOCATION | MESSAGE              |
       | other-feature | local    | other feature commit |
-
 
   Scenario: undoing the kill
     When I run "git-town undo"

--- a/features/kill/supplied_branch/perennial_branch.feature
+++ b/features/kill/supplied_branch/perennial_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-kill: errors when trying to kill a perennial branch
 
   (see ../current_branch/on_perennial_branch.feature)
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And my repo has the perennial branch "qa"
@@ -11,7 +10,6 @@ Feature: git town-kill: errors when trying to kill a perennial branch
       | feature | local, remote | good commit |
       | qa      | local, remote | qa commit   |
     And I am on the "feature" branch
-
 
   Scenario: result
     Given my workspace has an uncommitted file

--- a/features/main_branch/display.feature
+++ b/features/main_branch/display.feature
@@ -4,7 +4,6 @@ Feature: display the main branch configuration
   I want to be able to see this information simply and directly
   So that I can use it without furter thinking or processing, and my Git Town workflows are effective.
 
-
   Scenario: main branch not yet configured
     Given my repo doesn't have a main branch configured
     When I run "git-town main-branch"
@@ -12,7 +11,6 @@ Feature: display the main branch configuration
       """
       [none]
       """
-
 
   Scenario: main branch is configured
     Given the main branch is configured as "main"

--- a/features/main_branch/update.feature
+++ b/features/main_branch/update.feature
@@ -4,13 +4,11 @@ Feature: set the main branch configuration
   I want an easy way to specifically set the main branch
   So that I can configure Git Town safely, and the tool does exactly what I want.
 
-
   Scenario: main branch not yet configured
     Given my repo doesn't have a main branch configured
     When I run "git-town main-branch main"
     Then it prints no output
     And the main branch is now configured as "main"
-
 
   Scenario: main branch is configured
     Given my repo has the branches "main-old" and "main-new"
@@ -18,7 +16,6 @@ Feature: set the main branch configuration
     When I run "git-town main-branch main-new"
     Then it prints no output
     And the main branch is now configured as "main-new"
-
 
   Scenario: invalid branch name
     When I run "git-town main-branch non-existing"

--- a/features/new-branch-push-flag/display.feature
+++ b/features/new-branch-push-flag/display.feature
@@ -4,14 +4,12 @@ Feature: displaying the new branch push flag configuration
   I want to know what the existing value for the new branch push flag is
   So I can decide whether to I want to adjust it.
 
-
   Scenario: default setting
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
       false
       """
-
 
   Scenario: set to "true"
     Given the new-branch-push-flag configuration is true
@@ -21,7 +19,6 @@ Feature: displaying the new branch push flag configuration
       true
       """
 
-
   Scenario: set to "false"
     Given the new-branch-push-flag configuration is false
     When I run "git-town new-branch-push-flag"
@@ -30,7 +27,6 @@ Feature: displaying the new branch push flag configuration
       false
       """
 
-
   Scenario: globally set to "true", local unset
     Given the global new-branch-push-flag configuration is true
     When I run "git-town new-branch-push-flag"
@@ -38,7 +34,6 @@ Feature: displaying the new branch push flag configuration
       """
       true
       """
-
 
   Scenario: globally set to "true", local set to "false"
     Given the global new-branch-push-flag configuration is true

--- a/features/new-branch-push-flag/global_display.feature
+++ b/features/new-branch-push-flag/global_display.feature
@@ -7,7 +7,6 @@ Feature: displaying the global new branch push flag configuration
       false
       """
 
-
   Scenario: set to "true"
     Given the global new-branch-push-flag configuration is true
     When I run "git-town new-branch-push-flag --global"
@@ -15,7 +14,6 @@ Feature: displaying the global new branch push flag configuration
       """
       true
       """
-
 
   Scenario: set to false
     Given the global new-branch-push-flag configuration is false

--- a/features/new-branch-push-flag/global_update.feature
+++ b/features/new-branch-push-flag/global_update.feature
@@ -4,7 +4,6 @@ Feature: set the global new-branch-push-flag
     When I run "git-town new-branch-push-flag --global true"
     Then the new-branch-push-flag configuration is now true
 
-
   Scenario: globally update to "false"
     When I run "git-town new-branch-push-flag --global false"
     Then the new-branch-push-flag configuration is now false

--- a/features/new-branch-push-flag/update.feature
+++ b/features/new-branch-push-flag/update.feature
@@ -4,7 +4,6 @@ Feature: set the new-branch-push-flag
   I want an easy way to specifically set the new branch push flag
   So that I can configure Git Town safely, and the tool does exactly what I want.
 
-
   Scenario Outline: update
     When I run "git-town new-branch-push-flag <GIVE>"
     Then the new-branch-push-flag configuration is now <WANT>
@@ -17,7 +16,6 @@ Feature: set the new-branch-push-flag
       | false | false |
       | f     | false |
       | 0     | false |
-
 
   Scenario: invalid value
     When I run "git-town new-branch-push-flag zonk"

--- a/features/new-pull-request/bitbucket.feature
+++ b/features/new-pull-request/bitbucket.feature
@@ -4,7 +4,6 @@ Feature: git-new-pull-request when origin is on Bitbucket
   I want to be able to quickly create a pull request
   So that I have more time for coding the next feature instead of wasting it with process boilerplate.
 
-
   @skipWindows
   Scenario Outline: normal origin
     Given my repo has a feature branch named "feature"
@@ -26,7 +25,6 @@ Feature: git-new-pull-request when origin is on Bitbucket
       | git@bitbucket.org/git-town/git-town.git              |
       | git@bitbucket.org/git-town/git-town                  |
 
-
   @skipWindows
   Scenario Outline: origin includes path that looks like a URL
     Given my repo has a feature branch named "feature"
@@ -47,7 +45,6 @@ Feature: git-new-pull-request when origin is on Bitbucket
       | https://username@bitbucket.org/git-town/git-town.github.com     |
       | git@bitbucket.org/git-town/git-town.github.com.git              |
       | git@bitbucket.org/git-town/git-town.github.com                  |
-
 
   @skipWindows
   Scenario Outline: SSH style origin

--- a/features/new-pull-request/conflict.feature
+++ b/features/new-pull-request/conflict.feature
@@ -4,7 +4,6 @@ Feature: Syncing before creating the pull request
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has a local feature branch named "feature"
     And the following commits exist in my repo
@@ -16,7 +15,6 @@ Feature: Syncing before creating the pull request
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town new-pull-request"
-
 
   Scenario: result
     Then it runs the commands
@@ -37,7 +35,6 @@ Feature: Syncing before creating the pull request
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -51,7 +48,6 @@ Feature: Syncing before creating the pull request
     And there is no merge in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -62,7 +58,6 @@ Feature: Syncing before creating the pull request
     And I am still on the "feature" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   @skipWindows
   Scenario: continuing after resolving conflicts
@@ -86,7 +81,6 @@ Feature: Syncing before creating the pull request
       | feature | local, remote | feature commit                   | conflicting_file |
       |         |               | main commit                      | conflicting_file |
       |         |               | Merge branch 'main' into feature |                  |
-
 
   @skipWindows
   Scenario: continuing after resolving conflicts and committing

--- a/features/new-pull-request/gitea.feature
+++ b/features/new-pull-request/gitea.feature
@@ -4,10 +4,8 @@ Feature: git-new-pull-request when origin is on Gitea
   I want to be able to easily create a pull request
   So that I have more time for coding the next feature instead of wasting it with process boilerplate.
 
-
   Background:
     Given my computer has the "open" tool installed
-
 
   @skipWindows
   Scenario Outline: normal origin
@@ -29,7 +27,6 @@ Feature: git-new-pull-request when origin is on Gitea
       | git@gitea.com:git-town/git-town.git     |
       | git@gitea.com:git-town/git-town         |
 
-
   @skipWindows
   Scenario Outline: origin contains path that looks like a URL
     Given my repo has a feature branch named "feature"
@@ -50,7 +47,6 @@ Feature: git-new-pull-request when origin is on Gitea
       | git@gitea.com:git-town/git-town.gitea.com.git     |
       | git@gitea.com:git-town/git-town.gitea.com         |
 
-
   @skipWindows
   Scenario Outline: proper URL encoding
     Given my repo has a feature branch named "<BRANCH_NAME>"
@@ -69,7 +65,6 @@ Feature: git-new-pull-request when origin is on Gitea
       | fix-#2         | https://gitea.com/git-town/git-town/compare/main...fix-%232       |
       | test/feature   | https://gitea.com/git-town/git-town/compare/main...test%2Ffeature |
 
-
   @skipWindows
   Scenario Outline: SSH style origin
     Given my repo has a feature branch named "feature"
@@ -85,7 +80,6 @@ Feature: git-new-pull-request when origin is on Gitea
       | ORIGIN                                    |
       | ssh://git@gitea.com/git-town/git-town.git |
       | ssh://git@gitea.com/git-town/git-town     |
-
 
   @skipWindows
   Scenario: nested feature branch with known parent

--- a/features/new-pull-request/github.feature
+++ b/features/new-pull-request/github.feature
@@ -4,10 +4,8 @@ Feature: git-new-pull-request when origin is on GitHub
   I want to be able to easily create a pull request
   So that I have more time for coding the next feature instead of wasting it with process boilerplate.
 
-
   Background:
     Given my computer has the "open" tool installed
-
 
   @skipWindows
   Scenario Outline: normal origin
@@ -29,7 +27,6 @@ Feature: git-new-pull-request when origin is on GitHub
       | git@github.com:git-town/git-town.git     |
       | git@github.com:git-town/git-town         |
 
-
   @skipWindows
   Scenario Outline: origin contains path that looks like a URL
     Given my repo has a feature branch named "feature"
@@ -50,7 +47,6 @@ Feature: git-new-pull-request when origin is on GitHub
       | git@github.com:git-town/git-town.github.com.git     |
       | git@github.com:git-town/git-town.github.com         |
 
-
   @skipWindows
   Scenario Outline: proper URL encoding
     Given my repo has a feature branch named "<BRANCH_NAME>"
@@ -69,7 +65,6 @@ Feature: git-new-pull-request when origin is on GitHub
       | fix-#2         | https://github.com/git-town/git-town/compare/fix-%232?expand=1       |
       | test/feature   | https://github.com/git-town/git-town/compare/test%2Ffeature?expand=1 |
 
-
   @skipWindows
   Scenario Outline: SSH style origin
     Given my repo has a feature branch named "feature"
@@ -85,7 +80,6 @@ Feature: git-new-pull-request when origin is on GitHub
       | ORIGIN                                     |
       | ssh://git@github.com/git-town/git-town.git |
       | ssh://git@github.com/git-town/git-town     |
-
 
   @skipWindows
   Scenario: nested feature branch with known parent

--- a/features/new-pull-request/gitlab.feature
+++ b/features/new-pull-request/gitlab.feature
@@ -4,10 +4,8 @@ Feature: git-new-pull-request when origin is on GitLab
   I want to be able to easily create a pull request
   So that I have more time for coding the next feature instead of wasting it with process boilerplate.
 
-
   Background:
     Given my computer has the "open" tool installed
-
 
   @skipWindows
   Scenario Outline: creating pull-requests
@@ -24,7 +22,6 @@ Feature: git-new-pull-request when origin is on GitLab
       | ORIGIN                           |
       | https://gitlab.com/kadu/kadu.git |
       | git@gitlab.com:kadu/kadu.git     |
-
 
   @skipWindows
   Scenario: nested feature branch with known parent

--- a/features/new-pull-request/multi_platform_support.feature
+++ b/features/new-pull-request/multi_platform_support.feature
@@ -23,7 +23,6 @@ Feature: git-new-pull-request: multi-platform support
       | mozilla       |
       | netscape      |
 
-
   @skipWindows
   Scenario: no supported tool installed
     Given my repo has a feature branch named "feature"

--- a/features/new-pull-request/offline.feature
+++ b/features/new-pull-request/offline.feature
@@ -4,7 +4,6 @@ Feature: git new-pull-request: offline mode
   I want to be told that Git Town is in offline mode
   So that I know I cannot create new pull requests.
 
-
   Scenario: trying to create a new pull request in offline mode
     Given Git Town is in offline mode
     When I run "git-town new-pull-request"

--- a/features/new-pull-request/on_outdated_branch.feature
+++ b/features/new-pull-request/on_outdated_branch.feature
@@ -4,7 +4,6 @@ Feature: Syncing before creating the pull request
   I want my feature branch by synced before creating a pull request for it
   So that my reviewers see the most up-to-date version of my code and their review is accurate.
 
-
   Background:
     Given my code base has a feature branch named "parent-feature"
     And my code base has a feature branch named "child-feature" as a child of "parent-feature"
@@ -21,7 +20,6 @@ Feature: Syncing before creating the pull request
     And I am on the "child-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town new-pull-request"
-
 
   @skipWindows
   Scenario: result

--- a/features/new-pull-request/self_hosted.feature
+++ b/features/new-pull-request/self_hosted.feature
@@ -4,7 +4,6 @@ Feature: git-town new-pull-request: when origin is a self hosted servie
   I want to specify the type of the hosted repository
   So that Git Town can support specific features of my repository platform.
 
-
   @skipWindows
   Scenario Outline: self hosted
     And my computer has the "open" tool installed

--- a/features/new-pull-request/ssh_identity.feature
+++ b/features/new-pull-request/ssh_identity.feature
@@ -4,7 +4,6 @@ Feature: git-town new-pull-request: when origin is an ssh identity
   I want to be able to configure git town with the code hosting driver and origin hostname it should use
   So that new-pull-request works with my ssh identity
 
-
   @skipWindows
   Scenario Outline: ssh identity
     And my computer has the "open" tool installed

--- a/features/new-pull-request/unsupported_hosting_service.feature
+++ b/features/new-pull-request/unsupported_hosting_service.feature
@@ -4,12 +4,10 @@ Feature: git-new-pull-request: when origin is unsupported
   I should get an error that my hosting service is not supported
   So that I know why the command doesn't work.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
-
 
   Scenario: result
     Then it prints the error:

--- a/features/offline/display.feature
+++ b/features/offline/display.feature
@@ -4,7 +4,6 @@ Feature: Displaying the current offline status
   I want to know the current value for it
   So that I can decide whether I want to adjust it.
 
-
   Scenario: set to "true"
     Given Git Town is in offline mode
     When I run "git-town offline"
@@ -13,14 +12,12 @@ Feature: Displaying the current offline status
       true
       """
 
-
   Scenario: set to "false"
     When I run "git-town offline"
     Then it prints:
       """
       false
       """
-
 
   Scenario: invalid value
     Given the offline configuration is accidentally set to "zonk"

--- a/features/offline/set.feature
+++ b/features/offline/set.feature
@@ -4,17 +4,14 @@ Feature: enabling offline mode
   I want to be able to use Git Town without interactions with remote origins
   So that I can work on my code even without internet connection.
 
-
   Scenario: enabling offline mode
     When I run "git-town offline true"
     Then offline mode is enabled
-
 
   Scenario: disabling offline mode
     Given Git Town is in offline mode
     When I run "git-town offline false"
     Then offline mode is disabled
-
 
   Scenario: invalid value
     When I run "git-town offline zonk"
@@ -22,7 +19,6 @@ Feature: enabling offline mode
       """
       invalid argument: "zonk". Please provide either "true" or "false"
       """
-
 
   Scenario: multiple values
     When I run "git-town offline true false"

--- a/features/perennial_branches/add_branch.feature
+++ b/features/perennial_branches/add_branch.feature
@@ -4,11 +4,9 @@ Feature: add a branch to the perennial branches configuration
   I want an easy way to add a branch to my set of perennial branches
   So that I can configure Git Town safely, and the tool does exactly what I want.
 
-
   Background:
     Given my repo has the branches "staging" and "qa"
     And the perennial branches are configured as "qa"
-
 
   @skipWindows
   Scenario: adding a branch

--- a/features/perennial_branches/display.feature
+++ b/features/perennial_branches/display.feature
@@ -4,7 +4,6 @@ Feature: display the perennial branches configuration
   I want to be able to see this information simply and directly
   So that I can use it without furter thinking or processing, and my Git Town workflows are effective.
 
-
   Scenario: perennial branches are not configured
     Given the perennial branches are not configured
     When I run "git-town perennial-branches"
@@ -12,7 +11,6 @@ Feature: display the perennial branches configuration
       """
       [none]
       """
-
 
   Scenario: perennial branches are configured
     Given the perennial branches are configured as "qa" and "production"

--- a/features/perennial_branches/remove_branch.feature
+++ b/features/perennial_branches/remove_branch.feature
@@ -4,11 +4,9 @@ Feature: remove a branch from the perennial branches configuration
   I want an easy way to remove a branch from my set of perennial branches
   So that I can configure Git Town safely, and the tool does exactly what I want.
 
-
   Background:
     Given my repo has the branches "staging" and "qa"
     And the perennial branches are configured as "staging" and "qa"
-
 
   @skipWindows
   Scenario: removing a branch that is a perennial branch

--- a/features/prepend/hack-push-flag.feature
+++ b/features/prepend/hack-push-flag.feature
@@ -2,7 +2,6 @@ Feature: push branch to remote upon creation
 
   (see ../git-town-hack/hack_push_flag.feature)
 
-
   Background:
     Given the new-branch-push-flag configuration is true
     And my repo has a feature branch named "existing-feature"
@@ -11,7 +10,6 @@ Feature: push branch to remote upon creation
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
-
 
   Scenario: inserting a branch into the branch ancestry
     When I run "git-town prepend new-parent"
@@ -35,7 +33,6 @@ Feature: push branch to remote upon creation
       | BRANCH           | PARENT     |
       | existing-feature | new-parent |
       | new-parent       | main       |
-
 
   Scenario: Undo
     Given I run "git-town prepend new-parent"

--- a/features/prepend/offline.feature
+++ b/features/prepend/offline.feature
@@ -4,7 +4,6 @@ Feature: git prepend: offline mode
   I want that new branches are created without attempting network accesses
   So that I don't see unnecessary errors.
 
-
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "existing-feature"
@@ -13,7 +12,6 @@ Feature: git prepend: offline mode
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
-
 
   Scenario: inserting a branch into the branch ancestry
     When I run "git-town prepend new-parent"
@@ -35,7 +33,6 @@ Feature: git prepend: offline mode
       | BRANCH           | PARENT     |
       | existing-feature | new-parent |
       | new-parent       | main       |
-
 
   Scenario: Undo
     Given I run "git-town prepend new-parent"

--- a/features/prepend/on-feature-branch.feature
+++ b/features/prepend/on-feature-branch.feature
@@ -4,7 +4,6 @@ Feature: Prepending a branch to a feature branch
   I want to be able to insert a feature branch as the direct parent of my current feature branch
   So that I can review and commit the changes separately without losing access to them in my current feature branch.
 
-
   Background:
     Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: Prepending a branch to a feature branch
       | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
-
 
   Scenario: inserting a branch into the branch ancestry
     When I run "git-town prepend new-parent"
@@ -35,7 +33,6 @@ Feature: Prepending a branch to a feature branch
       | BRANCH           | PARENT     |
       | existing-feature | new-parent |
       | new-parent       | main       |
-
 
   Scenario: Undo
     Given I run "git-town prepend new-parent"

--- a/features/prepend/on-main-branch.feature
+++ b/features/prepend/on-main-branch.feature
@@ -4,14 +4,12 @@ Feature: git town-prepend: errors when trying to prepend something in front of t
   I should see an error that the main branch has no parents
   So that I know about my mistake and run "git hack" instead.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |
     And I am on the "main" branch
-
 
   Scenario: result
     Given my workspace has an uncommitted file

--- a/features/prepend/on-perennial-branch.feature
+++ b/features/prepend/on-perennial-branch.feature
@@ -4,12 +4,10 @@ Feature: git town-prepend: errors when trying to prepend something in front of t
   I should see an error that the main branch has no parents
   So that I know about my mistake and run "git hack" instead.
 
-
   Background:
     Given my repo has the perennial branches "qa" and "production"
     And I am on the "production" branch
     When I run "git-town prepend new-parent"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/prune-branches/nested_branches.feature
+++ b/features/prune-branches/nested_branches.feature
@@ -7,7 +7,6 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
   Rules:
   - pruned branches are completely removed from the branch hierarchy
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And my repo has a feature branch named "feature-child" as a child of "feature"
@@ -19,7 +18,6 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town prune-branches"
-
 
   Scenario: result
     Then it runs the commands
@@ -35,7 +33,6 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
     And Git Town is now aware of this branch hierarchy
       | BRANCH        | PARENT |
       | feature-child | main   |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/prune-branches/normal_branch.feature
+++ b/features/prune-branches/normal_branch.feature
@@ -8,7 +8,6 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
   - branches with a deleted tracking branch are removed
   - "git branch -vv" shows these branches with the remote branch name as "[origin/<branch name>: gone]"
 
-
   Background:
     Given my repo has the feature branches "active-feature" and "deleted-feature"
     And the following commits exist in my repo
@@ -19,7 +18,6 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
     And I am on the "deleted-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town prune-branches"
-
 
   Scenario: result
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: git town-prune-branches: delete branches that were shipped or removed o
       | REPOSITORY | BRANCHES             |
       | local      | main, active-feature |
       | remote     | main, active-feature |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/prune-branches/offline.feature
+++ b/features/prune-branches/offline.feature
@@ -4,7 +4,6 @@ Feature: git town-prune-branches: offline mode
   I want to still be able to prune branches
   So that I can work as much as possible even without internet connection.
 
-
   Scenario: trying to prune branches in offline mode
     Given Git Town is in offline mode
     When I run "git-town prune-branches"

--- a/features/prune-branches/perennial_branch.feature
+++ b/features/prune-branches/perennial_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-prune-branches: remove perennial branch configuration when pru
   I want the configuration to be removed
   So that my config does not contain outdated information.
 
-
   Background:
     Given my repo has the branches "active-perennial" and "deleted-perennial"
     And the perennial branches are configured as "active-perennial" and "deleted-perennial"
@@ -16,7 +15,6 @@ Feature: git town-prune-branches: remove perennial branch configuration when pru
     And I am on the "deleted-perennial" branch
     And my workspace has an uncommitted file
     When I run "git-town prune-branches"
-
 
   Scenario: result
     Then it runs the commands
@@ -31,7 +29,6 @@ Feature: git town-prune-branches: remove perennial branch configuration when pru
       | local      | main, active-perennial |
       | remote     | main, active-perennial |
     And the perennial branches are now configured as "active-perennial"
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/pull_branch_strategy/display.feature
+++ b/features/pull_branch_strategy/display.feature
@@ -4,14 +4,12 @@ Feature: passing an invalid option to the pull strategy configuration
   I want to know what the existing value for the pull-strategy is
   So I can decide whether to I want to adjust it.
 
-
   Scenario: default setting
     When I run "git-town pull-branch-strategy"
     Then it prints:
       """
       rebase
       """
-
 
   Scenario: explicit rebase
     Given the pull-branch-strategy configuration is "rebase"
@@ -20,7 +18,6 @@ Feature: passing an invalid option to the pull strategy configuration
       """
       rebase
       """
-
 
   Scenario: explicit merge
     Given the pull-branch-strategy configuration is "merge"

--- a/features/pull_branch_strategy/update.feature
+++ b/features/pull_branch_strategy/update.feature
@@ -4,11 +4,9 @@ Feature: set the pull branch strategy
   I want an easy way to specifically set the pull branch strategy
   So that I can configure Git Town safely, and the tool does exactly what I want.
 
-
   Scenario: update to merge
     When I run "git-town pull-branch-strategy merge"
     Then the pull-branch-strategy configuration is now "merge"
-
 
   Scenario: update to rebase
     When I run "git-town pull-branch-strategy rebase"

--- a/features/rename-branch/branch_does_not_exist.feature
+++ b/features/rename-branch/branch_does_not_exist.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: errors if the feature branch does not exist
   I should get an error that the given branch does not exist
   So that I can rename the correct branch.
 
-
   Background:
     Given the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE     |
@@ -12,7 +11,6 @@ Feature: git town-rename-branch: errors if the feature branch does not exist
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch non-existing-feature renamed-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/rename-branch/current_branch.feature
+++ b/features/rename-branch/current_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: rename current branch implicitly
   I should be able reference the current branch implicitly
   So that I can perform my rename quickly.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And my repo has the perennial branch "production"
@@ -13,7 +12,6 @@ Feature: git town-rename-branch: rename current branch implicitly
       | main       | local, remote | main commit |
       | feature    | local, remote | feat commit |
       | production | local, remote | prod commit |
-
 
   Scenario: rename feature branch
     Given I am on the "feature" branch
@@ -34,7 +32,6 @@ Feature: git town-rename-branch: rename current branch implicitly
       | production      | local, remote | prod commit |
       | renamed-feature | local, remote | feat commit |
 
-
   Scenario: rename branch to itself
     Given I am on the "feature" branch
     When I run "git-town rename-branch feature"
@@ -46,7 +43,6 @@ Feature: git town-rename-branch: rename current branch implicitly
     And I am now on the "feature" branch
     And my repo is left with my original commits
 
-
   Scenario: rename perennial branch
     Given I am on the "production" branch
     When I run "git-town rename-branch renamed-production"
@@ -55,7 +51,6 @@ Feature: git town-rename-branch: rename current branch implicitly
       """
       "production" is a perennial branch. Renaming a perennial branch typically requires other updates. If you are sure you want to do this, use '--force'
       """
-
 
   Scenario: rename perennial branch (forced)
     Given I am on the "production" branch
@@ -75,7 +70,6 @@ Feature: git town-rename-branch: rename current branch implicitly
       | main               | local, remote | main commit |
       | feature            | local, remote | feat commit |
       | renamed-production | local, remote | prod commit |
-
 
   Scenario: undo rename branch
     Given I am on the "feature" branch

--- a/features/rename-branch/destination_branch_exists_locally.feature
+++ b/features/rename-branch/destination_branch_exists_locally.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: errors when the destination branch exists local
   I want the command to abort with an error message
   So that I don't lose work by accidentally overwriting existing branches.
 
-
   Background:
     Given my repo has the feature branches "current-feature" and "existing-feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-rename-branch: errors when the destination branch exists local
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch current-feature existing-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/rename-branch/destination_branch_exists_remotely.feature
+++ b/features/rename-branch/destination_branch_exists_remotely.feature
@@ -2,7 +2,6 @@ Feature: git town-rename-branch: errors when the destination branch exists remot
 
   (see ./destination_branch_exists_locally.feature)
 
-
   Background:
     Given my repo has a feature branch named "current-feature"
     And my coworker has a feature branch named "existing-feature"
@@ -13,7 +12,6 @@ Feature: git town-rename-branch: errors when the destination branch exists remot
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch current-feature existing-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/rename-branch/feature_branch/branch_and_destination_same.feature
+++ b/features/rename-branch/feature_branch/branch_and_destination_same.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: does nothing if renaming a feature branch onto 
   I should get a message saying no action is needed
   So that I am aware that I just did a no-op.
 
-
   Background:
     Given my repo has a feature branch named "current-feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-rename-branch: does nothing if renaming a feature branch onto 
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch current-feature current-feature"
-
 
   Scenario: result
     Then it runs no commands

--- a/features/rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
   I want that the branch hierarchy information is updated to the new branch name
   So that my workspace is in a consistent and fully functional state after the rename.
 
-
   Background:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
@@ -14,7 +13,6 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
       | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |
     And I am on the "parent-feature" branch
     When I run "git-town rename-branch parent-feature renamed-parent-feature"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
       | BRANCH                 | PARENT                 |
       | child-feature          | renamed-parent-feature |
       | renamed-parent-feature | main                   |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
   I should get an error that the given branch is not in sync with its tracking branch
   So that I don't lose work by deleting branches that contain commits that haven't been pulled yet.
 
-
   Background:
     Given my repo has a feature branch named "current-feature"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch current-feature renamed-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/rename-branch/feature_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
   I should get an error that the given branch is not in sync with its tracking branch
   So that I know branches must be in sync in order to be renamed.
 
-
   Background:
     Given my repo has a feature branch named "current-feature"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git town-rename-branch: errors if renaming a feature branch that has un
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch current-feature renamed-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/rename-branch/offline.feature
+++ b/features/rename-branch/offline.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: offline mode
   I still want to be able to rename branches
   So that I can use Git Town despite no internet connection.
 
-
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "feature"
@@ -14,7 +13,6 @@ Feature: git town-rename-branch: offline mode
       | feature | local, remote | feat commit |
     And I am on the "feature" branch
     When I run "git-town rename-branch renamed-feature"
-
 
   Scenario: result
     Then it runs the commands
@@ -28,7 +26,6 @@ Feature: git town-rename-branch: offline mode
       | main            | local, remote | main commit |
       | feature         | remote        | feat commit |
       | renamed-feature | local         | feat commit |
-
 
   Scenario: undo rename branch
     When I run "git-town undo"

--- a/features/rename-branch/on_main_branch.feature
+++ b/features/rename-branch/on_main_branch.feature
@@ -4,10 +4,8 @@ Feature: git town-rename-branch: errors when renaming the main branch
   I should see an error that this is not possible
   So that I know that only other branches can be renamed.
 
-
   Background:
     Given I am on the "main" branch
-
 
   Scenario: error when trying to rename
     When I run "git-town rename-branch main renamed-main"
@@ -17,7 +15,6 @@ Feature: git town-rename-branch: errors when renaming the main branch
       the main branch cannot be renamed
       """
     And I am still on the "main" branch
-
 
   Scenario: error when trying to force rename
     When I run "git-town rename-branch main renamed-main --force"

--- a/features/rename-branch/perennial_branch/branch_and_destination_same.feature
+++ b/features/rename-branch/perennial_branch/branch_and_destination_same.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: does nothing if renaming a perennial branch ont
   I should get a message saying no action is needed
   So that I am aware that I just did a no-op.
 
-
   Background:
     Given my repo has the perennial branch "production"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-rename-branch: does nothing if renaming a perennial branch ont
     And I am on the "production" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch --force production production"
-
 
   Scenario: result
     Then it runs no commands

--- a/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
+++ b/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/in_sync.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
   I want to be able to rename it safely in one easy step
   So that the names of my branches match what they implement, and I can manage them effectively.
 
-
   Background:
     Given my repo has the perennial branches "qa" and "production"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
     And I am on the "production" branch
     And my workspace has an uncommitted file
 
-
   Scenario: error when trying to rename
     When I run "git-town rename-branch production renamed-production"
     Then it runs no commands
@@ -23,7 +21,6 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
       """
       "production" is a perennial branch. Renaming a perennial branch typically requires other updates. If you are sure you want to do this, use '--force'
       """
-
 
   Scenario: forcing rename
     When I run "git-town rename-branch --force production renamed-production"
@@ -43,7 +40,6 @@ Feature: git town-rename-branch: renaming a perennial branch with a tracking bra
       | main               | local, remote | main commit       |
       | qa                 | local, remote | qa commit         |
       | renamed-production | local, remote | production commit |
-
 
   Scenario: undo
     Given I run "git-town rename-branch --force production renamed-production"

--- a/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
+++ b/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_child_branches.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
   I want that the branch hierarchy information is updated to the new branch name
   So that my workspace is in a consistent and fully functional state after the rename.
 
-
   Background:
     Given my repo has the perennial branch "production"
     And my repo has a feature branch named "child-feature" as a child of "production"
@@ -14,7 +13,6 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
       | production    | local, remote | production commit    | production_file    | production content    |
     And I am on the "production" branch
     When I run "git-town rename-branch --force production renamed-production"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: git town-rename-branch: renaming a feature branch with child branches
     And Git Town is now aware of this branch hierarchy
       | BRANCH        | PARENT             |
       | child-feature | renamed-production |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
+++ b/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpulled_changes.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
   I should get an error that the given branch is not in sync with its tracking branch
   So that I don't lose work by deleting branches that contain commits that haven't been pulled yet.
 
-
   Background:
     Given my repo has the perennial branch "production"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
     And I am on the "production" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch --force production renamed-production"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
+++ b/features/rename-branch/perennial_branch/with_remote_origin/with_tracking_branch/with_unpushed_changes.feature
@@ -4,7 +4,6 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
   I should get an error that the given branch is not in sync with its tracking branch
   So that I know branches must be in sync in order to be renamed.
 
-
   Background:
     Given my repo has the perennial branch "production"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git town-rename-branch: errors if renaming a perennial branch that has 
     And I am on the "production" branch
     And my workspace has an uncommitted file
     When I run "git-town rename-branch --force production renamed-production"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/repo/multi_platform_support.feature
+++ b/features/repo/multi_platform_support.feature
@@ -15,7 +15,6 @@ Feature: git-repo: multi-platform support
       | open     |
       | xdg-open |
 
-
   @skipWindows
   Scenario: no supported tool installed
     Given my repo's origin is "https://github.com/git-town/git-town.git"

--- a/features/repo/offline.feature
+++ b/features/repo/offline.feature
@@ -4,7 +4,6 @@ Feature: git town-repo: offline mode
   I want Git Town to tell me that I cannot see my repository
   So that I don't get misleading error messages.
 
-
   Scenario: trying to prune branches in offline mode
     Given Git Town is in offline mode
     When I run "git-town repo"

--- a/features/repo/unsupported_hosting_service.feature
+++ b/features/repo/unsupported_hosting_service.feature
@@ -3,7 +3,6 @@ Feature: git-repo when origin is unsupported
   Background:
     When I run "git-town repo"
 
-
   Scenario: result
     Then it prints the error:
       """

--- a/features/set-parent-branch/set_parent_branch.feature
+++ b/features/set-parent-branch/set_parent_branch.feature
@@ -5,12 +5,10 @@ Feature: update the parent of a nested feature branch
   I want to be able to update the parent branch for my nested feature branch
   So that I can use it without messing with the git configuration directly
 
-
   Background:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And I am on the "child-feature" branch
-
 
   Scenario: selecting the default branch (current parent)
     When I run "git-town set-parent-branch" and answer the prompts:
@@ -21,7 +19,6 @@ Feature: update the parent of a nested feature branch
       | child-feature  | parent-feature |
       | parent-feature | main           |
 
-
   Scenario: selecting another branch
     When I run "git-town set-parent-branch" and answer the prompts:
       | PROMPT                                              | ANSWER      |
@@ -30,7 +27,6 @@ Feature: update the parent of a nested feature branch
       | BRANCH         | PARENT |
       | child-feature  | main   |
       | parent-feature | main   |
-
 
   Scenario: choosing "<none> (make a perennial branch)"
     When I run "git-town set-parent-branch" and answer the prompts:

--- a/features/shared/auto_remove_outdated_config.feature
+++ b/features/shared/auto_remove_outdated_config.feature
@@ -4,7 +4,6 @@ Feature: automatically remove outdated git-town configuration
   I want my outdated configuration to be automatically removed
   So that my Git configuration isn’t littered with outdated entries.
 
-
   Scenario: automatically remove outdated branch hierarchy information
     Given I run "git-town hack feature"
     And I run "git checkout main"

--- a/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_deleted.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_deleted.feature
@@ -2,7 +2,6 @@ Feature: deleting the current and previous branches makes the main branch the ne
 
   (see ../same_current_branch/previous_branch_same.feature)
 
-
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
     And the "previous" branch gets deleted on the remote

--- a/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_same.feature
@@ -2,14 +2,12 @@ Feature: Git checkout history is preserved when deleting the current branch
 
   (see ../same_current_branch/previous_branch_same.feature)
 
-
   Scenario: kill
     Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town kill"
     Then I am now on the "main" branch
     And the previous Git branch is still "previous"
-
 
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
@@ -21,7 +19,6 @@ Feature: Git checkout history is preserved when deleting the current branch
     When I run "git-town prune-branches"
     Then I am now on the "main" branch
     And the previous Git branch is still "previous"
-
 
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"

--- a/features/shared/checkout_previous_branch_after_success/current_branch_new/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_new/previous_branch_same.feature
@@ -2,7 +2,6 @@ Feature: creating a new branch makes the current branch the new previous branch
 
   (see ../same_current_branch/previous_branch_same.feature)
 
-
   Scenario: hack
     Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_renamed/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_renamed/previous_branch_same.feature
@@ -2,7 +2,6 @@ Feature: Git checkout history is preserved when renaming the current branch
 
   (see ../same_current_branch/previous_branch_same.feature)
 
-
   Scenario: rename-branch
     Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
@@ -2,14 +2,12 @@ Feature: deleting the current branch makes the main branch the new previous bran
 
   (see ./previous_branch_same.feature)
 
-
   Scenario: kill
     Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town kill previous"
     Then I am still on the "current" branch
     And the previous Git branch is now "main"
-
 
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
@@ -21,7 +19,6 @@ Feature: deleting the current branch makes the main branch the new previous bran
     When I run "git-town prune-branches"
     Then I am still on the "current" branch
     And the previous Git branch is now "main"
-
 
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_renamed.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_renamed.feature
@@ -2,7 +2,6 @@ Feature: renaming the previous branch makes the main branch the new previous bra
 
   (see ./previous_branch_same.feature)
 
-
   Scenario: rename-branch
     Given my repo has the feature branches "previous" and "current"
     And I am on the "current" branch with "previous" as the previous Git branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
@@ -4,7 +4,6 @@ Feature: Git checkout history is preserved when the current and previous branch 
   I want to am now on the expected previous branch
   So that Git Town supports my productive use of the Git checkout history
 
-
   Scenario: kill
     Given my repo has the feature branches "previous" and "current"
     And my repo has a feature branch named "victim"
@@ -12,7 +11,6 @@ Feature: Git checkout history is preserved when the current and previous branch 
     When I run "git-town kill victim"
     Then I am still on the "current" branch
     And the previous Git branch is still "previous"
-
 
   Scenario: new-pull-request
     Given my repo has the feature branches "previous" and "current"
@@ -22,7 +20,6 @@ Feature: Git checkout history is preserved when the current and previous branch 
     When I run "git-town new-pull-request"
     Then I am still on the "current" branch
     And the previous Git branch is still "previous"
-
 
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
@@ -35,7 +32,6 @@ Feature: Git checkout history is preserved when the current and previous branch 
     Then I am still on the "current" branch
     And the previous Git branch is still "previous"
 
-
   Scenario: repo
     Given my repo has the feature branches "previous" and "current"
     And my computer has the "open" tool installed
@@ -44,7 +40,6 @@ Feature: Git checkout history is preserved when the current and previous branch 
     When I run "git-town repo"
     Then I am still on the "current" branch
     And the previous Git branch is still "previous"
-
 
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"
@@ -56,7 +51,6 @@ Feature: Git checkout history is preserved when the current and previous branch 
     When I run "git-town ship feature -m "feature done""
     Then I am still on the "current" branch
     And the previous Git branch is still "previous"
-
 
   Scenario: sync
     Given my repo has the feature branches "previous" and "current"

--- a/features/shared/continuing_after_success.feature
+++ b/features/shared/continuing_after_success.feature
@@ -4,7 +4,6 @@ Feature: Show clear error if trying to continue after executing a successful com
   I should see a friendly and descriptive message that the command can not be continued
   So that I don't experience any cryptic errors.
 
-
   Scenario: continuing after successful git-hack
     Given I run "git-town hack new-feature"
     When I run "git-town continue"
@@ -12,7 +11,6 @@ Feature: Show clear error if trying to continue after executing a successful com
       """
       nothing to continue
       """
-
 
   Scenario: continuing after successful git-ship
     Given my repo has a feature branch named "current-feature"
@@ -26,7 +24,6 @@ Feature: Show clear error if trying to continue after executing a successful com
       """
       nothing to continue
       """
-
 
   Scenario: continuing after successful git-sync
     Given I am on the "main" branch

--- a/features/shared/entering_parent_branch.feature
+++ b/features/shared/entering_parent_branch.feature
@@ -5,11 +5,9 @@ Feature: Entering a parent branch name when prompted
   I want to be be able to enter the parent branch efficiently
   So that I am not slowed down much by the process of entering the parent branch.
 
-
   Background:
     Given my repo has the branches "feature-1" and "feature-2"
     And I am on the "feature-2" branch
-
 
   Scenario: choosing the default branch name
     When I run "git-town sync" and answer the prompts:
@@ -18,7 +16,6 @@ Feature: Entering a parent branch name when prompted
     Then Git Town is now aware of this branch hierarchy
       | BRANCH    | PARENT |
       | feature-2 | main   |
-
 
   Scenario: choosing other branches
     When I run "git-town sync" and answer the prompts:
@@ -29,7 +26,6 @@ Feature: Entering a parent branch name when prompted
       | BRANCH    | PARENT    |
       | feature-1 | main      |
       | feature-2 | feature-1 |
-
 
   Scenario: choosing "<none> (make a perennial branch)"
     When I run "git-town sync" and answer the prompts:

--- a/features/shared/invalid_invocation.feature
+++ b/features/shared/invalid_invocation.feature
@@ -4,7 +4,6 @@ Feature: invalid invocation
   I should be reminded of the usage
   So that I can use it correctly without having to look at documentation
 
-
   Scenario Outline: <DESCRIPTION>
     When I run "git-town <CMD>"
     Then it runs no commands

--- a/features/shared/prompting_for_parent_branch.feature
+++ b/features/shared/prompting_for_parent_branch.feature
@@ -5,7 +5,6 @@ Feature: Prompt for parent branch when unknown
   I should see a prompt asking for the information
   So the command can work as I expect
 
-
   Scenario: prompting for parent branch when running git town-append
     Given my repo has a branch "feature-1"
     And I am on the "feature-1" branch
@@ -17,7 +16,6 @@ Feature: Prompt for parent branch when unknown
       | BRANCH    | PARENT    |
       | feature-1 | main      |
       | feature-2 | feature-1 |
-
 
   Scenario: prompting for parent branch when running git town-hack -p
     Given my repo has a branch "feature-1"
@@ -32,7 +30,6 @@ Feature: Prompt for parent branch when unknown
       | feature-1 | main      |
       | feature-2 | feature-1 |
 
-
   Scenario: prompting for parent branch when running git town-kill
     Given my repo has a branch "feature"
     And I am on the "feature" branch
@@ -44,7 +41,6 @@ Feature: Prompt for parent branch when unknown
       | REPOSITORY | BRANCHES |
       | local      | main     |
       | remote     | main     |
-
 
   @skipWindows
   Scenario: prompting for parent branch when running git town-new-pull-request
@@ -59,7 +55,6 @@ Feature: Prompt for parent branch when unknown
       """
       https://github.com/git-town/git-town/compare/feature?expand=1
       """
-
 
   Scenario: prompting for parent branch when running git town-sync
     Given my repo has a branch "feature"
@@ -77,7 +72,6 @@ Feature: Prompt for parent branch when unknown
       | feature | local, remote | feature commit                   |
       |         |               | main commit                      |
       |         |               | Merge branch 'main' into feature |
-
 
   Scenario: prompting for parent branch when running git town-sync --all
     Given my repo has a branch "feature-1"

--- a/features/shared/strip_colors.feature
+++ b/features/shared/strip_colors.feature
@@ -5,7 +5,6 @@ Feature: Strip colors
   I expect the tool to still work
   So that Git Town does not place addititional constraints on my computer setup
 
-
   Scenario: colors are stripped from the output of git commands run internally
     Given I haven't configured Git Town yet
     And my repo has "color.ui" set to "always"

--- a/features/shared/undo.feature
+++ b/features/shared/undo.feature
@@ -4,7 +4,6 @@ Feature: cannot double undo
   I want to be warned that there is nothing to undo
   So that it does undo something twice (most likely causing errors) or undo the undo
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And I am on the "feature" branch
@@ -12,7 +11,6 @@ Feature: cannot double undo
     And I am now on the "main" branch
     And I run "git-town undo"
     And I am now on the "feature" branch
-
 
   Scenario:
     When I run "git-town undo"

--- a/features/shared/unfinished_state.feature
+++ b/features/shared/unfinished_state.feature
@@ -5,7 +5,6 @@ Feature: warn about unfinished prompt asking the user how to proceed
   I want to be warned about it and presented with options
   So I can finish work I started and discard old state that is now irrelevant
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -21,7 +20,6 @@ Feature: warn about unfinished prompt asking the user how to proceed
       To continue after having resolved conflicts, run "git-town continue".
       """
 
-
   Scenario: attempting to sync again and choosing to quit
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER  |
@@ -33,7 +31,6 @@ Feature: warn about unfinished prompt asking the user how to proceed
       """
     And my uncommitted file is stashed
 
-
   Scenario: attempting to sync again and choosing to continue without resolving conflicts
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER        |
@@ -44,7 +41,6 @@ Feature: warn about unfinished prompt asking the user how to proceed
       you must resolve the conflicts before continuing
       """
     And my uncommitted file is stashed
-
 
   Scenario: attempting to sync again and choosing to continue after resolving conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -61,7 +57,6 @@ Feature: warn about unfinished prompt asking the user how to proceed
       |         | git push                           |
       |         | git stash pop                      |
 
-
   Scenario: attempting to sync again and choosing to abort
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER              |
@@ -71,7 +66,6 @@ Feature: warn about unfinished prompt asking the user how to proceed
       | main    | git rebase --abort   |
       |         | git checkout feature |
       | feature | git stash pop        |
-
 
   Scenario: running another command after manually aborting
     Given I run "git rebase --abort"
@@ -88,7 +82,6 @@ Feature: warn about unfinished prompt asking the user how to proceed
       |         | git commit -m "WIP on feature" |
       |         | git checkout main              |
       | main    | git branch -D feature          |
-
 
   Scenario: does not report unfinished state after abort
     Given I run "git-town abort"

--- a/features/ship/current_branch/on_coworker_feature_branch.feature
+++ b/features/ship/current_branch/on_coworker_feature_branch.feature
@@ -4,14 +4,12 @@ Feature: git town-ship: shipping a coworker's feature branch
   I want my coworker to be the author of the commit added to the main branch
   So that my coworker is given credit for their work
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE         | FILE NAME     | AUTHOR                          |
       | feature | local, remote | coworker commit | coworker_file | coworker <coworker@example.com> |
     And I am on the "feature" branch
-
 
   Scenario: result (commit message via CLI)
     When I run "git-town ship -m 'feature done'"
@@ -32,7 +30,6 @@ Feature: git town-ship: shipping a coworker's feature branch
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME     | AUTHOR                          |
       | main   | local, remote | feature done | coworker_file | coworker <coworker@example.com> |
-
 
   Scenario: result (commit message via editor)
     When I run "git-town ship" and enter "feature done" for the commit message

--- a/features/ship/current_branch/on_feature_branch/offline.feature
+++ b/features/ship/current_branch/on_feature_branch/offline.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: offline mode
   I want to be able to ship branches on my local machine
   So that I can keep working as much as possible despite having no internet connection.
 
-
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "feature"
@@ -13,7 +12,6 @@ Feature: git town-ship: offline mode
       | feature | local, remote | feature commit |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -32,7 +30,6 @@ Feature: git town-ship: offline mode
       | BRANCH  | LOCATION | MESSAGE        |
       | main    | local    | feature done   |
       | feature | remote   | feature commit |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/on_child_branch.feature
+++ b/features/ship/current_branch/on_feature_branch/on_child_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: shipping a child branch
   I want to see a warning that this branch has unshipped parents
   So that I don't accidentally also ship the parent branch.
 
-
   Background:
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
@@ -16,7 +15,6 @@ Feature: git town-ship: shipping a child branch
       | feature-3 | local, remote | feature 3 commit | feature_3_file | feature 3 content |
     And I am on the "feature-3" branch
     When I run "git-town ship"
-
 
   Scenario: result
     Then it runs the commands
@@ -34,7 +32,6 @@ Feature: git town-ship: shipping a child branch
       | feature-1 | main      |
       | feature-2 | feature-1 |
       | feature-3 | feature-2 |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/on_parent_branch.feature
+++ b/features/ship/current_branch/on_feature_branch/on_parent_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: shipping a parent branch
   I want that the child branches are direct descendents of main after shipping
   So that my workspace stays in a consistent state at all times.
 
-
   Background:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
@@ -14,7 +13,6 @@ Feature: git town-ship: shipping a parent branch
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |
     And I am on the "parent-feature" branch
     When I run "git-town ship -m 'parent feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -39,7 +37,6 @@ Feature: git town-ship: shipping a parent branch
     And Git Town is now aware of this branch hierarchy
       | BRANCH        | PARENT |
       | child-feature | main   |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/with_open_changes.feature
+++ b/features/ship/current_branch/on_feature_branch/with_open_changes.feature
@@ -4,13 +4,11 @@ Feature: git town-ship: errors if there are open changes
   I should see an error that my branch is in an unfinished state
   So that my users don't experience half-baked features.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And my workspace has an uncommitted file
     And I am on the "feature" branch
     When I run "git-town ship"
-
 
   Scenario: result
     Then it runs no commands
@@ -22,7 +20,6 @@ Feature: git town-ship: errors if there are open changes
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
       | BRANCH | LOCATION |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/commit_message_containing_double_quotes.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: shipping the current feature branch
   I want it to still work as expected
   So shipping is a robust process.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: shipping the current feature branch
       | feature | local, remote | feature commit | feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship -m 'message containing "double quotes"'"
-
 
   Scenario: result
     Then it runs the commands
@@ -38,7 +36,6 @@ Feature: git town-ship: shipping the current feature branch
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                            | FILE NAME    |
       | main   | local, remote | message containing "double quotes" | feature_file |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | feature | local    | conflicting feature commit | conflicting_file | feature content |
     And I am on the "feature" branch
     And I run "git-town ship -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -47,7 +44,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -70,7 +66,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
       |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -31,7 +29,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -42,7 +39,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And there is no merge in progress
     And my repo is left with my original commits
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -65,7 +61,6 @@ Feature: git town-ship: resolving conflicts between the current feature branch a
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | feature | local    | feature commit            | feature_file     | feature content            |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -29,7 +27,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       """
     And my repo now has a rebase in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -39,7 +36,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
     And I am still on the "feature" branch
     And there is no rebase in progress
     And my repo is left with my original commits
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -67,7 +63,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
       |        |               | feature done              | feature_file     |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/default_commit_message.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: trying the ship of the current feature branch without ed
   I want the ship to abort if I don't edit the default commit message
   So that I don't have ugly commits merged into my main branch
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: trying the ship of the current feature branch without ed
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship" and close the editor
-
 
   Scenario: result
     Then it runs the commands
@@ -36,7 +34,6 @@ Feature: git town-ship: trying the ship of the current feature branch without ed
       """
     And I am still on the "feature" branch
     And my repo is left with my original commits
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/delete_remote_branch_disabled.feature
@@ -4,7 +4,6 @@ Feature: Skip deleting the remote branch when shipping the current branch
   I want "git ship" to skip deleting the remote feature branch
   So that I can keep using Git Town in this situation.
 
-
   Background:
     Given my code base has a feature branch named "feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: Skip deleting the remote branch when shipping the current branch
     And my repo has "git-town.ship-delete-remote-branch" set to "false"
     When I run "git-town ship -m 'feature done'"
     And the remote deletes the "feature" branch
-
 
   Scenario: result
     Then it runs the commands
@@ -38,7 +36,6 @@ Feature: Skip deleting the remote branch when shipping the current branch
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
   I want to be able to abort by entering an empty commit message
   So that shipping has the same experience as committing, and Git Town feels like a natural extension to Git.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship" and enter an empty commit message
-
 
   @skipWindows
   Scenario: result
@@ -37,7 +35,6 @@ Feature: git town-ship: aborting the ship of the current feature branch by enter
       """
     And I am still on the "feature" branch
     And my repo is left with my original commits
-
 
   @skipWindows
   Scenario: undo

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/in_subfolder.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: shipping the current feature branch from a subfolder
   I want the command to finish properly
   So that my repo is left in a consistent state and I don't lose any data
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: shipping the current feature branch from a subfolder
       | feature | local, remote | feature commit | new_folder/feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'" in the "new_folder" folder
-
 
   Scenario: result
     Then it runs the commands
@@ -37,7 +35,6 @@ Feature: git town-ship: shipping the current feature branch from a subfolder
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME               |
       | main   | local, remote | feature done | new_folder/feature_file |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/multiple_authors.feature
@@ -5,7 +5,6 @@ Feature: git town-ship: shipping a coworker's feature branch
   I want my coworker to be the author of the commit added to the main branch
   So that my coworker is given credit for their work
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git town-ship: shipping a coworker's feature branch
       |         |          | feature commit2 | developer <developer@example.com> |
       |         |          | feature commit3 | coworker <coworker@example.com>   |
     And I am on the "feature" branch
-
 
   Scenario Outline: prompt for squashed commit author
     When I run "git-town ship -m 'feature done'" and answer the prompts:

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/no_diff.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: errors when trying to ship the current feature branch th
   I should see an error telling me about this
   So that I can investigate this issue, and my users always see meaningful progress.
 
-
   Background:
     Given my repo has a feature branch named "empty-feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-ship: errors when trying to ship the current feature branch th
       | empty-feature | local    | feature commit | common_file | common content |
     And I am on the "empty-feature" branch
     When I run "git-town ship"
-
 
   Scenario: result
     Then it runs the commands
@@ -32,7 +30,6 @@ Feature: git town-ship: errors when trying to ship the current feature branch th
       the branch "empty-feature" has no shippable changes
       """
     And I am still on the "empty-feature" branch
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
   I want to be able to ship it safely in one easy step
   So that I can quickly move on to the next feature and remain productive.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
       | feature | local, remote | feature commit | feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -37,7 +35,6 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: shipping the current feature branch without a remote ori
   I want to be able to ship it safely in one easy step
   So that I can quickly move on to the next feature and remain productive.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And my repo does not have a remote origin
@@ -13,7 +12,6 @@ Feature: git town-ship: shipping the current feature branch without a remote ori
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -30,7 +28,6 @@ Feature: git town-ship: shipping the current feature branch without a remote ori
     And my repo now has the following commits
       | BRANCH | LOCATION | MESSAGE      | FILE NAME    |
       | main   | local    | feature done | feature_file |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
+++ b/features/ship/current_branch/on_feature_branch/without_open_changes/without_tracking_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping the current feature branch without a tracking b
 
   (see ./with_tracking_branch.feature)
 
-
   Background:
     Given my repo has a local feature branch named "feature"
     And the following commits exist in my repo
@@ -10,7 +9,6 @@ Feature: git town-ship: shipping the current feature branch without a tracking b
       | feature | local    | feature commit | feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: git town-ship: shipping the current feature branch without a tracking b
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
+++ b/features/ship/current_branch/on_hotfix_branch/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git town-ship: shipping hotfixes
   I want to ship them similar to feature branches
   So that I can use Git Town to work on hotfixes as well.
 
-
   Background:
     Given my repo has the perennial branch "production"
     And my repo has a feature branch named "hotfix" as a child of "production"
@@ -13,7 +12,6 @@ Feature: git town-ship: shipping hotfixes
       | hotfix | local, remote | hotfix commit | hotfix_file | hotfix content |
     And I am on the "hotfix" branch
     When I run "git-town ship -m 'hotfix done'"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/current_branch/on_main_branch.feature
+++ b/features/ship/current_branch/on_main_branch.feature
@@ -4,11 +4,9 @@ Feature: git town-ship: errors when trying to ship the main branch
   I should see an error that this is not possible
   So that I know how to ship things correctly without having to read the manual.
 
-
   Background:
     Given I am on the "main" branch
     When I run "git-town ship -m 'something done'"
-
 
   Scenario: result
     Then it prints the error:

--- a/features/ship/current_branch/on_non_feature_branch.feature
+++ b/features/ship/current_branch/on_non_feature_branch.feature
@@ -4,12 +4,10 @@ Feature: git town-ship: errors when trying to ship a perennial branch
   I should see an error that this is not possible
   So that I know how to ship things correctly without having to read the manual.
 
-
   Background:
     Given my repo has the perennial branches "qa" and "production"
     And I am on the "production" branch
     When I run "git-town ship"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/branch_does_not_exist.feature
+++ b/features/ship/supplied_branch/branch_does_not_exist.feature
@@ -4,12 +4,10 @@ Feature: git town-ship: errors when trying to ship a branch that doesn't exist
   I should see an error telling me about this
   So that I can ship the correct branch and remain productive.
 
-
   Background:
     Given I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town ship non-existing-branch"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
 
   (see ../../../current_branch/on_feature_branch/without_open_changes/feature_branch_merge_main_branch_conflict.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -35,7 +33,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -51,7 +48,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        |
       | main    | local, remote | conflicting main commit    | conflicting_file |
       | feature | local         | conflicting feature commit | conflicting_file |
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -77,7 +73,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        |
       | main   | local, remote | conflicting main commit | conflicting_file |
       |        |               | feature done            | conflicting_file |
-
 
   Scenario: continuing after resolving the conflicts and comitting
     Given I resolve the conflict in "conflicting_file"

--- a/features/ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/supplied_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
 
   (see ../../../current_branch/on_feature_branch/without_open_changes/feature_branch_merge_tracking_branch_conflict.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -33,7 +31,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -46,7 +43,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And my workspace still contains my uncommitted file
     And there is no merge in progress
     And my repo is left with my original commits
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -72,7 +68,6 @@ Feature: git town-ship: resolving conflicts between the supplied feature branch 
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        |
       | main   | local, remote | feature done | conflicting_file |
-
 
   Scenario: continuing after resolving the conflicts and comitting
     Given I resolve the conflict in "conflicting_file"

--- a/features/ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/supplied_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
 
   (see ../../../current_branch/on_feature_branch/without_open_changes/main_branch_rebase_tracking_branch_conflict.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -31,7 +29,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -43,7 +40,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
     And my workspace still contains my uncommitted file
     And there is no rebase in progress
     And my repo is left with my original commits
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -74,7 +70,6 @@ Feature: git town-ship: resolving conflicts between the main branch and its trac
       | main   | local, remote | conflicting remote commit | conflicting_file |
       |        |               | conflicting local commit  | conflicting_file |
       |        |               | feature done              | feature_file     |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
+++ b/features/ship/supplied_branch/feature_branch/delete_remote_branch_disabled.feature
@@ -4,7 +4,6 @@ Feature: Skip deleting the remote branch when shipping another branch
   I want "git ship" to skip deleting the remote feature branch
   So that I can keep using Git Town in this situation.
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: Skip deleting the remote branch when shipping another branch
     And my repo has "git-town.ship-delete-remote-branch" set to "false"
     When I run "git-town ship feature -m 'feature done'"
     And the remote deletes the "feature" branch
-
 
   Scenario: result
     Then it runs the commands
@@ -41,7 +39,6 @@ Feature: Skip deleting the remote branch when shipping another branch
       | BRANCH        | LOCATION      | MESSAGE      | FILE NAME    |
       | main          | local, remote | feature done | feature_file |
       | other-feature | local         | other commit | other_file   |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/supplied_branch/feature_branch/empty_commit_message.feature
+++ b/features/ship/supplied_branch/feature_branch/empty_commit_message.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: aborting the ship of the supplied feature branch by ente
 
   (see ../../current_branch/on_feature_branch/without_open_changes/empty_commit_message.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: aborting the ship of the supplied feature branch by ente
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file with name "feature_file" and content "conflicting content"
     When I run "git-town ship feature" and enter an empty commit message
-
 
   @skipWindows
   Scenario: result

--- a/features/ship/supplied_branch/feature_branch/in_subfolder.feature
+++ b/features/ship/supplied_branch/feature_branch/in_subfolder.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping the supplied feature branch from a subfolder
 
   (see ../../current_branch/on_feature_branch/without_open_changes/in_subfolder.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -11,7 +10,6 @@ Feature: git town-ship: shipping the supplied feature branch from a subfolder
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file with name "new_folder/other_feature_file" and content "other feature content"
     When I run "git-town ship feature -m 'feature done'" in the "new_folder" folder
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/no_diff.feature
+++ b/features/ship/supplied_branch/feature_branch/no_diff.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: errors when trying to ship the supplied feature branch t
 
   (see ../../current_branch/on_feature_branch/without_open_changes/no_diff.feature)
 
-
   Background:
     Given my repo has the feature branches "empty-feature" and "other-feature"
     And the following commits exist in my repo
@@ -12,7 +11,6 @@ Feature: git town-ship: errors when trying to ship the supplied feature branch t
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town ship empty-feature"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/on_supplied_branch/with_open_changes.feature
+++ b/features/ship/supplied_branch/feature_branch/on_supplied_branch/with_open_changes.feature
@@ -2,13 +2,11 @@ Feature: git town-ship: errors if on supplied branch and there are open changes
 
   (see ../../../current_branch/on_feature_branch/with_open_changes.feature)
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And my workspace has an uncommitted file
     And I am on the "feature" branch
     When I run "git-town ship feature"
-
 
   Scenario: result
     Then it runs no commands

--- a/features/ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
+++ b/features/ship/supplied_branch/feature_branch/on_supplied_branch/without_open_changes.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
 
   (see ../../../current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature)
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -10,7 +9,6 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
       | feature | local, remote | feature commit | feature_file | feature content |
     And I am on the "feature" branch
     When I run "git-town ship feature -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands
@@ -35,7 +33,6 @@ Feature: git town-ship: shipping the current feature branch with a tracking bran
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME    |
       | main   | local, remote | feature done | feature_file |
-
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/supplied_branch/feature_branch/remote_only_branch.feature
+++ b/features/ship/supplied_branch/feature_branch/remote_only_branch.feature
@@ -5,7 +5,6 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
   I want to be able to ship it without explicity fetching
   So that I can quickly move on to the next feature and remain productive.
 
-
   Background:
     Given my repo has a feature branch named "other-feature"
     And my origin has a feature branch named "feature"
@@ -17,7 +16,6 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
     When I run "git-town ship feature -m 'feature done'" and answer the prompts:
       | PROMPT                                        | ANSWER  |
       | Please specify the parent branch of 'feature' | [ENTER] |
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/with_child_branches.feature
+++ b/features/ship/supplied_branch/feature_branch/with_child_branches.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping a parent branch
 
   (see ../../current_branch/on_feature_branch/on_parent_branch.feature)
 
-
   Background:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
@@ -12,7 +11,6 @@ Feature: git town-ship: shipping a parent branch
       | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |
     And I am on the "child-feature" branch
     When I run "git-town ship parent-feature -m 'parent feature done'"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/with_parent_branch.feature
+++ b/features/ship/supplied_branch/feature_branch/with_parent_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping a child branch
 
   (see ../../current_branch/on_feature_branch/on_child_branch.feature)
 
-
   Background:
     Given my repo has a feature branch named "feature-1"
     And my repo has a feature branch named "feature-2" as a child of "feature-1"
@@ -14,7 +13,6 @@ Feature: git town-ship: shipping a child branch
       | feature-3 | local, remote | feature 3 commit | feature_3_file | feature 3 content |
     And I am on the "feature-1" branch
     When I run "git-town ship feature-3 -m 'feature 3 done'"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/with_tracking_branch.feature
+++ b/features/ship/supplied_branch/feature_branch/with_tracking_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
 
   (see ../../current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -11,7 +10,6 @@ Feature: git town-ship: shipping the supplied feature branch with a tracking bra
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file with name "feature_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/without_remote_origin.feature
+++ b/features/ship/supplied_branch/feature_branch/without_remote_origin.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping the supplied feature branch without a remote or
 
   (see ../../current_branch/on_feature_branch/without_open_changes/without_remote_origin.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And my repo does not have a remote origin
@@ -12,7 +11,6 @@ Feature: git town-ship: shipping the supplied feature branch without a remote or
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file with name "feature_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/feature_branch/without_tracking_branch.feature
+++ b/features/ship/supplied_branch/feature_branch/without_tracking_branch.feature
@@ -2,7 +2,6 @@ Feature: git town-ship: shipping the supplied feature branch without a tracking 
 
   (see ../../current_branch/on_feature_branch/without_open_changes/with_tracking_branch.feature)
 
-
   Background:
     Given my repo has the feature branches "feature" and "other-feature"
     And the following commits exist in my repo
@@ -11,7 +10,6 @@ Feature: git town-ship: shipping the supplied feature branch without a tracking 
     And I am on the "other-feature" branch
     And my workspace has an uncommitted file with name "feature_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/main_branch.feature
+++ b/features/ship/supplied_branch/main_branch.feature
@@ -2,13 +2,11 @@ Feature: git town-ship: errors when trying to ship the main branch
 
   (see ../current_branch/on_main_branch.feature)
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town ship main"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/ship/supplied_branch/perennial_branch.feature
+++ b/features/ship/supplied_branch/perennial_branch.feature
@@ -2,13 +2,11 @@ Feature: git town-ship: errors when trying to ship a perennial branch
 
   (see ../current_branch/on_perennial_branch.feature)
 
-
   Background:
     Given my repo has the perennial branches "qa" and "production"
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town ship production"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/first_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -33,7 +32,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -50,7 +48,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-1 | local         | feature-1 local commit  | conflicting_file     |
       |           | remote        | feature-1 remote commit | feature1_remote_file |
       | feature-2 | local, remote | feature-2 commit        | feature2_file        |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -76,7 +73,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | main commit                        | conflicting_file     |
       |           |               | Merge branch 'main' into feature-2 |                      |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -87,7 +83,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-1" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -116,7 +111,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local, remote | feature-2 commit                                               | feature2_file        |
       |           |               | main commit                                                    | conflicting_file     |
       |           |               | Merge branch 'main' into feature-2                             |                      |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates/last_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -37,7 +36,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -57,7 +55,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | Merge branch 'main' into feature-1 |                      |
       | feature-2 | local         | feature-2 local commit             | conflicting_file     |
       |           | remote        | feature-2 remote commit            | feature2_remote_file |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -79,7 +76,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local         | feature-2 local commit             | conflicting_file     |
       |           | remote        | feature-2 remote commit            | feature2_remote_file |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -90,7 +86,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-2" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -115,7 +110,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | Merge remote-tracking branch 'origin/feature-2' into feature-2 |                      |
       |           |               | main commit                                                    | conflicting_file     |
       |           |               | Merge branch 'main' into feature-2                             |                      |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                  |
@@ -30,7 +29,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -41,7 +39,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -68,7 +65,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | conflicting_file | main content      |
       | feature-2 | feature2_file    | feature-2 content |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -84,7 +80,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | feature-1 content |
       | feature-2 | feature2_file    | feature-2 content |
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -113,7 +108,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-1 | conflicting_file | resolved content  |
       | feature-2 | conflicting_file | main content      |
       | feature-2 | feature2_file    | feature-2 content |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                  |
@@ -32,7 +31,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -45,7 +43,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -70,7 +67,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-1 | feature1_file    | feature-1 content |
       | feature-2 | conflicting_file | feature-2 content |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -81,7 +77,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-2" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -108,7 +103,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-1 | conflicting_file | main content      |
       | feature-1 | feature1_file    | feature-1 content |
       | feature-2 | conflicting_file | resolved content  |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/first_branch.feature
@@ -11,7 +11,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -32,7 +31,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -47,7 +45,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | local, remote | main commit      | conflicting_file |
       | feature-1 | local, remote | feature-1 commit | conflicting_file |
       | feature-2 | local, remote | feature-2 commit | feature2_file    |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -71,7 +68,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | main commit                        | conflicting_file |
       |           |               | Merge branch 'main' into feature-2 |                  |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -82,7 +78,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-1" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -109,7 +104,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local, remote | feature-2 commit                   | feature2_file    |
       |           |               | main commit                        | conflicting_file |
       |           |               | Merge branch 'main' into feature-2 |                  |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates/last_branch.feature
@@ -11,7 +11,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -36,7 +35,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -54,7 +52,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | main commit                        | conflicting_file |
       |           |               | Merge branch 'main' into feature-1 |                  |
       | feature-2 | local, remote | feature-2 commit                   | conflicting_file |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -74,7 +71,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | Merge branch 'main' into feature-1 |                  |
       | feature-2 | local, remote | feature-2 commit                   | conflicting_file |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -85,7 +81,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-2" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -108,7 +103,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local, remote | feature-2 commit                   | conflicting_file |
       |           |               | main commit                        | conflicting_file |
       |           |               | Merge branch 'main' into feature-2 |                  |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/first_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -32,7 +31,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -48,7 +46,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-1 | local         | feature-1 local commit  | conflicting_file |
       |           | remote        | feature-1 remote commit | conflicting_file |
       | feature-2 | local, remote | feature-2 commit        | feature2_file    |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -73,7 +70,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | main commit                        | main_file        |
       |           |               | Merge branch 'main' into feature-2 |                  |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -84,7 +80,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-1" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -114,7 +109,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local, remote | feature-2 commit                                               | feature2_file    |
       |           |               | main commit                                                    | main_file        |
       |           |               | Merge branch 'main' into feature-2                             |                  |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_tracking_branch_conflict/last_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -36,7 +35,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -55,7 +53,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | Merge branch 'main' into feature-1 |                  |
       | feature-2 | local         | feature-2 local commit             | conflicting_file |
       |           | remote        | feature-2 remote commit            | conflicting_file |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -76,7 +73,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | feature-2 | local         | feature-2 local commit             | conflicting_file |
       |           | remote        | feature-2 remote commit            | conflicting_file |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -87,7 +83,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
     And I am still on the "feature-2" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -113,7 +108,6 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       |           |               | Merge remote-tracking branch 'origin/feature-2' into feature-2 |                  |
       |           |               | main commit                                                    | main_file        |
       |           |               | Merge branch 'main' into feature-2                             |                  |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -11,7 +11,6 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |
@@ -27,7 +26,6 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
     And my uncommitted file is stashed
     And my repo now has a rebase in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -42,7 +40,6 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |         | remote   | main remote commit | conflicting_file |
       | feature | local    | feature commit     | feature_file     |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -52,7 +49,6 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       """
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -78,7 +74,6 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |         |               | main remote commit               | conflicting_file |
       |         |               | main local commit                | conflicting_file |
       |         |               | Merge branch 'main' into feature |                  |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
+++ b/features/sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/first_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then I am not prompted for any parent branches
     And it runs the commands
@@ -32,7 +31,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
     And my uncommitted file is stashed
     And my repo now has a rebase in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -48,7 +46,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | production | local         | production local commit  | conflicting_file |
       |            | remote        | production remote commit | conflicting_file |
       | qa         | local, remote | qa commit                | qa_file          |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -69,7 +66,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       |            | remote        | production remote commit | conflicting_file |
       | qa         | local, remote | qa commit                | qa_file          |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -79,7 +75,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       """
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -101,7 +96,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | production | local, remote | production remote commit | conflicting_file |
       |            |               | production local commit  | conflicting_file |
       | qa         | local, remote | qa commit                | qa_file          |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
+++ b/features/sync/all_branches/conflicts/perennial_branch_rebase_tracking_branch_conflict/last_branch.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then I am not prompted for any parent branches
     And it runs the commands
@@ -34,7 +33,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
     And my uncommitted file is stashed
     And my repo now has a rebase in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -51,7 +49,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | production | local, remote | production commit | production_file  |
       | qa         | local         | qa local commit   | conflicting_file |
       |            | remote        | qa remote commit  | conflicting_file |
-
 
   Scenario: skipping
     When I run "git-town skip"
@@ -70,7 +67,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | qa         | local         | qa local commit   | conflicting_file |
       |            | remote        | qa remote commit  | conflicting_file |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -80,7 +76,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       """
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -100,7 +95,6 @@ Feature: git-town sync --all: handling rebase conflicts between perennial branch
       | production | local, remote | production commit | production_file  |
       | qa         | local, remote | qa remote commit  | conflicting_file |
       |            |               | qa local commit   | conflicting_file |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/feature_branches.feature
+++ b/features/sync/all_branches/feature_branches.feature
@@ -11,7 +11,6 @@ Feature: git-town sync --all: syncs all feature branches
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                              |

--- a/features/sync/all_branches/perennial_branches.feature
+++ b/features/sync/all_branches/perennial_branches.feature
@@ -13,7 +13,6 @@ Feature: git-town sync --all: syncs all perennial branches
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH     | COMMAND                      |

--- a/features/sync/all_branches/remote_only_branches.feature
+++ b/features/sync/all_branches/remote_only_branches.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: does not sync remote only branches
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH     | COMMAND                               |

--- a/features/sync/all_branches/tags.feature
+++ b/features/sync/all_branches/tags.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing all branches syncs the tags
   I want my tags to be published whenever I sync all my branches
   So that I can do tagging work effectively on my local machine.
 
-
   Background:
     Given my repo has the following tags
       | NAME       | LOCATION |
@@ -12,7 +11,6 @@ Feature: git-town sync: syncing all branches syncs the tags
       | remote-tag | remote   |
     And I am on the "main" branch
     When I run "git-town sync --all"
-
 
   Scenario: result
     Then my repo now has the following tags

--- a/features/sync/all_branches/without_remote_origin.feature
+++ b/features/sync/all_branches/without_remote_origin.feature
@@ -12,7 +12,6 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH    | COMMAND                  |

--- a/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -11,7 +11,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my workspace has an uncommitted file
     When I run "git-town sync"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                            |
@@ -34,7 +33,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -53,7 +51,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
       |         | remote        | feature commit             | feature_file     | feature content |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -64,7 +61,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -89,7 +85,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
       | feature | feature_file     | feature content  |
-
 
   Scenario: continuing after resolving the conflicts and comitting
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
+++ b/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin.feature
@@ -11,7 +11,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my workspace has an uncommitted file
     When I run "git-town sync"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                  |
@@ -28,7 +27,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -40,7 +38,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And there is no merge in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -51,7 +48,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -72,7 +68,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
-
 
   Scenario: continuing after resolving the conflicts and comitting
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
+++ b/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/without_tracking_branch_updates.feature
@@ -10,7 +10,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my workspace has an uncommitted file
     When I run "git-town sync"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                            |
@@ -33,7 +32,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -50,7 +48,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -61,7 +58,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -84,7 +80,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
-
   Scenario: continuing after resolving the conflicts resulting in no changes
     Given I resolve the conflict in "conflicting_file" with "feature content"
     When I run "git-town continue"
@@ -105,7 +100,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | BRANCH  | NAME             | CONTENT         |
       | main    | conflicting_file | main content    |
       | feature | conflicting_file | feature content |
-
 
   Scenario: continuing after resolving the conflicts and comitting
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_tracking_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands
@@ -36,7 +34,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -50,7 +47,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And there is no merge in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -61,7 +57,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And I am still on the "feature" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -82,7 +77,6 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
     And my repo now has the following committed files
       | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |
-
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/feature_branch/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands
@@ -32,7 +30,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -45,7 +42,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And there is no rebase in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -55,7 +51,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       """
     And my repo still has a rebase in progress
     And my uncommitted file is stashed
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -81,7 +76,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/feature_branch/deleted_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/deleted_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: restores deleted tracking branch
   I want a new tracking branch to be created
   So that my work is safe in case my local copy gets lost.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git-town sync: restores deleted tracking branch
     And the "feature" branch gets deleted on the remote
     And I am on the "feature" branch
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/dry_run.feature
+++ b/features/sync/current_branch/feature_branch/dry_run.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
   I want a dry run flag that doesn't run any commands
   So that I can be confident in what the tool does before I use it
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -16,7 +15,6 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --dry-run"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
+++ b/features/sync/current_branch/feature_branch/nested_feature_branch/known_parents.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing a nested feature branch (with known parent branc
   I want my branch to be synced off the updated parent branch
   So that I get correct updates when I sync my feature branch.
 
-
   Scenario:
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"

--- a/features/sync/current_branch/feature_branch/offline.feature
+++ b/features/sync/current_branch/feature_branch/offline.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: offline mode
   I still want to be able to sync my branches locally
   So that I can work despite having no internet connection.
 
-
   Background:
     Given Git Town is in offline mode
     And my repo has a feature branch named "feature"
@@ -17,7 +16,6 @@ Feature: git-town sync: offline mode
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/tags.feature
+++ b/features/sync/current_branch/feature_branch/tags.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing a feature branch pulls tags
   I want that tags are pulled automatically for me whenever I sync
   So that my local workspace has the same tags that exist on the remote
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And my repo has the following tags
@@ -13,7 +12,6 @@ Feature: git-town sync: syncing a feature branch pulls tags
       | remote-tag | remote   |
     And I am on the "feature" branch
     And I run "git-town sync"
-
 
   Scenario: result
     Then my repo now has the following tags

--- a/features/sync/current_branch/feature_branch/two_collaborators.feature
+++ b/features/sync/current_branch/feature_branch/two_collaborators.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: collaborative feature branch syncing
   I want each person to be able to sync their changes with the rest of the team
   So that our collaboration is effective.
 
-
   Background:
     Given I am collaborating with a coworker
     And my repo has a feature branch named "feature"
@@ -14,7 +13,6 @@ Feature: git-town sync: collaborative feature branch syncing
       | BRANCH  | LOCATION | MESSAGE         | FILE NAME     |
       | feature | local    | my commit       | my_file       |
       |         | coworker | coworker commit | coworker_file |
-
 
   Scenario: result
     And I am on the "feature" branch

--- a/features/sync/current_branch/feature_branch/with_ignored_files.feature
+++ b/features/sync/current_branch/feature_branch/with_ignored_files.feature
@@ -6,7 +6,6 @@ Feature: syncing with ignored files
 
   - all files ignored by Git survive a "git sync" process unchanged
 
-
   Scenario: running "git sync" with ignored files
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo

--- a/features/sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
+++ b/features/sync/current_branch/feature_branch/with_merge_pull_branch_strategy.feature
@@ -4,7 +4,6 @@ Feature: git-sync: on a feature branch with merge pull branch strategy
   I want my branch to merge in the main branch instead of rebasing
   So that I never have to rewrite history.
 
-
   Background:
     Given the pull-branch-strategy configuration is "merge"
     And my repo has a feature branch named "feature"
@@ -17,7 +16,6 @@ Feature: git-sync: on a feature branch with merge pull branch strategy
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/with_submodule.feature
+++ b/features/sync/current_branch/feature_branch/with_submodule.feature
@@ -11,7 +11,6 @@ Feature: git-sync: on a feature branch in a repository with a submodule that has
     And my workspace has an uncommitted file with name "submodule/file" and content "a change in the submodule"
     When I run "git-town sync"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                            |

--- a/features/sync/current_branch/feature_branch/with_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
   I want my branch to be updated with changes from the tracking branch and the main branch
   So that my work stays in sync with the main development line, can be merged easily later, and I remain productive.
 
-
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
@@ -16,7 +15,6 @@ Feature: git-town sync: syncing the current feature branch with a tracking branc
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/with_upstream.feature
+++ b/features/sync/current_branch/feature_branch/with_upstream.feature
@@ -11,7 +11,6 @@ Feature: git-sync: on a feature branch with a upstream remote
     And my workspace has an uncommitted file
     When I run "git-town sync"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                            |

--- a/features/sync/current_branch/feature_branch/without_remote_origin.feature
+++ b/features/sync/current_branch/feature_branch/without_remote_origin.feature
@@ -2,7 +2,6 @@ Feature: git-town sync: syncing the current feature branch (without a tracking b
 
   (see ./with_a_tracking_branch.feature)
 
-
   Background:
     Given my repo does not have a remote origin
     And my repo has a local feature branch named "feature"
@@ -13,7 +12,6 @@ Feature: git-town sync: syncing the current feature branch (without a tracking b
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/without_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/without_tracking_branch.feature
@@ -2,7 +2,6 @@ Feature: git-town sync: syncing the current feature branch without a tracking br
 
   (see ./with_a_tracking_branch.feature)
 
-
   Background:
     Given my repo has a local feature branch named "feature"
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git-town sync: syncing the current feature branch without a tracking br
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
+++ b/features/sync/current_branch/main_branch/no_conflict/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the main branch
   I want to be able update my ongoing work to include the latest finished features from the rest of the team
   So that our collaboration remains effective.
 
-
   Background:
     Given I am on the "main" branch
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git-town sync: syncing the main branch
       | remote   | remote commit | remote_file |
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/main_branch/no_conflict/with_upstream.feature
+++ b/features/sync/current_branch/main_branch/no_conflict/with_upstream.feature
@@ -9,7 +9,6 @@ Feature: git-sync: on the main branch with a upstream remote
     And my workspace has an uncommitted file
     When I run "git-town sync"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/sync/current_branch/main_branch/no_conflict/with_upstream_disabled.feature
+++ b/features/sync/current_branch/main_branch/no_conflict/with_upstream_disabled.feature
@@ -12,7 +12,6 @@ Feature: git-sync: on the main branch with a upstream remote
     And my workspace has an uncommitted file
     When I run "git-town sync"
 
-
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
+++ b/features/sync/current_branch/main_branch/no_conflict/without_remote_origin.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the main branch (without remote repo)
   I want to be able update my ongoing work to include the latest finished features from the rest of the team
   So that our collaboration remains effective.
 
-
   Background:
     Given my repo does not have a remote origin
     And I am on the "main" branch
@@ -13,7 +12,6 @@ Feature: git-town sync: syncing the main branch (without remote repo)
       | main   | local    | local commit | local_file |
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands

--- a/features/sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/rebase_tracking_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given I am on the "main" branch
     And the following commits exist in my repo
@@ -13,7 +12,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands
@@ -30,7 +28,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -42,7 +39,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And there is no rebase in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -52,7 +48,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
       """
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -72,7 +67,6 @@ Feature: git-town sync: resolving conflicts between the main branch and its trac
     And my repo now has the following committed files
       | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/main_branch/tags.feature
+++ b/features/sync/current_branch/main_branch/tags.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the main branch syncs the tags
   I want my tags to be published whenever I sync my main branch
   So that I can do tagging work effectively on my local machine.
 
-
   Scenario: Pushing tags
     Given my repo has the following tags
       | NAME      | LOCATION |
@@ -15,7 +14,6 @@ Feature: git-town sync: syncing the main branch syncs the tags
       | NAME      | LOCATION      |
       | local-tag | local, remote |
 
-
   Scenario: fetching tags on a pulled branch
     Given my repo has the following tags
       | NAME       | LOCATION |
@@ -25,7 +23,6 @@ Feature: git-town sync: syncing the main branch syncs the tags
     Then my repo now has the following tags
       | NAME       | LOCATION      |
       | remote-tag | local, remote |
-
 
   Scenario: fetching tags not on a branch
     Given my repo has a remote tag "remote-tag" that is not on a branch

--- a/features/sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
+++ b/features/sync/current_branch/perennial_branch/no_conflict/with_tracking_branch.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the current perennial branch
   I want to be able update my ongoing work to include the latest finished features from the rest of the team
   So that our collaboration remains effective.
 
-
   Background:
     Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git-town sync: syncing the current perennial branch
     And I am on the "qa" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: no conflict
     Then it runs the commands

--- a/features/sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
+++ b/features/sync/current_branch/perennial_branch/no_conflict/without_remote_origin.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the current perennial branch (without remote rep
   I want to be able update my ongoing work to include the latest finished features from the rest of the team
   So that our collaboration remains effective.
 
-
   Background:
     Given my repo does not have a remote origin
     And my repo has the local perennial branches "production" and "qa"
@@ -15,7 +14,6 @@ Feature: git-town sync: syncing the current perennial branch (without remote rep
     And I am on the "qa" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: no conflict
     Then it runs the commands

--- a/features/sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/rebase_tracking_branch_conflict.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
   I want to be given the choice to resolve the conflicts or abort
   So that I can finish the operation as planned or postpone it to a better time.
 
-
   Background:
     Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
     And I am on the "qa" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"
-
 
   Scenario: result
     Then it runs the commands
@@ -32,7 +30,6 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-
   Scenario: aborting
     When I run "git-town abort"
     Then it runs the commands
@@ -44,7 +41,6 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
     And there is no rebase in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
@@ -54,7 +50,6 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
       """
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"
@@ -74,7 +69,6 @@ Feature: git-town sync: resolving conflicts between the current perennial branch
     And my repo now has the following committed files
       | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |
-
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/perennial_branch/tags.feature
+++ b/features/sync/current_branch/perennial_branch/tags.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing the current perennial branch syncs the tags
   I want my tags to be published whenever I sync a perennial branch
   So that I can do tagging work effectively on my local machine.
 
-
   Background:
     Given my repo has the perennial branches "production" and "qa"
     And I am on the "production" branch
@@ -13,7 +12,6 @@ Feature: git-town sync: syncing the current perennial branch syncs the tags
       | local-tag  | local    |
       | remote-tag | remote   |
     When I run "git-town sync"
-
 
   Scenario: result
     Then my repo now has the following tags

--- a/features/sync/folder_does_not_exist_on_main_branch/conflict.feature
+++ b/features/sync/folder_does_not_exist_on_main_branch/conflict.feature
@@ -2,7 +2,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
 
   (see ./no_conflict.feature)
 
-
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repo
@@ -14,7 +13,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all" in the "new_folder" folder
-
 
   Scenario: result
     Then it runs the commands
@@ -35,7 +33,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
       exit status 1
       """
 
-
   Scenario: aborting
     When I run "git-town abort" in the "new_folder" folder
     Then it runs the commands
@@ -49,7 +46,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And there is no merge in progress
     And my repo is left with my original commits
 
-
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue" in the "new_folder" folder
     Then it runs no commands
@@ -60,7 +56,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And I am still on the "current-feature" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
-
 
   Scenario: continuing after resolving the conflicts
     Given I resolve the conflict in "conflicting_file"

--- a/features/sync/folder_does_not_exist_on_main_branch/no_conflict.feature
+++ b/features/sync/folder_does_not_exist_on_main_branch/no_conflict.feature
@@ -4,7 +4,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
   I want the command to finish properly
   So that my repo is left in a consistent state and I don't lose any data
 
-
   Background:
     Given my repo has the feature branches "current-feature" and "other-feature"
     And the following commits exist in my repo
@@ -15,7 +14,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
     And I am on the "current-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all" in the "new_folder" folder
-
 
   Scenario: result
     Then it runs the commands

--- a/features/version/version.feature
+++ b/features/version/version.feature
@@ -4,14 +4,12 @@ Feature: git town: show the current Git Town version
   I want to quickly get this information
   So that I can manage my Git Town deployment effectively.
 
-
   Scenario: Using "version" flag
     When I run "git-town version"
     Then it prints:
       """
       Git Town v0.0.0-dev
       """
-
 
   Scenario: Running outside of a Git repository
     Given my workspace is currently not a Git repo


### PR DESCRIPTION
I am working on a number of cleanups and simplifications to make Gherkin more "normal". Most of the things I'll remove are customizations that I championed when trying to use Gherkin as a platform for cross-disciplinary collaboration on GitHub around a working product. Having used Gherkin for a few more years, I now agree with the Cucumber team that Gherkin is more technical in nature. This is especially true for Git Town that has no other disciplines beyond engineering involved.

Another goal of streamlining our Gherkin is to bring the ratio of Gherkin in this codebase below the ratio of Go as measured by GitHub. Right now, GitHub lists Git Town as a Gherkin repo because Gherkin makes up 56% of the code in this repo. The goal is to get this repo listed as a Go repo, which more correctly reflects it's nature. GitHub uses the [total filesize](https://stackoverflow.com/a/5318688) of all files for each language.

This first PR in this series removes double-empty lines between scenarios. This style was inspired by some of Google's code styleguides. Having used Gherkin for more years, I now consider single empty lines readable enough. The double empty lines cost more in terms of losing automated formatting and bloating feature files than they bring around readability.