### PR TITLE
Verify branches against initial setup

### DIFF
--- a/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
@@ -37,5 +37,5 @@ Feature: the branch to kill has a deleted tracking branch
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
@@ -37,8 +37,5 @@ Feature: the branch to kill has a deleted tracking branch
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And the existing branches are
-      | REPOSITORY | BRANCHES                             |
-      | local      | main, current-feature, other-feature |
-      | remote     | main, other-feature                  |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -39,9 +39,6 @@ Feature: killing a local branch
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY | BRANCHES                             |
-      | local      | main, current-feature, other-feature |
-      | remote     | main, other-feature                  |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -39,6 +39,6 @@ Feature: killing a local branch
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/local_repo.feature
+++ b/features/kill/current_branch/features/local_repo.feature
@@ -38,8 +38,6 @@ Feature: in a local repo
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY | BRANCHES                             |
-      | local      | main, current-feature, other-feature |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/local_repo.feature
+++ b/features/kill/current_branch/features/local_repo.feature
@@ -38,6 +38,6 @@ Feature: in a local repo
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -41,6 +41,6 @@ Feature: offline mode
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -41,8 +41,6 @@ Feature: offline mode
       | current-feature | git reset {{ sha 'current feature commit' }}                  |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And the existing branches are
-      | REPOSITORY    | BRANCHES                             |
-      | local, remote | main, current-feature, other-feature |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/parent_branch.feature
+++ b/features/kill/current_branch/features/parent_branch.feature
@@ -46,6 +46,6 @@ Feature: killing a branch within a branch chain
       |           | git push -u origin feature-2                      |
     And I am now on the "feature-2" branch
     And my workspace has the uncommitted file again
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/features/parent_branch.feature
+++ b/features/kill/current_branch/features/parent_branch.feature
@@ -46,8 +46,6 @@ Feature: killing a branch within a branch chain
       |           | git push -u origin feature-2                      |
     And I am now on the "feature-2" branch
     And my workspace has the uncommitted file again
-    And the existing branches are
-      | REPOSITORY    | BRANCHES                              |
-      | local, remote | main, feature-1, feature-2, feature-3 |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -41,6 +41,6 @@ Feature: killing the current feature branch
       |                 | git push -u origin current-feature                            |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -41,7 +41,7 @@ Feature: killing the current feature branch
       |                 | git push -u origin current-feature                            |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And the existing branches are
+    And my repo now has the original branches
       | REPOSITORY    | BRANCHES                             |
       | local, remote | main, current-feature, other-feature |
     And my repo is left with my original commits

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -42,7 +42,5 @@ Feature: killing the current feature branch
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
     And my repo now has the original branches
-      | REPOSITORY    | BRANCHES                             |
-      | local, remote | main, current-feature, other-feature |
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -41,8 +41,6 @@ Feature: killing the current branch
       |                 | git push -u origin current-feature                            |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And the existing branches are
-      | REPOSITORY    | BRANCHES                             |
-      | local, remote | main, current-feature, other-feature |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -41,6 +41,6 @@ Feature: killing the current branch
       |                 | git push -u origin current-feature                            |
     And I am now on the "current-feature" branch
     And my workspace has the uncommitted file again
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/edge_cases/perennial_branches.feature
+++ b/features/kill/supplied_branch/edge_cases/perennial_branches.feature
@@ -41,8 +41,6 @@ Feature: does not kill perennial branches
       """
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY    | BRANCHES          |
-      | local, remote | main, feature, qa |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy

--- a/features/kill/supplied_branch/edge_cases/perennial_branches.feature
+++ b/features/kill/supplied_branch/edge_cases/perennial_branches.feature
@@ -41,6 +41,6 @@ Feature: does not kill perennial branches
       """
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy

--- a/features/kill/supplied_branch/features/local_branch.feature
+++ b/features/kill/supplied_branch/features/local_branch.feature
@@ -39,6 +39,6 @@ Feature: local branch
       | dead-feature | git reset {{ sha 'dead feature commit' }}               |
     And I am now on the "dead-feature" branch
     And my workspace has the uncommitted file again
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/features/local_branch.feature
+++ b/features/kill/supplied_branch/features/local_branch.feature
@@ -39,8 +39,6 @@ Feature: local branch
       | dead-feature | git reset {{ sha 'dead feature commit' }}               |
     And I am now on the "dead-feature" branch
     And my workspace has the uncommitted file again
-    And the existing branches are
-      | REPOSITORY | BRANCHES                          |
-      | local      | main, dead-feature, other-feature |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -42,6 +42,6 @@ Feature: local repository
       |              | git stash pop                                             |
     And I am still on the "good-feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -42,8 +42,6 @@ Feature: local repository
       |              | git stash pop                                             |
     And I am still on the "good-feature" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY | BRANCHES                          |
-      | local      | main, good-feature, other-feature |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/features/parent_branch.feature
+++ b/features/kill/supplied_branch/features/parent_branch.feature
@@ -41,6 +41,6 @@ Feature: killing a branch within a branch chain
       |           | git push -u origin feature-2                      |
     And I am now on the "feature-3" branch
     And my workspace has the uncommitted file again
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/features/parent_branch.feature
+++ b/features/kill/supplied_branch/features/parent_branch.feature
@@ -41,8 +41,6 @@ Feature: killing a branch within a branch chain
       |           | git push -u origin feature-2                      |
     And I am now on the "feature-3" branch
     And my workspace has the uncommitted file again
-    And the existing branches are
-      | REPOSITORY    | BRANCHES                              |
-      | local, remote | main, feature-1, feature-2, feature-3 |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/features/remote_branch.feature
+++ b/features/kill/supplied_branch/features/remote_branch.feature
@@ -24,8 +24,5 @@ Feature: deleting a remote only branch
     Then it runs the commands
       | BRANCH | COMMAND                                                                 |
       | main   | git push origin {{ sha-in-remote 'feature commit' }}:refs/heads/feature |
-    And the existing branches are
-      | REPOSITORY | BRANCHES      |
-      | local      | main          |
-      | remote     | main, feature |
+    And my repo now has the original branches
     And Git Town now has no branch hierarchy information

--- a/features/kill/supplied_branch/features/remote_branch.feature
+++ b/features/kill/supplied_branch/features/remote_branch.feature
@@ -24,5 +24,5 @@ Feature: deleting a remote only branch
     Then it runs the commands
       | BRANCH | COMMAND                                                                 |
       | main   | git push origin {{ sha-in-remote 'feature commit' }}:refs/heads/feature |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has no branch hierarchy information

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -38,8 +38,6 @@ Feature: deleting another than the current branch
       |              | git push -u origin dead-feature                     |
     And I am still on the "good-feature" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY    | BRANCHES                         |
-      | local, remote | main, dead-feature, good-feature |
+    And my repo now has the original branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -38,6 +38,6 @@ Feature: deleting another than the current branch
       |              | git push -u origin dead-feature                     |
     And I am still on the "good-feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/prune-branches/features/perennial_branch.feature
+++ b/features/prune-branches/features/perennial_branch.feature
@@ -1,8 +1,7 @@
 Feature: remove perennial branch configuration when pruning perennial branches
 
   Background:
-    Given my repo has the branches "active-perennial" and "deleted-perennial"
-    And the perennial branches are "active-perennial" and "deleted-perennial"
+    Given my repo has the perennial branches "active-perennial" and "deleted-perennial"
     And my repo contains the commits
       | BRANCH            | LOCATION      | MESSAGE                  |
       | active-perennial  | local, remote | active-perennial commit  |
@@ -33,8 +32,5 @@ Feature: remove perennial branch configuration when pruning perennial branches
       |        | git checkout deleted-perennial                                    |
     And I am now on the "deleted-perennial" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY | BRANCHES                                  |
