### PR TITLE
Simplify Gherkin syntax

### DIFF
--- a/features/append/append.feature
+++ b/features/append/append.feature
@@ -1,7 +1,7 @@
 Feature: appending a new feature branch to an existing feature branch
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |

--- a/features/append/features/local_repo.feature
+++ b/features/append/features/local_repo.feature
@@ -1,7 +1,7 @@
 Feature: in a local repo
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And my repo does not have a remote origin
     And the following commits exist in my repo
       | BRANCH           | LOCATION | MESSAGE                 |
@@ -31,12 +31,12 @@ Feature: in a local repo
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH           | COMMAND                        |
-      | new-feature      | git add -A                     |
-      |                  | git stash                      |
-      |                  | git checkout existing-feature  |
-      | existing-feature | git branch -d new-feature      |
-      |                  | git stash pop                  |
+      | BRANCH           | COMMAND                       |
+      | new-feature      | git add -A                    |
+      |                  | git stash                     |
+      |                  | git checkout existing-feature |
+      | existing-feature | git branch -d new-feature     |
+      |                  | git stash pop                 |
     And I am now on the "existing-feature" branch
     And Git Town is now aware of this branch hierarchy
       | BRANCH           | PARENT |

--- a/features/append/features/offline.feature
+++ b/features/append/features/offline.feature
@@ -2,7 +2,7 @@ Feature: append in offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has a feature branch named "existing-feature"
+    And my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing feature commit |

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -18,8 +18,8 @@ Feature: show the configuration
     Given the main branch is configured as "main"
     And my repo has the perennial branches "qa" and "staging"
     And my repo has the feature branches "parent-feature" and "stand-alone-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
-    And my repo has a feature branch named "qa-hotfix" as a child of "qa"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
+    And my repo has a feature branch "qa-hotfix" as a child of "qa"
     When I run "git-town config"
     Then it prints:
       """

--- a/features/diff-parent/current_branch.feature
+++ b/features/diff-parent/current_branch.feature
@@ -1,8 +1,8 @@
 Feature: View changes made on the current feature branch
 
   Scenario: on feature branch with parent
-    Given my repo has a feature branch named "feature-1"
-    And my repo has a feature branch named "feature-2" as a child of "feature-1"
+    Given my repo has a feature branch "feature-1"
+    And my repo has a feature branch "feature-2" as a child of "feature-1"
     And I am on the "feature-2" branch
     When I run "git-town diff-parent"
     Then it runs the commands
@@ -11,7 +11,7 @@ Feature: View changes made on the current feature branch
 
   @skipWindows
   Scenario: on feature branch without parent
-    Given my repo has a feature branch named "feature" with no parent
+    Given my repo has a feature branch "feature" with no parent
     And I am on the "feature" branch
     When I run "git-town diff-parent" and answer the prompts:
       | PROMPT                                        | ANSWER  |
@@ -24,7 +24,7 @@ Feature: View changes made on the current feature branch
       | feature | main   |
 
   Scenario: on main branch
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And I am on the "main" branch
     When I run "git-town diff-parent"
     Then it runs no commands

--- a/features/diff-parent/supplied_branch.feature
+++ b/features/diff-parent/supplied_branch.feature
@@ -1,8 +1,8 @@
 Feature: View changes made on another branch
 
   Scenario: feature branch with parent
-    Given my repo has a feature branch named "feature-1"
-    And my repo has a feature branch named "feature-2" as a child of "feature-1"
+    Given my repo has a feature branch "feature-1"
+    And my repo has a feature branch "feature-2" as a child of "feature-1"
     When I run "git-town diff-parent feature-2"
     Then it runs the commands
       | BRANCH | COMMAND                       |
@@ -10,7 +10,7 @@ Feature: View changes made on another branch
 
   @skipWindows
   Scenario: feature branch without parent
-    Given my repo has a feature branch named "feature" with no parent
+    Given my repo has a feature branch "feature" with no parent
     And I am on the "main" branch
     When I run "git-town diff-parent feature" and answer the prompts:
       | PROMPT                                        | ANSWER  |

--- a/features/hack/edge_cases/branch_exists.feature
+++ b/features/hack/edge_cases/branch_exists.feature
@@ -1,7 +1,7 @@
 Feature: already existing branch
 
   Scenario: branch exists locally
-    Given my repo has a feature branch named "existing"
+    Given my repo has a feature branch "existing"
     When I run "git-town hack existing"
     Then it runs the commands
       | BRANCH | COMMAND                  |
@@ -12,7 +12,7 @@ Feature: already existing branch
       """
 
   Scenario: branch exists remotely
-    Given my coworker has a feature branch named "existing-feature"
+    Given my coworker has a feature branch "existing-feature"
     And I am on the "main" branch
     When I run "git-town hack existing-feature"
     Then it runs the commands

