### PR TITLE
Omit duplicate branch names in file table

### DIFF
--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/first_branch.feature
@@ -63,7 +63,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | feature-1 content |
       | feature-2 | conflicting_file | main content      |
-      | feature-2 | feature2_file    | feature-2 content |
+      |           | feature2_file    | feature-2 content |
 
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
@@ -107,7 +107,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | resolved content  |
       | feature-2 | conflicting_file | main content      |
-      | feature-2 | feature2_file    | feature-2 content |
+      |           | feature2_file    | feature-2 content |
 
   Scenario: continuing after resolving the conflicts and committing
     Given I resolve the conflict in "conflicting_file"
@@ -135,4 +135,4 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | resolved content  |
       | feature-2 | conflicting_file | main content      |
-      | feature-2 | feature2_file    | feature-2 content |
+      |           | feature2_file    | feature-2 content |

--- a/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
+++ b/features/sync/all_branches/conflicts/feature_branch_merge_main_branch_conflict/without_remote_origin/last_branch.feature
@@ -64,7 +64,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | main content      |
-      | feature-1 | feature1_file    | feature-1 content |
+      |           | feature1_file    | feature-1 content |
       | feature-2 | conflicting_file | feature-2 content |
 
   Scenario: continuing without resolving the conflicts
@@ -101,7 +101,7 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | main content      |
-      | feature-1 | feature1_file    | feature-1 content |
+      |           | feature1_file    | feature-1 content |
       | feature-2 | conflicting_file | resolved content  |
 
   Scenario: continuing after resolving the conflicts and committing
@@ -127,5 +127,5 @@ Feature: git-town sync --all: handling merge conflicts between feature branch an
       | BRANCH    | NAME             | CONTENT           |
       | main      | conflicting_file | main content      |
       | feature-1 | conflicting_file | main content      |
-      | feature-1 | feature1_file    | feature-1 content |
+      |           | feature1_file    | feature-1 content |
       | feature-2 | conflicting_file | resolved content  |

--- a/features/sync/all_branches/without_remote_origin.feature
+++ b/features/sync/all_branches/without_remote_origin.feature
@@ -37,6 +37,6 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
       | BRANCH    | NAME          | CONTENT           |
       | main      | main_file     | main content      |
       | feature-1 | feature1_file | feature-1 content |
-      | feature-1 | main_file     | main content      |
+      |           | main_file     | main content      |
       | feature-2 | feature2_file | feature-2 content |
-      | feature-2 | main_file     | main content      |
+      |           | main_file     | main content      |

--- a/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
+++ b/features/sync/current_branch/feature_branch/conflicts/feature_branch_merge_main_branch_conflict/with_tracking_branch_updates.feature
@@ -84,7 +84,7 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
-      | feature | feature_file     | feature content  |
+      |         | feature_file     | feature content  |
 
   Scenario: continuing after resolving the conflicts and comitting
     Given I resolve the conflict in "conflicting_file"
@@ -108,4 +108,4 @@ Feature: git-town sync: resolving conflicts between the current feature branch a
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
-      | feature | feature_file     | feature content  |
+      |         | feature_file     | feature content  |

--- a/features/sync/current_branch/feature_branch/without_remote_origin.feature
+++ b/features/sync/current_branch/feature_branch/without_remote_origin.feature
@@ -30,4 +30,4 @@ Feature: git-town sync: syncing the current feature branch (without a tracking b
       | BRANCH  | NAME               | CONTENT         |
       | main    | local_main_file    | main content    |
       | feature | local_feature_file | feature content |
-      | feature | local_main_file    | main content    |
+      |         | local_main_file    | main content    |

--- a/features/sync/folder_does_not_exist_on_main_branch/conflict.feature
+++ b/features/sync/folder_does_not_exist_on_main_branch/conflict.feature
@@ -86,6 +86,6 @@ Feature: git-town sync: syncing inside a folder that doesn't exist on the main b
       | BRANCH          | NAME             | CONTENT          |
       | main            | conflicting_file | main content     |
       | current-feature | conflicting_file | resolved content |
-      | current-feature | new_folder/file1 |                  |
+      |                 | new_folder/file1 |                  |
       | other-feature   | conflicting_file | main content     |
-      | other-feature   | file2            |                  |
+      |                 | file2            |                  |

--- a/test/repo.go
+++ b/test/repo.go
@@ -81,6 +81,7 @@ func (repo *Repo) FilesInBranches() (result DataTable, err error) {
 	if err != nil {
 		return result, err
 	}
+	lastBranch := ""
 	for _, branch := range branches {
 		files, err := repo.FilesInBranch(branch)
 		if err != nil {
@@ -91,7 +92,12 @@ func (repo *Repo) FilesInBranches() (result DataTable, err error) {
 			if err != nil {
 				return result, err
 			}
-			result.AddRow(branch, file, content)
+			if branch == lastBranch {
+				result.AddRow("", file, content)
+			} else {
+				result.AddRow(branch, file, content)
+			}
+			lastBranch = branch
 		}
 	}
 	return result, err


### PR DESCRIPTION
This mirrors the behavior of the commit table.