### PR TITLE
Make the tenses of verbs consistent

### DIFF
--- a/features/hack/edge_cases/feature_branch_conflict_with_main.feature
+++ b/features/hack/edge_cases/feature_branch_conflict_with_main.feature
@@ -26,14 +26,14 @@ Feature: conflicts between uncommitted changes and the main branch
       """
     And the file "conflicting_file" contains unresolved conflicts
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it prints the error:
       """
       you must resolve the conflicts before continuing
       """
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs no commands

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -26,7 +26,7 @@ Feature: conflicts between the main branch and its tracking branch
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH           | COMMAND                       |

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -38,7 +38,7 @@ Feature: conflicts between the main branch and its tracking branch
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it prints the error:
       """
@@ -47,7 +47,7 @@ Feature: conflicts between the main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continuing after resolving the conflicts but not finishing the rebase
+  Scenario: continue after resolving the conflicts but not finishing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: conflicts between the main branch and its tracking branch
       | main        | conflicting_file | resolved content |
       | new-feature | conflicting_file | resolved content |
 
-  Scenario: continuing after resolving the conflicts and finishing the rebase
+  Scenario: continue after resolving the conflicts and finishing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/kill/current_branch/edge_cases/perennial_branches.feature
+++ b/features/kill/current_branch/edge_cases/perennial_branches.feature
@@ -1,6 +1,6 @@
 Feature: does not kill perennial branches
 
-  Scenario: trying to delete the main branch
+  Scenario: try delete the main branch
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION      | MESSAGE     |
@@ -20,7 +20,7 @@ Feature: does not kill perennial branches
       | local, remote | main, feature |
     And Git Town still has the original branch hierarchy
 
-  Scenario: trying to delete a perennial branch
+  Scenario: try to delete a perennial branch
     Given my repo has the perennial branch "qa"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE   |

--- a/features/kill/supplied_branch/edge_cases/perennial_branches.feature
+++ b/features/kill/supplied_branch/edge_cases/perennial_branches.feature
@@ -1,6 +1,6 @@
 Feature: does not kill perennial branches
 
-  Scenario: trying to delete the main branch
+  Scenario: try to delete the main branch
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION      | MESSAGE     |
@@ -24,7 +24,7 @@ Feature: does not kill perennial branches
       | BRANCH  | PARENT |
       | feature | main   |
 
-  Scenario: trying to delete a perennial branch
+  Scenario: try to delete a perennial branch
     Given my repo has a feature branch "feature"
     And my repo has the perennial branch "qa"
     And my repo contains the commits

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -31,7 +31,7 @@ Feature: merge conflict
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND              |

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -44,7 +44,7 @@ Feature: merge conflict
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -56,7 +56,7 @@ Feature: merge conflict
     And my repo still has a merge in progress
 
   @skipWindows
-  Scenario: continuing after resolving conflicts
+  Scenario: continue after resolving conflicts
     Given I resolve the conflict in "conflicting_file"
     When I run "git-town continue"
     Then it runs the commands
@@ -83,7 +83,7 @@ Feature: merge conflict
       | feature | conflicting_file | resolved content |
 
   @skipWindows
-  Scenario: continuing after resolving conflicts and committing
+  Scenario: continue after resolving conflicts and committing
     Given I resolve the conflict in "conflicting_file"
     When I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/new-pull-request/features/offline.feature
+++ b/features/new-pull-request/features/offline.feature
@@ -1,6 +1,6 @@
 Feature: offline mode
 
-  Scenario: trying to create a new pull request in offline mode
+  Scenario: try to create a new pull request in offline mode
     Given Git Town is in offline mode
     When I run "git-town new-pull-request"
     Then it prints the error:

--- a/features/prune-branches/features/offline.feature
+++ b/features/prune-branches/features/offline.feature
@@ -1,6 +1,6 @@
 Feature: offline mode
 
-  Scenario: trying to prune branches in offline mode
+  Scenario: try to prune branches in offline mode
     Given Git Town is in offline mode
     When I run "git-town prune-branches"
     Then it prints the error:

--- a/features/rename-branch/edge_cases/on_main_branch.feature
+++ b/features/rename-branch/edge_cases/on_main_branch.feature
@@ -3,7 +3,7 @@ Feature: refuses to rename the main branch
   Background:
     Given I am on the "main" branch
 
-  Scenario: trying to rename
+  Scenario: try to rename
     When I run "git-town rename-branch main renamed-main"
     Then it runs no commands
     And it prints the error:
@@ -12,7 +12,7 @@ Feature: refuses to rename the main branch
       """
     And I am still on the "main" branch
 
-  Scenario: trying to force rename
+  Scenario: try to force rename
     When I run "git-town rename-branch main renamed-main --force"
     Then it runs no commands
     And it prints the error:

--- a/features/repo/edge_cases/offline.feature
+++ b/features/repo/edge_cases/offline.feature
@@ -1,6 +1,6 @@
 Feature: offline mode
 
-  Scenario: trying to prune branches in offline mode
+  Scenario: try to prune branches in offline mode
     Given Git Town is in offline mode
     When I run "git-town repo"
     Then it prints the error:

--- a/features/set-parent-branch/set_parent_branch.feature
+++ b/features/set-parent-branch/set_parent_branch.feature
@@ -6,13 +6,13 @@ Feature: update the parent of a nested feature branch
     And my repo has a feature branch "child-feature" as a child of "parent-feature"
     And I am on the "child-feature" branch
 
-  Scenario: selecting the default branch (current parent)
+  Scenario: select the default branch (current parent)
     When I run "git-town set-parent-branch" and answer the prompts:
       | PROMPT                                              | ANSWER  |
       | Please specify the parent branch of 'child-feature' | [ENTER] |
     And Git Town still has the original branch hierarchy
 
-  Scenario: selecting another branch
+  Scenario: select another branch
     When I run "git-town set-parent-branch" and answer the prompts:
       | PROMPT                                              | ANSWER      |
       | Please specify the parent branch of 'child-feature' | [UP][ENTER] |
@@ -21,7 +21,7 @@ Feature: update the parent of a nested feature branch
       | child-feature  | main   |
       | parent-feature | main   |
 
-  Scenario: choosing "<none> (make a perennial branch)"
+  Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town set-parent-branch" and answer the prompts:
       | PROMPT                                              | ANSWER          |
       | Please specify the parent branch of 'child-feature' | [UP][UP][ENTER] |

--- a/features/shared/undo.feature
+++ b/features/shared/undo.feature
@@ -1,6 +1,6 @@
 Feature: does not double undo
 
-  Scenario: calling undo twice
+  Scenario: call undo twice
     Given my repo has a feature branch "feature"
     And I am on the "feature" branch
     And I run "git-town kill"

--- a/features/shared/unknown_parent_branch.feature
+++ b/features/shared/unknown_parent_branch.feature
@@ -16,7 +16,7 @@ Feature: Prompt for parent branch when unknown
       | prepend feature-2 |
       | sync              |
 
-  Scenario: prompting for parent branch when running git town-hack -p
+  Scenario: prompt for parent branch when running git town-hack -p
     Given my repo has a branch "feature-1"
     And I am on the "feature-1" branch
     When I run "git-town hack -p feature-2" and answer the prompts:
@@ -29,7 +29,7 @@ Feature: Prompt for parent branch when unknown
       | feature-1 | main      |
       | feature-2 | feature-1 |
 
-  Scenario: prompting for parent branch when running git town-new-pull-request
+  Scenario: prompt for parent branch when running git town-new-pull-request
     And my computer has the "open" tool installed
     And my repo has a branch "feature"
     And my repo's origin is "git@github.com:git-town/git-town.git"
@@ -42,7 +42,7 @@ Feature: Prompt for parent branch when unknown
       https://github.com/git-town/git-town/compare/feature?expand=1
       """
 
-  Scenario: prompting for parent branch when running git town-sync --all
+  Scenario: prompt for parent branch when running git town-sync --all
     Given my repo has a branch "feature-1"
     And my repo has a branch "feature-2"
     And my repo contains the commits

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -42,7 +42,7 @@ Feature: handle conflicts between the shipped branch and the main branch
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
     And Git Town still has the original branch hierarchy
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -64,7 +64,7 @@ Feature: handle conflicts between the shipped branch and the main branch
       |        |               | feature done            | conflicting_file | resolved content |
     And Git Town now has no branch hierarchy information
 
-  Scenario: continuing after resolving the conflicts and committing
+  Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -27,7 +27,7 @@ Feature: handle conflicts between the shipped branch and the main branch
     And I am still on the "feature" branch
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND              |

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -25,7 +25,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
     And I am still on the "feature" branch
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND              |

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -37,7 +37,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -59,7 +59,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
       | main   | local, remote | feature done | conflicting_file |
     And Git Town now has no branch hierarchy information
 