--- a/features/hack/edge_cases/feature_branch_conflict_with_main.feature
+++ b/features/hack/edge_cases/feature_branch_conflict_with_main.feature
@@ -1,7 +1,7 @@
 Feature: conflicts between uncommitted changes and the main branch
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT |
       | main   | local, remote | conflicting commit | conflicting_file | main content |

--- a/features/hack/edge_cases/feature_branch_in_committed_subfolder.feature
+++ b/features/hack/edge_cases/feature_branch_in_committed_subfolder.feature
@@ -1,7 +1,7 @@
 Feature: inside a committed subfolder only on the current feature branch
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE       | FILE NAME        |
       | existing-feature | local, remote | folder commit | new_folder/file1 |

--- a/features/hack/edge_cases/feature_branch_in_uncommitted_subfolder.feature
+++ b/features/hack/edge_cases/feature_branch_in_uncommitted_subfolder.feature
@@ -1,7 +1,7 @@
 Feature: inside an uncommitted subfolder on a feature branch
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, remote | main commit |

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -1,7 +1,7 @@
 Feature: conflicts between the main branch and its tracking branch
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
       | main   | local    | conflicting local commit  | conflicting_file | local content  |

--- a/features/hack/features/local_repo.feature
+++ b/features/hack/features/local_repo.feature
@@ -1,7 +1,7 @@
 Feature: local repo
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And my repo does not have a remote origin
     And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE     |

--- a/features/hack/on_feature_branch.feature
+++ b/features/hack/on_feature_branch.feature
@@ -1,7 +1,7 @@
 Feature: on the main branch
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION | MESSAGE                 |
       | main             | remote   | main commit             |

--- a/features/kill/current_branch/edge_cases/perennial_branches.feature
+++ b/features/kill/current_branch/edge_cases/perennial_branches.feature
@@ -1,7 +1,7 @@
 Feature: cannot kill perennial branches
 
   Scenario: trying to delete the main branch
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |

--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -1,8 +1,8 @@
 Feature: killing a local branch
 
   Background:
-    Given my repo has a feature branch named "other-feature"
-    And my repo has a local feature branch named "current-feature"
+    Given my repo has a feature branch "other-feature"
+    And my repo has a local feature branch "current-feature"
     And the following commits exist in my repo
       | BRANCH          | LOCATION      | MESSAGE                |
       | current-feature | local         | current feature commit |

--- a/features/kill/current_branch/features/parent_branch.feature
+++ b/features/kill/current_branch/features/parent_branch.feature
@@ -1,9 +1,9 @@
 Feature: killing a branch within a branch chain
 
   Background:
-    Given my repo has a feature branch named "feature-1"
-    And my repo has a feature branch named "feature-2" as a child of "feature-1"
-    And my repo has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "feature-1"
+    And my repo has a feature branch "feature-2" as a child of "feature-1"
+    And my repo has a feature branch "feature-3" as a child of "feature-2"
     And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |

--- a/features/kill/supplied_branch/edge_cases/perennial_branches.feature
+++ b/features/kill/supplied_branch/edge_cases/perennial_branches.feature
@@ -1,7 +1,7 @@
 Feature: cannot kill perennial branches
 
   Scenario: trying to delete the main branch
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |
@@ -26,7 +26,7 @@ Feature: cannot kill perennial branches
       | feature | main   |
 
   Scenario: trying to delete a perennial branch
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo has the perennial branch "qa"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |

--- a/features/kill/supplied_branch/edge_cases/remote_branch_when_offline.feature
+++ b/features/kill/supplied_branch/edge_cases/remote_branch_when_offline.feature
@@ -2,7 +2,7 @@ Feature: cannot kill a remote branch in offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my origin has a feature branch named "feature"
+    And my origin has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | remote   | feature commit |

--- a/features/kill/supplied_branch/features/parent_branch.feature
+++ b/features/kill/supplied_branch/features/parent_branch.feature
@@ -1,9 +1,9 @@
 Feature: killing a branch within a branch chain
 
   Background:
-    Given my repo has a feature branch named "feature-1"
-    And my repo has a feature branch named "feature-2" as a child of "feature-1"
-    And my repo has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "feature-1"
+    And my repo has a feature branch "feature-2" as a child of "feature-1"
+    And my repo has a feature branch "feature-3" as a child of "feature-2"
     And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |

--- a/features/kill/supplied_branch/features/remote_branch.feature
+++ b/features/kill/supplied_branch/features/remote_branch.feature
@@ -1,7 +1,7 @@
 Feature: deleting a remote only branch
 
   Background:
-    Given my origin has a feature branch named "feature"
+    Given my origin has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | remote   | feature commit |

--- a/features/new-pull-request/bitbucket.feature
+++ b/features/new-pull-request/bitbucket.feature
@@ -2,7 +2,7 @@ Feature: Bitbucket support
 
   @skipWindows
   Scenario Outline: normal origin
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And my computer has the "open" tool installed
     And I am on the "feature" branch