-      | local      | main, active-perennial, deleted-perennial |
-      | remote     | main, active-perennial                    |
+    And my repo now has the original branches
     And the perennial branches are now "active-perennial" and "deleted-perennial"

--- a/features/prune-branches/features/perennial_branch.feature
+++ b/features/prune-branches/features/perennial_branch.feature
@@ -32,5 +32,5 @@ Feature: remove perennial branch configuration when pruning perennial branches
       |        | git checkout deleted-perennial                                    |
     And I am now on the "deleted-perennial" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And the perennial branches are now "active-perennial" and "deleted-perennial"

--- a/features/prune-branches/features/shipped_parent.feature
+++ b/features/prune-branches/features/shipped_parent.feature
@@ -33,8 +33,5 @@ Feature: a parent branch of a local branch was shipped
       | main   | git branch feature {{ sha 'feature commit' }} |
     And I am now on the "main" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY | BRANCHES                     |
-      | local      | main, feature, feature-child |
-      | remote     | main, feature-child          |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/prune-branches/features/shipped_parent.feature
+++ b/features/prune-branches/features/shipped_parent.feature
@@ -33,5 +33,5 @@ Feature: a parent branch of a local branch was shipped
       | main   | git branch feature {{ sha 'feature commit' }} |
     And I am now on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/prune-branches/prune_branches.feature
+++ b/features/prune-branches/prune_branches.feature
@@ -34,5 +34,5 @@ Feature: delete branches that were shipped or removed on another machine
       |        | git checkout finished-feature                                   |
     And I am now on the "finished-feature" branch
     And my workspace still contains my uncommitted file
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/prune-branches/prune_branches.feature
+++ b/features/prune-branches/prune_branches.feature
@@ -34,8 +34,5 @@ Feature: delete branches that were shipped or removed on another machine
       |        | git checkout finished-feature                                   |
     And I am now on the "finished-feature" branch
     And my workspace still contains my uncommitted file
-    And the existing branches are
-      | REPOSITORY | BRANCHES                               |
-      | local      | main, active-feature, finished-feature |
-      | remote     | main, active-feature                   |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
+++ b/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
@@ -50,7 +50,7 @@ Feature: commit message can contain double-quotes
       | main    | local, remote | message containing "double quotes"          |
       |         |               | Revert "message containing "double quotes"" |
       | feature | local, remote | feature commit                              |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town is now aware of this branch hierarchy
       | BRANCH  | PARENT |
       | feature | main   |

--- a/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
+++ b/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
@@ -50,6 +50,7 @@ Feature: commit message can contain double-quotes
       | main    | local, remote | message containing "double quotes"          |
       |         |               | Revert "message containing "double quotes"" |
       | feature | local, remote | feature commit                              |
+    And my repo now has the original branches
     And Git Town is now aware of this branch hierarchy
       | BRANCH  | PARENT |
       | feature | main   |

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -55,9 +55,6 @@ Feature: handle conflicts between the shipped branch and the main branch
       |         | git push origin :feature     |
       |         | git branch -D feature        |
     And I am now on the "main" branch
-    And the existing branches are
-      | REPOSITORY    | BRANCHES |
-      | local, remote | main     |
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT     |
       | main   | local, remote | conflicting main commit | conflicting_file | main content     |

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -55,6 +55,9 @@ Feature: handle conflicts between the shipped branch and the main branch
       |         | git push origin :feature     |
       |         | git branch -D feature        |
     And I am now on the "main" branch
+    And the existing branches are
+      | REPOSITORY    | BRANCHES |
+      | local, remote | main     |
     And my repo now has the following commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT     |
       | main   | local, remote | conflicting main commit | conflicting_file | main content     |

