### PR TITLE
Remove unnecessary file details in end-to-end tests

### DIFF
--- a/features/hack/edge_cases/feature_branch_conflict_with_main.feature
+++ b/features/hack/edge_cases/feature_branch_conflict_with_main.feature
@@ -40,6 +40,6 @@ Feature: conflicts between uncommitted changes and the main branch
     And I am now on the "new-feature" branch
     And my workspace now contains the file "conflicting_file" with content "resolved content"
     And my repo now has the following commits
-      | BRANCH      | LOCATION      | MESSAGE            | FILE NAME        |
-      | main        | local, remote | conflicting commit | conflicting_file |
-      | new-feature | local         | conflicting commit | conflicting_file |
+      | BRANCH      | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT |
+      | main        | local, remote | conflicting commit | conflicting_file | main content |
+      | new-feature | local         | conflicting commit | conflicting_file | main content |

--- a/features/hack/edge_cases/feature_branch_in_uncommitted_subfolder.feature
+++ b/features/hack/edge_cases/feature_branch_in_uncommitted_subfolder.feature
@@ -3,8 +3,8 @@ Feature: inside an uncommitted subfolder on a feature branch
   Background:
     Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
-      | BRANCH | LOCATION      | MESSAGE     | FILE NAME |
-      | main   | local, remote | main commit | main_file |
+      | BRANCH | LOCATION      | MESSAGE     |
+      | main   | local, remote | main commit |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file in folder "new_folder"
     When I run "git-town hack new-feature" in the "new_folder" folder

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -37,6 +37,10 @@ Feature: conflicts between the main branch and its tracking branch
     And my workspace has the uncommitted file again
     And there is no rebase in progress
     And my repo is left with my original commits
+    And my repo now has the following commits
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
+      | main   | local    | conflicting local commit  | conflicting_file | local content  |
+      |        | remote   | conflicting remote commit | conflicting_file | remote content |
 
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
@@ -60,11 +64,15 @@ Feature: conflicts between the main branch and its tracking branch
     And I am now on the "new-feature" branch
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
-      | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        |
-      | main        | local, remote | conflicting remote commit | conflicting_file |
-      |             |               | conflicting local commit  | conflicting_file |
-      | new-feature | local         | conflicting remote commit | conflicting_file |
-      |             |               | conflicting local commit  | conflicting_file |
+      | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        | FILE CONTENT     |
+      | main        | local, remote | conflicting remote commit | conflicting_file | remote content   |
+      |             |               | conflicting local commit  | conflicting_file | resolved content |
+      | new-feature | local         | conflicting remote commit | conflicting_file | remote content   |
+      |             |               | conflicting local commit  | conflicting_file | resolved content |
+    And my repo now has the following committed files
+      | BRANCH      | NAME             | CONTENT          |
+      | main        | conflicting_file | resolved content |
+      | new-feature | conflicting_file | resolved content |
 
   Scenario: continuing after resolving the conflicts and finishing the rebase
     When I resolve the conflict in "conflicting_file"
@@ -78,9 +86,3 @@ Feature: conflicts between the main branch and its tracking branch
       | new-feature | git stash pop               |
     And I am now on the "new-feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the following commits
-      | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        |
-      | main        | local, remote | conflicting remote commit | conflicting_file |
-      |             |               | conflicting local commit  | conflicting_file |
-      | new-feature | local         | conflicting remote commit | conflicting_file |
-      |             |               | conflicting local commit  | conflicting_file |

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -4,10 +4,10 @@ Feature: local repository
     Given my repo does not have a remote origin
     And my repo has the local feature branches "good-feature" and "other-feature"
     And the following commits exist in my repo
-      | BRANCH        | LOCATION | MESSAGE              | FILE NAME            |
-      | main          | local    | main commit          | conflicting_file     |
-      | good-feature  | local    | good feature commit  | current_feature_file |
-      | other-feature | local    | other feature commit | other_feature_file   |
+      | BRANCH        | LOCATION | MESSAGE              | FILE NAME        |
+      | main          | local    | main commit          | conflicting_file |
+      | good-feature  | local    | good feature commit  | file             |
+      | other-feature | local    | other feature commit | file             |
     And I am on the "good-feature" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town kill other-feature"
