### PR TITLE
Remove verification of printing config prompt

### DIFF
--- a/features/hack/edge_cases/unconfigured.feature
+++ b/features/hack/edge_cases/unconfigured.feature
@@ -8,7 +8,6 @@ Feature: missing configuration
       | Please specify the main development branch | [ENTER] |
 
   Scenario: result
-    Then it prints the initial configuration prompt
     And it runs the commands
       | BRANCH | COMMAND                  |
       | main   | git fetch --prune --tags |

--- a/features/kill/current_branch/edge_cases/unconfigured.feature
+++ b/features/kill/current_branch/edge_cases/unconfigured.feature
@@ -6,7 +6,6 @@ Feature: ask for missing configuration
     When I run "git-town kill" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-    Then it prints the initial configuration prompt
     And the main branch is now "main"
     And my repo is now has no perennial branches
     And it prints the error:

--- a/features/new-pull-request/edge_cases/unconfigured.feature
+++ b/features/new-pull-request/edge_cases/unconfigured.feature
@@ -8,7 +8,6 @@ Feature: ask for missing configuration
     When I run "git-town new-pull-request" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-    Then it prints the initial configuration prompt
     And the main branch is now "main"
     And my repo is now has no perennial branches
     And "open" launches a new pull request with this url in my browser:

--- a/features/prune-branches/edge_cases/unconfigured.feature
+++ b/features/prune-branches/edge_cases/unconfigured.feature
@@ -6,6 +6,5 @@ Feature: ask for missing configuration
     When I run "git-town prune-branches" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-    Then it prints the initial configuration prompt
     And the main branch is now "main"
     And my repo is now has no perennial branches

--- a/features/repo/edge_cases/unconfigured.feature
+++ b/features/repo/edge_cases/unconfigured.feature
@@ -8,6 +8,5 @@ Feature: ask for missing configuration
     When I run "git-town repo" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-    Then it prints the initial configuration prompt
     And the main branch is now "main"
     And my repo is now has no perennial branches

--- a/features/ship/current_branch/edge_cases/unconfigured.feature
+++ b/features/ship/current_branch/edge_cases/unconfigured.feature
@@ -6,7 +6,6 @@ Feature: ask for missing configuration information
     When I run "git-town ship" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-    Then it prints the initial configuration prompt
     And the main branch is now "main"
     And my repo is now has no perennial branches
     And it prints the error:

--- a/features/sync/features/unconfigured.feature
+++ b/features/sync/features/unconfigured.feature
@@ -6,6 +6,5 @@ Feature: Ask for missing configuration information
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-    Then it prints the initial configuration prompt
     And the main branch is now "main"
     And my repo is now has no perennial branches

--- a/test/steps.go
+++ b/test/steps.go
@@ -282,14 +282,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^it prints the initial configuration prompt$`, func() error {
-		expected := "Git Town needs to be configured"
-		if !state.runRes.OutputContainsText(expected) {
-			return fmt.Errorf("text not found:\n\nEXPECTED: %q\n\nACTUAL:\n\n%q\n----------------------------", expected, state.runRes.Output())
-		}
-		return nil
-	})
-
 	suite.Step(`^it runs no commands$`, func() error {
 		commands := GitCommandsInGitTownOutput(state.runRes.Output())
 		if len(commands) > 0 {


### PR DESCRIPTION
The fact that configuration was asked from the user, and was correctly entered by the user, is implicitly tested by the fact that the configuration information later exists. Only a few scenarios ended up using this, so it's probably better to get rid of this step.