### PR TITLE
Remove unnecessary file name verification from commit tables

### DIFF
--- a/features/hack/edge_cases/feature_branch_conflict_with_main.feature
+++ b/features/hack/edge_cases/feature_branch_conflict_with_main.feature
@@ -38,8 +38,8 @@ Feature: conflicts between uncommitted changes and the main branch
     And I run "git-town continue" and close the editor
     Then it runs no commands
     And I am now on the "new-feature" branch
-    And my workspace now contains the file "conflicting_file" with content "resolved content"
     And my repo now has the following commits
       | BRANCH      | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT |
       | main        | local, remote | conflicting commit | conflicting_file | main content |
       | new-feature | local         | conflicting commit | conflicting_file | main content |
+    And my workspace now contains the file "conflicting_file" with content "resolved content"

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -37,10 +37,6 @@ Feature: conflicts between the main branch and its tracking branch
     And my workspace has the uncommitted file again
     And there is no rebase in progress anymore
     And my repo is left with my original commits
-    And my repo now has the following commits
-      | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
-      | main   | local    | conflicting local commit  | conflicting_file | local content  |
-      |        | remote   | conflicting remote commit | conflicting_file | remote content |
 
   Scenario: continuing without resolving the conflicts
     When I run "git-town continue"
@@ -64,11 +60,11 @@ Feature: conflicts between the main branch and its tracking branch
     And I am now on the "new-feature" branch
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
-      | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        | FILE CONTENT     |
-      | main        | local, remote | conflicting remote commit | conflicting_file | remote content   |
-      |             |               | conflicting local commit  | conflicting_file | resolved content |
-      | new-feature | local         | conflicting remote commit | conflicting_file | remote content   |
-      |             |               | conflicting local commit  | conflicting_file | resolved content |
+      | BRANCH      | LOCATION      | MESSAGE                   |
+      | main        | local, remote | conflicting remote commit |
+      |             |               | conflicting local commit  |
+      | new-feature | local         | conflicting remote commit |
+      |             |               | conflicting local commit  |
     And my repo now has the following committed files
       | BRANCH      | NAME             | CONTENT          |
       | main        | conflicting_file | resolved content |

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -23,9 +23,9 @@ Feature: deleting another than the current branch
       | REPOSITORY    | BRANCHES           |
       | local, remote | main, good-feature |
     And my repo now has the following commits
-      | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
-      | main         | local, remote | conflicting with uncommitted changes | conflicting_file |
-      | good-feature | local, remote | good commit                          | file             |
+      | BRANCH       | LOCATION      | MESSAGE                              |
+      | main         | local, remote | conflicting with uncommitted changes |
+      | good-feature | local, remote | good commit                          |
     And Git Town is now aware of this branch hierarchy
       | BRANCH       | PARENT |
       | good-feature | main   |

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -72,11 +72,15 @@ Feature: merge conflict
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
-      | BRANCH  | LOCATION      | MESSAGE                          | FILE NAME        | FILE CONTENT    |
-      | main    | local, remote | main commit                      | conflicting_file | main content    |
-      | feature | local, remote | feature commit                   | conflicting_file | feature content |
-      |         |               | main commit                      | conflicting_file | main content    |
-      |         |               | Merge branch 'main' into feature |                  |                 |
+      | BRANCH  | LOCATION      | MESSAGE                          |
+      | main    | local, remote | main commit                      |
+      | feature | local, remote | feature commit                   |
+      |         |               | main commit                      |
+      |         |               | Merge branch 'main' into feature |
+    And my repo now has the following committed files
+      | BRANCH  | NAME             | CONTENT          |
+      | main    | conflicting_file | main content     |
+      | feature | conflicting_file | resolved content |
 
   @skipWindows
   Scenario: continuing after resolving conflicts and committing

--- a/features/ship/current_branch/features/offline.feature
+++ b/features/ship/current_branch/features/offline.feature
@@ -39,9 +39,7 @@ Feature: offline mode
       | main    | git reset --hard {{ sha 'Initial commit' }}   |
       |         | git checkout feature                          |
     And I am now on the "feature" branch
-    And my repo now has the following commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature commit |
+    And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH  | PARENT |
       | feature | main   |

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -43,9 +43,9 @@ Feature: handle conflicts between the supplied feature branch and the main branc
     And my workspace still contains my uncommitted file
     And there is no merge in progress
     And my repo now has the following commits