-  Scenario: continuing after resolving the conflicts and committing
+  Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -23,7 +23,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       """
     And my repo now has a rebase in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH | COMMAND              |

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -61,7 +61,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       |        |               | feature done              |
     And Git Town now has no branch hierarchy information
 
-  Scenario: continuing after resolving the conflicts and continuing the rebase
+  Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/perennial_branch.feature
+++ b/features/ship/current_branch/edge_cases/perennial_branch.feature
@@ -1,6 +1,6 @@
 Feature: does not ship perennial branches
 
-  Scenario: trying to ship the main branch
+  Scenario: try to ship the main branch
     Given I am on the "main" branch
     When I run "git-town ship -m 'something done'"
     Then it prints the error:
@@ -9,7 +9,7 @@ Feature: does not ship perennial branches
       """
     And I am still on the "main" branch
 
-  Scenario: trying to ship a perennial branch
+  Scenario: try to ship a perennial branch
     Given my repo has the perennial branches "qa" and "production"
     And I am on the "production" branch
     When I run "git-town ship"

--- a/features/ship/current_branch/edge_cases/unconfigured.feature
+++ b/features/ship/current_branch/edge_cases/unconfigured.feature
@@ -1,7 +1,7 @@
 @skipWindows
 Feature: ask for missing configuration information
 
-  Scenario: running unconfigured
+  Scenario: unconfigured
     Given I haven't configured Git Town yet
     When I run "git-town ship" and answer the prompts:
       | PROMPT                                     | ANSWER  |

--- a/features/ship/current_branch/features/multiple_authors.feature
+++ b/features/ship/current_branch/features/multiple_authors.feature
@@ -10,7 +10,7 @@ Feature: shipping a coworker's feature branch
       |         |          | feature commit3 | coworker <coworker@example.com>   |
     And I am on the "feature" branch
 
-  Scenario: choosing myself as the author
+  Scenario: choose myself as the author
     When I run "git-town ship -m 'feature done'" and answer the prompts:
       | PROMPT                                        | ANSWER  |
       | Please choose an author for the squash commit | [ENTER] |
@@ -19,7 +19,7 @@ Feature: shipping a coworker's feature branch
       | main   | local, remote | feature done | developer <developer@example.com> |
     And Git Town now has no branch hierarchy information
 
-  Scenario: choosing my coworker as the author
+  Scenario: choose my coworker as the author
     When I run "git-town ship -m 'feature done'" and answer the prompts:
       | PROMPT                                        | ANSWER        |
       | Please choose an author for the squash commit | [DOWN][ENTER] |

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -48,7 +48,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | feature | local         | conflicting feature commit |
     And Git Town still has the original branch hierarchy
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -75,7 +75,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | BRANCH        | PARENT |
       | other-feature | main   |
 
-  Scenario: continuing after resolving the conflicts and comitting
+  Scenario: continue after resolving the conflicts and comitting
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -31,7 +31,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH        | COMMAND                    |

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -29,7 +29,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH        | COMMAND                    |

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -43,7 +43,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       | BRANCH        | PARENT |
       | other-feature | main   |
 
-  Scenario: continuing after resolving the conflicts and comitting
+  Scenario: continue after resolving the conflicts and comitting
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -27,7 +27,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH        | COMMAND                    |

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -40,7 +40,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -72,7 +72,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | BRANCH        | PARENT |
       | other-feature | main   |
 
-  Scenario: continuing after resolving the conflicts and continuing the rebase
+  Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -45,7 +45,7 @@ Feature: handling merge conflicts between feature branch and main branch in a lo
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
 
-  Scenario: skipping
+  Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
       | BRANCH    | COMMAND                  |
@@ -75,7 +75,7 @@ Feature: handling merge conflicts between feature branch and main branch in a lo
       | feature-3 | conflicting_file | main content      |
       |           | feature3_file    | feature-3 content |
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -86,7 +86,7 @@ Feature: handling merge conflicts between feature branch and main branch in a lo
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -108,7 +108,7 @@ Feature: handling merge conflicts between feature branch and main branch in a lo
       | feature-3 | conflicting_file | main content      |
       |           | feature3_file    | feature-3 content |
 
-  Scenario: continuing after resolving the conflicts and committing
+  Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -32,7 +32,7 @@ Feature: handling merge conflicts between feature branch and main branch in a lo
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH    | COMMAND                                       |

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/no_tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/no_tracking_branch_updates.feature
@@ -62,7 +62,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | feature-2 | conflicting_file | feature-2 content |
       | feature-3 | feature2_file    | feature-3 content |
 
-  Scenario: skipping
+  Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -95,7 +95,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | feature-3 | conflicting_file | main content      |
       |           | feature2_file    | feature-3 content |
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -106,7 +106,7 @@ Feature: handle merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -132,7 +132,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | feature-3 | conflicting_file | main content      |
       |           | feature2_file    | feature-3 content |
 