--- a/features/ship/current_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/current_branch/edge_cases/in_subfolder.feature
@@ -49,5 +49,5 @@ Feature: ship the current feature branch from a subfolder on the shipped branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/current_branch/edge_cases/in_subfolder.feature
@@ -49,4 +49,5 @@ Feature: ship the current feature branch from a subfolder on the shipped branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/commit_message_via_cli.feature
+++ b/features/ship/current_branch/features/commit_message_via_cli.feature
@@ -49,5 +49,5 @@ Feature: shipping the current feature branch with a tracking branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/commit_message_via_cli.feature
+++ b/features/ship/current_branch/features/commit_message_via_cli.feature
@@ -49,4 +49,5 @@ Feature: shipping the current feature branch with a tracking branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/hotfix_branch.feature
+++ b/features/ship/current_branch/features/hotfix_branch.feature
@@ -50,5 +50,5 @@ Feature: ship hotfixes
       | hotfix     | local, remote | hotfix commit        |
       | production | local, remote | hotfix done          |
       |            |               | Revert "hotfix done" |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/hotfix_branch.feature
+++ b/features/ship/current_branch/features/hotfix_branch.feature
@@ -50,4 +50,5 @@ Feature: ship hotfixes
       | hotfix     | local, remote | hotfix commit        |
       | production | local, remote | hotfix done          |
       |            |               | Revert "hotfix done" |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/local_branch.feature
+++ b/features/ship/current_branch/features/local_branch.feature
@@ -46,4 +46,5 @@ Feature: ship a local feature branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local         | feature commit        |
+    And my repo now has the original branches
     And Git Town still has the original branch hierarchy

--- a/features/ship/current_branch/features/local_branch.feature
+++ b/features/ship/current_branch/features/local_branch.feature
@@ -46,5 +46,5 @@ Feature: ship a local feature branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local         | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town still has the original branch hierarchy

--- a/features/ship/current_branch/features/local_repo.feature
+++ b/features/ship/current_branch/features/local_repo.feature
@@ -39,5 +39,5 @@ Feature: ship a feature branch in a local repo
       | main    | local    | feature done          |
       |         |          | Revert "feature done" |
       | feature | local    | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/local_repo.feature
+++ b/features/ship/current_branch/features/local_repo.feature
@@ -39,4 +39,5 @@ Feature: ship a feature branch in a local repo
       | main    | local    | feature done          |
       |         |          | Revert "feature done" |
       | feature | local    | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -49,4 +49,5 @@ Feature: ship-delete-remote-branch disabled
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local         | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -49,5 +49,5 @@ Feature: ship-delete-remote-branch disabled
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local         | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/ship_current_branch.feature
+++ b/features/ship/current_branch/ship_current_branch.feature
@@ -49,5 +49,5 @@ Feature: enter the commit message interactively via the editor
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/current_branch/ship_current_branch.feature
+++ b/features/ship/current_branch/ship_current_branch.feature
@@ -49,4 +49,5 @@ Feature: enter the commit message interactively via the editor
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -119,4 +119,5 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | feature | local, remote | conflicting feature commit       |
       |         | remote        | conflicting main commit          |
       |         |               | Merge branch 'main' into feature |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -119,5 +119,5 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | feature | local, remote | conflicting feature commit       |
       |         | remote        | conflicting main commit          |
       |         |               | Merge branch 'main' into feature |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -113,5 +113,5 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       | feature | local, remote | local conflicting commit                                   |
       |         |               | remote conflicting commit                                  |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -113,4 +113,5 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       | feature | local, remote | local conflicting commit                                   |
       |         |               | remote conflicting commit                                  |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -121,5 +121,5 @@ Feature: handle conflicts between the main branch and its tracking branch
       |         | remote        | conflicting remote commit        |
       |         |               | conflicting local commit         |
       |         |               | Merge branch 'main' into feature |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -121,4 +121,5 @@ Feature: handle conflicts between the main branch and its tracking branch
       |         | remote        | conflicting remote commit        |
       |         |               | conflicting local commit         |
       |         |               | Merge branch 'main' into feature |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/supplied_branch/edge_cases/in_subfolder.feature