@@ -23,7 +23,7 @@ Feature: Bitbucket support
 
   @skipWindows
   Scenario Outline: origin includes path that looks like a URL
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And my computer has the "open" tool installed
     And I am on the "feature" branch
@@ -44,7 +44,7 @@ Feature: Bitbucket support
 
   @skipWindows
   Scenario Outline: SSH style origin
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And my computer has the "open" tool installed
     And I am on the "feature" branch

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -1,7 +1,7 @@
 Feature: merge conflict
 
   Background:
-    Given my repo has a local feature branch named "feature"
+    Given my repo has a local feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | main commit    | conflicting_file | main content    |

--- a/features/new-pull-request/edge_cases/error_opening_browser.feature
+++ b/features/new-pull-request/edge_cases/error_opening_browser.feature
@@ -1,7 +1,7 @@
 Feature: print the URL when the browser crashes
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "git@github.com:git-town/git-town"
     And my computer has a broken "open" tool installed
     And I am on the "feature" branch

--- a/features/new-pull-request/edge_cases/no_tool.feature
+++ b/features/new-pull-request/edge_cases/no_tool.feature
@@ -1,7 +1,7 @@
 Feature: print the URL when no browser installed
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "git@github.com:git-town/git-town"
     And my computer has no tool to open browsers installed
     And I am on the "feature" branch

--- a/features/new-pull-request/edge_cases/unsupported_hosting_service.feature
+++ b/features/new-pull-request/edge_cases/unsupported_hosting_service.feature
@@ -1,7 +1,7 @@
 Feature: unsupported hosting service
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
 

--- a/features/new-pull-request/features/multi_platform_support.feature
+++ b/features/new-pull-request/features/multi_platform_support.feature
@@ -2,7 +2,7 @@ Feature: support many browsers and operating systems
 
   @skipWindows
   Scenario Outline: supported tool installed
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And my computer has the "<TOOL>" tool installed
     And I am on the "feature" branch
@@ -25,7 +25,7 @@ Feature: support many browsers and operating systems
 
   @skipWindows
   Scenario: no supported tool installed
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And my computer has no tool to open browsers installed
     And I am on the "feature" branch

--- a/features/new-pull-request/features/on_outdated_branch.feature
+++ b/features/new-pull-request/features/on_outdated_branch.feature
@@ -1,8 +1,8 @@
 Feature: syncing before creating the pull request
 
   Background:
-    Given my code base has a feature branch named "parent-feature"
-    And my code base has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my code base has a feature branch "parent-feature"
+    And my code base has a feature branch "child-feature" as a child of "parent-feature"
     And the following commits exist in my repo
       | BRANCH         | LOCATION | MESSAGE              |
       | main           | local    | local main commit    |

--- a/features/new-pull-request/features/self_hosted.feature
+++ b/features/new-pull-request/features/self_hosted.feature
@@ -3,7 +3,7 @@ Feature: self-hosted service
   @skipWindows
   Scenario Outline: self hosted
     And my computer has the "open" tool installed
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
     And my repo has "git-town.code-hosting-driver" set to "<DRIVER>"
     And I am on the "feature" branch

--- a/features/new-pull-request/features/ssh_identity.feature
+++ b/features/new-pull-request/features/ssh_identity.feature
@@ -3,7 +3,7 @@ Feature: using a SSH identity
   @skipWindows
   Scenario Outline: ssh identity
     And my computer has the "open" tool installed
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
     And my repo has "git-town.code-hosting-origin-hostname" set to "<ORIGIN_HOSTNAME>"
     And I am on the "feature" branch

--- a/features/new-pull-request/gitea.feature
+++ b/features/new-pull-request/gitea.feature
@@ -5,7 +5,7 @@ Feature: Gitea support
 
   @skipWindows
   Scenario Outline: normal origin
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -25,7 +25,7 @@ Feature: Gitea support
 
   @skipWindows
   Scenario Outline: origin contains path that looks like a URL
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -45,7 +45,7 @@ Feature: Gitea support
 
   @skipWindows
   Scenario Outline: proper URL encoding
-    Given my repo has a feature branch named "<BRANCH_NAME>"
+    Given my repo has a feature branch "<BRANCH_NAME>"
     And my repo's origin is "https://gitea.com/git-town/git-town"
     And I am on the "<BRANCH_NAME>" branch
     When I run "git-town new-pull-request"
@@ -63,7 +63,7 @@ Feature: Gitea support
 
   @skipWindows
   Scenario Outline: SSH style origin
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -79,8 +79,8 @@ Feature: Gitea support
 
   @skipWindows
   Scenario: nested feature branch with known parent
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And my repo's origin is "git@gitea.com:git-town/git-town.git"
     And I am on the "child-feature" branch
     When I run "git-town new-pull-request"

