### PR TITLE
Fix Netlify badge

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,4 @@
   base = "website/"
   publish = "book/"
   command = "make setup && make build"
+  ignore = "/bin/false"


### PR DESCRIPTION
It shows "failed" when the deploy gets auto-cancelled because there are no changes to the website in a commit. This is supposed to fix this by avoiding the auto-cancel.