### PR TITLE
Remove unnecessary specs

### DIFF
--- a/features/config/reset.feature
+++ b/features/config/reset.feature
@@ -10,15 +10,3 @@ Feature: reset the configuration
     Given I haven't configured Git Town yet
     When I run "git-town config reset"
     Then Git Town is no longer configured for this repo
-
-  Scenario: the main branch is configured but the perennial branches are not
-    Given the main branch is "main"
-    And the perennial branches are not configured
-    When I run "git-town config reset"
-    Then Git Town is no longer configured for this repo
-
-  Scenario: the main branch is not configured but the perennial branches are
-    Given the main branch is not configured
-    And the perennial branches are "qa"
-    When I run "git-town config reset"
-    Then Git Town is no longer configured for this repo


### PR DESCRIPTION
I think the two remaining specs that cover the extremes are enough. Covering every possible iteration of "this config value exists and this other doesn't" seems to not add meaningful test coverage in a test suite for simply deleting all configuration values. These specs were helpful when creating the feature, now they can be removed as redundant.