@@ -25,9 +25,9 @@ Feature: local repository
       | REPOSITORY | BRANCHES           |
       | local      | main, good-feature |
     And my repo now has the following commits
-      | BRANCH       | LOCATION | MESSAGE             | FILE NAME            |
-      | main         | local    | main commit         | conflicting_file     |
-      | good-feature | local    | good feature commit | current_feature_file |
+      | BRANCH       | LOCATION | MESSAGE             |
+      | main         | local    | main commit         |
+      | good-feature | local    | good feature commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH       | PARENT |
       | good-feature | main   |

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -5,8 +5,8 @@ Feature: deleting another than the current branch
     And the following commits exist in my repo
       | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
       | main         | local, remote | conflicting with uncommitted changes | conflicting_file |
-      | dead-feature | local, remote | dead-end commit                      | unfortunate_file |
-      | good-feature | local, remote | good commit                          | good_file        |
+      | dead-feature | local, remote | dead-end commit                      | file             |
+      | good-feature | local, remote | good commit                          | file             |
     And I am on the "good-feature" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town kill dead-feature"
@@ -26,7 +26,7 @@ Feature: deleting another than the current branch
     And my repo now has the following commits
       | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
       | main         | local, remote | conflicting with uncommitted changes | conflicting_file |
-      | good-feature | local, remote | good commit                          | good_file        |
+      | good-feature | local, remote | good commit                          | file             |
     And Git Town is now aware of this branch hierarchy
       | BRANCH       | PARENT |
       | good-feature | main   |

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -4,7 +4,7 @@ Feature: merge conflict
     Given my repo has a local feature branch named "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        | FILE CONTENT    |
-      | main    | local, remote | main commit    | conflicting_file | main_content    |
+      | main    | local, remote | main commit    | conflicting_file | main content    |
       | feature | local         | feature commit | conflicting_file | feature content |
     And my computer has the "open" tool installed
     And my repo's origin is "git@github.com:git-town/git-town.git"
@@ -72,11 +72,11 @@ Feature: merge conflict
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
-      | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
-      | main    | local, remote | main commit                      | conflicting_file |
-      | feature | local, remote | feature commit                   | conflicting_file |
-      |         |               | main commit                      | conflicting_file |
-      |         |               | Merge branch 'main' into feature |                  |
+      | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        | FILE CONTENT    |
+      | main    | local, remote | main commit                      | conflicting_file | main content    |
+      | feature | local, remote | feature commit                   | conflicting_file | feature content |
+      |         |               | main commit                      | conflicting_file | main content    |
+      |         |               | Merge branch 'main' into feature |                  |                 |
 
   @skipWindows
   Scenario: continuing after resolving conflicts and committing