--- a/features/new-pull-request/github.feature
+++ b/features/new-pull-request/github.feature
@@ -5,7 +5,7 @@ Feature: GitHub support
 
   @skipWindows
   Scenario Outline: normal origin
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -25,7 +25,7 @@ Feature: GitHub support
 
   @skipWindows
   Scenario Outline: origin contains path that looks like a URL
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -45,7 +45,7 @@ Feature: GitHub support
 
   @skipWindows
   Scenario Outline: proper URL encoding
-    Given my repo has a feature branch named "<BRANCH_NAME>"
+    Given my repo has a feature branch "<BRANCH_NAME>"
     And my repo's origin is "https://github.com/git-town/git-town"
     And I am on the "<BRANCH_NAME>" branch
     When I run "git-town new-pull-request"
@@ -63,7 +63,7 @@ Feature: GitHub support
 
   @skipWindows
   Scenario Outline: SSH style origin
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -79,8 +79,8 @@ Feature: GitHub support
 
   @skipWindows
   Scenario: nested feature branch with known parent
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And my repo's origin is "git@github.com:git-town/git-town.git"
     And I am on the "child-feature" branch
     When I run "git-town new-pull-request"

--- a/features/new-pull-request/gitlab.feature
+++ b/features/new-pull-request/gitlab.feature
@@ -5,7 +5,7 @@ Feature: GitLab support
 
   @skipWindows
   Scenario Outline: creating pull-requests
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo's origin is "<ORIGIN>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
@@ -21,8 +21,8 @@ Feature: GitLab support
 
   @skipWindows
   Scenario: nested feature branch with known parent
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And my repo's origin is "git@gitlab.com:kadu/kadu.git"
     And I am on the "child-feature" branch
     When I run "git-town new-pull-request"

--- a/features/prepend/edge_cases/on-perennial-branch.feature
+++ b/features/prepend/edge_cases/on-perennial-branch.feature
@@ -1,7 +1,7 @@
 Feature: cannot prepend perennial branches
 
   Scenario: on main branch
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | feature | local, remote | good commit |

--- a/features/prepend/features/hack-push-flag.feature
+++ b/features/prepend/features/hack-push-flag.feature
@@ -2,7 +2,7 @@ Feature: auto-push new branch
 
   Background:
     Given the new-branch-push-flag configuration is true
-    And my repo has a feature branch named "existing-feature"
+    And my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -2,7 +2,7 @@ Feature: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has a feature branch named "existing-feature"
+    And my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |

--- a/features/prepend/prepend.feature
+++ b/features/prepend/prepend.feature
@@ -1,7 +1,7 @@
 Feature: Prepend a branch to a feature branch
 
   Background:
-    Given my repo has a feature branch named "existing-feature"
+    Given my repo has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | existing-feature | local, remote | existing_feature_commit |

--- a/features/prune-branches/features/shipped_parent.feature
+++ b/features/prune-branches/features/shipped_parent.feature
@@ -1,8 +1,8 @@
 Feature: a parent branch of a local branch was shipped
 
   Background:
-    Given my repo has a feature branch named "feature"
-    And my repo has a feature branch named "feature-child" as a child of "feature"
+    Given my repo has a feature branch "feature"
+    And my repo has a feature branch "feature-child" as a child of "feature"
     And the following commits exist in my repo
       | BRANCH        | LOCATION      | MESSAGE              |
       | feature       | local, remote | feature commit       |

--- a/features/rename-branch/edge_cases/destination_branch_exists.feature
+++ b/features/rename-branch/edge_cases/destination_branch_exists.feature
@@ -22,8 +22,8 @@ Feature: destination branch exists
       | existing-feature | main   |
 
   Scenario: destination branch exists remotely
-    Given my repo has a feature branch named "current-feature"
-    And my coworker has a feature branch named "existing-feature"
+    Given my repo has a feature branch "current-feature"
+    And my coworker has a feature branch "existing-feature"
     And the following commits exist in my repo
       | BRANCH           | LOCATION      | MESSAGE                 |
       | current-feature  | local, remote | current-feature commit  |

--- a/features/rename-branch/edge_cases/offline.feature
+++ b/features/rename-branch/edge_cases/offline.feature
@@ -2,7 +2,7 @@ Feature: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE     |
       | main    | local, remote | main commit |

--- a/features/rename-branch/edge_cases/rename_to_itself.feature
+++ b/features/rename-branch/edge_cases/rename_to_itself.feature
@@ -1,7 +1,7 @@
 Feature: rename a branch to itself
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And I am on the "feature" branch
 
   Scenario: without force

--- a/features/rename-branch/edge_cases/unsynced.feature
+++ b/features/rename-branch/edge_cases/unsynced.feature
@@ -1,7 +1,7 @@
 Feature: rename an unsynced branch
 
   Background:
-    Given my repo has a feature branch named "current-feature"
+    Given my repo has a feature branch "current-feature"
 
   Scenario: unpulled remote commits
     And the following commits exist in my repo

--- a/features/rename-branch/features/parent_branch.feature
+++ b/features/rename-branch/features/parent_branch.feature
@@ -1,8 +1,8 @@
 Feature: rename a parent branch
 
   Background:
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And the following commits exist in my repo
       | BRANCH         | LOCATION      | MESSAGE               |
       | child-feature  | local, remote | child feature commit  |

--- a/features/rename-branch/features/perennial_branch.feature
+++ b/features/rename-branch/features/perennial_branch.feature
@@ -2,7 +2,7 @@ Feature: renaming a perennial branch with a tracking branch
 
   Background:
     Given my repo has the perennial branches "qa" and "production"
-    And my repo has a feature branch named "child-feature" as a child of "production"
+    And my repo has a feature branch "child-feature" as a child of "production"
     And the following commits exist in my repo
       | BRANCH        | LOCATION      | MESSAGE              |
       | production    | local, remote | production commit    |

--- a/features/rename-branch/rename_branch.feature
+++ b/features/rename-branch/rename_branch.feature
@@ -1,7 +1,7 @@
 Feature: rename the current branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo has the perennial branch "production"
     And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE     |

--- a/features/set-parent-branch/set_parent_branch.feature
+++ b/features/set-parent-branch/set_parent_branch.feature
@@ -2,8 +2,8 @@
 Feature: update the parent of a nested feature branch
 
   Background:
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And I am on the "child-feature" branch
 
   Scenario: selecting the default branch (current parent)

--- a/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
+++ b/features/shared/checkout_previous_branch_after_success/current_branch_same/previous_branch_same.feature
@@ -2,7 +2,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
   Scenario: kill
     Given my repo has the feature branches "previous" and "current"
-    And my repo has a feature branch named "victim"
+    And my repo has a feature branch "victim"
     And I am on the "current" branch with "previous" as the previous Git branch
     When I run "git-town kill victim"
     Then I am still on the "current" branch
@@ -35,7 +35,7 @@ Feature: Git checkout history is preserved when the current and previous branch 
 
   Scenario: ship
     Given my repo has the feature branches "previous" and "current"
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION |
       | feature | remote   |

--- a/features/shared/continue_after_success.feature
+++ b/features/shared/continue_after_success.feature
@@ -1,7 +1,7 @@
 Feature: Show explanation when trying to continue after a successful command
 
   Scenario Outline:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And I run "git-town <COMMAND>"
     When I run "git-town continue"
     Then it prints the error:

--- a/features/shared/undo.feature
+++ b/features/shared/undo.feature
@@ -1,7 +1,7 @@
 Feature: cannot double undo
 
   Scenario: calling undo twice
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And I am on the "feature" branch
     And I run "git-town kill"
     And I am now on the "main" branch

--- a/features/ship/current_branch/edge_cases/child_branch.feature
+++ b/features/ship/current_branch/edge_cases/child_branch.feature
@@ -1,9 +1,9 @@
 Feature: cannot ship a child branch
 
   Background:
-    Given my repo has a feature branch named "feature-1"
-    And my repo has a feature branch named "feature-2" as a child of "feature-1"
-    And my repo has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "feature-1"
+    And my repo has a feature branch "feature-2" as a child of "feature-1"
+    And my repo has a feature branch "feature-3" as a child of "feature-2"
     And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |

--- a/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
+++ b/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
@@ -1,7 +1,7 @@
 Feature: commit message can contain double-quotes
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | local    | feature commit |

--- a/features/ship/current_branch/edge_cases/default_commit_message.feature
+++ b/features/ship/current_branch/edge_cases/default_commit_message.feature
@@ -1,7 +1,7 @@
 Feature: must provide a commit message
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | local    | feature commit |

--- a/features/ship/current_branch/edge_cases/empty_branch.feature
+++ b/features/ship/current_branch/edge_cases/empty_branch.feature
@@ -1,7 +1,7 @@
 Feature: cannot ship an empty branch
 
   Background:
-    Given my repo has a feature branch named "empty-feature"
+    Given my repo has a feature branch "empty-feature"
     And the following commits exist in my repo
       | BRANCH        | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
       | main          | remote   | main commit    | common_file | common content |

--- a/features/ship/current_branch/edge_cases/empty_commit_message.feature
+++ b/features/ship/current_branch/edge_cases/empty_commit_message.feature
@@ -1,7 +1,7 @@
 Feature: aborting the ship by empty commit message
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | local    | feature commit |

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -1,7 +1,7 @@
 Feature: handle conflicts between the shipped branch and the main branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -1,7 +1,7 @@
 Feature: handle conflicts between the shipped branch and its tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |

--- a/features/ship/current_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/current_branch/edge_cases/in_subfolder.feature
@@ -1,7 +1,7 @@
 Feature: ship the current feature branch from a subfolder on the shipped branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME               |
       | feature | local, remote | feature commit | new_folder/feature_file |

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -1,7 +1,7 @@
 Feature: handle conflicts between the main branch and its tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/features/ship/current_branch/edge_cases/uncommitted_changes.feature
+++ b/features/ship/current_branch/edge_cases/uncommitted_changes.feature
@@ -1,7 +1,7 @@
 Feature: cannot ship with uncommitted changes
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town ship"

--- a/features/ship/current_branch/features/commit_message_via_cli.feature
+++ b/features/ship/current_branch/features/commit_message_via_cli.feature
@@ -1,7 +1,7 @@
 Feature: shipping the current feature branch with a tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |

--- a/features/ship/current_branch/features/coworker_branch.feature
+++ b/features/ship/current_branch/features/coworker_branch.feature
@@ -1,7 +1,7 @@
 Feature: shipping a coworker's feature branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE         | AUTHOR                          |
       | feature | local, remote | coworker commit | coworker <coworker@example.com> |

--- a/features/ship/current_branch/features/hotfix_branch.feature
+++ b/features/ship/current_branch/features/hotfix_branch.feature
@@ -2,7 +2,7 @@ Feature: ship hotfixes
 
   Background:
     Given my repo has the perennial branch "production"
-    And my repo has a feature branch named "hotfix" as a child of "production"
+    And my repo has a feature branch "hotfix" as a child of "production"
     And the following commits exist in my repo
       | BRANCH | LOCATION      | MESSAGE       |
       | hotfix | local, remote | hotfix commit |

--- a/features/ship/current_branch/features/local_branch.feature
+++ b/features/ship/current_branch/features/local_branch.feature
@@ -1,7 +1,7 @@
 Feature: ship a local feature branch
 
   Background:
-    Given my repo has a local feature branch named "feature"
+    Given my repo has a local feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | local    | feature commit |

--- a/features/ship/current_branch/features/local_repo.feature
+++ b/features/ship/current_branch/features/local_repo.feature
@@ -1,7 +1,7 @@
 Feature: ship a feature branch in a local repo
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my repo does not have a remote origin
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        |

--- a/features/ship/current_branch/features/multiple_authors.feature
+++ b/features/ship/current_branch/features/multiple_authors.feature
@@ -2,7 +2,7 @@
 Feature: shipping a coworker's feature branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE         | AUTHOR                            |
       | feature | local    | feature commit1 | developer <developer@example.com> |

--- a/features/ship/current_branch/features/offline.feature
+++ b/features/ship/current_branch/features/offline.feature
@@ -2,7 +2,7 @@ Feature: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |

--- a/features/ship/current_branch/features/parent_branch.feature
+++ b/features/ship/current_branch/features/parent_branch.feature
@@ -1,8 +1,8 @@
 Feature: shipping a parent branch
 
   Background:
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And the following commits exist in my repo
       | BRANCH         | LOCATION      | MESSAGE               |
       | parent-feature | local, remote | parent feature commit |

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -1,7 +1,7 @@
 Feature: ship-delete-remote-branch disabled
 
   Background:
-    Given my code base has a feature branch named "feature"
+    Given my code base has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |

--- a/features/ship/current_branch/ship_current_branch.feature
+++ b/features/ship/current_branch/ship_current_branch.feature
@@ -1,7 +1,7 @@
 Feature: enter the commit message interactively via the editor
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |

--- a/features/ship/supplied_branch/edge_cases/main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/main_branch.feature
@@ -1,7 +1,7 @@
 Feature: does not ship the main branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town ship main"

--- a/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -1,7 +1,7 @@
 Feature: shipping the current feature branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |

--- a/features/ship/supplied_branch/edge_cases/on_supplied_branch_with_open_changes.feature
+++ b/features/ship/supplied_branch/edge_cases/on_supplied_branch_with_open_changes.feature
@@ -1,7 +1,7 @@
 Feature: does not ship a branch that has open changes
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And my workspace has an uncommitted file
     And I am on the "feature" branch
     When I run "git-town ship feature"

--- a/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
@@ -2,8 +2,8 @@
 Feature: shipping a branch that exists only on the remote
 
   Background:
-    Given my repo has a feature branch named "other-feature"
-    And my origin has a feature branch named "feature"
+    Given my repo has a feature branch "other-feature"
+    And my origin has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME    |
       | feature | remote   | feature commit | feature_file |

--- a/features/ship/supplied_branch/features/child_branch.feature
+++ b/features/ship/supplied_branch/features/child_branch.feature
@@ -1,9 +1,9 @@
 Feature: cannot ship a child branch
 
   Background:
-    Given my repo has a feature branch named "feature-1"
-    And my repo has a feature branch named "feature-2" as a child of "feature-1"
-    And my repo has a feature branch named "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "feature-1"
+    And my repo has a feature branch "feature-2" as a child of "feature-1"
+    And my repo has a feature branch "feature-3" as a child of "feature-2"
     And the following commits exist in my repo
       | BRANCH    | LOCATION      | MESSAGE          |
       | feature-1 | local, remote | feature 1 commit |

--- a/features/ship/supplied_branch/features/parent_branch.feature
+++ b/features/ship/supplied_branch/features/parent_branch.feature
@@ -1,8 +1,8 @@
 Feature: shipping a parent branch
 
   Background:
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And the following commits exist in my repo
       | BRANCH         | LOCATION      | MESSAGE               |
       | parent-feature | local, remote | parent feature commit |

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -1,7 +1,7 @@
 Feature: handling rebase conflicts between main branch and its tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE            | FILE NAME        | FILE CONTENT        |
       | main    | local    | main local commit  | conflicting_file | main local content  |

--- a/features/sync/all_branches/edge_cases/remote_only_branches.feature
+++ b/features/sync/all_branches/edge_cases/remote_only_branches.feature
@@ -1,8 +1,8 @@
 Feature: does not sync remote only branches
 
   Background:
-    Given my repo has a feature branch named "my-feature"
-    And my coworker has a feature branch named "co-feature"
+    Given my repo has a feature branch "my-feature"
+    And my coworker has a feature branch "co-feature"
     And the following commits exist in my repo
       | BRANCH     | LOCATION      | MESSAGE         |
       | main       | remote        | main commit     |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -1,7 +1,7 @@
 Feature: handle conflicts between the current feature branch and the main branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -2,7 +2,7 @@ Feature: handle conflicts between the current feature branch and the main branch
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has a local feature branch named "feature"
+    And my repo has a local feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -1,7 +1,7 @@
 Feature: handle conflicts between the current feature branch and the main branch (with tracking branch updates)
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -1,7 +1,7 @@
 Feature: handle conflicts between the current feature branch and its tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -1,7 +1,7 @@
 Feature: handle conflicts between the main branch and its tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/features/sync/current_branch/feature_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/deleted_tracking_branch.feature
@@ -1,7 +1,7 @@
 Feature: restores deleted tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |

--- a/features/sync/current_branch/feature_branch/features/local_branch.feature
+++ b/features/sync/current_branch/feature_branch/features/local_branch.feature
@@ -1,7 +1,7 @@
 Feature: syncing the current feature branch without a tracking branch
 
   Background:
-    Given my repo has a local feature branch named "feature"
+    Given my repo has a local feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE              |
       | main    | local    | local main commit    |

