### PR TITLE
Simplify branch names in feature specs

### DIFF
--- a/features/append/append.feature
+++ b/features/append/append.feature
@@ -1,51 +1,51 @@
 Feature: append a new feature branch to an existing feature branch
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo contains the commits
-      | BRANCH           | LOCATION      | MESSAGE                 |
-      | existing-feature | local, remote | existing_feature_commit |
-    And I am on the "existing-feature" branch
+      | BRANCH   | LOCATION      | MESSAGE                 |
+      | existing | local, remote | existing_feature_commit |
+    And I am on the "existing" branch
     And my workspace has an uncommitted file
-    When I run "git-town append new-child"
+    When I run "git-town append new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                                     |
-      | existing-feature | git fetch --prune --tags                    |
-      |                  | git add -A                                  |
-      |                  | git stash                                   |
-      |                  | git checkout main                           |
-      | main             | git rebase origin/main                      |
-      |                  | git checkout existing-feature               |
-      | existing-feature | git merge --no-edit origin/existing-feature |
-      |                  | git merge --no-edit main                    |
-      |                  | git branch new-child existing-feature       |
-      |                  | git checkout new-child                      |
-      | new-child        | git stash pop                               |
-    And I am now on the "new-child" branch
+      | BRANCH   | COMMAND                             |
+      | existing | git fetch --prune --tags            |
+      |          | git add -A                          |
+      |          | git stash                           |
+      |          | git checkout main                   |
+      | main     | git rebase origin/main              |
+      |          | git checkout existing               |
+      | existing | git merge --no-edit origin/existing |
+      |          | git merge --no-edit main            |
+      |          | git branch new existing             |
+      |          | git checkout new                    |
+      | new      | git stash pop                       |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH           | LOCATION      | MESSAGE                 |
-      | existing-feature | local, remote | existing_feature_commit |
-      | new-child        | local         | existing_feature_commit |
+      | BRANCH   | LOCATION      | MESSAGE                 |
+      | existing | local, remote | existing_feature_commit |
+      | new      | local         | existing_feature_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH           | PARENT           |
-      | existing-feature | main             |
-      | new-child        | existing-feature |
+      | BRANCH   | PARENT   |
+      | existing | main     |
+      | new      | existing |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH           | COMMAND                       |
-      | new-child        | git add -A                    |
-      |                  | git stash                     |
-      |                  | git checkout existing-feature |
-      | existing-feature | git branch -D new-child       |
-      |                  | git checkout main             |
-      | main             | git checkout existing-feature |
-      | existing-feature | git stash pop                 |
-    And I am now on the "existing-feature" branch
+      | BRANCH   | COMMAND               |
+      | new      | git add -A            |
+      |          | git stash             |
+      |          | git checkout existing |
+      | existing | git branch -D new     |
+      |          | git checkout main     |
+      | main     | git checkout existing |
+      | existing | git stash pop         |
+    And I am now on the "existing" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy

--- a/features/append/edge_cases/on_main_branch.feature
+++ b/features/append/edge_cases/on_main_branch.feature
@@ -6,37 +6,37 @@ Feature: on the main branch
       | main   | remote   | main_commit |
     And I am on the "main" branch
     And my workspace has an uncommitted file
-    When I run "git-town append new-child"
+    When I run "git-town append new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                   |
-      | main      | git fetch --prune --tags  |
-      |           | git add -A                |
-      |           | git stash                 |
-      |           | git rebase origin/main    |
-      |           | git branch new-child main |
-      |           | git checkout new-child    |
-      | new-child | git stash pop             |
-    And I am now on the "new-child" branch
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git rebase origin/main   |
+      |        | git branch new main      |
+      |        | git checkout new         |
+      | new    | git stash pop            |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE     |
-      | main      | local, remote | main_commit |
-      | new-child | local         | main_commit |
+      | BRANCH | LOCATION      | MESSAGE     |
+      | main   | local, remote | main_commit |
+      | new    | local         | main_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT |
-      | new-child | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                 |
-      | new-child | git add -A              |
-      |           | git stash               |
-      |           | git checkout main       |
-      | main      | git branch -d new-child |
-      |           | git stash pop           |
+      | BRANCH | COMMAND           |
+      | new    | git add -A        |
+      |        | git stash         |
+      |        | git checkout main |
+      | main   | git branch -d new |
+      |        | git stash pop     |
     And I am now on the "main" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits

--- a/features/append/features/local_repo.feature
+++ b/features/append/features/local_repo.feature
@@ -1,43 +1,43 @@
 Feature: in a local repo
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo does not have a remote origin
     And my repo contains the commits
-      | BRANCH           | LOCATION | MESSAGE                 |
-      | existing-feature | local    | existing_feature_commit |
-    And I am on the "existing-feature" branch
+      | BRANCH   | LOCATION | MESSAGE                 |
+      | existing | local    | existing_feature_commit |
+    And I am on the "existing" branch
     And my workspace has an uncommitted file
-    When I run "git-town hack new-feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                     |
-      | existing-feature | git add -A                  |
-      |                  | git stash                   |
-      |                  | git branch new-feature main |
-      |                  | git checkout new-feature    |
-      | new-feature      | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH   | COMMAND             |
+      | existing | git add -A          |
+      |          | git stash           |
+      |          | git branch new main |
+      |          | git checkout new    |
+      | new      | git stash pop       |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH           | LOCATION | MESSAGE                 |
-      | existing-feature | local    | existing_feature_commit |
+      | BRANCH   | LOCATION | MESSAGE                 |
+      | existing | local    | existing_feature_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH           | PARENT |
-      | existing-feature | main   |
-      | new-feature      | main   |
+      | BRANCH   | PARENT |
+      | existing | main   |
+      | new      | main   |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH           | COMMAND                       |
-      | new-feature      | git add -A                    |
-      |                  | git stash                     |
-      |                  | git checkout existing-feature |
-      | existing-feature | git branch -d new-feature     |
-      |                  | git stash pop                 |
-    And I am now on the "existing-feature" branch
+      | BRANCH   | COMMAND               |
+      | new      | git add -A            |
+      |          | git stash             |
+      |          | git checkout existing |
+      | existing | git branch -d new     |
+      |          | git stash pop         |
+    And I am now on the "existing" branch
     And my repo is left with my original commits
     And my workspace still contains my uncommitted file
     And my repo now has its initial branches and branch hierarchy

--- a/features/append/features/new_branch_push_flag.feature
+++ b/features/append/features/new_branch_push_flag.feature
@@ -6,32 +6,32 @@ Feature: auto-push the new branch to the remote
       | BRANCH | LOCATION | MESSAGE     |
       | main   | remote   | main_commit |
     And I am on the "main" branch
-    When I run "git-town append new-child"
+    When I run "git-town append new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                      |
-      | main      | git fetch --prune --tags     |
-      |           | git rebase origin/main       |
-      |           | git branch new-child main    |
-      |           | git checkout new-child       |
-      | new-child | git push -u origin new-child |
-    And I am now on the "new-child" branch
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git rebase origin/main   |
+      |        | git branch new main      |
+      |        | git checkout new         |
+      | new    | git push -u origin new   |
+    And I am now on the "new" branch
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE     |
-      | main      | local, remote | main_commit |
-      | new-child | local, remote | main_commit |
+      | BRANCH | LOCATION      | MESSAGE     |
+      | main   | local, remote | main_commit |
+      | new    | local, remote | main_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT |
-      | new-child | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                    |
-      | new-child | git push origin :new-child |
-      |           | git checkout main          |
-      | main      | git branch -d new-child    |
+      | BRANCH | COMMAND              |
+      | new    | git push origin :new |
+      |        | git checkout main    |
+      | main   | git branch -d new    |
     And I am now on the "main" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |

--- a/features/append/features/offline.feature
+++ b/features/append/features/offline.feature
@@ -2,38 +2,38 @@ Feature: append in offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has a feature branch "existing-feature"
+    And my repo has a feature branch "existing"
     And my repo contains the commits
-      | BRANCH           | LOCATION      | MESSAGE                 |
-      | existing-feature | local, remote | existing feature commit |
-    And I am on the "existing-feature" branch
+      | BRANCH   | LOCATION      | MESSAGE                 |
+      | existing | local, remote | existing feature commit |
+    And I am on the "existing" branch
 
   Scenario: result
-    When I run "git-town append new-feature"
+    When I run "git-town append new"
     Then it runs the commands
-      | BRANCH           | COMMAND                                     |
-      | existing-feature | git checkout main                           |
-      | main             | git rebase origin/main                      |
-      |                  | git checkout existing-feature               |
-      | existing-feature | git merge --no-edit origin/existing-feature |
-      |                  | git merge --no-edit main                    |
-      |                  | git branch new-feature existing-feature     |
-      |                  | git checkout new-feature                    |
-    And I am now on the "new-feature" branch
+      | BRANCH   | COMMAND                             |
+      | existing | git checkout main                   |
+      | main     | git rebase origin/main              |
+      |          | git checkout existing               |
+      | existing | git merge --no-edit origin/existing |
+      |          | git merge --no-edit main            |
+      |          | git branch new existing             |
+      |          | git checkout new                    |
+    And I am now on the "new" branch
     And my repo now has the commits
-      | BRANCH           | LOCATION      | MESSAGE                 |
-      | existing-feature | local, remote | existing feature commit |
-      | new-feature      | local         | existing feature commit |
+      | BRANCH   | LOCATION      | MESSAGE                 |
+      | existing | local, remote | existing feature commit |
+      | new      | local         | existing feature commit |
 
   Scenario: undo
-    Given I ran "git-town append new-feature"
+    Given I ran "git-town append new"
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH           | COMMAND                       |
-      | new-feature      | git checkout existing-feature |
-      | existing-feature | git branch -D new-feature     |
-      |                  | git checkout main             |
-      | main             | git checkout existing-feature |
-    And I am now on the "existing-feature" branch
+      | BRANCH   | COMMAND               |
+      | new      | git checkout existing |
+      | existing | git branch -D new     |
+      |          | git checkout main     |
+      | main     | git checkout existing |
+    And I am now on the "existing" branch
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/append/features/on_perennial_branch.feature
+++ b/features/append/features/on_perennial_branch.feature
@@ -6,30 +6,30 @@ Feature: append to a perennial branch
       | BRANCH     | LOCATION | MESSAGE           |
       | production | remote   | production_commit |
     And I am on the "production" branch
-    When I run "git-town append new-child"
+    When I run "git-town append new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH     | COMMAND                         |
-      | production | git fetch --prune --tags        |
-      |            | git rebase origin/production    |
-      |            | git branch new-child production |
-      |            | git checkout new-child          |
-    And I am now on the "new-child" branch
+      | BRANCH     | COMMAND                      |
+      | production | git fetch --prune --tags     |
+      |            | git rebase origin/production |
+      |            | git branch new production    |
+      |            | git checkout new             |
+    And I am now on the "new" branch
     And my repo now has the commits
       | BRANCH     | LOCATION      | MESSAGE           |
-      | new-child  | local         | production_commit |
+      | new        | local         | production_commit |
       | production | local, remote | production_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT     |
-      | new-child | production |
+      | BRANCH | PARENT     |
+      | new    | production |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
       | BRANCH     | COMMAND                 |
-      | new-child  | git checkout production |
-      | production | git branch -D new-child |
+      | new        | git checkout production |
+      | production | git branch -D new       |
     And I am now on the "production" branch
     And my repo now has the commits
       | BRANCH     | LOCATION      | MESSAGE           |

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -17,8 +17,8 @@ Feature: show the configuration
   Scenario: all configured, with nested branches
     Given the main branch is "main"
     And my repo has the perennial branches "qa" and "staging"
-    And my repo has the feature branches "feature-1" and "feature-2"
-    And my repo has a feature branch "feature-1A" as a child of "feature-1"
+    And my repo has the feature branches "alpha" and "beta"
+    And my repo has a feature branch "child" as a child of "alpha"
     And my repo has a feature branch "hotfix" as a child of "qa"
     When I run "git-town config"
     Then it prints:
@@ -32,9 +32,9 @@ Feature: show the configuration
 
       Branch Ancestry:
         main
-          feature-1
-            feature-1A
-          feature-2
+          alpha
+            child
+          beta
 
         qa
           hotfix

--- a/features/diff-parent/current_branch/diff_parent.feature
+++ b/features/diff-parent/current_branch/diff_parent.feature
@@ -9,10 +9,10 @@ Feature: view changes made on the current feature branch
       | feature | git diff main..feature |
 
   Scenario: child branch
-    Given my repo has a feature branch "feature-1"
-    And my repo has a feature branch "feature-1A" as a child of "feature-1"
-    And I am on the "feature-1A" branch
+    Given my repo has a feature branch "parent"
+    And my repo has a feature branch "child" as a child of "parent"
+    And I am on the "child" branch
     When I run "git-town diff-parent"
     Then it runs the commands
-      | BRANCH     | COMMAND                        |
-      | feature-1A | git diff feature-1..feature-1A |
+      | BRANCH | COMMAND                |
+      | child  | git diff parent..child |

--- a/features/diff-parent/supplied_branch/diff_parent.feature
+++ b/features/diff-parent/supplied_branch/diff_parent.feature
@@ -1,17 +1,17 @@
 Feature: view changes made on another branch
 
   Background:
-    Given my repo has a feature branch "feature-1"
+    Given my repo has a feature branch "alpha"
 
   Scenario: feature branch
-    When I run "git-town diff-parent feature-1"
+    When I run "git-town diff-parent alpha"
     Then it runs the commands
-      | BRANCH | COMMAND                  |
-      | main   | git diff main..feature-1 |
+      | BRANCH | COMMAND              |
+      | main   | git diff main..alpha |
 
   Scenario: child branch
-    And my repo has a feature branch "feature-2" as a child of "feature-1"
-    When I run "git-town diff-parent feature-2"
+    And my repo has a feature branch "beta" as a child of "alpha"
+    When I run "git-town diff-parent beta"
     Then it runs the commands
-      | BRANCH | COMMAND                       |
-      | main   | git diff feature-1..feature-2 |
+      | BRANCH | COMMAND              |
+      | main   | git diff alpha..beta |

--- a/features/diff-parent/supplied_branch/diff_parent.feature
+++ b/features/diff-parent/supplied_branch/diff_parent.feature
@@ -1,14 +1,15 @@
 Feature: view changes made on another branch
 
-  Scenario: feature branch
+  Background:
     Given my repo has a feature branch "feature-1"
+
+  Scenario: feature branch
     When I run "git-town diff-parent feature-1"
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | main   | git diff main..feature-1 |
 
   Scenario: child branch
-    Given my repo has a feature branch "feature-1"
     And my repo has a feature branch "feature-2" as a child of "feature-1"
     When I run "git-town diff-parent feature-2"
     Then it runs the commands

--- a/features/hack/edge_cases/in_committed_subfolder.feature
+++ b/features/hack/edge_cases/in_committed_subfolder.feature
@@ -1,35 +1,35 @@
 Feature: inside a committed subfolder that exists only on the current feature branch
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo contains the commits
-      | BRANCH           | LOCATION      | MESSAGE       | FILE NAME        |
-      | existing-feature | local, remote | folder commit | new_folder/file1 |
-    And I am on the "existing-feature" branch
-    When I run "git-town hack new-feature" in the "new_folder" folder
+      | BRANCH   | LOCATION      | MESSAGE       | FILE NAME        |
+      | existing | local, remote | folder commit | new_folder/file1 |
+    And I am on the "existing" branch
+    When I run "git-town hack new" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                     |
-      | existing-feature | git fetch --prune --tags    |
-      |                  | git checkout main           |
-      | main             | git rebase origin/main      |
-      |                  | git branch new-feature main |
-      |                  | git checkout new-feature    |
-    And I am now on the "new-feature" branch
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git checkout main        |
+      | main     | git rebase origin/main   |
+      |          | git branch new main      |
+      |          | git checkout new         |
+    And I am now on the "new" branch
     And my repo is left with my original commits
     And Git Town is now aware of this branch hierarchy
-      | BRANCH           | PARENT |
-      | existing-feature | main   |
-      | new-feature      | main   |
+      | BRANCH   | PARENT |
+      | existing | main   |
+      | new      | main   |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH      | COMMAND                       |
-      | new-feature | git checkout main             |
-      | main        | git branch -d new-feature     |
-      |             | git checkout existing-feature |
-    And I am now on the "existing-feature" branch
+      | BRANCH | COMMAND               |
+      | new    | git checkout main     |
+      | main   | git branch -d new     |
+      |        | git checkout existing |
+    And I am now on the "existing" branch
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/hack/edge_cases/in_uncommitted_subfolder.feature
+++ b/features/hack/edge_cases/in_uncommitted_subfolder.feature
@@ -1,46 +1,46 @@
 Feature: inside an uncommitted subfolder on the current feature branch
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, remote | main commit |
-    And I am on the "existing-feature" branch
+    And I am on the "existing" branch
     And my workspace has an uncommitted file in folder "new_folder"
-    When I run "git-town hack new-feature" in the "new_folder" folder
+    When I run "git-town hack new" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                     |
-      | existing-feature | git fetch --prune --tags    |
-      |                  | git add -A                  |
-      |                  | git stash                   |
-      |                  | git checkout main           |
-      | main             | git rebase origin/main      |
-      |                  | git branch new-feature main |
-      |                  | git checkout new-feature    |
-      | new-feature      | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git add -A               |
+      |          | git stash                |
+      |          | git checkout main        |
+      | main     | git rebase origin/main   |
+      |          | git branch new main      |
+      |          | git checkout new         |
+      | new      | git stash pop            |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH      | LOCATION      | MESSAGE     |
-      | main        | local, remote | main commit |
-      | new-feature | local         | main commit |
+      | BRANCH | LOCATION      | MESSAGE     |
+      | main   | local, remote | main commit |
+      | new    | local         | main commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH           | PARENT |
-      | existing-feature | main   |
-      | new-feature      | main   |
+      | BRANCH   | PARENT |
+      | existing | main   |
+      | new      | main   |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH           | COMMAND                       |
-      | new-feature      | git add -A                    |
-      |                  | git stash                     |
-      |                  | git checkout main             |
-      | main             | git branch -d new-feature     |
-      |                  | git checkout existing-feature |
-      | existing-feature | git stash pop                 |
-    And I am now on the "existing-feature" branch
+      | BRANCH   | COMMAND               |
+      | new      | git add -A            |
+      |          | git stash             |
+      |          | git checkout main     |
+      | main     | git branch -d new     |
+      |          | git checkout existing |
+      | existing | git stash pop         |
+    And I am now on the "existing" branch
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -1,23 +1,23 @@
 Feature: conflicts between the main branch and its tracking branch
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
       | main   | local    | conflicting local commit  | conflicting_file | local content  |
       |        | remote   | conflicting remote commit | conflicting_file | remote content |
-    And I am on the "existing-feature" branch
+    And I am on the "existing" branch
     And my workspace has an uncommitted file