@@ -94,9 +94,3 @@ Feature: merge conflict
       """
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the following commits
-      | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
-      | main    | local, remote | main commit                      | conflicting_file |
-      | feature | local, remote | feature commit                   | conflicting_file |
-      |         |               | main commit                      | conflicting_file |
-      |         |               | Merge branch 'main' into feature |                  |

--- a/features/new-pull-request/features/on_outdated_branch.feature
+++ b/features/new-pull-request/features/on_outdated_branch.feature
@@ -4,13 +4,13 @@ Feature: syncing before creating the pull request
     Given my code base has a feature branch named "parent-feature"
     And my code base has a feature branch named "child-feature" as a child of "parent-feature"
     And the following commits exist in my repo
-      | BRANCH         | LOCATION | MESSAGE              | FILE NAME          |
-      | main           | local    | local main commit    | local_main_file    |
-      |                | remote   | remote main commit   | remote_main_file   |
-      | parent-feature | local    | local parent commit  | local_parent_file  |
-      |                | remote   | remote parent commit | remote_parent_file |
-      | child-feature  | local    | local child commit   | local_child_file   |
-      |                | remote   | remote child commit  | remote_child_file  |
+      | BRANCH         | LOCATION | MESSAGE              |
+      | main           | local    | local main commit    |
+      |                | remote   | remote main commit   |
+      | parent-feature | local    | local parent commit  |
+      |                | remote   | remote parent commit |
+      | child-feature  | local    | local child commit   |
+      |                | remote   | remote child commit  |
     And my computer has the "open" tool installed
     And my repo's origin is "git@github.com:git-town/git-town.git"
     And I am on the "child-feature" branch
@@ -44,22 +44,22 @@ Feature: syncing before creating the pull request
     And I am still on the "child-feature" branch
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
-      | BRANCH         | LOCATION      | MESSAGE                                                                  | FILE NAME          |
-      | main           | local, remote | remote main commit                                                       | remote_main_file   |
-      |                |               | local main commit                                                        | local_main_file    |
-      | child-feature  | local, remote | local child commit                                                       | local_child_file   |
-      |                |               | remote child commit                                                      | remote_child_file  |
-      |                |               | Merge remote-tracking branch 'origin/child-feature' into child-feature   |                    |
-      |                |               | local parent commit                                                      | local_parent_file  |
-      |                |               | remote parent commit                                                     | remote_parent_file |
-      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |                    |
-      |                |               | remote main commit                                                       | remote_main_file   |
-      |                |               | local main commit                                                        | local_main_file    |
-      |                |               | Merge branch 'main' into parent-feature                                  |                    |
-      |                |               | Merge branch 'parent-feature' into child-feature                         |                    |
-      | parent-feature | local, remote | local parent commit                                                      | local_parent_file  |
-      |                |               | remote parent commit                                                     | remote_parent_file |
-      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |                    |
-      |                |               | remote main commit                                                       | remote_main_file   |
-      |                |               | local main commit                                                        | local_main_file    |
-      |                |               | Merge branch 'main' into parent-feature                                  |                    |
+      | BRANCH         | LOCATION      | MESSAGE                                                                  |
+      | main           | local, remote | remote main commit                                                       |
+      |                |               | local main commit                                                        |
+      | child-feature  | local, remote | local child commit                                                       |
+      |                |               | remote child commit                                                      |
+      |                |               | Merge remote-tracking branch 'origin/child-feature' into child-feature   |
+      |                |               | local parent commit                                                      |
+      |                |               | remote parent commit                                                     |
+      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |
+      |                |               | remote main commit                                                       |
+      |                |               | local main commit                                                        |
+      |                |               | Merge branch 'main' into parent-feature                                  |
+      |                |               | Merge branch 'parent-feature' into child-feature                         |
+      | parent-feature | local, remote | local parent commit                                                      |
+      |                |               | remote parent commit                                                     |
+      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |
+      |                |               | remote main commit                                                       |
+      |                |               | local main commit                                                        |
+      |                |               | Merge branch 'main' into parent-feature                                  |

--- a/features/prepend/features/hack-push-flag.feature
+++ b/features/prepend/features/hack-push-flag.feature
@@ -4,8 +4,8 @@ Feature: auto-push new branch
     Given the new-branch-push-flag configuration is true
     And my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
-      | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
-      | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
+      | BRANCH           | LOCATION      | MESSAGE                 |
+      | existing-feature | local, remote | existing_feature_commit |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town prepend new-parent"

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -4,8 +4,8 @@ Feature: git prepend: offline mode
     Given Git Town is in offline mode
     And my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
-      | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
-      | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
+      | BRANCH           | LOCATION      | MESSAGE                 |
+      | existing-feature | local, remote | existing_feature_commit |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town prepend new-parent"

--- a/features/prepend/prepend.feature
+++ b/features/prepend/prepend.feature
@@ -3,8 +3,8 @@ Feature: Prepend a branch to a feature branch
   Background:
     Given my repo has a feature branch named "existing-feature"
     And the following commits exist in my repo
-      | BRANCH           | LOCATION      | MESSAGE                 | FILE NAME             | FILE CONTENT             |
-      | existing-feature | local, remote | existing_feature_commit | existing_feature_file | existing feature content |
+      | BRANCH           | LOCATION      | MESSAGE                 |
+      | existing-feature | local, remote | existing_feature_commit |
     And I am on the "existing-feature" branch
     And my workspace has an uncommitted file
     When I run "git-town prepend new-parent"

--- a/features/rename-branch/features/parent_branch.feature
+++ b/features/rename-branch/features/parent_branch.feature
@@ -4,9 +4,9 @@ Feature: rename a parent branch
     Given my repo has a feature branch named "parent-feature"
     And my repo has a feature branch named "child-feature" as a child of "parent-feature"
     And the following commits exist in my repo
-      | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
-      | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |
-      | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |
+      | BRANCH         | LOCATION      | MESSAGE               |
+      | child-feature  | local, remote | child feature commit  |
+      | parent-feature | local, remote | parent feature commit |
     And I am on the "parent-feature" branch
     When I run "git-town rename-branch parent-feature renamed-parent-feature"
 
@@ -21,9 +21,9 @@ Feature: rename a parent branch
       |                        | git branch -D parent-feature                     |
     And I am now on the "renamed-parent-feature" branch
     And my repo now has the following commits
-      | BRANCH                 | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
-      | child-feature          | local, remote | child feature commit  | child_feature_file  | child feature content  |
-      | renamed-parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |
+      | BRANCH                 | LOCATION      | MESSAGE               |
+      | child-feature          | local, remote | child feature commit  |
+      | renamed-parent-feature | local, remote | parent feature commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH                 | PARENT                 |
       | child-feature          | renamed-parent-feature |
@@ -40,9 +40,9 @@ Feature: rename a parent branch
       | parent-feature         | git branch -D renamed-parent-feature                        |
     And I am now on the "parent-feature" branch
     And my repo now has the following commits
-      | BRANCH         | LOCATION      | MESSAGE               | FILE NAME           | FILE CONTENT           |
-      | child-feature  | local, remote | child feature commit  | child_feature_file  | child feature content  |
-      | parent-feature | local, remote | parent feature commit | parent_feature_file | parent feature content |
+      | BRANCH         | LOCATION      | MESSAGE               |
+      | child-feature  | local, remote | child feature commit  |
+      | parent-feature | local, remote | parent feature commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH         | PARENT         |
       | child-feature  | parent-feature |

--- a/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_exists.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_deleted/previous_branch_exists.feature
@@ -18,8 +18,8 @@ Feature: Git checkout history is preserved when deleting the current branch
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"
     And the following commits exist in my repo
-      | BRANCH  | LOCATION | FILE NAME    |
-      | current | local    | feature_file |
+      | BRANCH  | LOCATION |
+      | current | local    |
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town ship -m 'feature done'"
     Then I am now on the "main" branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_deleted.feature
@@ -10,9 +10,6 @@ Feature: deleting the current branch makes the main branch the new previous bran
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
     And the "previous" branch gets deleted on the remote
-    And the following commits exist in my repo
-      | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
-      | current | local    | current_file | current content |
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town prune-branches"
     Then I am still on the "current" branch
@@ -21,8 +18,8 @@ Feature: deleting the current branch makes the main branch the new previous bran
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"
     And the following commits exist in my repo
-      | BRANCH   | LOCATION | FILE NAME    | FILE CONTENT    |
-      | previous | remote   | feature_file | feature content |
+      | BRANCH   | LOCATION |
+      | previous | local    |
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town ship previous -m 'feature done'"
     Then I am still on the "current" branch

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
@@ -19,10 +19,6 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
   Scenario: prune-branches
     Given my repo has the feature branches "previous" and "current"
-    And the following commits exist in my repo
-      | BRANCH   | LOCATION | FILE NAME     | FILE CONTENT     |
-      | previous | local    | previous_file | previous content |
-      | current  | local    | current_file  | current content  |
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town prune-branches"
     Then I am still on the "current" branch
@@ -41,8 +37,8 @@ Feature: Git checkout history is preserved when the current and previous branch 
     Given my repo has the feature branches "previous" and "current"
     And my repo has a feature branch named "feature"
     And the following commits exist in my repo
-      | BRANCH  | LOCATION | FILE NAME    | FILE CONTENT    |
-      | feature | remote   | feature_file | feature content |
+      | BRANCH  | LOCATION |
+      | feature | remote   |
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town ship feature -m "feature done""
     Then I am still on the "current" branch

--- a/features/sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -5,7 +5,7 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE            | FILE NAME        | FILE CONTENT        |
       | main    | local    | main local commit  | conflicting_file | main local content  |
-      | main    | remote   | main remote commit | conflicting_file | main remote content |
+      |         | remote   | main remote commit | conflicting_file | main remote content |
       | feature | local    | feature commit     | feature_file     | feature content     |
     And I am on the "main" branch
     And my workspace has an uncommitted file
@@ -34,11 +34,7 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |        | git stash pop      |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
-    And my repo now has the following commits
-      | BRANCH  | LOCATION | MESSAGE            | FILE NAME        |
-      | main    | local    | main local commit  | conflicting_file |
-      |         | remote   | main remote commit | conflicting_file |
-      | feature | local    | feature commit     | feature_file     |
+    And my repo is left with my original commits
 
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
@@ -67,13 +63,18 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo now has the following commits
-      | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
-      | main    | local, remote | main remote commit               | conflicting_file |
-      |         |               | main local commit                | conflicting_file |
-      | feature | local, remote | feature commit                   | feature_file     |
-      |         |               | main remote commit               | conflicting_file |
-      |         |               | main local commit                | conflicting_file |
-      |         |               | Merge branch 'main' into feature |                  |
+      | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        | FILE CONTENT        |
+      | main    | local, remote | main remote commit               | conflicting_file | main remote content |
+      |         |               | main local commit                | conflicting_file | resolved content    |
+      | feature | local, remote | feature commit                   | feature_file     | feature content     |
+      |         |               | main remote commit               | conflicting_file | main remote content |
+      |         |               | main local commit                | conflicting_file | resolved content    |
+      |         |               | Merge branch 'main' into feature |                  |                     |
+    And my repo now has the following committed files
+      | BRANCH  | NAME             | CONTENT          |
+      | main    | conflicting_file | resolved content |
+      | feature | conflicting_file | resolved content |
+      |         | feature_file     | feature content  |
 
   Scenario: continuing after resolving the conflicts and continuing the rebase
     Given I resolve the conflict in "conflicting_file"
@@ -91,11 +92,3 @@ Feature: git-town sync --all: handling rebase conflicts between main branch and 
       |         | git stash pop                      |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
-    And my repo now has the following commits
-      | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        |
-      | main    | local, remote | main remote commit               | conflicting_file |
-      |         |               | main local commit                | conflicting_file |
-      | feature | local, remote | feature commit                   | feature_file     |
-      |         |               | main remote commit               | conflicting_file |
-      |         |               | main local commit                | conflicting_file |
-      |         |               | Merge branch 'main' into feature |                  |

--- a/features/sync/all_branches/feature_branches.feature
+++ b/features/sync/all_branches/feature_branches.feature
@@ -3,10 +3,10 @@ Feature: git-town sync --all: syncs all feature branches
   Background:
     Given my repo has the feature branches "feature-1" and "feature-2"
     And the following commits exist in my repo
-      | BRANCH    | LOCATION      | MESSAGE          | FILE NAME     |
-      | main      | remote        | main commit      | main_file     |
-      | feature-1 | local, remote | feature-1 commit | feature1_file |
-      | feature-2 | local, remote | feature-2 commit | feature2_file |
+      | BRANCH    | LOCATION      | MESSAGE          |
+      | main      | remote        | main commit      |
+      | feature-1 | local, remote | feature-1 commit |
+      | feature-2 | local, remote | feature-2 commit |
     And I am on the "feature-1" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
@@ -34,11 +34,11 @@ Feature: git-town sync --all: syncs all feature branches
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
     And my repo now has the following commits
-      | BRANCH    | LOCATION      | MESSAGE                            | FILE NAME     |
-      | main      | local, remote | main commit                        | main_file     |
-      | feature-1 | local, remote | feature-1 commit                   | feature1_file |
-      |           |               | main commit                        | main_file     |
-      |           |               | Merge branch 'main' into feature-1 |               |
-      | feature-2 | local, remote | feature-2 commit                   | feature2_file |
-      |           |               | main commit                        | main_file     |
-      |           |               | Merge branch 'main' into feature-2 |               |
+      | BRANCH    | LOCATION      | MESSAGE                            |
+      | main      | local, remote | main commit                        |
+      | feature-1 | local, remote | feature-1 commit                   |
+      |           |               | main commit                        |
+      |           |               | Merge branch 'main' into feature-1 |
+      | feature-2 | local, remote | feature-2 commit                   |
+      |           |               | main commit                        |
+      |           |               | Merge branch 'main' into feature-2 |

--- a/features/sync/all_branches/perennial_branches.feature
+++ b/features/sync/all_branches/perennial_branches.feature
@@ -3,12 +3,12 @@ Feature: git-town sync --all: syncs all perennial branches
   Background:
     Given my repo has the perennial branches "production" and "qa"
     And the following commits exist in my repo
-      | BRANCH     | LOCATION | MESSAGE                  | FILE NAME              |
-      | main       | remote   | main commit              | main_file              |
-      | production | local    | production local commit  | production_local_file  |
-      |            | remote   | production remote commit | production_remote_file |
-      | qa         | local    | qa local commit          | qa_local_file          |
-      |            | remote   | qa remote commit         | qa_remote_file         |
+      | BRANCH     | LOCATION | MESSAGE                  |
+      | main       | remote   | main commit              |
+      | production | local    | production local commit  |
+      |            | remote   | production remote commit |
+      | qa         | local    | qa local commit          |
+      |            | remote   | qa remote commit         |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
@@ -33,9 +33,9 @@ Feature: git-town sync --all: syncs all perennial branches
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
     And my repo now has the following commits
-      | BRANCH     | LOCATION      | MESSAGE                  | FILE NAME              |
-      | main       | local, remote | main commit              | main_file              |
-      | production | local, remote | production remote commit | production_remote_file |
-      |            |               | production local commit  | production_local_file  |
-      | qa         | local, remote | qa remote commit         | qa_remote_file         |
-      |            |               | qa local commit          | qa_local_file          |
+      | BRANCH     | LOCATION      | MESSAGE                  |
+      | main       | local, remote | main commit              |
+      | production | local, remote | production remote commit |
+      |            |               | production local commit  |
+      | qa         | local, remote | qa remote commit         |
+      |            |               | qa local commit          |

--- a/features/sync/all_branches/remote_only_branches.feature
+++ b/features/sync/all_branches/remote_only_branches.feature
@@ -4,10 +4,10 @@ Feature: git-town sync --all: does not sync remote only branches
     Given my repo has a feature branch named "my-feature"
     And my coworker has a feature branch named "co-feature"
     And the following commits exist in my repo
-      | BRANCH     | LOCATION      | MESSAGE         | FILE NAME     |
-      | main       | remote        | main commit     | main_file     |
-      | my-feature | local, remote | my commit       | my_file       |
-      | co-feature | remote        | coworker commit | coworker_file |
+      | BRANCH     | LOCATION      | MESSAGE         |
+      | main       | remote        | main commit     |
+      | my-feature | local, remote | my commit       |
+      | co-feature | remote        | coworker commit |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
@@ -30,9 +30,9 @@ Feature: git-town sync --all: does not sync remote only branches
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
     And my repo now has the following commits
-      | BRANCH     | LOCATION      | MESSAGE                             | FILE NAME     |
-      | main       | local, remote | main commit                         | main_file     |
-      | co-feature | remote        | coworker commit                     | coworker_file |
-      | my-feature | local, remote | my commit                           | my_file       |
-      |            |               | main commit                         | main_file     |
-      |            |               | Merge branch 'main' into my-feature |               |
+      | BRANCH     | LOCATION      | MESSAGE                             |
+      | main       | local, remote | main commit                         |
+      | co-feature | remote        | coworker commit                     |
+      | my-feature | local, remote | my commit                           |
+      |            |               | main commit                         |
+      |            |               | Merge branch 'main' into my-feature |

--- a/features/sync/all_branches/without_remote_origin.feature
+++ b/features/sync/all_branches/without_remote_origin.feature
@@ -4,10 +4,10 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
     Given my repo does not have a remote origin
     And my repo has the local feature branches "feature-1" and "feature-2"
     And the following commits exist in my repo
-      | BRANCH    | LOCATION | MESSAGE          | FILE NAME     | FILE CONTENT      |
-      | main      | local    | main commit      | main_file     | main content      |
-      | feature-1 | local    | feature-1 commit | feature1_file | feature-1 content |
-      | feature-2 | local    | feature-2 commit | feature2_file | feature-2 content |
+      | BRANCH    | LOCATION | MESSAGE          |
+      | main      | local    | main commit      |
+      | feature-1 | local    | feature-1 commit |
+      | feature-2 | local    | feature-2 commit |
     And I am on the "feature-1" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
@@ -25,18 +25,11 @@ Feature: git-town sync --all: syncs all feature branches (without remote repo)
     And I am still on the "feature-1" branch
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
-      | BRANCH    | LOCATION | MESSAGE                            | FILE NAME     |
-      | main      | local    | main commit                        | main_file     |
-      | feature-1 | local    | feature-1 commit                   | feature1_file |
-      |           |          | main commit                        | main_file     |
-      |           |          | Merge branch 'main' into feature-1 |               |
-      | feature-2 | local    | feature-2 commit                   | feature2_file |
-      |           |          | main commit                        | main_file     |
-      |           |          | Merge branch 'main' into feature-2 |               |
-    And my repo now has the following committed files
-      | BRANCH    | NAME          | CONTENT           |
-      | main      | main_file     | main content      |
-      | feature-1 | feature1_file | feature-1 content |
-      |           | main_file     | main content      |
-      | feature-2 | feature2_file | feature-2 content |
-      |           | main_file     | main content      |
+      | BRANCH    | LOCATION | MESSAGE                            |
+      | main      | local    | main commit                        |
+      | feature-1 | local    | feature-1 commit                   |
+      |           |          | main commit                        |
+      |           |          | Merge branch 'main' into feature-1 |
+      | feature-2 | local    | feature-2 commit                   |
+      |           |          | main commit                        |
+      |           |          | Merge branch 'main' into feature-2 |

--- a/features/sync/unfinished_state.feature
+++ b/features/sync/unfinished_state.feature
@@ -4,9 +4,9 @@ Feature: warn about unfinished prompt asking the user how to proceed
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
+      | main   | local    | conflicting local commit  | conflicting_file | local content  |
+      |        | remote   | conflicting remote commit | conflicting_file | remote content |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     And I run "git-town sync"

--- a/features/sync/unfinished_state.feature
+++ b/features/sync/unfinished_state.feature
@@ -4,9 +4,9 @@ Feature: warn about unfinished prompt asking the user how to proceed
   Background:
     Given my repo has a feature branch named "feature"
     And the following commits exist in my repo
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
-      | main   | local    | conflicting local commit  | conflicting_file | local content  |
-      |        | remote   | conflicting remote commit | conflicting_file | remote content |
+      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
+      | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
+      |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     And I run "git-town sync"

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -516,7 +516,7 @@ func (r *Runner) FileContentInCommit(sha string, filename string) (result string
 	}
 	result = outcome.OutputSanitized()
 	if strings.HasPrefix(result, "tree ") {
-		// merge commits get an empty file content
+		// merge commits get an empty file content instead of "tree <SHA>"
 		result = ""
 	}
 	return result, nil

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -514,7 +514,12 @@ func (r *Runner) FileContentInCommit(sha string, filename string) (result string
 	if err != nil {
 		return result, fmt.Errorf("cannot determine the content for file %q in commit %q: %w", filename, sha, err)
 	}
-	return outcome.OutputSanitized(), nil
+	result = outcome.OutputSanitized()
+	if strings.HasPrefix(result, "tree ") {
+		// merge commits get an empty file content
+		result = ""
+	}
+	return result, nil
 }
 
 // FilesInCommit provides the names of the files that the commit with the given SHA changes.


### PR DESCRIPTION
Many tests don't require specifying file name or content, others should verify those elements if they are relevant for the test. Please comment with areas where you disagree and I restore them.