--- a/features/sync/current_branch/feature_branch/features/local_repo.feature
+++ b/features/sync/current_branch/feature_branch/features/local_repo.feature
@@ -2,7 +2,7 @@ Feature: syncing the current feature branch (without a tracking branch or remote
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has a local feature branch named "feature"
+    And my repo has a local feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE              |
       | main    | local    | local main commit    |

--- a/features/sync/current_branch/feature_branch/features/nested_feature_branches.feature
+++ b/features/sync/current_branch/feature_branch/features/nested_feature_branches.feature
@@ -1,8 +1,8 @@
 Feature: nested feature branches
 
   Scenario:
-    Given my repo has a feature branch named "parent-feature"
-    And my repo has a feature branch named "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent-feature"
+    And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And the following commits exist in my repo
       | BRANCH         | LOCATION | MESSAGE                      |
       | main           | local    | local main commit            |

--- a/features/sync/current_branch/feature_branch/features/offline.feature
+++ b/features/sync/current_branch/feature_branch/features/offline.feature
@@ -2,7 +2,7 @@ Feature: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               |
       | main    | local    | local main commit     |

--- a/features/sync/current_branch/feature_branch/features/pull_branch_strategy.feature
+++ b/features/sync/current_branch/feature_branch/features/pull_branch_strategy.feature
@@ -2,7 +2,7 @@ Feature: with pull-branch-strategy set to "merge"
 
   Background:
     Given the pull-branch-strategy configuration is "merge"
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               |
       | main    | local    | local main commit     |

--- a/features/sync/current_branch/feature_branch/features/two_collaborators.feature
+++ b/features/sync/current_branch/feature_branch/features/two_collaborators.feature
@@ -2,7 +2,7 @@ Feature: collaborative feature branch syncing
 
   Background:
     Given I am collaborating with a coworker
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And my coworker fetches updates
     And my coworker sets the parent branch of "feature" as "main"
     And the following commits exist in my repo

--- a/features/sync/current_branch/feature_branch/features/upstream.feature
+++ b/features/sync/current_branch/feature_branch/features/upstream.feature
@@ -2,7 +2,7 @@ Feature: with upstream remote
 
   Background:
     Given my repo has an upstream repo
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE         |
       | main    | upstream | upstream commit |

--- a/features/sync/current_branch/feature_branch/sync_current_feature_branch.feature
+++ b/features/sync/current_branch/feature_branch/sync_current_feature_branch.feature
@@ -1,7 +1,7 @@
 Feature: syncing the current feature branch with a tracking branch
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               |
       | main    | local    | local main commit     |

--- a/features/sync/features/dry_run.feature
+++ b/features/sync/features/dry_run.feature
@@ -1,7 +1,7 @@
 Feature: dry run
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE               |
       | main    | local    | local main commit     |

--- a/features/sync/features/git_submodules.feature
+++ b/features/sync/features/git_submodules.feature
@@ -2,7 +2,7 @@ Feature: on a feature branch in a repository with a submodule that has uncommitt
 
   Background:
     Given my repo has a submodule
-    And my repo has a feature branch named "feature"
+    And my repo has a feature branch "feature"
     And I am on the "feature" branch
     And my workspace has an uncommitted file with name "submodule/file" and content "a change in the submodule"
     When I run "git-town sync"

--- a/features/sync/features/ignored_files.feature
+++ b/features/sync/features/ignored_files.feature
@@ -1,7 +1,7 @@
 Feature: ignoring files
 
   Scenario: running "git sync" with ignored files
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH  | LOCATION | MESSAGE   | FILE NAME  | FILE CONTENT |
       | feature | local    | my commit | .gitignore | ignored      |

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -2,7 +2,7 @@
 Feature: warn about unfinished prompt asking the user how to proceed
 
   Background:
-    Given my repo has a feature branch named "feature"
+    Given my repo has a feature branch "feature"
     And the following commits exist in my repo
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |

--- a/test/steps.go
+++ b/test/steps.go
@@ -330,7 +330,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my code base has a feature branch named "([^"]*)"$`, func(name string) error {
+	suite.Step(`^my code base has a feature branch "([^"]*)"$`, func(name string) error {
 		err := state.gitEnv.DevRepo.CreateFeatureBranch(name)
 		if err != nil {
 			return err
@@ -338,7 +338,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.PushBranchSetUpstream(name)
 	})
 
-	suite.Step(`^my code base has a feature branch named "([^"]*)" as a child of "([^"]*)"$`, func(branch, parent string) error {
+	suite.Step(`^my code base has a feature branch "([^"]*)" as a child of "([^"]*)"$`, func(branch, parent string) error {
 		err := state.gitEnv.DevRepo.CreateChildFeatureBranch(branch, parent)
 		if err != nil {
 			return err
@@ -363,7 +363,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevShell.MockCommand(tool)
 	})
 
-	suite.Step(`^my (?:coworker|origin) has a feature branch named "([^"]*)"$`, func(branch string) error {
+	suite.Step(`^my (?:coworker|origin) has a feature branch "([^"]*)"$`, func(branch string) error {
 		return state.gitEnv.OriginRepo.CreateBranch(branch, "main")
 	})
 
@@ -413,11 +413,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.CreateBranch(branch, "main")
 	})
 
-	suite.Step(`^my repo has a feature branch named "([^"]*)" with no parent$`, func(branch string) error {
+	suite.Step(`^my repo has a feature branch "([^"]*)" with no parent$`, func(branch string) error {
 		return state.gitEnv.DevRepo.CreateFeatureBranchNoParent(branch)
 	})
 
-	suite.Step(`^my repo has a feature branch named "([^"]+)" as a child of "([^"]+)"$`, func(childBranch, parentBranch string) error {
+	suite.Step(`^my repo has a feature branch "([^"]+)" as a child of "([^"]+)"$`, func(childBranch, parentBranch string) error {
 		err := state.gitEnv.DevRepo.CreateChildFeatureBranch(childBranch, parentBranch)
 		if err != nil {
 			return fmt.Errorf("cannot create feature branch %q: %w", childBranch, err)
@@ -425,7 +425,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.PushBranchSetUpstream(childBranch)
 	})
 
-	suite.Step(`^my repo has a (local )?feature branch named "([^"]*)"$`, func(localStr, branch string) error {
+	suite.Step(`^my repo has a (local )?feature branch "([^"]*)"$`, func(localStr, branch string) error {
 		isLocal := localStr != ""
 		err := state.gitEnv.DevRepo.CreateFeatureBranch(branch)
 		if err != nil {


### PR DESCRIPTION
Removes the filler word "named" from branch definitions. This made the end-to-end tests feel repetitive and read unnecessarily stiff. It was also inconsistent, for example in

> my repo has a feature branch named "child-feature" as a child of "parent-feature"