-    When I run "git-town hack new-feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                  |
-      | existing-feature | git fetch --prune --tags |
-      |                  | git add -A               |
-      |                  | git stash                |
-      |                  | git checkout main        |
-      | main             | git rebase origin/main   |
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git add -A               |
+      |          | git stash                |
+      |          | git checkout main        |
+      | main     | git rebase origin/main   |
     And it prints the error:
       """
       To abort, run "git-town abort".
@@ -29,11 +29,11 @@ Feature: conflicts between the main branch and its tracking branch
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH           | COMMAND                       |
-      | main             | git rebase --abort            |
-      |                  | git checkout existing-feature |
-      | existing-feature | git stash pop                 |
-    And I am now on the "existing-feature" branch
+      | BRANCH   | COMMAND               |
+      | main     | git rebase --abort    |
+      |          | git checkout existing |
+      | existing | git stash pop         |
+    And I am now on the "existing" branch
     And my workspace has the uncommitted file again
     And there is no rebase in progress anymore
     And my repo is left with my original commits
@@ -51,34 +51,34 @@ Feature: conflicts between the main branch and its tracking branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
-      | BRANCH      | COMMAND                     |
-      | main        | git rebase --continue       |
-      |             | git push                    |
-      |             | git branch new-feature main |
-      |             | git checkout new-feature    |
-      | new-feature | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH | COMMAND               |
+      | main   | git rebase --continue |
+      |        | git push              |
+      |        | git branch new main   |
+      |        | git checkout new      |
+      | new    | git stash pop         |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH      | LOCATION      | MESSAGE                   |
-      | main        | local, remote | conflicting remote commit |
-      |             |               | conflicting local commit  |
-      | new-feature | local         | conflicting remote commit |
-      |             |               | conflicting local commit  |
+      | BRANCH | LOCATION      | MESSAGE                   |
+      | main   | local, remote | conflicting remote commit |
+      |        |               | conflicting local commit  |
+      | new    | local         | conflicting remote commit |
+      |        |               | conflicting local commit  |
     And my repo now has these committed files
-      | BRANCH      | NAME             | CONTENT          |
-      | main        | conflicting_file | resolved content |
-      | new-feature | conflicting_file | resolved content |
+      | BRANCH | NAME             | CONTENT          |
+      | main   | conflicting_file | resolved content |
+      | new    | conflicting_file | resolved content |
 
   Scenario: continue after resolving the conflicts and finishing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH      | COMMAND                     |
-      | main        | git push                    |
-      |             | git branch new-feature main |
-      |             | git checkout new-feature    |
-      | new-feature | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH | COMMAND             |
+      | main   | git push            |
+      |        | git branch new main |
+      |        | git checkout new    |
+      | new    | git stash pop       |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file

--- a/features/hack/edge_cases/main_branch_subfolder.feature
+++ b/features/hack/edge_cases/main_branch_subfolder.feature
@@ -6,38 +6,38 @@ Feature: in a subfolder on the main branch
       | main   | local    | folder commit | new_folder/file1 |
     And I am on the "main" branch
     And my workspace has an uncommitted file
-    When I run "git-town hack new-feature" in the "new_folder" folder
+    When I run "git-town hack new" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH      | COMMAND                     |
-      | main        | git fetch --prune --tags    |
-      |             | git add -A                  |
-      |             | git stash                   |
-      |             | git rebase origin/main      |
-      |             | git push                    |
-      |             | git branch new-feature main |
-      |             | git checkout new-feature    |
-      | new-feature | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git rebase origin/main   |
+      |        | git push                 |
+      |        | git branch new main      |
+      |        | git checkout new         |
+      | new    | git stash pop            |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH      | LOCATION      | MESSAGE       |
-      | main        | local, remote | folder commit |
-      | new-feature | local         | folder commit |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | main   | local, remote | folder commit |
+      | new    | local         | folder commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH      | PARENT |
-      | new-feature | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH      | COMMAND                   |
-      | new-feature | git add -A                |
-      |             | git stash                 |
-      |             | git checkout main         |
-      | main        | git branch -d new-feature |
-      |             | git stash pop             |
+      | BRANCH | COMMAND           |
+      | new    | git add -A        |
+      |        | git stash         |
+      |        | git checkout main |
+      | main   | git branch -d new |
+      |        | git stash pop     |
     And I am now on the "main" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE       |

--- a/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
+++ b/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
@@ -1,25 +1,25 @@
 Feature: conflicts between uncommitted changes and the main branch
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT |
       | main   | local, remote | conflicting commit | conflicting_file | main content |
-    And I am on the "existing-feature" branch
+    And I am on the "existing" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
-    When I run "git-town hack new-feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                     |
-      | existing-feature | git fetch --prune --tags    |
-      |                  | git add -A                  |
-      |                  | git stash                   |
-      |                  | git checkout main           |
-      | main             | git rebase origin/main      |
-      |                  | git branch new-feature main |
-      |                  | git checkout new-feature    |
-      | new-feature      | git stash pop               |
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git add -A               |
+      |          | git stash                |
+      |          | git checkout main        |
+      | main     | git rebase origin/main   |
+      |          | git branch new main      |
+      |          | git checkout new         |
+      | new      | git stash pop            |
     And it prints the error:
       """
       conflicts between your uncommmitted changes and the main branch
@@ -29,25 +29,25 @@ Feature: conflicts between uncommitted changes and the main branch
   Scenario: abort without resolving the conflicts fails due to unresolved merge conflicts
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH      | COMMAND           |
-      | new-feature | git checkout main |
+      | BRANCH | COMMAND           |
+      | new    | git checkout main |
     And it prints the error:
       """
       cannot check out branch "main"
       """
-    And I am still on the "new-feature" branch
+    And I am still on the "new" branch
 
   Scenario: abort after resolving the conflicts undoes the hack and indicates the merge conflict in the uncommitted file
     Given I resolve the conflict in "conflicting_file"
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH      | COMMAND                       |
-      | new-feature | git checkout main             |
-      | main        | git branch -d new-feature     |
-      |             | git checkout existing-feature |
+      | BRANCH | COMMAND               |
+      | new    | git checkout main     |
+      | main   | git branch -d new     |
+      |        | git checkout existing |
     And it prints the error:
       """
-      cannot check out branch "existing-feature"
+      cannot check out branch "existing"
       """
     And I am now on the "main" branch
     And my repo is left with my original commits
@@ -64,11 +64,11 @@ Feature: conflicts between uncommitted changes and the main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs no commands
-    And I am now on the "new-feature" branch
+    And I am now on the "new" branch
     And my repo now has the commits
-      | BRANCH      | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT |
-      | main        | local, remote | conflicting commit | conflicting_file | main content |
-      | new-feature | local         | conflicting commit | conflicting_file | main content |
+      | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT |
+      | main   | local, remote | conflicting commit | conflicting_file | main content |
+      | new    | local         | conflicting commit | conflicting_file | main content |
     And my workspace now contains the file "conflicting_file" with content "resolved content"
 
   Scenario: undo after resolving the conflicts undoes the hack but cannot get back to the original branch due to merge conflicts
@@ -76,13 +76,13 @@ Feature: conflicts between uncommitted changes and the main branch
     And I run "git-town continue" and close the editor
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH      | COMMAND                       |
-      | new-feature | git checkout main             |
-      | main        | git branch -d new-feature     |
-      |             | git checkout existing-feature |
+      | BRANCH | COMMAND               |
+      | new    | git checkout main     |
+      | main   | git branch -d new     |
+      |        | git checkout existing |
     And it prints the error:
       """
-      cannot check out branch "existing-feature"
+      cannot check out branch "existing"
       """
     And I am now on the "main" branch
     And my repo is left with my original commits

--- a/features/hack/features/custom_parent.feature
+++ b/features/hack/features/custom_parent.feature
@@ -2,35 +2,35 @@
 Feature: customize the parent for the new feature branch
 
   Background:
-    Given my repo has a branch "feature-1"
-    And I am on the "feature-1" branch
-    When I run "git-town hack -p feature-2" and answer the prompts:
-      | PROMPT                                          | ANSWER        |
-      | Please specify the parent branch of 'feature-2' | [DOWN][ENTER] |
-      | Please specify the parent branch of 'feature-1' | [ENTER]       |
+    Given my repo has a branch "existing"
+    And I am on the "existing" branch
+    When I run "git-town hack -p new" and answer the prompts:
+      | PROMPT                                         | ANSWER        |
+      | Please specify the parent branch of 'new'      | [DOWN][ENTER] |
+      | Please specify the parent branch of 'existing' | [ENTER]       |
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                        |
-      | feature-1 | git fetch --prune --tags       |
-      |           | git merge --no-edit main       |
-      |           | git push -u origin feature-1   |
-      |           | git branch feature-2 feature-1 |
-      |           | git checkout feature-2         |
-    And I am now on the "feature-2" branch
+      | BRANCH   | COMMAND                     |
+      | existing | git fetch --prune --tags    |
+      |          | git merge --no-edit main    |
+      |          | git push -u origin existing |
+      |          | git branch new existing     |
+      |          | git checkout new            |
+    And I am now on the "new" branch
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT    |
-      | feature-1 | main      |
-      | feature-2 | feature-1 |
+      | BRANCH   | PARENT   |
+      | existing | main     |
+      | new      | existing |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                    |
-      | feature-2 | git checkout feature-1     |
-      | feature-1 | git branch -d feature-2    |
-      |           | git push origin :feature-1 |
-    And I am now on the "feature-1" branch
+      | BRANCH   | COMMAND                   |
+      | new      | git checkout existing     |
+      | existing | git branch -d new         |
+      |          | git push origin :existing |
+    And I am now on the "existing" branch
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT |
-      | feature-1 | main   |
+      | BRANCH   | PARENT |
+      | existing | main   |

--- a/features/hack/features/local_repo.feature
+++ b/features/hack/features/local_repo.feature
@@ -1,30 +1,30 @@
 Feature: local repo
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo does not have a remote origin
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE     |
       | main   | local    | main commit |
-    And I am on the "existing-feature" branch
+    And I am on the "existing" branch
     And my workspace has an uncommitted file
-    When I run "git-town hack new-feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                     |
-      | existing-feature | git add -A                  |
-      |                  | git stash                   |
-      |                  | git branch new-feature main |
-      |                  | git checkout new-feature    |
-      | new-feature      | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH   | COMMAND             |
+      | existing | git add -A          |
+      |          | git stash           |
+      |          | git branch new main |
+      |          | git checkout new    |
+      | new      | git stash pop       |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH      | LOCATION | MESSAGE     |
-      | main        | local    | main commit |
-      | new-feature | local    | main commit |
+      | BRANCH | LOCATION | MESSAGE     |
+      | main   | local    | main commit |
+      | new    | local    | main commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH           | PARENT |
-      | existing-feature | main   |
-      | new-feature      | main   |
+      | BRANCH   | PARENT |
+      | existing | main   |
+      | new      | main   |

--- a/features/hack/features/new_branch_push_flag.feature
+++ b/features/hack/features/new_branch_push_flag.feature
@@ -6,32 +6,32 @@ Feature: auto-push the new branch
       | BRANCH | LOCATION | MESSAGE       |
       | main   | remote   | remote commit |
     And I am on the "main" branch
-    When I run "git-town hack feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                    |
-      | main    | git fetch --prune --tags   |
-      |         | git rebase origin/main     |
-      |         | git branch feature main    |
-      |         | git checkout feature       |
-      | feature | git push -u origin feature |
-    And I am now on the "feature" branch
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git rebase origin/main   |
+      |        | git branch new main      |
+      |        | git checkout new         |
+      | new    | git push -u origin new   |
+    And I am now on the "new" branch
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE       |
-      | main    | local, remote | remote commit |
-      | feature | local, remote | remote commit |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | main   | local, remote | remote commit |
+      | new    | local, remote | remote commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                  |
-      | feature | git push origin :feature |
-      |         | git checkout main        |
-      | main    | git branch -d feature    |
+      | BRANCH | COMMAND              |
+      | new    | git push origin :new |
+      |        | git checkout main    |
+      | main   | git branch -d new    |
     And I am now on the "main" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE       |

--- a/features/hack/features/offline.feature
+++ b/features/hack/features/offline.feature
@@ -6,36 +6,36 @@ Feature: offline mode
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, remote | main commit |
     And my workspace has an uncommitted file
-    When I run "git-town hack feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                 |
-      | main    | git add -A              |
-      |         | git stash               |
-      |         | git rebase origin/main  |
-      |         | git branch feature main |
-      |         | git checkout feature    |
-      | feature | git stash pop           |
-    And I am now on the "feature" branch
+      | BRANCH | COMMAND                |
+      | main   | git add -A             |
+      |        | git stash              |
+      |        | git rebase origin/main |
+      |        | git branch new main    |
+      |        | git checkout new       |
+      | new    | git stash pop          |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE     |
-      | main    | local, remote | main commit |
-      | feature | local         | main commit |
+      | BRANCH | LOCATION      | MESSAGE     |
+      | main   | local, remote | main commit |
+      | new    | local         | main commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND               |
-      | feature | git add -A            |
-      |         | git stash             |
-      |         | git checkout main     |
-      | main    | git branch -d feature |
-      |         | git stash pop         |
+      | BRANCH | COMMAND           |
+      | new    | git add -A        |
+      |        | git stash         |
+      |        | git checkout main |
+      | main   | git branch -d new |
+      |        | git stash pop     |
     And I am now on the "main" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits

--- a/features/hack/features/with_upstream.feature
+++ b/features/hack/features/with_upstream.feature
@@ -7,37 +7,37 @@ Feature: on a forked repo
       | main   | upstream | upstream commit |
     And I am on the "main" branch
     And my workspace has an uncommitted file
-    When I run "git-town hack new-feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH      | COMMAND                     |
-      | main        | git fetch --prune --tags    |
-      |             | git add -A                  |
-      |             | git stash                   |
-      |             | git rebase origin/main      |
-      |             | git fetch upstream main     |
-      |             | git rebase upstream/main    |
-      |             | git push                    |
-      |             | git branch new-feature main |
-      |             | git checkout new-feature    |
-      | new-feature | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git rebase origin/main   |
+      |        | git fetch upstream main  |
+      |        | git rebase upstream/main |
+      |        | git push                 |
+      |        | git branch new main      |
+      |        | git checkout new         |
+      | new    | git stash pop            |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH      | LOCATION                | MESSAGE         |
-      | main        | local, remote, upstream | upstream commit |
-      | new-feature | local                   | upstream commit |
+      | BRANCH | LOCATION                | MESSAGE         |
+      | main   | local, remote, upstream | upstream commit |
+      | new    | local                   | upstream commit |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH      | COMMAND                   |
-      | new-feature | git add -A                |
-      |             | git stash                 |
-      |             | git checkout main         |
-      | main        | git branch -d new-feature |
-      |             | git stash pop             |
+      | BRANCH | COMMAND           |
+      | new    | git add -A        |
+      |        | git stash         |
+      |        | git checkout main |
+      | main   | git branch -d new |
+      |        | git stash pop     |
     And I am now on the "main" branch
     And my repo now has the commits
       | BRANCH | LOCATION                | MESSAGE         |

--- a/features/hack/on_feature_branch.feature
+++ b/features/hack/on_feature_branch.feature
@@ -1,51 +1,51 @@
 Feature: on the main branch
 
   Background:
-    Given my repo has a feature branch "existing-feature"
+    Given my repo has a feature branch "existing"
     And my repo contains the commits
-      | BRANCH           | LOCATION | MESSAGE                 |
-      | main             | remote   | main commit             |
-      | existing-feature | local    | existing feature commit |
-    And I am on the "existing-feature" branch
+      | BRANCH   | LOCATION | MESSAGE                 |
+      | main     | remote   | main commit             |
+      | existing | local    | existing feature commit |
+    And I am on the "existing" branch
     And my workspace has an uncommitted file
-    When I run "git-town hack new-feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH           | COMMAND                     |
-      | existing-feature | git fetch --prune --tags    |
-      |                  | git add -A                  |
-      |                  | git stash                   |
-      |                  | git checkout main           |
-      | main             | git rebase origin/main      |
-      |                  | git branch new-feature main |
-      |                  | git checkout new-feature    |
-      | new-feature      | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git add -A               |
+      |          | git stash                |
+      |          | git checkout main        |
+      | main     | git rebase origin/main   |
+      |          | git branch new main      |
+      |          | git checkout new         |
+      | new      | git stash pop            |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH           | LOCATION      | MESSAGE                 |
-      | main             | local, remote | main commit             |
-      | existing-feature | local         | existing feature commit |
-      | new-feature      | local         | main commit             |
+      | BRANCH   | LOCATION      | MESSAGE                 |
+      | main     | local, remote | main commit             |
+      | existing | local         | existing feature commit |
+      | new      | local         | main commit             |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH           | PARENT |
-      | existing-feature | main   |
-      | new-feature      | main   |
+      | BRANCH   | PARENT |
+      | existing | main   |
+      | new      | main   |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH           | COMMAND                       |
-      | new-feature      | git add -A                    |
-      |                  | git stash                     |
-      |                  | git checkout main             |
-      | main             | git branch -d new-feature     |
-      |                  | git checkout existing-feature |
-      | existing-feature | git stash pop                 |
-    And I am now on the "existing-feature" branch
+      | BRANCH   | COMMAND               |
+      | new      | git add -A            |
+      |          | git stash             |
+      |          | git checkout main     |
+      | main     | git branch -d new     |
+      |          | git checkout existing |
+      | existing | git stash pop         |
+    And I am now on the "existing" branch
     And my repo now has the commits
-      | BRANCH           | LOCATION      | MESSAGE                 |
-      | main             | local, remote | main commit             |
-      | existing-feature | local         | existing feature commit |
+      | BRANCH   | LOCATION      | MESSAGE                 |
+      | main     | local, remote | main commit             |
+      | existing | local         | existing feature commit |
     And Git Town now has the original branch hierarchy

--- a/features/hack/on_main_branch.feature
+++ b/features/hack/on_main_branch.feature
@@ -6,37 +6,37 @@ Feature: on a feature branch
       | main   | remote   | main_commit |
     And I am on the "main" branch
     And my workspace has an uncommitted file
-    When I run "git-town hack new-feature"
+    When I run "git-town hack new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH      | COMMAND                     |
-      | main        | git fetch --prune --tags    |
-      |             | git add -A                  |
-      |             | git stash                   |
-      |             | git rebase origin/main      |
-      |             | git branch new-feature main |
-      |             | git checkout new-feature    |
-      | new-feature | git stash pop               |
-    And I am now on the "new-feature" branch
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git rebase origin/main   |
+      |        | git branch new main      |
+      |        | git checkout new         |
+      | new    | git stash pop            |
+    And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH      | LOCATION      | MESSAGE     |
-      | main        | local, remote | main_commit |
-      | new-feature | local         | main_commit |
+      | BRANCH | LOCATION      | MESSAGE     |
+      | main   | local, remote | main_commit |
+      | new    | local         | main_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH      | PARENT |
-      | new-feature | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
 
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands
-      | BRANCH      | COMMAND                   |
-      | new-feature | git add -A                |
-      |             | git stash                 |
-      |             | git checkout main         |
-      | main        | git branch -d new-feature |
-      |             | git stash pop             |
+      | BRANCH | COMMAND           |
+      | new    | git add -A        |
+      |        | git stash         |
+      |        | git checkout main |
+      | main   | git branch -d new |
+      |        | git stash pop     |
     And I am now on the "main" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |

--- a/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
@@ -1,47 +1,47 @@
 Feature: the branch to kill has a deleted tracking branch
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "old" and "other"
     And my repo contains the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | feature       | local, remote | feature commit       |
-      | other-feature | local, remote | other feature commit |
-    And the "feature" branch gets deleted on the remote
-    And I am on the "feature" branch
+      | BRANCH | LOCATION      | MESSAGE              |
+      | old    | local, remote | old commit           |
+      | other  | local, remote | other feature commit |
+    And the "old" branch gets deleted on the remote
+    And I am on the "old" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                        |
-      | feature | git fetch --prune --tags       |
-      |         | git add -A                     |
-      |         | git commit -m "WIP on feature" |
-      |         | git checkout main              |
-      | main    | git branch -D feature          |
+      | BRANCH | COMMAND                    |
+      | old    | git fetch --prune --tags   |
+      |        | git add -A                 |
+      |        | git commit -m "WIP on old" |
+      |        | git checkout main          |
+      | main   | git branch -D old          |
     And I am now on the "main" branch
     And my repo doesn't have any uncommitted files
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | other-feature | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE              |
+      | other  | local, remote | other feature commit |
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                                       |
-      | main    | git branch feature {{ sha 'WIP on feature' }} |
-      |         | git checkout feature                          |
-      | feature | git reset {{ sha 'feature commit' }}          |
-    And I am now on the "feature" branch
+      | BRANCH | COMMAND                               |
+      | main   | git branch old {{ sha 'WIP on old' }} |
+      |        | git checkout old                      |
+      | old    | git reset {{ sha 'old commit' }}      |
+    And I am now on the "old" branch
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | feature       | local         | feature commit       |
-      | other-feature | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE              |
+      | old    | local         | old commit           |
+      | other  | local, remote | other feature commit |
     And my workspace has the uncommitted file again
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -1,43 +1,36 @@
 Feature: delete a local branch
 
   Background:
-    Given my repo has a feature branch "feature"
-    And my repo has a local feature branch "local-feature"
+    And my repo has a local feature branch "local"
     And my repo contains the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | feature       | local, remote | feature commit       |
-      | local-feature | local         | local feature commit |
-    And I am on the "local-feature" branch
+      | BRANCH | LOCATION | MESSAGE      |
+      | local  | local    | local commit |
+    And I am on the "local" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                              |
-      | local-feature | git fetch --prune --tags             |
-      |               | git add -A                           |
-      |               | git commit -m "WIP on local-feature" |
-      |               | git checkout main                    |
-      | main          | git branch -D local-feature          |
+      | BRANCH | COMMAND                      |
+      | local  | git fetch --prune --tags     |
+      |        | git add -A                   |
+      |        | git commit -m "WIP on local" |
+      |        | git checkout main            |
+      | main   | git branch -D local          |
     And I am now on the "main" branch
     And the existing branches are