-  Scenario: continuing after resolving the conflicts and committing
+  Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/no_tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/no_tracking_branch_updates.feature
@@ -36,7 +36,7 @@ Feature: handle merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH    | COMMAND                |

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -64,7 +64,7 @@ Feature: handling merge conflicts between feature branch and main branch
       |           | feature1_file    | feature-1 content       |
       | feature-2 | conflicting_file | feature-2 local content |
 
-  Scenario: skipping
+  Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
       | BRANCH    | COMMAND                                             |
@@ -99,7 +99,7 @@ Feature: handling merge conflicts between feature branch and main branch
       | feature-3 | conflicting_file | main content            |
       |           | feature3_file    | feature-3 content       |
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -110,7 +110,7 @@ Feature: handling merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -137,7 +137,7 @@ Feature: handling merge conflicts between feature branch and main branch
       | feature-3 | conflicting_file     | main content             |
       |           | feature3_file        | feature-3 content        |
 
-  Scenario: continuing after resolving the conflicts and committing
+  Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -37,7 +37,7 @@ Feature: handling merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH    | COMMAND                                             |

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -36,7 +36,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH    | COMMAND                |

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -63,7 +63,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | feature-2 | conflicting_file | feature-2 local content |
       | feature-3 | feature3_file    | feature-3 content       |
 
-  Scenario: skipping
+  Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
       | BRANCH    | COMMAND                              |
@@ -97,7 +97,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | feature-3 | feature3_file    | feature-3 content       |
       |           | main_file        | main content            |
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -108,7 +108,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -136,7 +136,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | feature-3 | feature3_file    | feature-3 content |
       |           | main_file        | main content      |
 
-  Scenario: continuing after resolving the conflicts and committing
+  Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -26,7 +26,7 @@ Feature: handling rebase conflicts between main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo now has a rebase in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH | COMMAND            |

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -36,7 +36,7 @@ Feature: handling rebase conflicts between main branch and its tracking branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -46,7 +46,7 @@ Feature: handling rebase conflicts between main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -69,7 +69,7 @@ Feature: handling rebase conflicts between main branch and its tracking branch
       | feature | conflicting_file | resolved content |
       |         | feature_file     | feature content  |
 
-  Scenario: continuing after resolving the conflicts and continuing the rebase
+  Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: handling rebase conflicts between perennial branch and its tracking bra
     And my uncommitted file is stashed
     And my repo now has a rebase in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH      | COMMAND                  |

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -52,7 +52,7 @@ Feature: handling rebase conflicts between perennial branch and its tracking bra
       |             | remote        | perennial-2 remote commit |
       | perennial-3 | local, remote | perennial-3 commit        |
 
-  Scenario: skipping
+  Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
       | BRANCH      | COMMAND                       |
@@ -72,7 +72,7 @@ Feature: handling rebase conflicts between perennial branch and its tracking bra
       |             | remote        | perennial-2 remote commit |
       | perennial-3 | local, remote | perennial-3 commit        |
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -82,7 +82,7 @@ Feature: handling rebase conflicts between perennial branch and its tracking bra
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -98,7 +98,7 @@ Feature: handling rebase conflicts between perennial branch and its tracking bra
     And my workspace has the uncommitted file again
     And all branches are now synchronized
 
-  Scenario: continuing after resolving the conflicts and continuing the rebase
+  Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -48,7 +48,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -59,7 +59,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -75,7 +75,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continuing after resolving the conflicts resulting in no changes
+  Scenario: continue after resolving the conflicts resulting in no changes
     When I resolve the conflict in "conflicting_file" with "feature content"
     And I run "git-town continue"
     Then it runs the commands
@@ -91,7 +91,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content    |
       | feature | conflicting_file | feature content |
 
-  Scenario: continuing after resolving the conflicts and comitting
+  Scenario: continue after resolving the conflicts and comitting
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -32,7 +32,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND              |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -27,7 +27,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND           |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -38,7 +38,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -49,7 +49,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -64,7 +64,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continuing after resolving the conflicts and comitting
+  Scenario: continue after resolving the conflicts and comitting
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -51,7 +51,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
       |         | remote        | feature commit             | feature_file     | feature content |
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -62,7 +62,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -79,7 +79,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | feature | conflicting_file | resolved content |
       |         | feature_file     | feature content  |
 
-  Scenario: continuing after resolving the conflicts and comitting
+  Scenario: continue after resolving the conflicts and comitting
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -33,7 +33,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND                                                 |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -43,7 +43,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -54,7 +54,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
       | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continuing after resolving the conflicts and committing