@@ -62,5 +62,5 @@ Feature: shipping the supplied feature branch from a subfolder
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | remote        | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/supplied_branch/edge_cases/in_subfolder.feature
@@ -62,4 +62,5 @@ Feature: shipping the supplied feature branch from a subfolder
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | remote        | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -49,5 +49,5 @@ Feature: shipping the current feature branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -49,4 +49,5 @@ Feature: shipping the current feature branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
@@ -65,6 +65,9 @@ Feature: shipping a branch that exists only on the remote
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And the existing branches are
+      | REPOSITORY    | BRANCHES                     |
+      | local, remote | main, feature, other-feature |
     And Git Town is now aware of this branch hierarchy
       | BRANCH        | PARENT |
       | feature       | main   |

--- a/features/ship/supplied_branch/features/commit_message_via_cli.feature
+++ b/features/ship/supplied_branch/features/commit_message_via_cli.feature
@@ -61,4 +61,5 @@ Feature: provide the commit message via a CLI argument
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/commit_message_via_cli.feature
+++ b/features/ship/supplied_branch/features/commit_message_via_cli.feature
@@ -61,5 +61,5 @@ Feature: provide the commit message via a CLI argument
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/local_branch.feature
+++ b/features/ship/supplied_branch/features/local_branch.feature
@@ -61,4 +61,5 @@ Feature: shipping the supplied feature branch without a tracking branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/local_branch.feature
+++ b/features/ship/supplied_branch/features/local_branch.feature
@@ -61,5 +61,5 @@ Feature: shipping the supplied feature branch without a tracking branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/local_repo.feature
+++ b/features/ship/supplied_branch/features/local_repo.feature
@@ -53,4 +53,5 @@ Feature: shipping the supplied feature branch without a remote origin
       | main    | local    | feature done          |
       |         |          | Revert "feature done" |
       | feature | local    | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/local_repo.feature
+++ b/features/ship/supplied_branch/features/local_repo.feature
@@ -53,5 +53,5 @@ Feature: shipping the supplied feature branch without a remote origin
       | main    | local    | feature done          |
       |         |          | Revert "feature done" |
       | feature | local    | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -56,4 +56,8 @@ Feature: Skip deleting the remote branch when shipping another branch
       |               |               | Revert "feature done" |
       | feature       | local         | feature commit        |
       | other-feature | local         | other commit          |
+    And the existing branches are
+      | REPOSITORY | BRANCHES                     |
+      | local      | main, feature, other-feature |
+      | remote     | main, other-feature          |
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/ship_supplied_branch.feature
+++ b/features/ship/supplied_branch/ship_supplied_branch.feature
@@ -61,4 +61,5 @@ Feature: shipping the supplied feature branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
+    And my repo now has the original branches
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/ship_supplied_branch.feature
+++ b/features/ship/supplied_branch/ship_supplied_branch.feature
@@ -61,5 +61,5 @@ Feature: shipping the supplied feature branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
-    And my repo now has the original branches
+    And my repo now has the initial branches
     And Git Town now has the original branch hierarchy