-      | REPOSITORY    | BRANCHES      |
-      | local, remote | main, feature |
-    And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature commit |
-    And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | main   |
+      | REPOSITORY    | BRANCHES |
+      | local, remote | main     |
+    And Git Town now has no branch hierarchy information
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                                   |
-      | main          | git branch local-feature {{ sha 'WIP on local-feature' }} |
-      |               | git checkout local-feature                                |
-      | local-feature | git reset {{ sha 'local feature commit' }}                |
-    And I am now on the "local-feature" branch
+      | BRANCH | COMMAND                                   |
+      | main   | git branch local {{ sha 'WIP on local' }} |
+      |        | git checkout local                        |
+      | local  | git reset {{ sha 'local commit' }}        |
+    And I am now on the "local" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/features/local_repo.feature
+++ b/features/kill/current_branch/features/local_repo.feature
@@ -2,11 +2,11 @@ Feature: in a local repo
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has the local feature branches "feature" and "other-feature"
+    And my repo has the local feature branches "feature" and "other"
     And my repo contains the commits
-      | BRANCH        | LOCATION | MESSAGE              |
-      | feature       | local    | feature commit       |
-      | other-feature | local    | other feature commit |
+      | BRANCH  | LOCATION | MESSAGE              |
+      | feature | local    | feature commit       |
+      | other   | local    | other feature commit |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
@@ -20,14 +20,14 @@ Feature: in a local repo
       | main    | git branch -D feature          |
     And I am now on the "main" branch
     And the existing branches are
-      | REPOSITORY | BRANCHES            |
-      | local      | main, other-feature |
+      | REPOSITORY | BRANCHES    |
+      | local      | main, other |
     And my repo now has the commits
-      | BRANCH        | LOCATION | MESSAGE              |
-      | other-feature | local    | other feature commit |
+      | BRANCH | LOCATION | MESSAGE              |
+      | other  | local    | other feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -2,11 +2,11 @@ Feature: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has the feature branches "feature" and "other-feature"
+    And my repo has the feature branches "feature" and "other"
     And my repo contains the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | feature       | local, remote | feature commit       |
-      | other-feature | local, remote | other feature commit |
+      | BRANCH  | LOCATION      | MESSAGE              |
+      | feature | local, remote | feature commit       |
+      | other   | local, remote | other feature commit |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
@@ -21,16 +21,16 @@ Feature: offline mode
     And I am now on the "main" branch
     And my repo doesn't have any uncommitted files
     And the existing branches are
-      | REPOSITORY | BRANCHES                     |
-      | local      | main, other-feature          |
-      | remote     | main, feature, other-feature |
+      | REPOSITORY | BRANCHES             |
+      | local      | main, other          |
+      | remote     | main, feature, other |
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | feature       | remote        | feature commit       |
-      | other-feature | local, remote | other feature commit |
+      | BRANCH  | LOCATION      | MESSAGE              |
+      | feature | remote        | feature commit       |
+      | other   | local, remote | other feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/kill/current_branch/features/parent_branch.feature
+++ b/features/kill/current_branch/features/parent_branch.feature
@@ -1,50 +1,50 @@
 Feature: delete a branch within a branch chain
 
   Background:
-    Given my repo has a feature branch "feature-1"
-    And my repo has a feature branch "feature-2" as a child of "feature-1"
-    And my repo has a feature branch "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "alpha"
+    And my repo has a feature branch "beta" as a child of "alpha"
+    And my repo has a feature branch "gamma" as a child of "beta"
     And my repo contains the commits
-      | BRANCH    | LOCATION      | MESSAGE          |
-      | feature-1 | local, remote | feature 1 commit |
-      | feature-2 | local, remote | feature 2 commit |
-      | feature-3 | local, remote | feature 3 commit |
-    And I am on the "feature-2" branch
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, remote | alpha commit |
+      | beta   | local, remote | beta commit  |
+      | gamma  | local, remote | gamma commit |
+    And I am on the "beta" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                          |
-      | feature-2 | git fetch --prune --tags         |
-      |           | git push origin :feature-2       |
-      |           | git add -A                       |
-      |           | git commit -m "WIP on feature-2" |
-      |           | git checkout feature-1           |
-      | feature-1 | git branch -D feature-2          |
-    And I am now on the "feature-1" branch
+      | BRANCH | COMMAND                     |
+      | beta   | git fetch --prune --tags    |
+      |        | git push origin :beta       |
+      |        | git add -A                  |
+      |        | git commit -m "WIP on beta" |
+      |        | git checkout alpha          |
+      | alpha  | git branch -D beta          |
+    And I am now on the "alpha" branch
     And my repo doesn't have any uncommitted files
     And the existing branches are
-      | REPOSITORY    | BRANCHES                   |
-      | local, remote | main, feature-1, feature-3 |
+      | REPOSITORY    | BRANCHES           |
+      | local, remote | main, alpha, gamma |
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE          |
-      | feature-1 | local, remote | feature 1 commit |
-      | feature-3 | local, remote | feature 3 commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, remote | alpha commit |
+      | gamma  | local, remote | gamma commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT    |
-      | feature-1 | main      |
-      | feature-3 | feature-1 |
+      | BRANCH | PARENT |
+      | alpha  | main   |
+      | gamma  | alpha  |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                                           |
-      | feature-1 | git branch feature-2 {{ sha 'WIP on feature-2' }} |
-      |           | git checkout feature-2                            |
-      | feature-2 | git reset {{ sha 'feature 2 commit' }}            |
-      |           | git push -u origin feature-2                      |
-    And I am now on the "feature-2" branch
+      | BRANCH | COMMAND                                 |
+      | alpha  | git branch beta {{ sha 'WIP on beta' }} |
+      |        | git checkout beta                       |
+      | beta   | git reset {{ sha 'beta commit' }}       |
+      |        | git push -u origin beta                 |
+    And I am now on the "beta" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -1,45 +1,45 @@
 Feature: delete the current feature branch
 
   Background:
-    Given my repo has the feature branches "current-feature" and "other-feature"
+    Given my repo has the feature branches "current" and "other"
     And my repo contains the commits
-      | BRANCH          | LOCATION      | MESSAGE                |
-      | current-feature | local, remote | current feature commit |
-      | other-feature   | local, remote | other feature commit   |
-    And I am on the "current-feature" branch
+      | BRANCH  | LOCATION      | MESSAGE                |
+      | current | local, remote | current feature commit |
+      | other   | local, remote | other feature commit   |
+    And I am on the "current" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH          | COMMAND                                |
-      | current-feature | git fetch --prune --tags               |
-      |                 | git push origin :current-feature       |
-      |                 | git add -A                             |
-      |                 | git commit -m "WIP on current-feature" |
-      |                 | git checkout main                      |
-      | main            | git branch -D current-feature          |
+      | BRANCH  | COMMAND                        |
+      | current | git fetch --prune --tags       |
+      |         | git push origin :current       |
+      |         | git add -A                     |
+      |         | git commit -m "WIP on current" |
+      |         | git checkout main              |
+      | main    | git branch -D current          |
     And I am now on the "main" branch
     And my repo doesn't have any uncommitted files
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | other-feature | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE              |
+      | other  | local, remote | other feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH          | COMMAND                                                       |
-      | main            | git branch current-feature {{ sha 'WIP on current-feature' }} |
-      |                 | git checkout current-feature                                  |
-      | current-feature | git reset {{ sha 'current feature commit' }}                  |
-      |                 | git push -u origin current-feature                            |
-    And I am now on the "current-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | main    | git branch current {{ sha 'WIP on current' }} |
+      |         | git checkout current                          |
+      | current | git reset {{ sha 'current feature commit' }}  |
+      |         | git push -u origin current                    |
+    And I am now on the "current" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/edge_cases/non_existing_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/non_existing_branch.feature
@@ -3,13 +3,13 @@ Feature: non-existing branch
   Scenario:
     Given I am on the "main" branch
     And my workspace has an uncommitted file
-    When I run "git-town kill non-existing-feature"
+    When I run "git-town kill non-existing"
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | main   | git fetch --prune --tags |
     And it prints the error:
       """
-      there is no branch named "non-existing-feature"
+      there is no branch named "non-existing"
       """
     And I am now on the "main" branch
     And my workspace still contains my uncommitted file

--- a/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -1,45 +1,45 @@
 Feature: delete the current branch
 
   Background:
-    Given my repo has the feature branches "other-feature" and "current-feature"
+    Given my repo has the feature branches "other" and "current"
     And my repo contains the commits
-      | BRANCH          | LOCATION      | MESSAGE                |
-      | current-feature | local, remote | current feature commit |
-      | other-feature   | local, remote | other feature commit   |
-    And I am on the "current-feature" branch
+      | BRANCH  | LOCATION      | MESSAGE                |
+      | current | local, remote | current feature commit |
+      | other   | local, remote | other feature commit   |
+    And I am on the "current" branch
     And my workspace has an uncommitted file
-    When I run "git-town kill current-feature"
+    When I run "git-town kill current"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH          | COMMAND                                |
-      | current-feature | git fetch --prune --tags               |
-      |                 | git push origin :current-feature       |
-      |                 | git add -A                             |
-      |                 | git commit -m "WIP on current-feature" |
-      |                 | git checkout main                      |
-      | main            | git branch -D current-feature          |
+      | BRANCH  | COMMAND                        |
+      | current | git fetch --prune --tags       |
+      |         | git push origin :current       |
+      |         | git add -A                     |
+      |         | git commit -m "WIP on current" |
+      |         | git checkout main              |
+      | main    | git branch -D current          |
     And I am now on the "main" branch
     And my repo doesn't have any uncommitted files
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE              |
-      | other-feature | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE              |
+      | other  | local, remote | other feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH          | COMMAND                                                       |
-      | main            | git branch current-feature {{ sha 'WIP on current-feature' }} |
-      |                 | git checkout current-feature                                  |
-      | current-feature | git reset {{ sha 'current feature commit' }}                  |
-      |                 | git push -u origin current-feature                            |
-    And I am now on the "current-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | main    | git branch current {{ sha 'WIP on current' }} |
+      |         | git checkout current                          |
+      | current | git reset {{ sha 'current feature commit' }}  |
+      |         | git push -u origin current                    |
+    And I am now on the "current" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/edge_cases/perennial_branches.feature
+++ b/features/kill/supplied_branch/edge_cases/perennial_branches.feature
@@ -13,16 +13,11 @@ Feature: does not kill perennial branches
     And my repo still has its initial branches and branch hierarchy
 
   Scenario: perennial branch
-    Given my repo has a feature branch "feature"
     And my repo has a perennial branch "qa"
-    And I am on the "feature" branch
-    And my workspace has an uncommitted file
+    And I am on the "main" branch
     When I run "git-town kill qa"
     Then it runs no commands
     And it prints the error:
       """
       you can only kill feature branches
       """
-    And I am still on the "feature" branch
-    And my workspace still contains my uncommitted file
-    And my repo still has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/features/local_branch.feature
+++ b/features/kill/supplied_branch/features/local_branch.feature
@@ -2,42 +2,42 @@ Feature: local branch
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has the local feature branches "dead-feature" and "other-feature"
+    And my repo has the local feature branches "dead" and "other"
     And my repo contains the commits
-      | BRANCH        | LOCATION | MESSAGE              |
-      | dead-feature  | local    | dead feature commit  |
-      | other-feature | local    | other feature commit |
-    And I am on the "dead-feature" branch
+      | BRANCH | LOCATION | MESSAGE              |
+      | dead   | local    | dead feature commit  |
+      | other  | local    | other feature commit |
+    And I am on the "dead" branch
     And my workspace has an uncommitted file
-    When I run "git-town kill dead-feature"
+    When I run "git-town kill dead"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH       | COMMAND                             |
-      | dead-feature | git add -A                          |
-      |              | git commit -m "WIP on dead-feature" |
-      |              | git checkout main                   |
-      | main         | git branch -D dead-feature          |
+      | BRANCH | COMMAND                     |
+      | dead   | git add -A                  |
+      |        | git commit -m "WIP on dead" |
+      |        | git checkout main           |
+      | main   | git branch -D dead          |
     And I am now on the "main" branch
     And my repo doesn't have any uncommitted files
     And the existing branches are
-      | REPOSITORY | BRANCHES            |
-      | local      | main, other-feature |
+      | REPOSITORY | BRANCHES    |
+      | local      | main, other |
     And my repo now has the commits
-      | BRANCH        | LOCATION | MESSAGE              |
-      | other-feature | local    | other feature commit |
+      | BRANCH | LOCATION | MESSAGE              |
+      | other  | local    | other feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH       | COMMAND                                                 |
-      | main         | git branch dead-feature {{ sha 'WIP on dead-feature' }} |
-      |              | git checkout dead-feature                               |
-      | dead-feature | git reset {{ sha 'dead feature commit' }}               |
-    And I am now on the "dead-feature" branch
+      | BRANCH | COMMAND                                   |
+      | main   | git branch dead {{ sha 'WIP on dead' }}   |
+      |        | git checkout dead                         |
+      | dead   | git reset {{ sha 'dead feature commit' }} |
+    And I am now on the "dead" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -2,45 +2,45 @@ Feature: local repository
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has the local feature branches "good-feature" and "other-feature"
+    And my repo has the local feature branches "good" and "other"
     And my repo contains the commits
-      | BRANCH        | LOCATION | MESSAGE              | FILE NAME        |
-      | main          | local    | main commit          | conflicting_file |
-      | good-feature  | local    | good feature commit  | file             |
-      | other-feature | local    | other feature commit | file             |
-    And I am on the "good-feature" branch
+      | BRANCH | LOCATION | MESSAGE              | FILE NAME        |
+      | main   | local    | main commit          | conflicting_file |
+      | good   | local    | good feature commit  | file             |
+      | other  | local    | other feature commit | file             |
+    And I am on the "good" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
-    When I run "git-town kill other-feature"
+    When I run "git-town kill other"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH       | COMMAND                     |
-      | good-feature | git add -A                  |
-      |              | git stash                   |
-      |              | git branch -D other-feature |
-      |              | git stash pop               |
-    And I am still on the "good-feature" branch
+      | BRANCH | COMMAND             |
+      | good   | git add -A          |
+      |        | git stash           |
+      |        | git branch -D other |
+      |        | git stash pop       |
+    And I am still on the "good" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY | BRANCHES           |
-      | local      | main, good-feature |
+      | REPOSITORY | BRANCHES   |
+      | local      | main, good |
     And my repo now has the commits
-      | BRANCH       | LOCATION | MESSAGE             |
-      | main         | local    | main commit         |
-      | good-feature | local    | good feature commit |
+      | BRANCH | LOCATION | MESSAGE             |
+      | main   | local    | main commit         |
+      | good   | local    | good feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH       | PARENT |
-      | good-feature | main   |
+      | BRANCH | PARENT |
+      | good   | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH       | COMMAND                                                   |
-      | good-feature | git add -A                                                |
-      |              | git stash                                                 |
-      |              | git branch other-feature {{ sha 'other feature commit' }} |
-      |              | git stash pop                                             |
-    And I am still on the "good-feature" branch
+      | BRANCH | COMMAND                                           |
+      | good   | git add -A                                        |
+      |        | git stash                                         |
+      |        | git branch other {{ sha 'other feature commit' }} |
+      |        | git stash pop                                     |
+    And I am still on the "good" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/features/parent_branch.feature
+++ b/features/kill/supplied_branch/features/parent_branch.feature
@@ -1,45 +1,45 @@
 Feature: delete a parent branch
 
   Background:
-    Given my repo has a feature branch "feature-1"
-    And my repo has a feature branch "feature-2" as a child of "feature-1"
-    And my repo has a feature branch "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "alpha"
+    And my repo has a feature branch "beta" as a child of "alpha"
+    And my repo has a feature branch "gamma" as a child of "beta"
     And my repo contains the commits
-      | BRANCH    | LOCATION      | MESSAGE          |
-      | feature-1 | local, remote | feature 1 commit |
-      | feature-2 | local, remote | feature 2 commit |
-      | feature-3 | local, remote | feature 3 commit |
-    And I am on the "feature-3" branch
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, remote | alpha commit |
+      | beta   | local, remote | beta commit  |
+      | gamma  | local, remote | gamma commit |
+    And I am on the "gamma" branch
     And my workspace has an uncommitted file
-    When I run "git-town kill feature-2"
+    When I run "git-town kill beta"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                    |
-      | feature-3 | git fetch --prune --tags   |
-      |           | git push origin :feature-2 |
-      |           | git branch -D feature-2    |
-    And I am now on the "feature-3" branch
+      | BRANCH | COMMAND                  |
+      | gamma  | git fetch --prune --tags |
+      |        | git push origin :beta    |
+      |        | git branch -D beta       |
+    And I am now on the "gamma" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES                   |
-      | local, remote | main, feature-1, feature-3 |
+      | REPOSITORY    | BRANCHES           |
+      | local, remote | main, alpha, gamma |
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE          |
-      | feature-1 | local, remote | feature 1 commit |
-      | feature-3 | local, remote | feature 3 commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, remote | alpha commit |
+      | gamma  | local, remote | gamma commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT    |
-      | feature-1 | main      |
-      | feature-3 | feature-1 |
+      | BRANCH | PARENT |
+      | alpha  | main   |
+      | gamma  | alpha  |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                                           |
-      | feature-3 | git branch feature-2 {{ sha 'feature 2 commit' }} |
-      |           | git push -u origin feature-2                      |
-    And I am now on the "feature-3" branch
+      | BRANCH | COMMAND                                 |
+      | gamma  | git branch beta {{ sha 'beta commit' }} |
+      |        | git push -u origin beta                 |
+    And I am now on the "gamma" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -1,42 +1,42 @@
 Feature: delete another than the current branch
 
   Background:
-    Given my repo has the feature branches "good-feature" and "dead-feature"
+    Given my repo has the feature branches "good" and "dead"
     And my repo contains the commits
-      | BRANCH       | LOCATION      | MESSAGE                              | FILE NAME        |
-      | main         | local, remote | conflicting with uncommitted changes | conflicting_file |
-      | dead-feature | local, remote | dead-end commit                      | file             |
-      | good-feature | local, remote | good commit                          | file             |
-    And I am on the "good-feature" branch
+      | BRANCH | LOCATION      | MESSAGE                              | FILE NAME        |
+      | main   | local, remote | conflicting with uncommitted changes | conflicting_file |
+      | dead   | local, remote | dead-end commit                      | file             |
+      | good   | local, remote | good commit                          | file             |
+    And I am on the "good" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
-    When I run "git-town kill dead-feature"
+    When I run "git-town kill dead"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH       | COMMAND                       |
-      | good-feature | git fetch --prune --tags      |
-      |              | git push origin :dead-feature |
-      |              | git branch -D dead-feature    |
-    And I am still on the "good-feature" branch
+      | BRANCH | COMMAND                  |
+      | good   | git fetch --prune --tags |
+      |        | git push origin :dead    |
+      |        | git branch -D dead       |
+    And I am still on the "good" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES           |
-      | local, remote | main, good-feature |
+      | REPOSITORY    | BRANCHES   |
+      | local, remote | main, good |
     And my repo now has the commits
-      | BRANCH       | LOCATION      | MESSAGE                              |
-      | main         | local, remote | conflicting with uncommitted changes |
-      | good-feature | local, remote | good commit                          |
+      | BRANCH | LOCATION      | MESSAGE                              |
+      | main   | local, remote | conflicting with uncommitted changes |
+      | good   | local, remote | good commit                          |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH       | PARENT |
-      | good-feature | main   |
+      | BRANCH | PARENT |
+      | good   | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH       | COMMAND                                             |
-      | good-feature | git branch dead-feature {{ sha 'dead-end commit' }} |
-      |              | git push -u origin dead-feature                     |
-    And I am still on the "good-feature" branch
+      | BRANCH | COMMAND                                     |
+      | good   | git branch dead {{ sha 'dead-end commit' }} |
+      |        | git push -u origin dead                     |
+    And I am still on the "good" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/main_branch/update.feature
+++ b/features/main_branch/update.feature
@@ -7,11 +7,11 @@ Feature: configure the main branch
     And the main branch is now "main"
 
   Scenario: configured
-    Given my repo has the branches "main-old" and "main-new"
-    And the main branch is "main-old"
-    When I run "git-town main-branch main-new"
+    Given my repo has the branches "old" and "new"
+    And the main branch is "old"
+    When I run "git-town main-branch new"
     Then it prints no output
-    And the main branch is now "main-new"
+    And the main branch is now "new"
 
   Scenario: non-existing branch
     When I run "git-town main-branch non-existing"

--- a/features/new-pull-request/features/on_outdated_branch.feature
+++ b/features/new-pull-request/features/on_outdated_branch.feature
@@ -2,64 +2,64 @@
 Feature: sync before creating the pull request
 
   Background:
-    Given my repo has a feature branch "parent-feature"
-    And my repo has a feature branch "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent"
+    And my repo has a feature branch "child" as a child of "parent"
     And my repo contains the commits