+  Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -30,7 +30,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND              |

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -38,7 +38,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -48,7 +48,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo still has a rebase in progress
     And my uncommitted file is stashed
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -68,7 +68,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continuing after resolving the conflicts and continuing the rebase
+  Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -26,7 +26,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH  | COMMAND              |

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -31,7 +31,7 @@ Feature: syncing inside a folder that doesn't exist on the main branch
       exit status 1
       """
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort" in the "new_folder" folder
     Then it runs the commands
       | BRANCH          | COMMAND                      |

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -44,7 +44,7 @@ Feature: syncing inside a folder that doesn't exist on the main branch
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue" in the "new_folder" folder
     Then it runs no commands
     And it prints the error:
@@ -55,7 +55,7 @@ Feature: syncing inside a folder that doesn't exist on the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" in the "new_folder" folder
     Then it runs the commands

--- a/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -35,7 +35,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -45,7 +45,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -61,7 +61,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
       | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
 
-  Scenario: continuing after resolving the conflicts and continuing the rebase
+  Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -24,7 +24,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH | COMMAND            |

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -26,7 +26,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     And my repo now has a rebase in progress
     And my uncommitted file is stashed
 
-  Scenario: aborting
+  Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH | COMMAND            |

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -37,7 +37,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continuing without resolving the conflicts
+  Scenario: continue without resolving the conflicts
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -47,7 +47,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continuing after resolving the conflicts
+  Scenario: continue after resolving the conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -63,7 +63,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
       | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |
 
-  Scenario: continuing after resolving the conflicts and continuing the rebase
+  Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/features/ignored_files.feature
+++ b/features/sync/features/ignored_files.feature
@@ -1,6 +1,6 @@
 Feature: ignoring files
 
-  Scenario: running "git sync" with ignored files
+  Scenario: with ignored files
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE   | FILE NAME  | FILE CONTENT |

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -16,7 +16,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
       To continue after having resolved conflicts, run "git-town continue".
       """
 
-  Scenario: attempting to sync again and choosing to quit
+  Scenario: attempt to sync again and choosing to quit
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER  |
       | Please choose how to proceed | [ENTER] |
@@ -27,7 +27,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
       """
     And my uncommitted file is stashed
 
-  Scenario: attempting to sync again and choosing to continue without resolving conflicts
+  Scenario: attempt to sync again and choosing to continue without resolving conflicts
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER        |
       | Please choose how to proceed | [DOWN][ENTER] |
@@ -38,7 +38,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
       """
     And my uncommitted file is stashed
 
-  Scenario: attempting to sync again and choosing to continue after resolving conflicts
+  Scenario: attempt to sync again and choosing to continue after resolving conflicts
     When I resolve the conflict in "conflicting_file"
     And I run "git-town sync", answer the prompts, and close the next editor:
       | PROMPT                       | ANSWER        |
@@ -53,7 +53,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
       |         | git push                           |
       |         | git stash pop                      |
 
-  Scenario: attempting to sync again and choosing to abort
+  Scenario: attempt to sync again and choosing to abort
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER              |
       | Please choose how to proceed | [DOWN][DOWN][ENTER] |
@@ -63,7 +63,7 @@ Feature: warn about unfinished prompt asking the user how to proceed
       |         | git checkout feature |
       | feature | git stash pop        |
 
-  Scenario: running another command after manually aborting
+  Scenario: run another command after manually aborting
     When I run "git rebase --abort"
     And I run "git checkout feature"
     And I run "git stash pop"

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -5,7 +5,7 @@ Feature: Entering a parent branch name when prompted
     Given my repo has the branches "feature-1" and "feature-2"
     And I am on the "feature-2" branch
 
-  Scenario: choosing the default branch name
+  Scenario: choose the default branch name
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                          | ANSWER  |
       | Please specify the parent branch of 'feature-2' | [ENTER] |
@@ -13,7 +13,7 @@ Feature: Entering a parent branch name when prompted
       | BRANCH    | PARENT |
       | feature-2 | main   |
 
-  Scenario: choosing other branches
+  Scenario: choose other branches
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                          | ANSWER        |
       | Please specify the parent branch of 'feature-2' | [DOWN][ENTER] |
@@ -23,7 +23,7 @@ Feature: Entering a parent branch name when prompted
       | feature-1 | main      |
       | feature-2 | feature-1 |
 
-  Scenario: choosing "<none> (make a perennial branch)"
+  Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                          | ANSWER      |
       | Please specify the parent branch of 'feature-2' | [UP][ENTER] |


### PR DESCRIPTION
Many scenarios use present tense, some use present continuous tense. This makes all scenarios use present tense, which is shorter and is easier to read.