--- a/test/scenario_state.go
+++ b/test/scenario_state.go
@@ -10,6 +10,12 @@ type ScenarioState struct {
 	// the GitEnvironment used in the current scenario
 	gitEnv GitEnvironment
 
+	// initialLocalBranches contains the local branches before the WHEN steps run
+	initialLocalBranches []string
+
+	// initialRemoteBranches contains the remote branches before the WHEN steps run
+	initialRemoteBranches []string
+
 	// initialCommits describes the commits in this Git environment before the WHEN steps ran.
 	initialCommits *messages.PickleStepArgument_PickleTable
 
@@ -35,6 +41,8 @@ type ScenarioState struct {
 // Reset restores the null value of this ScenarioState.
 func (state *ScenarioState) Reset(gitEnv GitEnvironment) {
 	state.gitEnv = gitEnv
+	state.initialLocalBranches = []string{}
+	state.initialRemoteBranches = []string{}
 	state.initialCommits = nil
 	state.initialBranchHierarchy = DataTable{Cells: [][]string{{"BRANCH", "PARENT"}}}
 	state.runRes = nil

--- a/test/scenario_state.go
+++ b/test/scenario_state.go
@@ -41,7 +41,7 @@ type ScenarioState struct {
 // Reset restores the null value of this ScenarioState.
 func (state *ScenarioState) Reset(gitEnv GitEnvironment) {
 	state.gitEnv = gitEnv
-	state.initialLocalBranches = []string{}
+	state.initialLocalBranches = []string{"main"}
 	state.initialRemoteBranches = []string{}
 	state.initialCommits = nil
 	state.initialBranchHierarchy = DataTable{Cells: [][]string{{"BRANCH", "PARENT"}}}

--- a/test/scenario_state.go
+++ b/test/scenario_state.go
@@ -42,7 +42,7 @@ type ScenarioState struct {
 func (state *ScenarioState) Reset(gitEnv GitEnvironment) {
 	state.gitEnv = gitEnv
 	state.initialLocalBranches = []string{"main"}
-	state.initialRemoteBranches = []string{}
+	state.initialRemoteBranches = []string{"main"}
 	state.initialCommits = nil
 	state.initialBranchHierarchy = DataTable{Cells: [][]string{{"BRANCH", "PARENT"}}}
 	state.runRes = nil

--- a/test/steps.go
+++ b/test/steps.go
@@ -343,6 +343,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			return err
 		}
 		state.initialLocalBranches = append(state.initialLocalBranches, branch)
+		state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
 		state.initialBranchHierarchy.AddRow(branch, parent)
 		return state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
 	})
@@ -428,6 +429,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			return fmt.Errorf("cannot create feature branch %q: %w", childBranch, err)
 		}
 		state.initialLocalBranches = append(state.initialLocalBranches, childBranch)
+		state.initialRemoteBranches = append(state.initialRemoteBranches, childBranch)
 		state.initialBranchHierarchy.AddRow(childBranch, parentBranch)
 		return state.gitEnv.DevRepo.PushBranchSetUpstream(childBranch)
 	})

--- a/test/steps.go
+++ b/test/steps.go
@@ -664,7 +664,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repo now has the original branches$`, func() error {
+	suite.Step(`^my repo now has the initial branches$`, func() error {
 		have, err := state.gitEnv.Branches()
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -329,6 +330,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
+		state.initialLocalBranches = append(state.initialLocalBranches, name)
 		state.initialBranchHierarchy.AddRow(name, "main")
 		return state.gitEnv.DevRepo.PushBranchSetUpstream(name)
 	})
@@ -338,6 +340,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
+		state.initialLocalBranches = append(state.initialLocalBranches, branch)
 		state.initialBranchHierarchy.AddRow(branch, parent)
 		return state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
 	})
@@ -360,6 +363,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my (?:coworker|origin) has a feature branch "([^"]*)"$`, func(branch string) error {
+		state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
 		return state.gitEnv.OriginRepo.CreateBranch(branch, "main")
 	})
 
@@ -406,10 +410,12 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my repo has a branch "([^"]*)"$`, func(branch string) error {
+		state.initialLocalBranches = append(state.initialLocalBranches, branch)
 		return state.gitEnv.DevRepo.CreateBranch(branch, "main")
 	})
 
 	suite.Step(`^my repo has a feature branch "([^"]*)" with no parent$`, func(branch string) error {
+		state.initialLocalBranches = append(state.initialLocalBranches, branch)
 		return state.gitEnv.DevRepo.CreateFeatureBranchNoParent(branch)
 	})
 
@@ -418,6 +424,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return fmt.Errorf("cannot create feature branch %q: %w", childBranch, err)
 		}
+		state.initialLocalBranches = append(state.initialLocalBranches, childBranch)
 		state.initialBranchHierarchy.AddRow(childBranch, parentBranch)
 		return state.gitEnv.DevRepo.PushBranchSetUpstream(childBranch)
 	})