-      | BRANCH         | LOCATION | MESSAGE              |
-      | main           | local    | local main commit    |
-      |                | remote   | remote main commit   |
-      | parent-feature | local    | local parent commit  |
-      |                | remote   | remote parent commit |
-      | child-feature  | local    | local child commit   |
-      |                | remote   | remote child commit  |
+      | BRANCH | LOCATION | MESSAGE              |
+      | main   | local    | local main commit    |
+      |        | remote   | remote main commit   |
+      | parent | local    | local parent commit  |
+      |        | remote   | remote parent commit |
+      | child  | local    | local child commit   |
+      |        | remote   | remote child commit  |
     And my computer has the "open" tool installed
     And my repo's origin is "git@github.com:git-town/git-town.git"
-    And I am on the "child-feature" branch
+    And I am on the "child" branch
     And my workspace has an uncommitted file
     When I run "git-town new-pull-request"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH         | COMMAND                                                                                   |
-      | child-feature  | git fetch --prune --tags                                                                  |
-      |                | git add -A                                                                                |
-      |                | git stash                                                                                 |
-      |                | git checkout main                                                                         |
-      | main           | git rebase origin/main                                                                    |
-      |                | git push                                                                                  |
-      |                | git checkout parent-feature                                                               |
-      | parent-feature | git merge --no-edit origin/parent-feature                                                 |
-      |                | git merge --no-edit main                                                                  |
-      |                | git push                                                                                  |
-      |                | git checkout child-feature                                                                |
-      | child-feature  | git merge --no-edit origin/child-feature                                                  |
-      |                | git merge --no-edit parent-feature                                                        |
-      |                | git push                                                                                  |
-      |                | git stash pop                                                                             |
-      | <none>         | open https://github.com/git-town/git-town/compare/parent-feature...child-feature?expand=1 |
+      | BRANCH | COMMAND                                                                   |
+      | child  | git fetch --prune --tags                                                  |
+      |        | git add -A                                                                |
+      |        | git stash                                                                 |
+      |        | git checkout main                                                         |
+      | main   | git rebase origin/main                                                    |
+      |        | git push                                                                  |
+      |        | git checkout parent                                                       |
+      | parent | git merge --no-edit origin/parent                                         |
+      |        | git merge --no-edit main                                                  |
+      |        | git push                                                                  |
+      |        | git checkout child                                                        |
+      | child  | git merge --no-edit origin/child                                          |
+      |        | git merge --no-edit parent                                                |
+      |        | git push                                                                  |
+      |        | git stash pop                                                             |
+      | <none> | open https://github.com/git-town/git-town/compare/parent...child?expand=1 |
     And "open" launches a new pull request with this url in my browser:
       """
-      https://github.com/git-town/git-town/compare/parent-feature...child-feature?expand=1
+      https://github.com/git-town/git-town/compare/parent...child?expand=1
       """
-    And I am still on the "child-feature" branch
+    And I am still on the "child" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH         | LOCATION      | MESSAGE                                                                  |
-      | main           | local, remote | remote main commit                                                       |
-      |                |               | local main commit                                                        |
-      | child-feature  | local, remote | local child commit                                                       |
-      |                |               | remote child commit                                                      |
-      |                |               | Merge remote-tracking branch 'origin/child-feature' into child-feature   |
-      |                |               | local parent commit                                                      |
-      |                |               | remote parent commit                                                     |
-      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |
-      |                |               | remote main commit                                                       |
-      |                |               | local main commit                                                        |
-      |                |               | Merge branch 'main' into parent-feature                                  |
-      |                |               | Merge branch 'parent-feature' into child-feature                         |
-      | parent-feature | local, remote | local parent commit                                                      |
-      |                |               | remote parent commit                                                     |
-      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |
-      |                |               | remote main commit                                                       |
-      |                |               | local main commit                                                        |
-      |                |               | Merge branch 'main' into parent-feature                                  |
+      | BRANCH | LOCATION      | MESSAGE                                                  |
+      | main   | local, remote | remote main commit                                       |
+      |        |               | local main commit                                        |
+      | child  | local, remote | local child commit                                       |
+      |        |               | remote child commit                                      |
+      |        |               | Merge remote-tracking branch 'origin/child' into child   |
+      |        |               | local parent commit                                      |
+      |        |               | remote parent commit                                     |
+      |        |               | Merge remote-tracking branch 'origin/parent' into parent |
+      |        |               | remote main commit                                       |
+      |        |               | local main commit                                        |
+      |        |               | Merge branch 'main' into parent                          |
+      |        |               | Merge branch 'parent' into child                         |
+      | parent | local, remote | local parent commit                                      |
+      |        |               | remote parent commit                                     |
+      |        |               | Merge remote-tracking branch 'origin/parent' into parent |
+      |        |               | remote main commit                                       |
+      |        |               | local main commit                                        |
+      |        |               | Merge branch 'main' into parent                          |

--- a/features/prepend/edge_cases/on_perennial_branch.feature
+++ b/features/prepend/edge_cases/on_perennial_branch.feature
@@ -2,7 +2,7 @@ Feature: does not prepend perennial branches
 
   Scenario: on main branch
     And I am on the "main" branch
-    When I run "git-town prepend feature"
+    When I run "git-town prepend new"
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | main   | git fetch --prune --tags |
@@ -15,7 +15,7 @@ Feature: does not prepend perennial branches
   Scenario: on perennial branch
     Given my repo has a perennial branch "production"
     And I am on the "production" branch
-    When I run "git-town prepend feature"
+    When I run "git-town prepend new"
     Then it runs the commands
       | BRANCH     | COMMAND                  |
       | production | git fetch --prune --tags |

--- a/features/prepend/edge_cases/unknown_parent.feature
+++ b/features/prepend/edge_cases/unknown_parent.feature
@@ -15,5 +15,5 @@ Feature: ask for missing parent information
       |        | git checkout new         |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
-      | old    | new    |
       | new    | main   |
+      | old    | new    |

--- a/features/prepend/edge_cases/unknown_parent.feature
+++ b/features/prepend/edge_cases/unknown_parent.feature
@@ -1,19 +1,19 @@
 Feature: ask for missing parent information
 
   Scenario:
-    Given my repo has a branch "feature"
-    And I am on the "feature" branch
+    Given my repo has a branch "old"
+    And I am on the "old" branch
     When I run "git-town prepend new" and answer the prompts:
       | PROMPT                                    | ANSWER  |
       | Please specify the parent branch of 'new' | [ENTER] |
     Then it runs the commands
-      | BRANCH  | COMMAND                  |
-      | feature | git fetch --prune --tags |
-      |         | git checkout main        |
-      | main    | git rebase origin/main   |
-      |         | git branch new main      |
-      |         | git checkout new         |
+      | BRANCH | COMMAND                  |
+      | old    | git fetch --prune --tags |
+      |        | git checkout main        |
+      | main   | git rebase origin/main   |
+      |        | git branch new main      |
+      |        | git checkout new         |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | new    |
-      | new     | main   |
+      | BRANCH | PARENT |
+      | old    | new    |
+      | new    | main   |

--- a/features/prepend/features/hack_push_flag.feature
+++ b/features/prepend/features/hack_push_flag.feature
@@ -2,39 +2,39 @@ Feature: auto-push new branches
 
   Background:
     Given the new-branch-push-flag configuration is true
-    And my repo has a feature branch "feature"
+    And my repo has a feature branch "old"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature_commit |
-    And I am on the "feature" branch
-    When I run "git-town prepend parent"
+      | BRANCH | LOCATION      | MESSAGE        |
+      | old    | local, remote | feature_commit |
+    And I am on the "old" branch
+    When I run "git-town prepend new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                   |
-      | feature | git fetch --prune --tags  |
-      |         | git checkout main         |
-      | main    | git rebase origin/main    |
-      |         | git branch parent main    |
-      |         | git checkout parent       |
-      | parent  | git push -u origin parent |
-    And I am now on the "parent" branch
+      | BRANCH | COMMAND                  |
+      | old    | git fetch --prune --tags |
+      |        | git checkout main        |
+      | main   | git rebase origin/main   |
+      |        | git branch new main      |
+      |        | git checkout new         |
+      | new    | git push -u origin new   |
+    And I am now on the "new" branch
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature_commit |
+      | BRANCH | LOCATION      | MESSAGE        |
+      | old    | local, remote | feature_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | parent |
-      | parent  | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
+      | old    | new    |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                 |
-      | parent | git push origin :parent |
-      |        | git checkout main       |
-      | main   | git branch -d parent    |
-      |        | git checkout feature    |
-    And I am now on the "feature" branch
+      | BRANCH | COMMAND              |
+      | new    | git push origin :new |
+      |        | git checkout main    |
+      | main   | git branch -d new    |
+      |        | git checkout old     |
+    And I am now on the "old" branch
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -2,36 +2,36 @@ Feature: offline mode
 
   Background:
     Given Git Town is in offline mode
-    And my repo has a feature branch "feature"
+    And my repo has a feature branch "old"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature_commit |
-    And I am on the "feature" branch
-    When I run "git-town prepend parent"
+      | BRANCH | LOCATION      | MESSAGE    |
+      | old    | local, remote | old_commit |
+    And I am on the "old" branch
+    When I run "git-town prepend new"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                |
-      | feature | git checkout main      |
-      | main    | git rebase origin/main |
-      |         | git branch parent main |
-      |         | git checkout parent    |
-    And I am now on the "parent" branch
+      | BRANCH | COMMAND                |
+      | old    | git checkout main      |
+      | main   | git rebase origin/main |
+      |        | git branch new main    |
+      |        | git checkout new       |
+    And I am now on the "new" branch
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature_commit |
+      | BRANCH | LOCATION      | MESSAGE    |
+      | old    | local, remote | old_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | parent |
-      | parent  | main   |
+      | BRANCH | PARENT |
+      | new    | main   |
+      | old    | new    |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND              |
-      | parent | git checkout main    |
-      | main   | git branch -d parent |
-      |        | git checkout feature |
-    And I am now on the "feature" branch
+      | BRANCH | COMMAND           |
+      | new    | git checkout main |
+      | main   | git branch -d new |
+      |        | git checkout old  |
+    And I am now on the "old" branch
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/prepend/prepend.feature
+++ b/features/prepend/prepend.feature
@@ -1,46 +1,46 @@
 Feature: prepend a branch to a feature branch
 
   Background:
-    Given my repo has a feature branch "feature"
+    Given my repo has a feature branch "old"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature_commit |
-    And I am on the "feature" branch
+      | BRANCH | LOCATION      | MESSAGE    |
+      | old    | local, remote | old_commit |
+    And I am on the "old" branch
     And my workspace has an uncommitted file
     When I run "git-town prepend parent"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                  |
-      | feature | git fetch --prune --tags |
-      |         | git add -A               |
-      |         | git stash                |
-      |         | git checkout main        |
-      | main    | git rebase origin/main   |
-      |         | git branch parent main   |
-      |         | git checkout parent      |
-      | parent  | git stash pop            |
+      | BRANCH | COMMAND                  |
+      | old    | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git checkout main        |
+      | main   | git rebase origin/main   |
+      |        | git branch parent main   |
+      |        | git checkout parent      |
+      | parent | git stash pop            |
     And I am now on the "parent" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature_commit |
+      | BRANCH | LOCATION      | MESSAGE    |
+      | old    | local, remote | old_commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | parent |
-      | parent  | main   |
+      | BRANCH | PARENT |
+      | old    | parent |
+      | parent | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND              |
-      | parent  | git add -A           |
-      |         | git stash            |
-      |         | git checkout main    |
-      | main    | git branch -d parent |
-      |         | git checkout feature |
-      | feature | git stash pop        |
-    And I am now on the "feature" branch
+      | BRANCH | COMMAND              |
+      | parent | git add -A           |
+      |        | git stash            |
+      |        | git checkout main    |
+      | main   | git branch -d parent |
+      |        | git checkout old     |
+      | old    | git stash pop        |
+    And I am now on the "old" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/prune-branches/prune_branches.feature
+++ b/features/prune-branches/prune_branches.feature
@@ -1,11 +1,11 @@
 Feature: delete branches that were shipped or removed on another machine
 
   Background:
-    Given my repo has the feature branches "feature" and "old"
+    Given my repo has the feature branches "active" and "old"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE        |
-      | feature | local, remote | feature commit |
-      | old     | local, remote | old commit     |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | active | local, remote | active commit |
+      | old    | local, remote | old commit    |
     And the "old" branch gets deleted on the remote
     And I am on the "old" branch
     And my workspace has an uncommitted file
@@ -20,11 +20,11 @@ Feature: delete branches that were shipped or removed on another machine
     And I am now on the "main" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES      |
-      | local, remote | main, feature |
+      | REPOSITORY    | BRANCHES     |
+      | local, remote | main, active |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH  | PARENT |
-      | feature | main   |
+      | BRANCH | PARENT |
+      | active | main   |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/edge_cases/child_branch.feature
+++ b/features/ship/current_branch/edge_cases/child_branch.feature
@@ -1,27 +1,27 @@
 Feature: does not ship a child branch
 
   Background:
-    Given my repo has a feature branch "feature-1"
-    And my repo has a feature branch "feature-2" as a child of "feature-1"
-    And my repo has a feature branch "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "alpha"
+    And my repo has a feature branch "beta" as a child of "alpha"
+    And my repo has a feature branch "gamma" as a child of "beta"
     And my repo contains the commits
-      | BRANCH    | LOCATION      | MESSAGE          |
-      | feature-1 | local, remote | feature 1 commit |
-      | feature-2 | local, remote | feature 2 commit |
-      | feature-3 | local, remote | feature 3 commit |
-    And I am on the "feature-3" branch
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, remote | alpha commit |
+      | beta   | local, remote | beta commit  |
+      | gamma  | local, remote | gamma commit |
+    And I am on the "gamma" branch
     When I run "git-town ship"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                  |
-      | feature-3 | git fetch --prune --tags |
+      | BRANCH | COMMAND                  |
+      | gamma  | git fetch --prune --tags |
     And it prints the error:
       """
-      shipping this branch would ship "feature-1, feature-2" as well,
-      please ship "feature-1" first
+      shipping this branch would ship "alpha, beta" as well,
+      please ship "alpha" first
       """
-    And I am still on the "feature-3" branch
+    And I am still on the "gamma" branch
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy
 
@@ -32,6 +32,6 @@ Feature: does not ship a child branch
       """
       nothing to undo
       """
-    And I am still on the "feature-3" branch
+    And I am still on the "gamma" branch
     And my repo is left with my original commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/current_branch/features/parent_branch.feature
+++ b/features/ship/current_branch/features/parent_branch.feature
@@ -1,54 +1,54 @@
 Feature: ship a parent branch
 
   Background:
-    Given my repo has a feature branch "parent-feature"
-    And my repo has a feature branch "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent"
+    And my repo has a feature branch "child" as a child of "parent"
     And my repo contains the commits
-      | BRANCH         | LOCATION      | MESSAGE               |
-      | parent-feature | local, remote | parent feature commit |
-      | child-feature  | local, remote | child feature commit  |
-    And I am on the "parent-feature" branch
+      | BRANCH | LOCATION      | MESSAGE               |
+      | parent | local, remote | parent feature commit |
+      | child  | local, remote | child feature commit  |
+    And I am on the "parent" branch
     When I run "git-town ship -m 'parent feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH         | COMMAND                                   |
-      | parent-feature | git fetch --prune --tags                  |
-      |                | git checkout main                         |
-      | main           | git rebase origin/main                    |
-      |                | git checkout parent-feature               |
-      | parent-feature | git merge --no-edit origin/parent-feature |
-      |                | git merge --no-edit main                  |
-      |                | git checkout main                         |
-      | main           | git merge --squash parent-feature         |
-      |                | git commit -m "parent feature done"       |
-      |                | git push                                  |
-      |                | git branch -D parent-feature              |
+      | BRANCH | COMMAND                             |
+      | parent | git fetch --prune --tags            |
+      |        | git checkout main                   |
+      | main   | git rebase origin/main              |
+      |        | git checkout parent                 |
+      | parent | git merge --no-edit origin/parent   |
+      |        | git merge --no-edit main            |
+      |        | git checkout main                   |
+      | main   | git merge --squash parent           |
+      |        | git commit -m "parent feature done" |
+      |        | git push                            |
+      |        | git branch -D parent                |
     And I am now on the "main" branch
     And my repo now has the commits
-      | BRANCH         | LOCATION      | MESSAGE               |
-      | main           | local, remote | parent feature done   |
-      | child-feature  | local, remote | child feature commit  |
-      | parent-feature | remote        | parent feature commit |
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, remote | parent feature done   |
+      | child  | local, remote | child feature commit  |
+      | parent | remote        | parent feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | child-feature | main   |
+      | BRANCH | PARENT |
+      | child  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH         | COMMAND                                                     |
-      | main           | git branch parent-feature {{ sha 'parent feature commit' }} |
-      |                | git revert {{ sha 'parent feature done' }}                  |
-      |                | git push                                                    |
-      |                | git checkout parent-feature                                 |
-      | parent-feature | git checkout main                                           |
-      | main           | git checkout parent-feature                                 |
-    And I am now on the "parent-feature" branch
+      | BRANCH | COMMAND                                             |
+      | main   | git branch parent {{ sha 'parent feature commit' }} |
+      |        | git revert {{ sha 'parent feature done' }}          |
+      |        | git push                                            |
+      |        | git checkout parent                                 |
+      | parent | git checkout main                                   |
+      | main   | git checkout parent                                 |
+    And I am now on the "parent" branch
     And my repo now has the commits
-      | BRANCH         | LOCATION      | MESSAGE                      |
-      | main           | local, remote | parent feature done          |
-      |                |               | Revert "parent feature done" |
-      | child-feature  | local, remote | child feature commit         |
-      | parent-feature | local, remote | parent feature commit        |
+      | BRANCH | LOCATION      | MESSAGE                      |
+      | main   | local, remote | parent feature done          |
+      |        |               | Revert "parent feature done" |
+      | child  | local, remote | child feature commit         |
+      | parent | local, remote | parent feature commit        |
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -1,27 +1,27 @@
 Feature: handle conflicts between the supplied feature branch and the main branch
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local    | conflicting main commit    | conflicting_file | main content    |
       | feature | local    | conflicting feature commit | conflicting_file | feature content |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git add -A                         |
-      |               | git stash                          |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git push                           |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git push                           |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
     And it prints the error:
       """
       To abort, run "git-town abort".
@@ -34,12 +34,12 @@ Feature: handle conflicts between the supplied feature branch and the main branc
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH        | COMMAND                    |
-      | feature       | git merge --abort          |
-      |               | git checkout main          |
-      | main          | git checkout other-feature |
-      | other-feature | git stash pop              |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND            |
+      | feature | git merge --abort  |
+      |         | git checkout main  |
+      | main    | git checkout other |
+      | other   | git stash pop      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And there is no merge in progress
     And my repo now has the commits
@@ -52,44 +52,44 @@ Feature: handle conflicts between the supplied feature branch and the main branc
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH        | COMMAND                      |
-      | feature       | git commit --no-edit         |
-      |               | git checkout main            |
-      | main          | git merge --squash feature   |
-      |               | git commit -m "feature done" |
-      |               | git push                     |
-      |               | git push origin :feature     |
-      |               | git branch -D feature        |
-      |               | git checkout other-feature   |
-      | other-feature | git stash pop                |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                      |
+      | feature | git commit --no-edit         |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git push origin :feature     |
+      |         | git branch -D feature        |
+      |         | git checkout other           |
+      | other   | git stash pop                |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT     |
       | main   | local, remote | conflicting main commit | conflicting_file | main content     |
       |        |               | feature done            | conflicting_file | resolved content |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: continue after resolving the conflicts and comitting
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH        | COMMAND                      |
-      | feature       | git checkout main            |
-      | main          | git merge --squash feature   |
-      |               | git commit -m "feature done" |
-      |               | git push                     |
-      |               | git push origin :feature     |
-      |               | git branch -D feature        |
-      |               | git checkout other-feature   |
-      | other-feature | git stash pop                |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                      |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git push origin :feature     |
+      |         | git branch -D feature        |
+      |         | git checkout other           |
+      | other   | git stash pop                |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
 
   Scenario: undo after continue
@@ -97,20 +97,20 @@ Feature: handle conflicts between the supplied feature branch and the main branc
     And I run "git-town continue"
     And I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                                         |
-      | other-feature | git add -A                                                      |
-      |               | git stash                                                       |
-      |               | git checkout main                                               |
-      | main          | git branch feature {{ sha 'Merge branch 'main' into feature' }} |
-      |               | git push -u origin feature                                      |
-      |               | git revert {{ sha 'feature done' }}                             |
-      |               | git push                                                        |
-      |               | git checkout feature                                            |
-      | feature       | git reset --hard {{ sha 'conflicting feature commit' }}         |
-      |               | git checkout main                                               |
-      | main          | git checkout other-feature                                      |
-      | other-feature | git stash pop                                                   |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                                         |
+      | other   | git add -A                                                      |
+      |         | git stash                                                       |
+      |         | git checkout main                                               |
+      | main    | git branch feature {{ sha 'Merge branch 'main' into feature' }} |
+      |         | git push -u origin feature                                      |
+      |         | git revert {{ sha 'feature done' }}                             |
+      |         | git push                                                        |
+      |         | git checkout feature                                            |
+      | feature | git reset --hard {{ sha 'conflicting feature commit' }}         |
+      |         | git checkout main                                               |
+      | main    | git checkout other                                              |
+      | other   | git stash pop                                                   |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE                          |
       | main    | local, remote | conflicting main commit          |

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -1,25 +1,25 @@
 Feature: handle conflicts between the supplied feature branch and its tracking branch
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
       |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git add -A                         |
-      |               | git stash                          |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
     And it prints the error:
       """
       To abort, run "git-town abort".
