### PR TITLE
More expressive rebase check

### DIFF
--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -35,7 +35,7 @@ Feature: conflicts between the main branch and its tracking branch
       | existing-feature | git stash pop                 |
     And I am now on the "existing-feature" branch
     And my workspace has the uncommitted file again
-    And there is no rebase in progress
+    And there is no rebase in progress anymore
     And my repo is left with my original commits
     And my repo now has the following commits
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -30,7 +30,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | main   | git rebase --abort   |
       |        | git checkout feature |
     And I am still on the "feature" branch
-    And there is no rebase in progress
+    And there is no rebase in progress anymore
     And my repo is left with my original commits
     And Git Town is still aware of this branch hierarchy
       | BRANCH  | PARENT |

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -36,7 +36,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | other-feature | git stash pop              |
     And I am still on the "other-feature" branch
     And my workspace still contains my uncommitted file
-    And there is no rebase in progress
+    And there is no rebase in progress anymore
     And my repo is left with my original commits
     And Git Town is still aware of this branch hierarchy
       | BRANCH        | PARENT |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -35,7 +35,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | feature | git stash pop        |
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And there is no rebase in progress
+    And there is no rebase in progress anymore
     And my repo is left with my original commits
 
   Scenario: continuing without resolving the conflicts

--- a/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -32,7 +32,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
       |        | git stash pop      |
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
-    And there is no rebase in progress
+    And there is no rebase in progress anymore
     And my repo is left with my original commits
 
   Scenario: continuing without resolving the conflicts

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
       |        | git stash pop      |
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
-    And there is no rebase in progress
+    And there is no rebase in progress anymore
     And my repo is left with my original commits
 
   Scenario: continuing without resolving the conflicts

--- a/test/steps.go
+++ b/test/steps.go
@@ -929,7 +929,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^there is no rebase in progress$`, func() error {
+	suite.Step(`^there is no rebase in progress anymore$`, func() error {
 		hasRebase, err := state.gitEnv.DevRepo.HasRebaseInProgress()
 		if err != nil {
 			return err


### PR DESCRIPTION
We only check that there is no rebase in progress after there was one. This change makes this more clear.