@@ -428,6 +435,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
+		state.initialLocalBranches = append(state.initialLocalBranches, branch)
 		state.initialBranchHierarchy.AddRow(branch, "main")
 		if !isLocal {
 			return state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
@@ -478,11 +486,14 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^my repo has the branches "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
-		err := state.gitEnv.DevRepo.CreateBranch(branch1, "main")
-		if err != nil {
-			return err
+		for _, branch := range []string{branch1, branch2} {
+			err := state.gitEnv.DevRepo.CreateBranch(branch, "main")
+			if err != nil {
+				return err
+			}
+			state.initialLocalBranches = append(state.initialLocalBranches, branch)
 		}
-		return state.gitEnv.DevRepo.CreateBranch(branch2, "main")
+		return nil
 	})
 
 	suite.Step(`^my repo has the following tags$`, func(table *messages.PickleStepArgument_PickleTable) error {
@@ -496,12 +507,14 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			if err != nil {
 				return err
 			}
+			state.initialLocalBranches = append(state.initialLocalBranches, branch)
 			state.initialBranchHierarchy.AddRow(branch, "main")
 			if !isLocal {
 				err = state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
 				if err != nil {
 					return err
 				}
+				state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
 			}
 		}
 		return nil
@@ -514,12 +527,14 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			if err != nil {
 				return err
 			}
+			state.initialLocalBranches = append(state.initialLocalBranches, branch)
 			state.initialBranchHierarchy.AddRow(branch, "main")
 			if !isLocal {
 				err = state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
 				if err != nil {
 					return err
 				}
+				state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
 			}
 		}
 		return nil
@@ -531,7 +546,9 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return fmt.Errorf("cannot create perennial branches: %w", err)
 		}
+		state.initialLocalBranches = append(state.initialLocalBranches, branch1, branch2)
 		if !isLocal {
+			state.initialRemoteBranches = append(state.initialRemoteBranches, branch1, branch2)
 			err = state.gitEnv.DevRepo.PushBranchSetUpstream(branch1)
 			if err != nil {
 				return err
@@ -548,22 +565,26 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			if err != nil {
 				return fmt.Errorf("cannot create perennial branches: %w", err)
 			}
+			state.initialLocalBranches = append(state.initialLocalBranches, branch)
 			if !isLocal {
 				err = state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
 				if err != nil {
 					return fmt.Errorf("cannot push perennial branch upstream: %w", err)
 				}
+				state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
 			}
 		}
 		return nil
 	})
 