@@ -32,12 +32,12 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH        | COMMAND                    |
-      | feature       | git merge --abort          |
-      |               | git checkout main          |
-      | main          | git checkout other-feature |
-      | other-feature | git stash pop              |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND            |
+      | feature | git merge --abort  |
+      |         | git checkout main  |
+      | main    | git checkout other |
+      | other   | git stash pop      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And there is no merge in progress
     And my repo is left with my original commits
@@ -47,45 +47,45 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH        | COMMAND                      |
-      | feature       | git commit --no-edit         |
-      |               | git merge --no-edit main     |
-      |               | git checkout main            |
-      | main          | git merge --squash feature   |
-      |               | git commit -m "feature done" |
-      |               | git push                     |
-      |               | git push origin :feature     |
-      |               | git branch -D feature        |
-      |               | git checkout other-feature   |
-      | other-feature | git stash pop                |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                      |
+      | feature | git commit --no-edit         |
+      |         | git merge --no-edit main     |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git push origin :feature     |
+      |         | git branch -D feature        |
+      |         | git checkout other           |
+      | other   | git stash pop                |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, remote | feature done |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: continue after resolving the conflicts and comitting
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH        | COMMAND                      |
-      | feature       | git merge --no-edit main     |
-      |               | git checkout main            |
-      | main          | git merge --squash feature   |
-      |               | git commit -m "feature done" |
-      |               | git push                     |
-      |               | git push origin :feature     |
-      |               | git branch -D feature        |
-      |               | git checkout other-feature   |
-      | other-feature | git stash pop                |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                      |
+      | feature | git merge --no-edit main     |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git push origin :feature     |
+      |         | git branch -D feature        |
+      |         | git checkout other           |
+      | other   | git stash pop                |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
 
   Scenario: undo after continue
@@ -93,19 +93,19 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And I run "git-town continue"
     And I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                                                                   |
-      | other-feature | git add -A                                                                                |
-      |               | git stash                                                                                 |
-      |               | git checkout main                                                                         |
-      | main          | git branch feature {{ sha 'Merge remote-tracking branch 'origin/feature' into feature' }} |
-      |               | git push -u origin feature                                                                |
-      |               | git revert {{ sha 'feature done' }}                                                       |
-      |               | git push                                                                                  |
-      |               | git checkout feature                                                                      |
-      | feature       | git checkout main                                                                         |
-      | main          | git checkout other-feature                                                                |
-      | other-feature | git stash pop                                                                             |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                                                                   |
+      | other   | git add -A                                                                                |
+      |         | git stash                                                                                 |
+      |         | git checkout main                                                                         |
+      | main    | git branch feature {{ sha 'Merge remote-tracking branch 'origin/feature' into feature' }} |
+      |         | git push -u origin feature                                                                |
+      |         | git revert {{ sha 'feature done' }}                                                       |
+      |         | git push                                                                                  |
+      |         | git checkout feature                                                                      |
+      | feature | git checkout main                                                                         |
+      | main    | git checkout other                                                                        |
+      | other   | git stash pop                                                                             |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE                                                    |
       | main    | local, remote | feature done                                               |

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -1,24 +1,24 @@
 Feature: handle conflicts between the main branch and its tracking branch
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |
       |         | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
       | feature | local    | feature commit            | feature_file     | feature content            |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                  |
-      | other-feature | git fetch --prune --tags |
-      |               | git add -A               |
-      |               | git stash                |
-      |               | git checkout main        |
-      | main          | git rebase origin/main   |
+      | BRANCH | COMMAND                  |
+      | other  | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git checkout main        |
+      | main   | git rebase origin/main   |
     And it prints the error:
       """
       To abort, run "git-town abort".
@@ -30,11 +30,11 @@ Feature: handle conflicts between the main branch and its tracking branch
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH        | COMMAND                    |
-      | main          | git rebase --abort         |
-      |               | git checkout other-feature |
-      | other-feature | git stash pop              |
-    And I am still on the "other-feature" branch
+      | BRANCH | COMMAND            |
+      | main   | git rebase --abort |
+      |        | git checkout other |
+      | other  | git stash pop      |
+    And I am still on the "other" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress anymore
     And my repo is left with my original commits
@@ -44,21 +44,21 @@ Feature: handle conflicts between the main branch and its tracking branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | main          | git rebase --continue              |
-      |               | git push                           |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit -m "feature done"       |
-      |               | git push                           |
-      |               | git push origin :feature           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-      | other-feature | git stash pop                      |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | main    | git rebase --continue              |
+      |         | git push                           |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+      | other   | git stash pop                      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        | FILE CONTENT               |
@@ -66,51 +66,51 @@ Feature: handle conflicts between the main branch and its tracking branch
       |        |               | conflicting local commit  | conflicting_file | resolved content           |
       |        |               | feature done              | feature_file     | feature content            |
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: continue after resolving the conflicts and continuing the rebase
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | main          | git push                           |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit -m "feature done"       |
-      |               | git push                           |
-      |               | git push origin :feature           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-      | other-feature | git stash pop                      |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | main    | git push                           |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+      | other   | git stash pop                      |
+    And I am now on the "other" branch
 
   Scenario: undo after continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     And I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                                         |
-      | other-feature | git add -A                                                      |
-      |               | git stash                                                       |
-      |               | git checkout main                                               |
-      | main          | git branch feature {{ sha 'Merge branch 'main' into feature' }} |
-      |               | git push -u origin feature                                      |
-      |               | git revert {{ sha 'feature done' }}                             |
-      |               | git push                                                        |
-      |               | git checkout feature                                            |
-      | feature       | git reset --hard {{ sha 'feature commit' }}                     |
-      |               | git checkout main                                               |
-      | main          | git checkout other-feature                                      |
-      | other-feature | git stash pop                                                   |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                                         |
+      | other   | git add -A                                                      |
+      |         | git stash                                                       |
+      |         | git checkout main                                               |
+      | main    | git branch feature {{ sha 'Merge branch 'main' into feature' }} |
+      |         | git push -u origin feature                                      |
+      |         | git revert {{ sha 'feature done' }}                             |
+      |         | git push                                                        |
+      |         | git checkout feature                                            |
+      | feature | git reset --hard {{ sha 'feature commit' }}                     |
+      |         | git checkout main                                               |
+      | main    | git checkout other                                              |
+      | other   | git stash pop                                                   |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE                          |
       | main    | local, remote | conflicting remote commit        |

--- a/features/ship/supplied_branch/edge_cases/empty_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_branch.feature
@@ -1,35 +1,35 @@
 Feature: does not ship empty feature branches
 
   Background:
-    Given my repo has the feature branches "empty-feature" and "other-feature"
+    Given my repo has the feature branches "empty" and "other"
     And my repo contains the commits
-      | BRANCH        | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
-      | main          | remote   | main commit    | common_file | common content |
-      | empty-feature | local    | feature commit | common_file | common content |
-    And I am on the "other-feature" branch
+      | BRANCH | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
+      | main   | remote   | main commit    | common_file | common content |
+      | empty  | local    | feature commit | common_file | common content |
+    And I am on the "other" branch
     And my workspace has an uncommitted file
-    When I run "git-town ship empty-feature"
+    When I run "git-town ship empty"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                                     |
-      | other-feature | git fetch --prune --tags                    |
-      |               | git add -A                                  |
-      |               | git stash                                   |
-      |               | git checkout main                           |
-      | main          | git rebase origin/main                      |
-      |               | git checkout empty-feature                  |
-      | empty-feature | git merge --no-edit origin/empty-feature    |
-      |               | git merge --no-edit main                    |
-      |               | git reset --hard {{ sha 'feature commit' }} |
-      |               | git checkout main                           |
-      | main          | git checkout other-feature                  |
-      | other-feature | git stash pop                               |
+      | BRANCH | COMMAND                                     |
+      | other  | git fetch --prune --tags                    |
+      |        | git add -A                                  |
+      |        | git stash                                   |
+      |        | git checkout main                           |
+      | main   | git rebase origin/main                      |
+      |        | git checkout empty                          |
+      | empty  | git merge --no-edit origin/empty            |
+      |        | git merge --no-edit main                    |
+      |        | git reset --hard {{ sha 'feature commit' }} |
+      |        | git checkout main                           |
+      | main   | git checkout other                          |
+      | other  | git stash pop                               |
     And it prints the error:
       """
-      the branch "empty-feature" has no shippable changes
+      the branch "empty" has no shippable changes
       """
-    And I am still on the "other-feature" branch
+    And I am still on the "other" branch
     And my workspace still contains my uncommitted file
     And Git Town still has the original branch hierarchy
 
@@ -40,9 +40,9 @@ Feature: does not ship empty feature branches
       """
       nothing to undo
       """
-    And I am still on the "other-feature" branch
+    And I am still on the "other" branch
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE        |
-      | main          | local, remote | main commit    |
-      | empty-feature | local         | feature commit |
+      | BRANCH | LOCATION      | MESSAGE        |
+      | main   | local, remote | main commit    |
+      | empty  | local         | feature commit |
     And Git Town still has the original branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
@@ -1,41 +1,41 @@
 Feature: abort the ship via empty commit message
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | main commit    | main_file        | main content    |
       | feature | local         | feature commit | conflicting_file | feature content |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature" and enter an empty commit message
 
   @skipWindows
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                                     |
-      | other-feature | git fetch --prune --tags                    |
-      |               | git add -A                                  |
-      |               | git stash                                   |
-      |               | git checkout main                           |
-      | main          | git rebase origin/main                      |
-      |               | git checkout feature                        |
-      | feature       | git merge --no-edit origin/feature          |
-      |               | git merge --no-edit main                    |
-      |               | git checkout main                           |
-      | main          | git merge --squash feature                  |
-      |               | git commit                                  |
-      |               | git reset --hard                            |
-      |               | git checkout feature                        |
-      | feature       | git reset --hard {{ sha 'feature commit' }} |
-      |               | git checkout main                           |
-      | main          | git checkout other-feature                  |
-      | other-feature | git stash pop                               |
+      | BRANCH  | COMMAND                                     |
+      | other   | git fetch --prune --tags                    |
+      |         | git add -A                                  |
+      |         | git stash                                   |
+      |         | git checkout main                           |
+      | main    | git rebase origin/main                      |
+      |         | git checkout feature                        |
+      | feature | git merge --no-edit origin/feature          |
+      |         | git merge --no-edit main                    |
+      |         | git checkout main                           |
+      | main    | git merge --squash feature                  |
+      |         | git commit                                  |
+      |         | git reset --hard                            |
+      |         | git checkout feature                        |
+      | feature | git reset --hard {{ sha 'feature commit' }} |
+      |         | git checkout main                           |
+      | main    | git checkout other                          |
+      | other   | git stash pop                               |
     And it prints the error:
       """
       aborted because commit exited with error
       """
-    And I am still on the "other-feature" branch
+    And I am still on the "other" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
@@ -47,7 +47,7 @@ Feature: abort the ship via empty commit message
       """
       nothing to undo
       """
-    And I am still on the "other-feature" branch
+    And I am still on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE        |
       | main    | local, remote | main commit    |

--- a/features/ship/supplied_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/supplied_branch/edge_cases/in_subfolder.feature
@@ -1,62 +1,62 @@
 Feature: ship the supplied feature branch from a subfolder
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | remote   | feature commit |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file with name "new_folder/other_feature_file" and content "other feature content"
     When I run "git-town ship feature -m 'feature done'" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git add -A                         |
-      |               | git stash                          |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit -m "feature done"       |
-      |               | git push                           |
-      |               | git push origin :feature           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-      | other-feature | git stash pop                      |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+      | other   | git stash pop                      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, remote | feature done |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                       |
-      | other-feature | git add -A                                    |
-      |               | git stash                                     |
-      |               | git checkout main                             |
-      | main          | git branch feature {{ sha 'feature commit' }} |
-      |               | git push -u origin feature                    |
-      |               | git revert {{ sha 'feature done' }}           |
-      |               | git push                                      |
-      |               | git checkout feature                          |
-      | feature       | git reset --hard {{ sha 'Initial commit' }}   |
-      |               | git checkout main                             |
-      | main          | git checkout other-feature                    |
-      | other-feature | git stash pop                                 |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | other   | git add -A                                    |
+      |         | git stash                                     |
+      |         | git checkout main                             |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git push -u origin feature                    |
+      |         | git revert {{ sha 'feature done' }}           |
+      |         | git push                                      |
+      |         | git checkout feature                          |
+      | feature | git reset --hard {{ sha 'Initial commit' }}   |
+      |         | git checkout main                             |
+      | main    | git checkout other                            |
+      | other   | git stash pop                                 |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, remote | feature done          |

--- a/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
@@ -2,12 +2,12 @@
 Feature: ship a branch that exists only on the remote
 
   Background:
-    Given my repo has a feature branch "other-feature"
+    Given my repo has a feature branch "other"
     And the origin has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME        |
       | feature | remote   | feature commit | conflicting_file |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'" and answer the prompts:
       | PROMPT                                        | ANSWER  |
@@ -15,60 +15,60 @@ Feature: ship a branch that exists only on the remote
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git add -A                         |
-      |               | git stash                          |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit -m "feature done"       |
-      |               | git push                           |
-      |               | git push origin :feature           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-      | other-feature | git stash pop                      |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+      | other   | git stash pop                      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, remote | feature done |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                       |
-      | other-feature | git add -A                                    |
-      |               | git stash                                     |
-      |               | git checkout main                             |
-      | main          | git branch feature {{ sha 'feature commit' }} |
-      |               | git push -u origin feature                    |
-      |               | git revert {{ sha 'feature done' }}           |
-      |               | git push                                      |
-      |               | git checkout feature                          |
-      | feature       | git checkout main                             |
-      | main          | git checkout other-feature                    |
-      | other-feature | git stash pop                                 |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | other   | git add -A                                    |
+      |         | git stash                                     |
+      |         | git checkout main                             |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git push -u origin feature                    |
+      |         | git revert {{ sha 'feature done' }}           |
+      |         | git push                                      |
+      |         | git checkout feature                          |
+      | feature | git checkout main                             |
+      | main    | git checkout other                            |
+      | other   | git stash pop                                 |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | feature commit        |
     And the existing branches are
-      | REPOSITORY    | BRANCHES                     |
-      | local, remote | main, feature, other-feature |
+      | REPOSITORY    | BRANCHES             |
+      | local, remote | main, feature, other |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | feature       | main   |
-      | other-feature | main   |
+      | BRANCH  | PARENT |
+      | feature | main   |
+      | other   | main   |

--- a/features/ship/supplied_branch/features/child_branch.feature
+++ b/features/ship/supplied_branch/features/child_branch.feature
@@ -1,27 +1,27 @@
 Feature: does not ship a child branch
 
   Background:
-    Given my repo has a feature branch "feature-1"
-    And my repo has a feature branch "feature-2" as a child of "feature-1"
-    And my repo has a feature branch "feature-3" as a child of "feature-2"
+    Given my repo has a feature branch "alpha"
+    And my repo has a feature branch "beta" as a child of "alpha"
+    And my repo has a feature branch "gamma" as a child of "beta"
     And my repo contains the commits
-      | BRANCH    | LOCATION      | MESSAGE          |
-      | feature-1 | local, remote | feature 1 commit |
-      | feature-2 | local, remote | feature 2 commit |
-      | feature-3 | local, remote | feature 3 commit |
-    And I am on the "feature-1" branch
-    When I run "git-town ship feature-3 -m 'feature 3 done'"
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, remote | alpha commit |
+      | beta   | local, remote | beta commit  |
+      | gamma  | local, remote | gamma commit |
+    And I am on the "alpha" branch
+    When I run "git-town ship gamma -m 'gamma done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                  |
-      | feature-1 | git fetch --prune --tags |
+      | BRANCH | COMMAND                  |
+      | alpha  | git fetch --prune --tags |
     And it prints the error:
       """