-      | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
-      | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
-      | feature | local         | conflicting feature commit | conflicting_file | feature content |
+      | BRANCH  | LOCATION      | MESSAGE                    |
+      | main    | local, remote | conflicting main commit    |
+      | feature | local         | conflicting feature commit |
     And Git Town is still aware of this branch hierarchy
       | BRANCH        | PARENT |
       | feature       | main   |

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
@@ -33,11 +33,11 @@ Feature: syncing inside a folder that doesn't exist on the main branch
     And I am still on the "current-feature" branch
     And my workspace still contains my uncommitted file
     And my repo now has the following commits
-      | BRANCH          | LOCATION      | MESSAGE                                  | FILE NAME        |
-      | main            | local, remote | main commit                              | main_file        |
-      | current-feature | local, remote | folder commit                            | new_folder/file1 |
-      |                 |               | main commit                              | main_file        |
-      |                 |               | Merge branch 'main' into current-feature |                  |
-      | other-feature   | local, remote | other feature commit                     | file2            |
-      |                 |               | main commit                              | main_file        |
-      |                 |               | Merge branch 'main' into other-feature   |                  |
+      | BRANCH          | LOCATION      | MESSAGE                                  |
+      | main            | local, remote | main commit                              |
+      | current-feature | local, remote | folder commit                            |
+      |                 |               | main commit                              |
+      |                 |               | Merge branch 'main' into current-feature |
+      | other-feature   | local, remote | other feature commit                     |
+      |                 |               | main commit                              |
+      |                 |               | Merge branch 'main' into other-feature   |

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -73,15 +73,15 @@ Feature: syncing inside a folder that doesn't exist on the main branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has the following commits
-      | BRANCH          | LOCATION      | MESSAGE                                  | FILE NAME        |
-      | main            | local, remote | conflicting main commit                  | conflicting_file |
-      | current-feature | local, remote | conflicting feature commit               | conflicting_file |
-      |                 |               | folder commit                            | new_folder/file1 |
-      |                 |               | conflicting main commit                  | conflicting_file |
-      |                 |               | Merge branch 'main' into current-feature |                  |
-      | other-feature   | local, remote | other feature commit                     | file2            |
-      |                 |               | conflicting main commit                  | conflicting_file |
-      |                 |               | Merge branch 'main' into other-feature   |                  |
+      | BRANCH          | LOCATION      | MESSAGE                                  |
+      | main            | local, remote | conflicting main commit                  |
+      | current-feature | local, remote | conflicting feature commit               |
+      |                 |               | folder commit                            |
+      |                 |               | conflicting main commit                  |
+      |                 |               | Merge branch 'main' into current-feature |
+      | other-feature   | local, remote | other feature commit                     |
+      |                 |               | conflicting main commit                  |
+      |                 |               | Merge branch 'main' into other-feature   |
     And my repo still has the following committed files
       | BRANCH          | NAME             | CONTENT          |
       | main            | conflicting_file | main content     |

--- a/features/sync/current_branch/main_branch/sync_current_main_branch.feature
+++ b/features/sync/current_branch/main_branch/sync_current_main_branch.feature
@@ -23,6 +23,6 @@ Feature: syncing the main branch
     And my workspace still contains my uncommitted file
     And all branches are now synchronized
     And my repo now has the following commits
-      | BRANCH | LOCATION      | MESSAGE       | FILE NAME   |
-      | main   | local, remote | remote commit | remote_file |
-      |        |               | local commit  | local_file  |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | main   | local, remote | remote commit |
+      |        |               | local commit  |

--- a/features/sync/current_branch/perennial_branch/sync_perennial_branch.feature
+++ b/features/sync/current_branch/perennial_branch/sync_perennial_branch.feature
@@ -20,7 +20,7 @@ Feature: syncing the current perennial branch
     And I am still on the "qa" branch
     And all branches are now synchronized
     And my repo now has the following commits
-      | BRANCH | LOCATION      | MESSAGE       | FILE NAME   |
-      | main   | local, remote | main commit   | main_file   |
-      | qa     | local, remote | remote commit | remote_file |
-      |        |               | local commit  | local_file  |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | main   | local, remote | main commit   |
+      | qa     | local, remote | remote commit |
+      |        |               | local commit  |


### PR DESCRIPTION
The file names of commits are clear from the commit messages, no point in listing them redundantly.