-	suite.Step(`^my repo has the perennial branch "([^"]+)"`, func(branch1 string) error {
-		err := state.gitEnv.DevRepo.CreatePerennialBranches(branch1)
+	suite.Step(`^my repo has the perennial branch "([^"]+)"`, func(branch string) error {
+		err := state.gitEnv.DevRepo.CreatePerennialBranches(branch)
 		if err != nil {
 			return fmt.Errorf("cannot create perennial branches: %w", err)
 		}
-		return state.gitEnv.DevRepo.PushBranchSetUpstream(branch1)
+		state.initialLocalBranches = append(state.initialLocalBranches, branch)
+		state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
+		return state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
 	})
 
 	suite.Step(`^my repo is left with my original commits$`, func() error {
@@ -633,6 +654,32 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			fmt.Printf("\nERROR! Found %d differences in the existing files\n\n", errorCount)
 			fmt.Println(diff)
 			return fmt.Errorf("mismatching files found, see diff above")
+		}
+		return nil
+	})
+
+	suite.Step(`^my repo now has the original branches$`, func() error {
+		have, err := state.gitEnv.Branches()
+		if err != nil {
+			return err
+		}
+		want := DataTable{}
+		want.AddRow("REPOSITORY", "BRANCHES")
+		sort.Strings(state.initialLocalBranches)
+		sort.Strings(state.initialRemoteBranches)
+		localBranchesJoined := strings.Join(state.initialLocalBranches, ", ")
+		remoteBranchesJoined := strings.Join(state.initialRemoteBranches, ", ")
+		if localBranchesJoined == remoteBranchesJoined {
+			want.AddRow("local, remote", localBranchesJoined)
+		} else {
+			want.AddRow("local", localBranchesJoined)
+			want.AddRow("remote", remoteBranchesJoined)
+		}
+		diff, errorCount := have.EqualDataTable(want)
+		if errorCount != 0 {
+			fmt.Printf("\nERROR! Found %d differences in the existing branches\n\n", errorCount)
+			fmt.Println(diff)
+			return fmt.Errorf("mismatching branches found, see diff above")
 		}
 		return nil
 	})
@@ -778,7 +825,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		// remove the master branch from the remote since it exists only as a performance optimization
 		diff, errCount := existing.EqualGherkin(table)
 		if errCount > 0 {
 			fmt.Printf("\nERROR! Found %d differences in the branches\n\n", errCount)

--- a/test/steps.go
+++ b/test/steps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
 	"github.com/git-town/git-town/v7/src/cli"
+	"github.com/git-town/git-town/v7/src/git"
 	"github.com/git-town/git-town/v7/src/run"
 )
 
@@ -666,7 +667,9 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		want := DataTable{}
 		want.AddRow("REPOSITORY", "BRANCHES")
 		sort.Strings(state.initialLocalBranches)
+		state.initialLocalBranches = git.MainFirst(state.initialLocalBranches)
 		sort.Strings(state.initialRemoteBranches)
+		state.initialRemoteBranches = git.MainFirst(state.initialRemoteBranches)
 		localBranchesJoined := strings.Join(state.initialLocalBranches, ", ")
 		remoteBranchesJoined := strings.Join(state.initialRemoteBranches, ", ")
 		if localBranchesJoined == remoteBranchesJoined {
@@ -675,6 +678,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			want.AddRow("local", localBranchesJoined)
 			want.AddRow("remote", remoteBranchesJoined)
 		}
+		// fmt.Printf("HAVE:\n%s\n", have.String())
+		// fmt.Printf("WANT:\n%s\n", want.String())
 		diff, errorCount := have.EqualDataTable(want)
 		if errorCount != 0 {
 			fmt.Printf("\nERROR! Found %d differences in the existing branches\n\n", errorCount)

--- a/test/steps.go
+++ b/test/steps.go
@@ -18,6 +18,7 @@ import (
 	"github.com/git-town/git-town/v7/src/cli"
 	"github.com/git-town/git-town/v7/src/git"
 	"github.com/git-town/git-town/v7/src/run"
+	"github.com/git-town/git-town/v7/src/stringslice"
 )
 
 // beforeSuiteMux ensures that we run BeforeSuite only once globally.
@@ -391,6 +392,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
+		state.initialRemoteBranches = []string{}
 		state.gitEnv.OriginRepo = nil
 		return nil
 	})
@@ -439,6 +441,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		state.initialLocalBranches = append(state.initialLocalBranches, branch)
 		state.initialBranchHierarchy.AddRow(branch, "main")
 		if !isLocal {
+			state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
 			return state.gitEnv.DevRepo.PushBranchSetUpstream(branch)
 		}
 		return nil
@@ -676,7 +679,9 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			want.AddRow("local, remote", localBranchesJoined)
 		} else {
 			want.AddRow("local", localBranchesJoined)
-			want.AddRow("remote", remoteBranchesJoined)
+			if remoteBranchesJoined != "" {
+				want.AddRow("remote", remoteBranchesJoined)
+			}
 		}
 		// fmt.Printf("HAVE:\n%s\n", have.String())
 		// fmt.Printf("WANT:\n%s\n", want.String())
@@ -802,6 +807,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the "([^"]*)" branch gets deleted on the remote$`, func(name string) error {
+		state.initialRemoteBranches = stringslice.Remove(state.initialRemoteBranches, name)
 		return state.gitEnv.OriginRepo.RemoveBranch(name)
 	})
 


### PR DESCRIPTION
This expresses the intent of the tests better - that after the undo operation the branches have their initial setup again.