-      shipping this branch would ship "feature-1, feature-2" as well,
-      please ship "feature-1" first
+      shipping this branch would ship "alpha, beta" as well,
+      please ship "alpha" first
       """
-    And I am now on the "feature-1" branch
+    And I am now on the "alpha" branch
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy
 
@@ -32,6 +32,6 @@ Feature: does not ship a child branch
       """
       nothing to undo
       """
-    And I am still on the "feature-1" branch
+    And I am still on the "alpha" branch
     And my repo is left with my original commits
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/commit_message_via_cli.feature
+++ b/features/ship/supplied_branch/features/commit_message_via_cli.feature
@@ -1,61 +1,61 @@
 Feature: provide the commit message via a CLI argument
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        |
       | feature | local, remote | feature commit | conflicting_file |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git add -A                         |
-      |               | git stash                          |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit -m "feature done"       |
-      |               | git push                           |
-      |               | git push origin :feature           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-      | other-feature | git stash pop                      |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+      | other   | git stash pop                      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, remote | feature done |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                       |
-      | other-feature | git add -A                                    |
-      |               | git stash                                     |
-      |               | git checkout main                             |
-      | main          | git branch feature {{ sha 'feature commit' }} |
-      |               | git push -u origin feature                    |
-      |               | git revert {{ sha 'feature done' }}           |
-      |               | git push                                      |
-      |               | git checkout feature                          |
-      | feature       | git checkout main                             |
-      | main          | git checkout other-feature                    |
-      | other-feature | git stash pop                                 |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | other   | git add -A                                    |
+      |         | git stash                                     |
+      |         | git checkout main                             |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git push -u origin feature                    |
+      |         | git revert {{ sha 'feature done' }}           |
+      |         | git push                                      |
+      |         | git checkout feature                          |
+      | feature | git checkout main                             |
+      | main    | git checkout other                            |
+      | other   | git stash pop                                 |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, remote | feature done          |

--- a/features/ship/supplied_branch/features/local_branch.feature
+++ b/features/ship/supplied_branch/features/local_branch.feature
@@ -1,61 +1,61 @@
 Feature: ship the supplied feature branch without a tracking branch
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME        |
       | feature | local    | feature commit | conflicting_file |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git add -A                         |
-      |               | git stash                          |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit -m "feature done"       |
-      |               | git push                           |
-      |               | git push origin :feature           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-      | other-feature | git stash pop                      |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+      | other   | git stash pop                      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, remote | feature done |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                       |
-      | other-feature | git add -A                                    |
-      |               | git stash                                     |
-      |               | git checkout main                             |
-      | main          | git branch feature {{ sha 'feature commit' }} |
-      |               | git push -u origin feature                    |
-      |               | git revert {{ sha 'feature done' }}           |
-      |               | git push                                      |
-      |               | git checkout feature                          |
-      | feature       | git checkout main                             |
-      | main          | git checkout other-feature                    |
-      | other-feature | git stash pop                                 |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | other   | git add -A                                    |
+      |         | git stash                                     |
+      |         | git checkout main                             |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git push -u origin feature                    |
+      |         | git revert {{ sha 'feature done' }}           |
+      |         | git push                                      |
+      |         | git checkout feature                          |
+      | feature | git checkout main                             |
+      | main    | git checkout other                            |
+      | other   | git stash pop                                 |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, remote | feature done          |

--- a/features/ship/supplied_branch/features/local_repo.feature
+++ b/features/ship/supplied_branch/features/local_repo.feature
@@ -1,53 +1,53 @@
 Feature: ship the supplied feature branch without a remote origin
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo does not have a remote origin
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE        | FILE NAME        |
       | feature | local    | feature commit | conflicting_file |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                      |
-      | other-feature | git add -A                   |
-      |               | git stash                    |
-      |               | git checkout feature         |
-      | feature       | git merge --no-edit main     |
-      |               | git checkout main            |
-      | main          | git merge --squash feature   |
-      |               | git commit -m "feature done" |
-      |               | git branch -D feature        |
-      |               | git checkout other-feature   |
-      | other-feature | git stash pop                |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                      |
+      | other   | git add -A                   |
+      |         | git stash                    |
+      |         | git checkout feature         |
+      | feature | git merge --no-edit main     |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git branch -D feature        |
+      |         | git checkout other           |
+      | other   | git stash pop                |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY | BRANCHES            |
-      | local      | main, other-feature |
+      | REPOSITORY | BRANCHES    |
+      | local      | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION | MESSAGE      |
       | main   | local    | feature done |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                       |
-      | other-feature | git add -A                                    |
-      |               | git stash                                     |
-      |               | git checkout main                             |
-      | main          | git branch feature {{ sha 'feature commit' }} |
-      |               | git revert {{ sha 'feature done' }}           |
-      |               | git checkout feature                          |
-      | feature       | git checkout other-feature                    |
-      | other-feature | git stash pop                                 |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | other   | git add -A                                    |
+      |         | git stash                                     |
+      |         | git checkout main                             |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git revert {{ sha 'feature done' }}           |
+      |         | git checkout feature                          |
+      | feature | git checkout other                            |
+      | other   | git stash pop                                 |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION | MESSAGE               |
       | main    | local    | feature done          |

--- a/features/ship/supplied_branch/features/parent_branch.feature
+++ b/features/ship/supplied_branch/features/parent_branch.feature
@@ -1,56 +1,56 @@
 Feature: ship a parent branch
 
   Background:
-    Given my repo has a feature branch "parent-feature"
-    And my repo has a feature branch "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent"
+    And my repo has a feature branch "child" as a child of "parent"
     And my repo contains the commits
-      | BRANCH         | LOCATION      | MESSAGE               |
-      | parent-feature | local, remote | parent feature commit |
-      | child-feature  | local, remote | child feature commit  |
-    And I am on the "child-feature" branch
-    When I run "git-town ship parent-feature -m 'parent feature done'"
+      | BRANCH | LOCATION      | MESSAGE               |
+      | parent | local, remote | parent feature commit |
+      | child  | local, remote | child feature commit  |
+    And I am on the "child" branch
+    When I run "git-town ship parent -m 'parent done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH         | COMMAND                                   |
-      | child-feature  | git fetch --prune --tags                  |
-      |                | git checkout main                         |
-      | main           | git rebase origin/main                    |
-      |                | git checkout parent-feature               |
-      | parent-feature | git merge --no-edit origin/parent-feature |
-      |                | git merge --no-edit main                  |
-      |                | git checkout main                         |
-      | main           | git merge --squash parent-feature         |
-      |                | git commit -m "parent feature done"       |
-      |                | git push                                  |
-      |                | git branch -D parent-feature              |
-      |                | git checkout child-feature                |
-    And I am now on the "child-feature" branch
+      | BRANCH | COMMAND                           |
+      | child  | git fetch --prune --tags          |
+      |        | git checkout main                 |
+      | main   | git rebase origin/main            |
+      |        | git checkout parent               |
+      | parent | git merge --no-edit origin/parent |
+      |        | git merge --no-edit main          |
+      |        | git checkout main                 |
+      | main   | git merge --squash parent         |
+      |        | git commit -m "parent done"       |
+      |        | git push                          |
+      |        | git branch -D parent              |
+      |        | git checkout child                |
+    And I am now on the "child" branch
     And my repo now has the commits
-      | BRANCH         | LOCATION      | MESSAGE               |
-      | main           | local, remote | parent feature done   |
-      | child-feature  | local, remote | child feature commit  |
-      | parent-feature | remote        | parent feature commit |
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, remote | parent done           |
+      | child  | local, remote | child feature commit  |
+      | parent | remote        | parent feature commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | child-feature | main   |
+      | BRANCH | PARENT |
+      | child  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH         | COMMAND                                                     |
-      | child-feature  | git checkout main                                           |
-      | main           | git branch parent-feature {{ sha 'parent feature commit' }} |
-      |                | git revert {{ sha 'parent feature done' }}                  |
-      |                | git push                                                    |
-      |                | git checkout parent-feature                                 |
-      | parent-feature | git checkout main                                           |
-      | main           | git checkout child-feature                                  |
-    And I am now on the "child-feature" branch
+      | BRANCH | COMMAND                                             |
+      | child  | git checkout main                                   |
+      | main   | git branch parent {{ sha 'parent feature commit' }} |
+      |        | git revert {{ sha 'parent done' }}                  |
+      |        | git push                                            |
+      |        | git checkout parent                                 |
+      | parent | git checkout main                                   |
+      | main   | git checkout child                                  |
+    And I am now on the "child" branch
     And my repo now has the commits
-      | BRANCH         | LOCATION      | MESSAGE                      |
-      | main           | local, remote | parent feature done          |
-      |                |               | Revert "parent feature done" |
-      | child-feature  | local, remote | child feature commit         |
-      | parent-feature | local, remote | parent feature commit        |
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, remote | parent done           |
+      |        |               | Revert "parent done"  |
+      | child  | local, remote | child feature commit  |
+      | parent | local, remote | parent feature commit |
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -1,63 +1,63 @@
 Feature: skip deleting the remote branch when shipping another branch
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
-      | BRANCH        | LOCATION      | MESSAGE        |
-      | feature       | local, remote | feature commit |
-      | other-feature | local         | other commit   |
-    And I am on the "other-feature" branch
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, remote | feature commit |
+      | other   | local         | other commit   |
+    And I am on the "other" branch
     And my repo has "git-town.ship-delete-remote-branch" set to "false"
     When I run "git-town ship feature -m 'feature done'"
     And the remote deletes the "feature" branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit -m "feature done"       |
-      |               | git push                           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+    And I am now on the "other" branch
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE      |
-      | main          | local, remote | feature done |
-      | other-feature | local         | other commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | main   | local, remote | feature done |
+      | other  | local         | other commit |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                       |
-      | other-feature | git checkout main                             |
-      | main          | git branch feature {{ sha 'feature commit' }} |
-      |               | git revert {{ sha 'feature done' }}           |
-      |               | git push                                      |
-      |               | git checkout feature                          |
-      | feature       | git checkout main                             |
-      | main          | git checkout other-feature                    |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | other   | git checkout main                             |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git revert {{ sha 'feature done' }}           |
+      |         | git push                                      |
+      |         | git checkout feature                          |
+      | feature | git checkout main                             |
+      | main    | git checkout other                            |
+    And I am now on the "other" branch
     And my repo now has the commits
-      | BRANCH        | LOCATION      | MESSAGE               |
-      | main          | local, remote | feature done          |
-      |               |               | Revert "feature done" |
-      | feature       | local         | feature commit        |
-      | other-feature | local         | other commit          |
+      | BRANCH  | LOCATION      | MESSAGE               |
+      | main    | local, remote | feature done          |
+      |         |               | Revert "feature done" |
+      | feature | local         | feature commit        |
+      | other   | local         | other commit          |
     And the existing branches are
-      | REPOSITORY | BRANCHES                     |
-      | local      | main, feature, other-feature |
-      | remote     | main, other-feature          |
+      | REPOSITORY | BRANCHES             |
+      | local      | main, feature, other |
+      | remote     | main, other          |
     And Git Town now has the original branch hierarchy

--- a/features/ship/supplied_branch/ship_supplied_branch.feature
+++ b/features/ship/supplied_branch/ship_supplied_branch.feature
@@ -1,61 +1,61 @@
 Feature: ship the supplied feature branch
 
   Background:
-    Given my repo has the feature branches "feature" and "other-feature"
+    Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        |
       | feature | local, remote | feature commit | conflicting_file |
-    And I am on the "other-feature" branch
+    And I am on the "other" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature" and enter "feature done" for the commit message
 
   Scenario: result
     Then it runs the commands
-      | BRANCH        | COMMAND                            |
-      | other-feature | git fetch --prune --tags           |
-      |               | git add -A                         |
-      |               | git stash                          |
-      |               | git checkout main                  |
-      | main          | git rebase origin/main             |
-      |               | git checkout feature               |
-      | feature       | git merge --no-edit origin/feature |
-      |               | git merge --no-edit main           |
-      |               | git checkout main                  |
-      | main          | git merge --squash feature         |
-      |               | git commit                         |
-      |               | git push                           |
-      |               | git push origin :feature           |
-      |               | git branch -D feature              |
-      |               | git checkout other-feature         |
-      | other-feature | git stash pop                      |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                            |
+      | other   | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit                         |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
+      |         | git checkout other                 |
+      | other   | git stash pop                      |
+    And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And the existing branches are
-      | REPOSITORY    | BRANCHES            |
-      | local, remote | main, other-feature |
+      | REPOSITORY    | BRANCHES    |
+      | local, remote | main, other |
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, remote | feature done |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH        | PARENT |
-      | other-feature | main   |
+      | BRANCH | PARENT |
+      | other  | main   |
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH        | COMMAND                                       |
-      | other-feature | git add -A                                    |
-      |               | git stash                                     |
-      |               | git checkout main                             |
-      | main          | git branch feature {{ sha 'feature commit' }} |
-      |               | git push -u origin feature                    |
-      |               | git revert {{ sha 'feature done' }}           |
-      |               | git push                                      |
-      |               | git checkout feature                          |
-      | feature       | git checkout main                             |
-      | main          | git checkout other-feature                    |
-      | other-feature | git stash pop                                 |
-    And I am now on the "other-feature" branch
+      | BRANCH  | COMMAND                                       |
+      | other   | git add -A                                    |
+      |         | git stash                                     |
+      |         | git checkout main                             |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git push -u origin feature                    |
+      |         | git revert {{ sha 'feature done' }}           |
+      |         | git push                                      |
+      |         | git checkout feature                          |
+      | feature | git checkout main                             |
+      | main    | git checkout other                            |
+      | other   | git stash pop                                 |
+    And I am now on the "other" branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, remote | feature done          |

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -1,101 +1,101 @@
 Feature: handle merge conflicts between feature branch and main branch
 
   Background:
-    Given my repo has the local feature branches "feature-1", "feature-2", and "feature-3"
+    Given my repo has the local feature branches "alpha", "beta", and "gamma"
     And my repo contains the commits
-      | BRANCH    | LOCATION      | MESSAGE          | FILE NAME        | FILE CONTENT      |
-      | main      | remote        | main commit      | conflicting_file | main content      |
-      | feature-1 | local, remote | feature-1 commit | feature1_file    | feature-1 content |
-      | feature-2 | local, remote | feature-2 commit | conflicting_file | feature-2 content |
-      | feature-3 | local, remote | feature-3 commit | feature2_file    | feature-3 content |
+      | BRANCH | LOCATION      | MESSAGE      | FILE NAME        | FILE CONTENT  |
+      | main   | remote        | main commit  | conflicting_file | main content  |
+      | alpha  | local, remote | alpha commit | feature1_file    | alpha content |
+      | beta   | local, remote | beta commit  | conflicting_file | beta content  |
+      | gamma  | local, remote | gamma commit | feature2_file    | gamma content |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | main      | git fetch --prune --tags             |
-      |           | git add -A                           |
-      |           | git stash                            |
-      |           | git rebase origin/main               |
-      |           | git checkout feature-1               |
-      | feature-1 | git merge --no-edit origin/feature-1 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout feature-2               |
-      | feature-2 | git merge --no-edit origin/feature-2 |
-      |           | git merge --no-edit main             |
+      | BRANCH | COMMAND                          |
+      | main   | git fetch --prune --tags         |
+      |        | git add -A                       |
+      |        | git stash                        |
+      |        | git rebase origin/main           |
+      |        | git checkout alpha               |
+      | alpha  | git merge --no-edit origin/alpha |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout beta                |
+      | beta   | git merge --no-edit origin/beta  |
+      |        | git merge --no-edit main         |
     And it prints the error:
       """
       To abort, run "git-town abort".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
       """
-    And I am now on the "feature-2" branch
+    And I am now on the "beta" branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH    | COMMAND                |
-      | feature-2 | git merge --abort      |
-      |           | git checkout feature-1 |
-      | feature-1 | git checkout main      |
-      | main      | git stash pop          |
+      | BRANCH | COMMAND            |
+      | beta   | git merge --abort  |
+      |        | git checkout alpha |
+      | alpha  | git checkout main  |
+      | main   | git stash pop      |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE                            |
-      | main      | local, remote | main commit                        |
-      | feature-1 | local, remote | feature-1 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-1 |
-      | feature-2 | local, remote | feature-2 commit                   |
-      | feature-3 | local, remote | feature-3 commit                   |
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, remote | main commit                    |
+      | alpha  | local, remote | alpha commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into alpha |
+      | beta   | local, remote | beta commit                    |
+      | gamma  | local, remote | gamma commit                   |
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT           |
-      | main      | conflicting_file | main content      |
-      | feature-1 | conflicting_file | main content      |
-      |           | feature1_file    | feature-1 content |
-      | feature-2 | conflicting_file | feature-2 content |
-      | feature-3 | feature2_file    | feature-3 content |
+      | BRANCH | NAME             | CONTENT       |
+      | main   | conflicting_file | main content  |
+      | alpha  | conflicting_file | main content  |
+      |        | feature1_file    | alpha content |
+      | beta   | conflicting_file | beta content  |
+      | gamma  | feature2_file    | gamma content |
 
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git merge --abort                    |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git merge --abort                |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE                            |
-      | main      | local, remote | main commit                        |
-      | feature-1 | local, remote | feature-1 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-1 |
-      | feature-2 | local, remote | feature-2 commit                   |
-      | feature-3 | local, remote | feature-3 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-3 |
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, remote | main commit                    |
+      | alpha  | local, remote | alpha commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into alpha |
+      | beta   | local, remote | beta commit                    |
+      | gamma  | local, remote | gamma commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into gamma |
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT           |
-      | main      | conflicting_file | main content      |
-      | feature-1 | conflicting_file | main content      |
-      |           | feature1_file    | feature-1 content |
-      | feature-2 | conflicting_file | feature-2 content |
-      | feature-3 | conflicting_file | main content      |
-      |           | feature2_file    | feature-3 content |
+      | BRANCH | NAME             | CONTENT       |
+      | main   | conflicting_file | main content  |
+      | alpha  | conflicting_file | main content  |
+      |        | feature1_file    | alpha content |
+      | beta   | conflicting_file | beta content  |
+      | gamma  | conflicting_file | main content  |
+      |        | feature2_file    | gamma content |
 
   Scenario: continue without resolving the conflicts
     When I run "git-town continue"
@@ -104,7 +104,7 @@ Feature: handle merge conflicts between feature branch and main branch
       """
       you must resolve the conflicts before continuing
       """
-    And I am still on the "feature-2" branch
+    And I am still on the "beta" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
@@ -112,40 +112,40 @@ Feature: handle merge conflicts between feature branch and main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git commit --no-edit                 |
-      |           | git push                             |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git commit --no-edit             |
+      |        | git push                         |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And all branches are now synchronized
     And there is no merge in progress
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT           |
-      | main      | conflicting_file | main content      |
-      | feature-1 | conflicting_file | main content      |
-      |           | feature1_file    | feature-1 content |
-      | feature-2 | conflicting_file | resolved content  |
-      | feature-3 | conflicting_file | main content      |
-      |           | feature2_file    | feature-3 content |
+      | BRANCH | NAME             | CONTENT          |
+      | main   | conflicting_file | main content     |
+      | alpha  | conflicting_file | main content     |
+      |        | feature1_file    | alpha content    |
+      | beta   | conflicting_file | resolved content |
+      | gamma  | conflicting_file | main content     |
+      |        | feature2_file    | gamma content    |
 
   Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git push                             |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git push                         |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -2,45 +2,45 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has the local feature branches "feature-1", "feature-2", and "feature-3"
+    And my repo has the local feature branches "alpha", "beta", and "gamma"
     And my repo contains the commits
-      | BRANCH    | LOCATION | MESSAGE          | FILE NAME        | FILE CONTENT      |
-      | main      | local    | main commit      | conflicting_file | main content      |
-      | feature-1 | local    | feature-1 commit | feature1_file    | feature-1 content |
-      | feature-2 | local    | feature-2 commit | conflicting_file | feature-2 content |
-      | feature-3 | local    | feature-3 commit | feature3_file    | feature-3 content |
+      | BRANCH | LOCATION | MESSAGE      | FILE NAME        | FILE CONTENT  |
+      | main   | local    | main commit  | conflicting_file | main content  |
+      | alpha  | local    | alpha commit | feature1_file    | alpha content |
+      | beta   | local    | beta commit  | conflicting_file | beta content  |
+      | gamma  | local    | gamma commit | feature3_file    | gamma content |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                  |
-      | main      | git add -A               |
-      |           | git stash                |
-      |           | git checkout feature-1   |
-      | feature-1 | git merge --no-edit main |
-      |           | git checkout feature-2   |
-      | feature-2 | git merge --no-edit main |
+      | BRANCH | COMMAND                  |
+      | main   | git add -A               |
+      |        | git stash                |
+      |        | git checkout alpha       |
+      | alpha  | git merge --no-edit main |
+      |        | git checkout beta        |
+      | beta   | git merge --no-edit main |
     And it prints the error:
       """
       To abort, run "git-town abort".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
       """
-    And I am now on the "feature-2" branch
+    And I am now on the "beta" branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH    | COMMAND                                       |
-      | feature-2 | git merge --abort                             |
-      |           | git checkout feature-1                        |
-      | feature-1 | git reset --hard {{ sha 'feature-1 commit' }} |
-      |           | git checkout main                             |
-      | main      | git stash pop                                 |
+      | BRANCH | COMMAND                                   |
+      | beta   | git merge --abort                         |
+      |        | git checkout alpha                        |
+      | alpha  | git reset --hard {{ sha 'alpha commit' }} |
+      |        | git checkout main                         |
+      | main   | git stash pop                             |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
@@ -49,33 +49,33 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
-      | BRANCH    | COMMAND                  |
-      | feature-2 | git merge --abort        |
-      |           | git checkout feature-3   |
-      | feature-3 | git merge --no-edit main |
-      |           | git checkout main        |
-      | main      | git stash pop            |
+      | BRANCH | COMMAND                  |
+      | beta   | git merge --abort        |
+      |        | git checkout gamma       |
+      | gamma  | git merge --no-edit main |
+      |        | git checkout main        |
+      | main   | git stash pop            |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has the commits
-      | BRANCH    | LOCATION | MESSAGE                            |
-      | main      | local    | main commit                        |
-      | feature-1 | local    | feature-1 commit                   |
-      |           |          | main commit                        |
-      |           |          | Merge branch 'main' into feature-1 |
-      | feature-2 | local    | feature-2 commit                   |
-      | feature-3 | local    | feature-3 commit                   |
-      |           |          | main commit                        |
-      |           |          | Merge branch 'main' into feature-3 |
+      | BRANCH | LOCATION | MESSAGE                        |
+      | main   | local    | main commit                    |
+      | alpha  | local    | alpha commit                   |
+      |        |          | main commit                    |
+      |        |          | Merge branch 'main' into alpha |
+      | beta   | local    | beta commit                    |
+      | gamma  | local    | gamma commit                   |
+      |        |          | main commit                    |
+      |        |          | Merge branch 'main' into gamma |
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT           |
-      | main      | conflicting_file | main content      |
-      | feature-1 | conflicting_file | main content      |
-      |           | feature1_file    | feature-1 content |
-      | feature-2 | conflicting_file | feature-2 content |
-      | feature-3 | conflicting_file | main content      |
-      |           | feature3_file    | feature-3 content |
+      | BRANCH | NAME             | CONTENT       |
+      | main   | conflicting_file | main content  |
+      | alpha  | conflicting_file | main content  |
+      |        | feature1_file    | alpha content |
+      | beta   | conflicting_file | beta content  |
+      | gamma  | conflicting_file | main content  |
+      |        | feature3_file    | gamma content |
 
   Scenario: continue without resolving the conflicts
     When I run "git-town continue"
@@ -84,7 +84,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
       """
       you must resolve the conflicts before continuing
       """
-    And I am still on the "feature-2" branch
+    And I am still on the "beta" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
@@ -92,32 +92,32 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                  |
-      | feature-2 | git commit --no-edit     |
-      |           | git checkout feature-3   |
-      | feature-3 | git merge --no-edit main |
-      |           | git checkout main        |
-      | main      | git stash pop            |
+      | BRANCH | COMMAND                  |
+      | beta   | git commit --no-edit     |
+      |        | git checkout gamma       |
+      | gamma  | git merge --no-edit main |
+      |        | git checkout main        |
+      | main   | git stash pop            |
     And all branches are now synchronized
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT           |
-      | main      | conflicting_file | main content      |
-      | feature-1 | conflicting_file | main content      |
-      |           | feature1_file    | feature-1 content |
-      | feature-2 | conflicting_file | resolved content  |
-      | feature-3 | conflicting_file | main content      |
-      |           | feature3_file    | feature-3 content |
+      | BRANCH | NAME             | CONTENT          |
+      | main   | conflicting_file | main content     |
+      | alpha  | conflicting_file | main content     |
+      |        | feature1_file    | alpha content    |
+      | beta   | conflicting_file | resolved content |
+      | gamma  | conflicting_file | main content     |
+      |        | feature3_file    | gamma content    |
 
   Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                  |
-      | feature-2 | git checkout feature-3   |
-      | feature-3 | git merge --no-edit main |
-      |           | git checkout main        |
-      | main      | git stash pop            |
+      | BRANCH | COMMAND                  |
+      | beta   | git checkout gamma       |
+      | gamma  | git merge --no-edit main |
+      |        | git checkout main        |
+      | main   | git stash pop            |

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -1,105 +1,105 @@
 Feature: handle merge conflicts between feature branch and main branch
 
   Background:
-    Given my repo has the feature branches "feature-1", "feature-2", and "feature-3"
+    Given my repo has the feature branches "alpha", "beta", and "gamma"
     And my repo contains the commits
-      | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME            | FILE CONTENT             |
-      | main      | remote        | main commit             | conflicting_file     | main content             |
-      | feature-1 | local, remote | feature-1 commit        | feature1_file        | feature-1 content        |
-      | feature-2 | local         | feature-2 local commit  | conflicting_file     | feature-2 local content  |
-      |           | remote        | feature-2 remote commit | feature2_remote_file | feature-2 remote content |
-      | feature-3 | remote        | feature-3 commit        | feature3_file        | feature-3 content        |
+      | BRANCH | LOCATION      | MESSAGE            | FILE NAME            | FILE CONTENT        |
+      | main   | remote        | main commit        | conflicting_file     | main content        |
+      | alpha  | local, remote | alpha commit       | feature1_file        | alpha content       |
+      | beta   | local         | beta local commit  | conflicting_file     | beta local content  |
+      |        | remote        | beta remote commit | feature2_remote_file | beta remote content |
+      | gamma  | remote        | gamma commit       | feature3_file        | gamma content       |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | main      | git fetch --prune --tags             |
-      |           | git add -A                           |
-      |           | git stash                            |
-      |           | git rebase origin/main               |
-      |           | git checkout feature-1               |
-      | feature-1 | git merge --no-edit origin/feature-1 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout feature-2               |
-      | feature-2 | git merge --no-edit origin/feature-2 |
-      |           | git merge --no-edit main             |
+      | BRANCH | COMMAND                          |
+      | main   | git fetch --prune --tags         |
+      |        | git add -A                       |
+      |        | git stash                        |
+      |        | git rebase origin/main           |
+      |        | git checkout alpha               |
+      | alpha  | git merge --no-edit origin/alpha |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout beta                |
+      | beta   | git merge --no-edit origin/beta  |
+      |        | git merge --no-edit main         |
     And it prints the error:
       """
       To abort, run "git-town abort".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
       """
-    And I am now on the "feature-2" branch
+    And I am now on the "beta" branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH    | COMMAND                                             |
-      | feature-2 | git merge --abort                                   |
-      |           | git reset --hard {{ sha 'feature-2 local commit' }} |
-      |           | git checkout feature-1                              |
-      | feature-1 | git checkout main                                   |
-      | main      | git stash pop                                       |
+      | BRANCH | COMMAND                                        |
+      | beta   | git merge --abort                              |
+      |        | git reset --hard {{ sha 'beta local commit' }} |
+      |        | git checkout alpha                             |
+      | alpha  | git checkout main                              |
+      | main   | git stash pop                                  |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE                            |
-      | main      | local, remote | main commit                        |
-      | feature-1 | local, remote | feature-1 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-1 |
-      | feature-2 | local         | feature-2 local commit             |
-      |           | remote        | feature-2 remote commit            |
-      | feature-3 | remote        | feature-3 commit                   |
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, remote | main commit                    |
+      | alpha  | local, remote | alpha commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into alpha |
+      | beta   | local         | beta local commit              |
+      |        | remote        | beta remote commit             |
+      | gamma  | remote        | gamma commit                   |
     And my repo still has these committed files
-      | BRANCH    | NAME             | CONTENT                 |
-      | main      | conflicting_file | main content            |
-      | feature-1 | conflicting_file | main content            |
-      |           | feature1_file    | feature-1 content       |
-      | feature-2 | conflicting_file | feature-2 local content |
+      | BRANCH | NAME             | CONTENT            |
+      | main   | conflicting_file | main content       |
+      | alpha  | conflicting_file | main content       |
+      |        | feature1_file    | alpha content      |
+      | beta   | conflicting_file | beta local content |
 
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
-      | BRANCH    | COMMAND                                             |
-      | feature-2 | git merge --abort                                   |
-      |           | git reset --hard {{ sha 'feature-2 local commit' }} |
-      |           | git checkout feature-3                              |
-      | feature-3 | git merge --no-edit origin/feature-3                |
-      |           | git merge --no-edit main                            |
-      |           | git push                                            |
-      |           | git checkout main                                   |
-      | main      | git push --tags                                     |
-      |           | git stash pop                                       |
+      | BRANCH | COMMAND                                        |
+      | beta   | git merge --abort                              |
+      |        | git reset --hard {{ sha 'beta local commit' }} |
+      |        | git checkout gamma                             |
+      | gamma  | git merge --no-edit origin/gamma               |
+      |        | git merge --no-edit main                       |
+      |        | git push                                       |
+      |        | git checkout main                              |
+      | main   | git push --tags                                |
+      |        | git stash pop                                  |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE                            |
-      | main      | local, remote | main commit                        |
-      | feature-1 | local, remote | feature-1 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-1 |
-      | feature-2 | local         | feature-2 local commit             |
-      |           | remote        | feature-2 remote commit            |
-      | feature-3 | local, remote | feature-3 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-3 |
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, remote | main commit                    |
+      | alpha  | local, remote | alpha commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into alpha |
+      | beta   | local         | beta local commit              |
+      |        | remote        | beta remote commit             |
+      | gamma  | local, remote | gamma commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into gamma |
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT                 |
-      | main      | conflicting_file | main content            |
-      | feature-1 | conflicting_file | main content            |
-      |           | feature1_file    | feature-1 content       |
-      | feature-2 | conflicting_file | feature-2 local content |
-      | feature-3 | conflicting_file | main content            |
-      |           | feature3_file    | feature-3 content       |
+      | BRANCH | NAME             | CONTENT            |
+      | main   | conflicting_file | main content       |
+      | alpha  | conflicting_file | main content       |
+      |        | feature1_file    | alpha content      |
+      | beta   | conflicting_file | beta local content |
+      | gamma  | conflicting_file | main content       |
+      |        | feature3_file    | gamma content      |
 
   Scenario: continue without resolving the conflicts
     When I run "git-town continue"
@@ -108,7 +108,7 @@ Feature: handle merge conflicts between feature branch and main branch
       """
       you must resolve the conflicts before continuing
       """
-    And I am still on the "feature-2" branch
+    And I am still on the "beta" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
@@ -116,41 +116,41 @@ Feature: handle merge conflicts between feature branch and main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git commit --no-edit                 |
-      |           | git push                             |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git commit --no-edit             |
+      |        | git push                         |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And all branches are now synchronized
     And there is no merge in progress
     And my repo now has these committed files
-      | BRANCH    | NAME                 | CONTENT                  |
-      | main      | conflicting_file     | main content             |
-      | feature-1 | conflicting_file     | main content             |
-      |           | feature1_file        | feature-1 content        |
-      | feature-2 | conflicting_file     | resolved content         |
-      |           | feature2_remote_file | feature-2 remote content |
-      | feature-3 | conflicting_file     | main content             |
-      |           | feature3_file        | feature-3 content        |
+      | BRANCH | NAME                 | CONTENT             |
+      | main   | conflicting_file     | main content        |
+      | alpha  | conflicting_file     | main content        |
+      |        | feature1_file        | alpha content       |
+      | beta   | conflicting_file     | resolved content    |
+      |        | feature2_remote_file | beta remote content |
+      | gamma  | conflicting_file     | main content        |
+      |        | feature3_file        | gamma content       |
 
   Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git push                             |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git push                         |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -1,101 +1,101 @@
 Feature: handle merge conflicts between feature branches and their tracking branches
 
   Background:
-    Given my repo has the feature branches "feature-1", "feature-2", and "feature-3"
+    Given my repo has the feature branches "alpha", "beta", and "gamma"
     And my repo contains the commits
-      | BRANCH    | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT             |
-      | main      | remote        | main commit             | main_file        | main content             |
-      | feature-1 | local, remote | feature-1 commit        | feature1_file    | feature-1 content        |
-      | feature-2 | local         | feature-2 local commit  | conflicting_file | feature-2 local content  |
-      |           | remote        | feature-2 remote commit | conflicting_file | feature-2 remote content |
-      | feature-3 | local, remote | feature-3 commit        | feature3_file    | feature-3 content        |
+      | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT        |
+      | main   | remote        | main commit        | main_file        | main content        |
+      | alpha  | local, remote | alpha commit       | feature1_file    | alpha content       |
+      | beta   | local         | beta local commit  | conflicting_file | beta local content  |
+      |        | remote        | beta remote commit | conflicting_file | beta remote content |
+      | gamma  | local, remote | gamma commit       | feature3_file    | gamma content       |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | main      | git fetch --prune --tags             |
-      |           | git add -A                           |
-      |           | git stash                            |
-      |           | git rebase origin/main               |
-      |           | git checkout feature-1               |
-      | feature-1 | git merge --no-edit origin/feature-1 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout feature-2               |
-      | feature-2 | git merge --no-edit origin/feature-2 |
+      | BRANCH | COMMAND                          |
+      | main   | git fetch --prune --tags         |
+      |        | git add -A                       |
+      |        | git stash                        |
+      |        | git rebase origin/main           |
+      |        | git checkout alpha               |
+      | alpha  | git merge --no-edit origin/alpha |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout beta                |
+      | beta   | git merge --no-edit origin/beta  |
     And it prints the error:
       """
       To abort, run "git-town abort".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
       """
-    And I am now on the "feature-2" branch
+    And I am now on the "beta" branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
 
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH    | COMMAND                |
-      | feature-2 | git merge --abort      |
-      |           | git checkout feature-1 |
-      | feature-1 | git checkout main      |
-      | main      | git stash pop          |
+      | BRANCH | COMMAND            |
+      | beta   | git merge --abort  |
+      |        | git checkout alpha |
+      | alpha  | git checkout main  |
+      | main   | git stash pop      |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE                            |
-      | main      | local, remote | main commit                        |
-      | feature-1 | local, remote | feature-1 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-1 |
-      | feature-2 | local         | feature-2 local commit             |
-      |           | remote        | feature-2 remote commit            |
-      | feature-3 | local, remote | feature-3 commit                   |
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, remote | main commit                    |
+      | alpha  | local, remote | alpha commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into alpha |
+      | beta   | local         | beta local commit              |
+      |        | remote        | beta remote commit             |
+      | gamma  | local, remote | gamma commit                   |
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT                 |
-      | main      | main_file        | main content            |
-      | feature-1 | feature1_file    | feature-1 content       |
-      |           | main_file        | main content            |
-      | feature-2 | conflicting_file | feature-2 local content |
-      | feature-3 | feature3_file    | feature-3 content       |
+      | BRANCH | NAME             | CONTENT            |
+      | main   | main_file        | main content       |
+      | alpha  | feature1_file    | alpha content      |
+      |        | main_file        | main content       |
+      | beta   | conflicting_file | beta local content |
+      | gamma  | feature3_file    | gamma content      |
 
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git merge --abort                    |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git merge --abort                |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo now has the commits
-      | BRANCH    | LOCATION      | MESSAGE                            |
-      | main      | local, remote | main commit                        |
-      | feature-1 | local, remote | feature-1 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-1 |
-      | feature-2 | local         | feature-2 local commit             |
-      |           | remote        | feature-2 remote commit            |
-      | feature-3 | local, remote | feature-3 commit                   |
-      |           |               | main commit                        |
-      |           |               | Merge branch 'main' into feature-3 |
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, remote | main commit                    |
+      | alpha  | local, remote | alpha commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into alpha |
+      | beta   | local         | beta local commit              |
+      |        | remote        | beta remote commit             |
+      | gamma  | local, remote | gamma commit                   |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into gamma |
     And my repo now has these committed files
-      | BRANCH    | NAME             | CONTENT                 |
-      | main      | main_file        | main content            |
-      | feature-1 | feature1_file    | feature-1 content       |
-      |           | main_file        | main content            |
-      | feature-2 | conflicting_file | feature-2 local content |
-      | feature-3 | feature3_file    | feature-3 content       |
-      |           | main_file        | main content            |
+      | BRANCH | NAME             | CONTENT            |
+      | main   | main_file        | main content       |
+      | alpha  | feature1_file    | alpha content      |
+      |        | main_file        | main content       |
+      | beta   | conflicting_file | beta local content |
+      | gamma  | feature3_file    | gamma content      |
+      |        | main_file        | main content       |
 
   Scenario: continue without resolving the conflicts
     When I run "git-town continue"
@@ -104,7 +104,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       """
       you must resolve the conflicts before continuing
       """
-    And I am still on the "feature-2" branch
+    And I am still on the "beta" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
@@ -112,43 +112,43 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git commit --no-edit                 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git commit --no-edit             |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |
     And all branches are now synchronized
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo still has these committed files
-      | BRANCH    | NAME             | CONTENT           |
-      | main      | main_file        | main content      |
-      | feature-1 | feature1_file    | feature-1 content |
-      |           | main_file        | main content      |
-      | feature-2 | conflicting_file | resolved content  |
-      |           | main_file        | main content      |
-      | feature-3 | feature3_file    | feature-3 content |
-      |           | main_file        | main content      |
+      | BRANCH | NAME             | CONTENT          |
+      | main   | main_file        | main content     |
+      | alpha  | feature1_file    | alpha content    |
+      |        | main_file        | main content     |
+      | beta   | conflicting_file | resolved content |
+      |        | main_file        | main content     |
+      | gamma  | feature3_file    | gamma content    |
+      |        | main_file        | main content     |
 
   Scenario: continue after resolving the conflicts and committing
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                              |
-      | feature-2 | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout feature-3               |
-      | feature-3 | git merge --no-edit origin/feature-3 |
-      |           | git merge --no-edit main             |
-      |           | git push                             |
-      |           | git checkout main                    |
-      | main      | git push --tags                      |
-      |           | git stash pop                        |
+      | BRANCH | COMMAND                          |
+      | beta   | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout gamma               |
+      | gamma  | git merge --no-edit origin/gamma |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout main                |
+      | main   | git push --tags                  |
+      |        | git stash pop                    |

--- a/features/sync/all_branches/edge_cases/remote_only_branches.feature
+++ b/features/sync/all_branches/edge_cases/remote_only_branches.feature
@@ -1,33 +1,33 @@
 Feature: does not sync branches that exist only on the remote
 
   Background:
-    Given my repo has a feature branch "my-feature"
-    And a coworker has a feature branch "co-feature"
+    Given my repo has a feature branch "mine"
+    And a coworker has a feature branch "other"
     And my repo contains the commits
-      | BRANCH     | LOCATION      | MESSAGE         |
-      | main       | remote        | main commit     |
-      | my-feature | local, remote | my commit       |
-      | co-feature | remote        | coworker commit |
+      | BRANCH | LOCATION      | MESSAGE         |
+      | main   | remote        | main commit     |
+      | mine   | local, remote | my commit       |
+      | other  | remote        | coworker commit |
     And I am on the "main" branch
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH     | COMMAND                               |
-      | main       | git fetch --prune --tags              |
-      |            | git rebase origin/main                |
-      |            | git checkout my-feature               |
-      | my-feature | git merge --no-edit origin/my-feature |
-      |            | git merge --no-edit main              |
-      |            | git push                              |
-      |            | git checkout main                     |
-      | main       | git push --tags                       |
+      | BRANCH | COMMAND                         |
+      | main   | git fetch --prune --tags        |
+      |        | git rebase origin/main          |
+      |        | git checkout mine               |
+      | mine   | git merge --no-edit origin/mine |
+      |        | git merge --no-edit main        |
+      |        | git push                        |
+      |        | git checkout main               |
+      | main   | git push --tags                 |
     And I am still on the "main" branch
     And all branches are now synchronized
     And my repo now has the commits
-      | BRANCH     | LOCATION      | MESSAGE                             |
-      | main       | local, remote | main commit                         |
-      | co-feature | remote        | coworker commit                     |
-      | my-feature | local, remote | my commit                           |
-      |            |               | main commit                         |
-      |            |               | Merge branch 'main' into my-feature |
+      | BRANCH | LOCATION      | MESSAGE                       |
+      | main   | local, remote | main commit                   |
+      | mine   | local, remote | my commit                     |
+      |        |               | main commit                   |
+      |        |               | Merge branch 'main' into mine |
+      | other  | remote        | coworker commit               |

--- a/features/sync/all_branches/features/local_repo.feature
+++ b/features/sync/all_branches/features/local_repo.feature
@@ -2,21 +2,21 @@ Feature: syncs all feature branches (without remote repo)
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has the local feature branches "feature-1" and "feature-2"
+    And my repo has the local feature branches "one" and "two"
     And my repo contains the commits
-      | BRANCH    | LOCATION | MESSAGE          |
-      | main      | local    | main commit      |
-      | feature-1 | local    | feature-1 commit |
-      | feature-2 | local    | feature-2 commit |
-    And I am on the "feature-1" branch
+      | BRANCH | LOCATION | MESSAGE     |
+      | main   | local    | main commit |
+      | one    | local    | one commit  |
+      | two    | local    | two commit  |
+    And I am on the "one" branch
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                  |
-      | feature-1 | git merge --no-edit main |
-      |           | git checkout feature-2   |
-      | feature-2 | git merge --no-edit main |
-      |           | git checkout feature-1   |
-    And I am still on the "feature-1" branch
+      | BRANCH | COMMAND                  |
+      | one    | git merge --no-edit main |
+      |        | git checkout two         |
+      | two    | git merge --no-edit main |
+      |        | git checkout one         |
+    And I am still on the "one" branch
     And all branches are now synchronized

--- a/features/sync/all_branches/features/local_repo.feature
+++ b/features/sync/all_branches/features/local_repo.feature
@@ -2,21 +2,21 @@ Feature: syncs all feature branches (without remote repo)
 
   Background:
     Given my repo does not have a remote origin
-    And my repo has the local feature branches "one" and "two"
+    And my repo has the local feature branches "alpha" and "beta"
     And my repo contains the commits
-      | BRANCH | LOCATION | MESSAGE     |
-      | main   | local    | main commit |
-      | one    | local    | one commit  |
-      | two    | local    | two commit  |
-    And I am on the "one" branch
+      | BRANCH | LOCATION | MESSAGE      |
+      | main   | local    | main commit  |
+      | alpha  | local    | alpha commit |
+      | beta   | local    | beta commit  |
+    And I am on the "alpha" branch
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |
-      | one    | git merge --no-edit main |
-      |        | git checkout two         |
-      | two    | git merge --no-edit main |
-      |        | git checkout one         |
-    And I am still on the "one" branch
+      | alpha  | git merge --no-edit main |
+      |        | git checkout beta        |
+      | beta   | git merge --no-edit main |
+      |        | git checkout alpha       |
+    And I am still on the "alpha" branch
     And all branches are now synchronized

--- a/features/sync/all_branches/sync_all_branches.feature
+++ b/features/sync/all_branches/sync_all_branches.feature
@@ -1,41 +1,41 @@
 Feature: sync all feature branches
 
   Background:
-    Given my repo has the feature branches "feature-1" and "feature-2"
+    Given my repo has the feature branches "alpha" and "beta"
     And my repo has the perennial branches "production" and "qa"
     And my repo contains the commits
       | BRANCH     | LOCATION      | MESSAGE                  |
       | main       | remote        | main commit              |
-      | feature-1  | local, remote | feature-1 commit         |
-      | feature-2  | local, remote | feature-2 commit         |
+      | alpha      | local, remote | alpha commit             |
+      | beta       | local, remote | beta commit              |
       | production | local         | production local commit  |
       |            | remote        | production remote commit |
       | qa         | local         | qa local commit          |
       |            | remote        | qa remote commit         |
-    And I am on the "feature-1" branch
+    And I am on the "alpha" branch
     When I run "git-town sync --all"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH     | COMMAND                              |
-      | feature-1  | git fetch --prune --tags             |
-      |            | git checkout main                    |
-      | main       | git rebase origin/main               |
-      |            | git checkout feature-1               |
-      | feature-1  | git merge --no-edit origin/feature-1 |
-      |            | git merge --no-edit main             |
-      |            | git push                             |
-      |            | git checkout feature-2               |
-      | feature-2  | git merge --no-edit origin/feature-2 |
-      |            | git merge --no-edit main             |
-      |            | git push                             |
-      |            | git checkout production              |
-      | production | git rebase origin/production         |
-      |            | git push                             |
-      |            | git checkout qa                      |
-      | qa         | git rebase origin/qa                 |
-      |            | git push                             |
-      |            | git checkout feature-1               |
-      | feature-1  | git push --tags                      |
-    And I am still on the "feature-1" branch
+      | BRANCH     | COMMAND                          |
+      | alpha      | git fetch --prune --tags         |
+      |            | git checkout main                |
+      | main       | git rebase origin/main           |
+      |            | git checkout alpha               |
+      | alpha      | git merge --no-edit origin/alpha |
+      |            | git merge --no-edit main         |
+      |            | git push                         |
+      |            | git checkout beta                |
+      | beta       | git merge --no-edit origin/beta  |
+      |            | git merge --no-edit main         |
+      |            | git push                         |
+      |            | git checkout production          |
+      | production | git rebase origin/production     |
+      |            | git push                         |
+      |            | git checkout qa                  |
+      | qa         | git rebase origin/qa             |
+      |            | git push                         |
+      |            | git checkout alpha               |
+      | alpha      | git push --tags                  |
+    And I am still on the "alpha" branch
     And all branches are now synchronized

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
@@ -1,44 +1,44 @@
 Feature: sync inside a folder that doesn't exist on the main branch
 
   Background:
-    Given my repo has the feature branches "current-feature" and "other-feature"
+    Given my repo has the feature branches "current" and "other"
     And my repo contains the commits
-      | BRANCH          | LOCATION      | MESSAGE              | FILE NAME        |
-      | main            | local, remote | main commit          | main_file        |
-      | current-feature | local, remote | folder commit        | new_folder/file1 |
-      | other-feature   | local, remote | other feature commit | file2            |
-    And I am on the "current-feature" branch
+      | BRANCH  | LOCATION      | MESSAGE              | FILE NAME        |
+      | main    | local, remote | main commit          | main_file        |
+      | current | local, remote | folder commit        | new_folder/file1 |
+      | other   | local, remote | other feature commit | file2            |
+    And I am on the "current" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH          | COMMAND                                    |
-      | current-feature | git fetch --prune --tags                   |
-      |                 | git add -A                                 |
-      |                 | git stash                                  |
-      |                 | git checkout main                          |
-      | main            | git rebase origin/main                     |
-      |                 | git checkout current-feature               |
-      | current-feature | git merge --no-edit origin/current-feature |
-      |                 | git merge --no-edit main                   |
-      |                 | git push                                   |
-      |                 | git checkout other-feature                 |
-      | other-feature   | git merge --no-edit origin/other-feature   |
-      |                 | git merge --no-edit main                   |
-      |                 | git push                                   |
-      |                 | git checkout current-feature               |
-      | current-feature | git push --tags                            |
-      |                 | git stash pop                              |
+      | BRANCH  | COMMAND                            |
+      | current | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout current               |
+      | current | git merge --no-edit origin/current |
+      |         | git merge --no-edit main           |
+      |         | git push                           |
+      |         | git checkout other                 |
+      | other   | git merge --no-edit origin/other   |
+      |         | git merge --no-edit main           |
+      |         | git push                           |
+      |         | git checkout current               |
+      | current | git push --tags                    |
+      |         | git stash pop                      |
     And all branches are now synchronized
-    And I am still on the "current-feature" branch
+    And I am still on the "current" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH          | LOCATION      | MESSAGE                                  |
-      | main            | local, remote | main commit                              |
-      | current-feature | local, remote | folder commit                            |
-      |                 |               | main commit                              |
-      |                 |               | Merge branch 'main' into current-feature |
-      | other-feature   | local, remote | other feature commit                     |
-      |                 |               | main commit                              |
-      |                 |               | Merge branch 'main' into other-feature   |
+      | BRANCH  | LOCATION      | MESSAGE                          |
+      | main    | local, remote | main commit                      |
+      | current | local, remote | folder commit                    |
+      |         |               | main commit                      |
+      |         |               | Merge branch 'main' into current |
+      | other   | local, remote | other feature commit             |
+      |         |               | main commit                      |
+      |         |               | Merge branch 'main' into other   |

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
@@ -1,44 +1,44 @@
 Feature: sync inside a folder that doesn't exist on the main branch
 
   Background:
-    Given my repo has the feature branches "current" and "other"
+    Given my repo has the feature branches "alpha" and "beta"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE              | FILE NAME        |
-      | main    | local, remote | main commit          | main_file        |
-      | current | local, remote | folder commit        | new_folder/file1 |
-      | other   | local, remote | other feature commit | file2            |
-    And I am on the "current" branch
+      | BRANCH | LOCATION      | MESSAGE             | FILE NAME        |
+      | main   | local, remote | main commit         | main_file        |
+      | alpha  | local, remote | folder commit       | new_folder/file1 |
+      | beta   | local, remote | beta feature commit | file2            |
+    And I am on the "alpha" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | current | git fetch --prune --tags           |
-      |         | git add -A                         |
-      |         | git stash                          |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout current               |
-      | current | git merge --no-edit origin/current |
-      |         | git merge --no-edit main           |
-      |         | git push                           |
-      |         | git checkout other                 |
-      | other   | git merge --no-edit origin/other   |
-      |         | git merge --no-edit main           |
-      |         | git push                           |
-      |         | git checkout current               |
-      | current | git push --tags                    |
-      |         | git stash pop                      |
+      | BRANCH | COMMAND                          |
+      | alpha  | git fetch --prune --tags         |
+      |        | git add -A                       |
+      |        | git stash                        |
+      |        | git checkout main                |
+      | main   | git rebase origin/main           |
+      |        | git checkout alpha               |
+      | alpha  | git merge --no-edit origin/alpha |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout beta                |
+      | beta   | git merge --no-edit origin/beta  |
+      |        | git merge --no-edit main         |
+      |        | git push                         |
+      |        | git checkout alpha               |
+      | alpha  | git push --tags                  |
+      |        | git stash pop                    |
     And all branches are now synchronized
-    And I am still on the "current" branch
+    And I am still on the "alpha" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE                          |
-      | main    | local, remote | main commit                      |
-      | current | local, remote | folder commit                    |
-      |         |               | main commit                      |
-      |         |               | Merge branch 'main' into current |
-      | other   | local, remote | other feature commit             |
-      |         |               | main commit                      |
-      |         |               | Merge branch 'main' into other   |
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, remote | main commit                    |
+      | alpha  | local, remote | folder commit                  |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into alpha |
+      | beta   | local, remote | beta feature commit            |
+      |        |               | main commit                    |
+      |        |               | Merge branch 'main' into beta  |

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -1,29 +1,29 @@
 Feature: sync inside a folder that doesn't exist on the main branch
 
   Background:
-    Given my repo has the feature branches "current-feature" and "other-feature"
+    Given my repo has the feature branches "current" and "other"
     And my repo contains the commits
-      | BRANCH          | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
-      | main            | local, remote | conflicting main commit    | conflicting_file | main content    |
-      | current-feature | local         | conflicting feature commit | conflicting_file | feature content |
-      |                 |               | folder commit              | new_folder/file1 |                 |
-      | other-feature   | local, remote | other feature commit       | file2            |                 |
-    And I am on the "current-feature" branch
+      | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
+      | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
+      | current | local         | conflicting feature commit | conflicting_file | feature content |
+      |         |               | folder commit              | new_folder/file1 |                 |
+      | other   | local, remote | other feature commit       | file2            |                 |
+    And I am on the "current" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH          | COMMAND                                    |
-      | current-feature | git fetch --prune --tags                   |
-      |                 | git add -A                                 |
-      |                 | git stash                                  |
-      |                 | git checkout main                          |
-      | main            | git rebase origin/main                     |
-      |                 | git checkout current-feature               |
-      | current-feature | git merge --no-edit origin/current-feature |
-      |                 | git merge --no-edit main                   |
-    And I am still on the "current-feature" branch
+      | BRANCH  | COMMAND                            |
+      | current | git fetch --prune --tags           |
+      |         | git add -A                         |
+      |         | git stash                          |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout current               |
+      | current | git merge --no-edit origin/current |
+      |         | git merge --no-edit main           |
+    And I am still on the "current" branch
     And my uncommitted file is stashed
     And my repo now has a merge in progress
     And it prints the error:
@@ -34,12 +34,12 @@ Feature: sync inside a folder that doesn't exist on the main branch
   Scenario: abort
     When I run "git-town abort" in the "new_folder" folder
     Then it runs the commands
-      | BRANCH          | COMMAND                      |
-      | current-feature | git merge --abort            |
-      |                 | git checkout main            |
-      | main            | git checkout current-feature |
-      | current-feature | git stash pop                |
-    And I am still on the "current-feature" branch
+      | BRANCH  | COMMAND              |
+      | current | git merge --abort    |
+      |         | git checkout main    |
+      | main    | git checkout current |
+      | current | git stash pop        |
+    And I am still on the "current" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo is left with my original commits
@@ -51,7 +51,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
       """
       you must resolve the conflicts before continuing
       """
-    And I am still on the "current-feature" branch
+    And I am still on the "current" branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
@@ -59,34 +59,34 @@ Feature: sync inside a folder that doesn't exist on the main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" in the "new_folder" folder
     Then it runs the commands
-      | BRANCH          | COMMAND                                  |
-      | current-feature | git commit --no-edit                     |
-      |                 | git push                                 |
-      |                 | git checkout other-feature               |
-      | other-feature   | git merge --no-edit origin/other-feature |
-      |                 | git merge --no-edit main                 |
-      |                 | git push                                 |
-      |                 | git checkout current-feature             |
-      | current-feature | git push --tags                          |
-      |                 | git stash pop                            |
+      | BRANCH  | COMMAND                          |
+      | current | git commit --no-edit             |
+      |         | git push                         |
+      |         | git checkout other               |
+      | other   | git merge --no-edit origin/other |
+      |         | git merge --no-edit main         |
+      |         | git push                         |
+      |         | git checkout current             |
+      | current | git push --tags                  |
+      |         | git stash pop                    |
     And all branches are now synchronized
-    And I am still on the "current-feature" branch
+    And I am still on the "current" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
     And my repo now has the commits
-      | BRANCH          | LOCATION      | MESSAGE                                  |
-      | main            | local, remote | conflicting main commit                  |
-      | current-feature | local, remote | conflicting feature commit               |
-      |                 |               | folder commit                            |
-      |                 |               | conflicting main commit                  |
-      |                 |               | Merge branch 'main' into current-feature |
-      | other-feature   | local, remote | other feature commit                     |
-      |                 |               | conflicting main commit                  |
-      |                 |               | Merge branch 'main' into other-feature   |
+      | BRANCH  | LOCATION      | MESSAGE                          |
+      | main    | local, remote | conflicting main commit          |
+      | current | local, remote | conflicting feature commit       |
+      |         |               | folder commit                    |
+      |         |               | conflicting main commit          |
+      |         |               | Merge branch 'main' into current |
+      | other   | local, remote | other feature commit             |
+      |         |               | conflicting main commit          |
+      |         |               | Merge branch 'main' into other   |
     And my repo still has these committed files
-      | BRANCH          | NAME             | CONTENT          |
-      | main            | conflicting_file | main content     |
-      | current-feature | conflicting_file | resolved content |
-      |                 | new_folder/file1 |                  |
-      | other-feature   | conflicting_file | main content     |
-      |                 | file2            |                  |
+      | BRANCH  | NAME             | CONTENT          |
+      | main    | conflicting_file | main content     |
+      | current | conflicting_file | resolved content |
+      |         | new_folder/file1 |                  |
+      | other   | conflicting_file | main content     |
+      |         | file2            |                  |

--- a/features/sync/current_branch/feature_branch/features/nested_feature_branches.feature
+++ b/features/sync/current_branch/feature_branch/features/nested_feature_branches.feature
@@ -1,51 +1,51 @@
 Feature: nested feature branches
 
   Scenario:
-    Given my repo has a feature branch "parent-feature"
-    And my repo has a feature branch "child-feature" as a child of "parent-feature"
+    Given my repo has a feature branch "parent"
+    And my repo has a feature branch "child" as a child of "parent"
     And my repo contains the commits
-      | BRANCH         | LOCATION | MESSAGE                      |
-      | main           | local    | local main commit            |
-      |                | remote   | remote main commit           |
-      | parent-feature | local    | local parent feature commit  |
-      |                | remote   | remote parent feature commit |
-      | child-feature  | local    | local child feature commit   |
-      |                | remote   | remote child feature commit  |
-    And I am on the "child-feature" branch
+      | BRANCH | LOCATION | MESSAGE                      |
+      | main   | local    | local main commit            |
+      |        | remote   | remote main commit           |
+      | parent | local    | local parent feature commit  |
+      |        | remote   | remote parent feature commit |
+      | child  | local    | local child feature commit   |
+      |        | remote   | remote child feature commit  |
+    And I am on the "child" branch
     When I run "git-town sync"
     Then it runs the commands
-      | BRANCH         | COMMAND                                   |
-      | child-feature  | git fetch --prune --tags                  |
-      |                | git checkout main                         |
-      | main           | git rebase origin/main                    |
-      |                | git push                                  |
-      |                | git checkout parent-feature               |
-      | parent-feature | git merge --no-edit origin/parent-feature |
-      |                | git merge --no-edit main                  |
-      |                | git push                                  |
-      |                | git checkout child-feature                |
-      | child-feature  | git merge --no-edit origin/child-feature  |
-      |                | git merge --no-edit parent-feature        |
-      |                | git push                                  |
+      | BRANCH | COMMAND                           |
+      | child  | git fetch --prune --tags          |
+      |        | git checkout main                 |
+      | main   | git rebase origin/main            |
+      |        | git push                          |
+      |        | git checkout parent               |
+      | parent | git merge --no-edit origin/parent |
+      |        | git merge --no-edit main          |
+      |        | git push                          |
+      |        | git checkout child                |
+      | child  | git merge --no-edit origin/child  |
+      |        | git merge --no-edit parent        |
+      |        | git push                          |
     And all branches are now synchronized
-    And I am still on the "child-feature" branch
+    And I am still on the "child" branch
     And my repo now has the commits
-      | BRANCH         | LOCATION      | MESSAGE                                                                  |
-      | main           | local, remote | remote main commit                                                       |
-      |                |               | local main commit                                                        |
-      | child-feature  | local, remote | local child feature commit                                               |
-      |                |               | remote child feature commit                                              |
-      |                |               | Merge remote-tracking branch 'origin/child-feature' into child-feature   |
-      |                |               | local parent feature commit                                              |
-      |                |               | remote parent feature commit                                             |
-      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |
-      |                |               | remote main commit                                                       |
-      |                |               | local main commit                                                        |
-      |                |               | Merge branch 'main' into parent-feature                                  |
-      |                |               | Merge branch 'parent-feature' into child-feature                         |
-      | parent-feature | local, remote | local parent feature commit                                              |
-      |                |               | remote parent feature commit                                             |
-      |                |               | Merge remote-tracking branch 'origin/parent-feature' into parent-feature |
-      |                |               | remote main commit                                                       |
-      |                |               | local main commit                                                        |
-      |                |               | Merge branch 'main' into parent-feature                                  |
+      | BRANCH | LOCATION      | MESSAGE                                                  |
+      | main   | local, remote | remote main commit                                       |
+      |        |               | local main commit                                        |
+      | child  | local, remote | local child feature commit                               |
+      |        |               | remote child feature commit                              |
+      |        |               | Merge remote-tracking branch 'origin/child' into child   |
+      |        |               | local parent feature commit                              |
+      |        |               | remote parent feature commit                             |
+      |        |               | Merge remote-tracking branch 'origin/parent' into parent |
+      |        |               | remote main commit                                       |
+      |        |               | local main commit                                        |
+      |        |               | Merge branch 'main' into parent                          |
+      |        |               | Merge branch 'parent' into child                         |
+      | parent | local, remote | local parent feature commit                              |
+      |        |               | remote parent feature commit                             |
+      |        |               | Merge remote-tracking branch 'origin/parent' into parent |
+      |        |               | remote main commit                                       |
+      |        |               | local main commit                                        |
+      |        |               | Merge branch 'main' into parent                          |

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -2,39 +2,39 @@
 Feature: enter a parent branch name when prompted
 
   Background:
-    Given my repo has the branches "feature-1" and "feature-2"
-    And I am on the "feature-2" branch
+    Given my repo has the branches "one" and "two"
+    And I am on the "two" branch
 
   Scenario: choose the default branch name
     When I run "git-town sync" and answer the prompts:
-      | PROMPT                                          | ANSWER  |
-      | Please specify the parent branch of 'feature-2' | [ENTER] |
+      | PROMPT                                    | ANSWER  |
+      | Please specify the parent branch of 'two' | [ENTER] |
     Then Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT |
-      | feature-2 | main   |
+      | BRANCH | PARENT |
+      | two    | main   |
 
   Scenario: choose other branches
     When I run "git-town sync" and answer the prompts:
-      | PROMPT                                          | ANSWER        |
-      | Please specify the parent branch of 'feature-2' | [DOWN][ENTER] |
-      | Please specify the parent branch of 'feature-1' | [ENTER]       |
+      | PROMPT                                    | ANSWER        |
+      | Please specify the parent branch of 'two' | [DOWN][ENTER] |
+      | Please specify the parent branch of 'one' | [ENTER]       |
     And Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT    |
-      | feature-1 | main      |
-      | feature-2 | feature-1 |
+      | BRANCH | PARENT |
+      | one    | main   |
+      | two    | one    |
 
   Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town sync" and answer the prompts:
-      | PROMPT                                          | ANSWER      |
-      | Please specify the parent branch of 'feature-2' | [UP][ENTER] |
-    Then the perennial branches are now "feature-2"
+      | PROMPT                                    | ANSWER      |
+      | Please specify the parent branch of 'two' | [UP][ENTER] |
+    Then the perennial branches are now "two"
 
   Scenario: enter the parent for several branches
     When I run "git-town sync --all" and answer the prompts:
-      | PROMPT                                          | ANSWER  |
-      | Please specify the parent branch of 'feature-1' | [ENTER] |
-      | Please specify the parent branch of 'feature-2' | [ENTER] |
+      | PROMPT                                    | ANSWER  |
+      | Please specify the parent branch of 'one' | [ENTER] |
+      | Please specify the parent branch of 'two' | [ENTER] |
     Then Git Town is now aware of this branch hierarchy
-      | BRANCH    | PARENT |
-      | feature-1 | main   |
-      | feature-2 | main   |
+      | BRANCH | PARENT |
+      | one    | main   |
+      | two    | main   |

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -2,39 +2,39 @@
 Feature: enter a parent branch name when prompted
 
   Background:
-    Given my repo has the branches "one" and "two"
-    And I am on the "two" branch
+    Given my repo has the branches "alpha" and "beta"
+    And I am on the "beta" branch
 
   Scenario: choose the default branch name
     When I run "git-town sync" and answer the prompts:
-      | PROMPT                                    | ANSWER  |
-      | Please specify the parent branch of 'two' | [ENTER] |
+      | PROMPT                                     | ANSWER  |
+      | Please specify the parent branch of 'beta' | [ENTER] |
     Then Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
-      | two    | main   |
+      | beta   | main   |
 
   Scenario: choose other branches
     When I run "git-town sync" and answer the prompts:
-      | PROMPT                                    | ANSWER        |
-      | Please specify the parent branch of 'two' | [DOWN][ENTER] |
-      | Please specify the parent branch of 'one' | [ENTER]       |
+      | PROMPT                                      | ANSWER        |
+      | Please specify the parent branch of 'beta'  | [DOWN][ENTER] |
+      | Please specify the parent branch of 'alpha' | [ENTER]       |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
-      | one    | main   |
-      | two    | one    |
+      | alpha  | main   |
+      | beta   | alpha  |
 
   Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town sync" and answer the prompts:
-      | PROMPT                                    | ANSWER      |
-      | Please specify the parent branch of 'two' | [UP][ENTER] |
-    Then the perennial branches are now "two"
+      | PROMPT                                     | ANSWER      |
+      | Please specify the parent branch of 'beta' | [UP][ENTER] |
+    Then the perennial branches are now "beta"
 
   Scenario: enter the parent for several branches
     When I run "git-town sync --all" and answer the prompts:
-      | PROMPT                                    | ANSWER  |
-      | Please specify the parent branch of 'one' | [ENTER] |
-      | Please specify the parent branch of 'two' | [ENTER] |
+      | PROMPT                                      | ANSWER  |
+      | Please specify the parent branch of 'alpha' | [ENTER] |
+      | Please specify the parent branch of 'beta'  | [ENTER] |
     Then Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
-      | one    | main   |
-      | two    | main   |
+      | alpha  | main   |
+      | beta   | main   |


### PR DESCRIPTION
Many branches have unnecessarily long names. This incidental complexity makes the feature specs more complicated than necessary. This PR shortens the branch names to concise, easy to recognize words.