### PR TITLE
Shorter commit messages

### DIFF
--- a/features/append/append.feature
+++ b/features/append/append.feature
@@ -3,8 +3,8 @@ Feature: append a new feature branch to an existing feature branch
   Background:
     Given my repo has a feature branch "existing"
     And my repo contains the commits
-      | BRANCH   | LOCATION      | MESSAGE                 |
-      | existing | local, remote | existing_feature_commit |
+      | BRANCH   | LOCATION      | MESSAGE         |
+      | existing | local, remote | existing_commit |
     And I am on the "existing" branch
     And my workspace has an uncommitted file
     When I run "git-town append new"
@@ -26,9 +26,9 @@ Feature: append a new feature branch to an existing feature branch
     And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH   | LOCATION      | MESSAGE                 |
-      | existing | local, remote | existing_feature_commit |
-      | new      | local         | existing_feature_commit |
+      | BRANCH   | LOCATION      | MESSAGE         |
+      | existing | local, remote | existing_commit |
+      | new      | local         | existing_commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH   | PARENT   |
       | existing | main     |

--- a/features/append/features/local_repo.feature
+++ b/features/append/features/local_repo.feature
@@ -4,8 +4,8 @@ Feature: in a local repo
     Given my repo has a feature branch "existing"
     And my repo does not have a remote origin
     And my repo contains the commits
-      | BRANCH   | LOCATION | MESSAGE                 |
-      | existing | local    | existing_feature_commit |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | existing | local    | existing_commit |
     And I am on the "existing" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new"
@@ -21,8 +21,8 @@ Feature: in a local repo
     And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH   | LOCATION | MESSAGE                 |
-      | existing | local    | existing_feature_commit |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | existing | local    | existing_commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH   | PARENT |
       | existing | main   |

--- a/features/append/features/offline.feature
+++ b/features/append/features/offline.feature
@@ -4,8 +4,8 @@ Feature: append in offline mode
     Given Git Town is in offline mode
     And my repo has a feature branch "existing"
     And my repo contains the commits
-      | BRANCH   | LOCATION      | MESSAGE                 |
-      | existing | local, remote | existing feature commit |
+      | BRANCH   | LOCATION      | MESSAGE         |
+      | existing | local, remote | existing commit |
     And I am on the "existing" branch
 
   Scenario: result
@@ -21,9 +21,9 @@ Feature: append in offline mode
       |          | git checkout new                    |
     And I am now on the "new" branch
     And my repo now has the commits
-      | BRANCH   | LOCATION      | MESSAGE                 |
-      | existing | local, remote | existing feature commit |
-      | new      | local         | existing feature commit |
+      | BRANCH   | LOCATION      | MESSAGE         |
+      | existing | local, remote | existing commit |
+      | new      | local         | existing commit |
 
   Scenario: undo
     Given I ran "git-town append new"

--- a/features/hack/on_feature_branch.feature
+++ b/features/hack/on_feature_branch.feature
@@ -3,9 +3,9 @@ Feature: on the main branch
   Background:
     Given my repo has a feature branch "existing"
     And my repo contains the commits
-      | BRANCH   | LOCATION | MESSAGE                 |
-      | main     | remote   | main commit             |
-      | existing | local    | existing feature commit |
+      | BRANCH   | LOCATION | MESSAGE         |
+      | main     | remote   | main commit     |
+      | existing | local    | existing commit |
     And I am on the "existing" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new"
@@ -24,10 +24,10 @@ Feature: on the main branch
     And I am now on the "new" branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
-      | BRANCH   | LOCATION      | MESSAGE                 |
-      | main     | local, remote | main commit             |
-      | existing | local         | existing feature commit |
-      | new      | local         | main commit             |
+      | BRANCH   | LOCATION      | MESSAGE         |
+      | main     | local, remote | main commit     |
+      | existing | local         | existing commit |
+      | new      | local         | main commit     |
     And Git Town is now aware of this branch hierarchy
       | BRANCH   | PARENT |
       | existing | main   |
@@ -45,7 +45,7 @@ Feature: on the main branch
       | existing | git stash pop         |
     And I am now on the "existing" branch
     And my repo now has the commits
-      | BRANCH   | LOCATION      | MESSAGE                 |
-      | main     | local, remote | main commit             |
-      | existing | local         | existing feature commit |
+      | BRANCH   | LOCATION      | MESSAGE         |
+      | main     | local, remote | main commit     |
+      | existing | local         | existing commit |
     And Git Town now has the original branch hierarchy

--- a/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
@@ -3,9 +3,9 @@ Feature: the branch to kill has a deleted tracking branch
   Background:
     Given my repo has the feature branches "old" and "other"
     And my repo contains the commits
-      | BRANCH | LOCATION      | MESSAGE              |
-      | old    | local, remote | old commit           |
-      | other  | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | old    | local, remote | old commit   |
+      | other  | local, remote | other commit |
     And the "old" branch gets deleted on the remote
     And I am on the "old" branch
     And my workspace has an uncommitted file
@@ -22,8 +22,8 @@ Feature: the branch to kill has a deleted tracking branch
     And I am now on the "main" branch
     And my repo doesn't have any uncommitted files
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE              |
-      | other  | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | other  | local, remote | other commit |
     And the existing branches are
       | REPOSITORY    | BRANCHES    |
       | local, remote | main, other |
@@ -40,8 +40,8 @@ Feature: the branch to kill has a deleted tracking branch
       | old    | git reset {{ sha 'old commit' }}      |
     And I am now on the "old" branch
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE              |
-      | old    | local         | old commit           |
-      | other  | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | old    | local         | old commit   |
+      | other  | local, remote | other commit |
     And my workspace has the uncommitted file again
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/features/local_repo.feature
+++ b/features/kill/current_branch/features/local_repo.feature
@@ -4,9 +4,9 @@ Feature: in a local repo
     Given my repo does not have a remote origin
     And my repo has the local feature branches "feature" and "other"
     And my repo contains the commits
-      | BRANCH  | LOCATION | MESSAGE              |
-      | feature | local    | feature commit       |
-      | other   | local    | other feature commit |
+      | BRANCH  | LOCATION | MESSAGE        |
+      | feature | local    | feature commit |
+      | other   | local    | other commit   |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
@@ -23,8 +23,8 @@ Feature: in a local repo
       | REPOSITORY | BRANCHES    |
       | local      | main, other |
     And my repo now has the commits
-      | BRANCH | LOCATION | MESSAGE              |
-      | other  | local    | other feature commit |
+      | BRANCH | LOCATION | MESSAGE      |
+      | other  | local    | other commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | other  | main   |

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -4,9 +4,9 @@ Feature: offline mode
     Given Git Town is in offline mode
     And my repo has the feature branches "feature" and "other"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE              |
-      | feature | local, remote | feature commit       |
-      | other   | local, remote | other feature commit |
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, remote | feature commit |
+      | other   | local, remote | other commit   |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
@@ -25,9 +25,9 @@ Feature: offline mode
       | local      | main, other          |
       | remote     | main, feature, other |
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE              |
-      | feature | remote        | feature commit       |
-      | other   | local, remote | other feature commit |
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | remote        | feature commit |
+      | other   | local, remote | other commit   |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | other  | main   |

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -3,9 +3,9 @@ Feature: delete the current feature branch
   Background:
     Given my repo has the feature branches "current" and "other"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE                |
-      | current | local, remote | current feature commit |
-      | other   | local, remote | other feature commit   |
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | current | local, remote | current commit |
+      | other   | local, remote | other commit   |
     And I am on the "current" branch
     And my workspace has an uncommitted file
     When I run "git-town kill"
@@ -25,8 +25,8 @@ Feature: delete the current feature branch
       | REPOSITORY    | BRANCHES    |
       | local, remote | main, other |
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE              |
-      | other  | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | other  | local, remote | other commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | other  | main   |
@@ -37,7 +37,7 @@ Feature: delete the current feature branch
       | BRANCH  | COMMAND                                       |
       | main    | git branch current {{ sha 'WIP on current' }} |
       |         | git checkout current                          |
-      | current | git reset {{ sha 'current feature commit' }}  |
+      | current | git reset {{ sha 'current commit' }}          |
       |         | git push -u origin current                    |
     And I am now on the "current" branch
     And my workspace has the uncommitted file again

--- a/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -3,9 +3,9 @@ Feature: delete the current branch
   Background:
     Given my repo has the feature branches "other" and "current"
     And my repo contains the commits
-      | BRANCH  | LOCATION      | MESSAGE                |
-      | current | local, remote | current feature commit |
-      | other   | local, remote | other feature commit   |
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | current | local, remote | current commit |
+      | other   | local, remote | other commit   |
     And I am on the "current" branch
     And my workspace has an uncommitted file
     When I run "git-town kill current"
@@ -25,8 +25,8 @@ Feature: delete the current branch
       | REPOSITORY    | BRANCHES    |
       | local, remote | main, other |
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE              |
-      | other  | local, remote | other feature commit |
+      | BRANCH | LOCATION      | MESSAGE      |
+      | other  | local, remote | other commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | other  | main   |
@@ -37,7 +37,7 @@ Feature: delete the current branch
       | BRANCH  | COMMAND                                       |
       | main    | git branch current {{ sha 'WIP on current' }} |
       |         | git checkout current                          |
-      | current | git reset {{ sha 'current feature commit' }}  |
+      | current | git reset {{ sha 'current commit' }}          |
       |         | git push -u origin current                    |
     And I am now on the "current" branch
     And my workspace has the uncommitted file again

--- a/features/kill/supplied_branch/features/local_branch.feature
+++ b/features/kill/supplied_branch/features/local_branch.feature
@@ -4,9 +4,9 @@ Feature: local branch
     Given my repo does not have a remote origin
     And my repo has the local feature branches "dead" and "other"
     And my repo contains the commits
-      | BRANCH | LOCATION | MESSAGE              |
-      | dead   | local    | dead feature commit  |
-      | other  | local    | other feature commit |
+      | BRANCH | LOCATION | MESSAGE      |
+      | dead   | local    | dead commit  |
+      | other  | local    | other commit |
     And I am on the "dead" branch
     And my workspace has an uncommitted file
     When I run "git-town kill dead"
@@ -24,8 +24,8 @@ Feature: local branch
       | REPOSITORY | BRANCHES    |
       | local      | main, other |
     And my repo now has the commits
-      | BRANCH | LOCATION | MESSAGE              |
-      | other  | local    | other feature commit |
+      | BRANCH | LOCATION | MESSAGE      |
+      | other  | local    | other commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | other  | main   |
@@ -33,10 +33,10 @@ Feature: local branch
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                                   |
-      | main   | git branch dead {{ sha 'WIP on dead' }}   |
-      |        | git checkout dead                         |
-      | dead   | git reset {{ sha 'dead feature commit' }} |
+      | BRANCH | COMMAND                                 |
+      | main   | git branch dead {{ sha 'WIP on dead' }} |
+      |        | git checkout dead                       |
+      | dead   | git reset {{ sha 'dead commit' }}       |
     And I am now on the "dead" branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -4,10 +4,10 @@ Feature: local repository
     Given my repo does not have a remote origin
     And my repo has the local feature branches "good" and "other"
     And my repo contains the commits
-      | BRANCH | LOCATION | MESSAGE              | FILE NAME        |
-      | main   | local    | main commit          | conflicting_file |
-      | good   | local    | good feature commit  | file             |
-      | other  | local    | other feature commit | file             |
+      | BRANCH | LOCATION | MESSAGE      | FILE NAME        |
+      | main   | local    | main commit  | conflicting_file |
+      | good   | local    | good commit  | file             |
+      | other  | local    | other commit | file             |
     And I am on the "good" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town kill other"
@@ -25,9 +25,9 @@ Feature: local repository
       | REPOSITORY | BRANCHES   |
       | local      | main, good |
     And my repo now has the commits
-      | BRANCH | LOCATION | MESSAGE             |
-      | main   | local    | main commit         |
-      | good   | local    | good feature commit |
+      | BRANCH | LOCATION | MESSAGE     |
+      | main   | local    | main commit |
+      | good   | local    | good commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | good   | main   |
@@ -35,11 +35,11 @@ Feature: local repository
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                                           |
-      | good   | git add -A                                        |
-      |        | git stash                                         |
-      |        | git branch other {{ sha 'other feature commit' }} |
-      |        | git stash pop                                     |
+      | BRANCH | COMMAND                                   |
+      | good   | git add -A                                |
+      |        | git stash                                 |
+      |        | git branch other {{ sha 'other commit' }} |
+      |        | git stash pop                             |
     And I am still on the "good" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -3,10 +3,10 @@ Feature: delete another than the current branch
   Background:
     Given my repo has the feature branches "good" and "dead"
     And my repo contains the commits
-      | BRANCH | LOCATION      | MESSAGE                              | FILE NAME        |
-      | main   | local, remote | conflicting with uncommitted changes | conflicting_file |
-      | dead   | local, remote | dead-end commit                      | file             |
-      | good   | local, remote | good commit                          | file             |
+      | BRANCH | LOCATION      | MESSAGE            | FILE NAME        |
+      | main   | local, remote | conflicting commit | conflicting_file |
+      | dead   | local, remote | dead-end commit    | file             |
+      | good   | local, remote | good commit        | file             |
     And I am on the "good" branch
     And my workspace has an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town kill dead"
@@ -23,9 +23,9 @@ Feature: delete another than the current branch
       | REPOSITORY    | BRANCHES   |
       | local, remote | main, good |
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE                              |
-      | main   | local, remote | conflicting with uncommitted changes |
-      | good   | local, remote | good commit                          |
+      | BRANCH | LOCATION      | MESSAGE            |
+      | main   | local, remote | conflicting commit |
+      | good   | local, remote | good commit        |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | good   | main   |

--- a/features/rename-branch/edge_cases/unsynced.feature
+++ b/features/rename-branch/edge_cases/unsynced.feature
@@ -5,8 +5,8 @@ Feature: rename an unsynced branch
 
   Scenario: unpulled remote commits
     Given my repo contains the commits
-      | BRANCH | LOCATION | MESSAGE               |
-      | old    | remote   | remote feature commit |
+      | BRANCH | LOCATION | MESSAGE       |
+      | old    | remote   | remote commit |
     And I am on the "old" branch
     When I run "git-town rename-branch old new"
     Then it runs the commands
@@ -20,8 +20,8 @@ Feature: rename an unsynced branch
 
   Scenario: unpushed local commits
     Given my repo contains the commits
-      | BRANCH | LOCATION | MESSAGE              |
-      | old    | local    | local feature commit |
+      | BRANCH | LOCATION | MESSAGE      |
+      | old    | local    | local commit |
     And I am on the "old" branch
     When I run "git-town rename-branch old new"
     Then it runs the commands

--- a/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
+++ b/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
@@ -6,48 +6,48 @@ Feature: commit message can contain double-quotes
       | BRANCH  | LOCATION | MESSAGE        |
       | feature | local    | feature commit |
     And I am on the "feature" branch
-    When I run "git-town ship -m 'message containing "double quotes"'"
+    When I run "git-town ship -m 'with "double quotes"'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                                            |
-      | feature | git fetch --prune --tags                           |
-      |         | git checkout main                                  |
-      | main    | git rebase origin/main                             |
-      |         | git checkout feature                               |
-      | feature | git merge --no-edit origin/feature                 |
-      |         | git merge --no-edit main                           |
-      |         | git checkout main                                  |
-      | main    | git merge --squash feature                         |
-      |         | git commit -m "message containing "double quotes"" |
-      |         | git push                                           |
-      |         | git push origin :feature                           |
-      |         | git branch -D feature                              |
+      | BRANCH  | COMMAND                              |
+      | feature | git fetch --prune --tags             |
+      |         | git checkout main                    |
+      | main    | git rebase origin/main               |
+      |         | git checkout feature                 |
+      | feature | git merge --no-edit origin/feature   |
+      |         | git merge --no-edit main             |
+      |         | git checkout main                    |
+      | main    | git merge --squash feature           |
+      |         | git commit -m "with "double quotes"" |
+      |         | git push                             |
+      |         | git push origin :feature             |
+      |         | git branch -D feature                |
     And I am now on the "main" branch
     And the existing branches are
       | REPOSITORY    | BRANCHES |
       | local, remote | main     |
     And my repo doesn't have any uncommitted files
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE                            |
-      | main   | local, remote | message containing "double quotes" |
+      | BRANCH | LOCATION      | MESSAGE              |
+      | main   | local, remote | with "double quotes" |
     And Git Town now has no branch hierarchy information
 
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                                                   |
-      | main    | git branch feature {{ sha 'feature commit' }}             |
-      |         | git push -u origin feature                                |
-      |         | git revert {{ sha 'message containing "double quotes"' }} |
-      |         | git push                                                  |
-      |         | git checkout feature                                      |
-      | feature | git checkout main                                         |
-      | main    | git checkout feature                                      |
+      | BRANCH  | COMMAND                                       |
+      | main    | git branch feature {{ sha 'feature commit' }} |
+      |         | git push -u origin feature                    |
+      |         | git revert {{ sha 'with "double quotes"' }}   |
+      |         | git push                                      |
+      |         | git checkout feature                          |
+      | feature | git checkout main                             |
+      | main    | git checkout feature                          |
     And I am now on the "feature" branch
     And my repo now has the commits
-      | BRANCH  | LOCATION      | MESSAGE                                     |
-      | main    | local, remote | message containing "double quotes"          |
-      |         |               | Revert "message containing "double quotes"" |
-      | feature | local, remote | feature commit                              |
+      | BRANCH  | LOCATION      | MESSAGE                       |
+      | main    | local, remote | with "double quotes"          |
+      |         |               | Revert "with "double quotes"" |
+      | feature | local, remote | feature commit                |
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the shipped branch and its tracking branch
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
-      |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |
+      | feature | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |         | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"
 

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the main branch and its tracking branch
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |         | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | main    | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |         | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
       | feature | local    | feature commit            | feature_file     | feature content            |
     And I am on the "feature" branch
     When I run "git-town ship -m 'feature done'"

--- a/features/ship/current_branch/edge_cases/perennial_branch.feature
+++ b/features/ship/current_branch/edge_cases/perennial_branch.feature
@@ -2,7 +2,7 @@ Feature: does not ship perennial branches
 
   Scenario: try to ship the main branch
     Given I am on the "main" branch
-    When I run "git-town ship -m 'something done'"
+    When I run "git-town ship -m done"
     Then it prints the error:
       """
       the branch "main" is not a feature branch. Only feature branches can be shipped

--- a/features/ship/current_branch/features/multiple_authors.feature
+++ b/features/ship/current_branch/features/multiple_authors.feature
@@ -4,10 +4,10 @@ Feature: ship a coworker's feature branch
   Background:
     Given my repo has a feature branch "feature"
     And my repo contains the commits
-      | BRANCH  | LOCATION | MESSAGE         | AUTHOR                            |
-      | feature | local    | feature commit1 | developer <developer@example.com> |
-      |         |          | feature commit2 | developer <developer@example.com> |
-      |         |          | feature commit3 | coworker <coworker@example.com>   |
+      | BRANCH  | LOCATION | MESSAGE            | AUTHOR                            |
+      | feature | local    | developer commit 1 | developer <developer@example.com> |
+      |         |          | developer commit 2 | developer <developer@example.com> |
+      |         |          | coworker commit    | coworker <coworker@example.com>   |
     And I am on the "feature" branch
 
   Scenario: choose myself as the author
@@ -35,7 +35,7 @@ Feature: ship a coworker's feature branch
     When I run "git-town undo"
     Then it runs the commands
       | BRANCH  | COMMAND                                        |
-      | main    | git branch feature {{ sha 'feature commit3' }} |
+      | main    | git branch feature {{ sha 'coworker commit' }} |
       |         | git push -u origin feature                     |
       |         | git revert {{ sha 'feature done' }}            |
       |         | git push                                       |
@@ -47,7 +47,7 @@ Feature: ship a coworker's feature branch
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
-      | feature | local, remote | feature commit1       |
-      |         |               | feature commit2       |
-      |         |               | feature commit3       |
+      | feature | local, remote | developer commit 1    |
+      |         |               | developer commit 2    |
+      |         |               | coworker commit       |
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/current_branch/features/parent_branch.feature
+++ b/features/ship/current_branch/features/parent_branch.feature
@@ -4,32 +4,32 @@ Feature: ship a parent branch
     Given my repo has a feature branch "parent"
     And my repo has a feature branch "child" as a child of "parent"
     And my repo contains the commits
-      | BRANCH | LOCATION      | MESSAGE               |
-      | parent | local, remote | parent feature commit |
-      | child  | local, remote | child feature commit  |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | parent | local, remote | parent commit |
+      | child  | local, remote | child commit  |
     And I am on the "parent" branch
-    When I run "git-town ship -m 'parent feature done'"
+    When I run "git-town ship -m 'parent done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                             |
-      | parent | git fetch --prune --tags            |
-      |        | git checkout main                   |
-      | main   | git rebase origin/main              |
-      |        | git checkout parent                 |
-      | parent | git merge --no-edit origin/parent   |
-      |        | git merge --no-edit main            |
-      |        | git checkout main                   |
-      | main   | git merge --squash parent           |
-      |        | git commit -m "parent feature done" |
-      |        | git push                            |
-      |        | git branch -D parent                |
+      | BRANCH | COMMAND                           |
+      | parent | git fetch --prune --tags          |
+      |        | git checkout main                 |
+      | main   | git rebase origin/main            |
+      |        | git checkout parent               |
+      | parent | git merge --no-edit origin/parent |
+      |        | git merge --no-edit main          |
+      |        | git checkout main                 |
+      | main   | git merge --squash parent         |
+      |        | git commit -m "parent done"       |
+      |        | git push                          |
+      |        | git branch -D parent              |
     And I am now on the "main" branch
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE               |
-      | main   | local, remote | parent feature done   |
-      | child  | local, remote | child feature commit  |
-      | parent | remote        | parent feature commit |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | main   | local, remote | parent done   |
+      | child  | local, remote | child commit  |
+      | parent | remote        | parent commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | child  | main   |
@@ -37,18 +37,18 @@ Feature: ship a parent branch
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                                             |
-      | main   | git branch parent {{ sha 'parent feature commit' }} |
-      |        | git revert {{ sha 'parent feature done' }}          |
-      |        | git push                                            |
-      |        | git checkout parent                                 |
-      | parent | git checkout main                                   |
-      | main   | git checkout parent                                 |
+      | BRANCH | COMMAND                                     |
+      | main   | git branch parent {{ sha 'parent commit' }} |
+      |        | git revert {{ sha 'parent done' }}          |
+      |        | git push                                    |
+      |        | git checkout parent                         |
+      | parent | git checkout main                           |
+      | main   | git checkout parent                         |
     And I am now on the "parent" branch
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE                      |
-      | main   | local, remote | parent feature done          |
-      |        |               | Revert "parent feature done" |
-      | child  | local, remote | child feature commit         |
-      | parent | local, remote | parent feature commit        |
+      | BRANCH | LOCATION      | MESSAGE              |
+      | main   | local, remote | parent done          |
+      |        |               | Revert "parent done" |
+      | child  | local, remote | child commit         |
+      | parent | local, remote | parent commit        |
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
-      |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |
+      | feature | local    | conflicting local commit  | conflicting_file | local conflicting content  |
+      |         | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
     And I am on the "other" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"
@@ -110,7 +110,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       | BRANCH  | LOCATION      | MESSAGE                                                    |
       | main    | local, remote | feature done                                               |
       |         |               | Revert "feature done"                                      |
-      | feature | local, remote | local conflicting commit                                   |
-      |         |               | remote conflicting commit                                  |
+      | feature | local, remote | conflicting local commit                                   |
+      |         |               | conflicting remote commit                                  |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | feature | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |         | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | feature | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |         | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
     And I am on the "other" branch
     And my workspace has an uncommitted file
     And I run "git-town ship feature -m 'feature done'"

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the main branch and its tracking branch
     Given my repo has the feature branches "feature" and "other"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main    | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |         | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | main    | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |         | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
       | feature | local    | feature commit            | feature_file     | feature content            |
     And I am on the "other" branch
     And my workspace has an uncommitted file
@@ -62,7 +62,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main   | local, remote | conflicting remote commit | conflicting_file | remote conflicting content |
+      | main   | local, remote | conflicting remote commit | conflicting_file | conflicting remote content |
       |        |               | conflicting local commit  | conflicting_file | resolved content           |
       |        |               | feature done              | feature_file     | feature content            |
     And the existing branches are

--- a/features/ship/supplied_branch/features/parent_branch.feature
+++ b/features/ship/supplied_branch/features/parent_branch.feature
@@ -4,9 +4,9 @@ Feature: ship a parent branch
     Given my repo has a feature branch "parent"
     And my repo has a feature branch "child" as a child of "parent"
     And my repo contains the commits
-      | BRANCH | LOCATION      | MESSAGE               |
-      | parent | local, remote | parent feature commit |
-      | child  | local, remote | child feature commit  |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | parent | local, remote | parent commit |
+      | child  | local, remote | child commit  |
     And I am on the "child" branch
     When I run "git-town ship parent -m 'parent done'"
 
@@ -27,10 +27,10 @@ Feature: ship a parent branch
       |        | git checkout child                |
     And I am now on the "child" branch
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE               |
-      | main   | local, remote | parent done           |
-      | child  | local, remote | child feature commit  |
-      | parent | remote        | parent feature commit |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | main   | local, remote | parent done   |
+      | child  | local, remote | child commit  |
+      | parent | remote        | parent commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | child  | main   |
@@ -38,19 +38,19 @@ Feature: ship a parent branch
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                                             |
-      | child  | git checkout main                                   |
-      | main   | git branch parent {{ sha 'parent feature commit' }} |
-      |        | git revert {{ sha 'parent done' }}                  |
-      |        | git push                                            |
-      |        | git checkout parent                                 |
-      | parent | git checkout main                                   |
-      | main   | git checkout child                                  |
+      | BRANCH | COMMAND                                     |
+      | child  | git checkout main                           |
+      | main   | git branch parent {{ sha 'parent commit' }} |
+      |        | git revert {{ sha 'parent done' }}          |
+      |        | git push                                    |
+      |        | git checkout parent                         |
+      | parent | git checkout main                           |
+      | main   | git checkout child                          |
     And I am now on the "child" branch
     And my repo now has the commits
-      | BRANCH | LOCATION      | MESSAGE               |
-      | main   | local, remote | parent done           |
-      |        |               | Revert "parent done"  |
-      | child  | local, remote | child feature commit  |
-      | parent | local, remote | parent feature commit |
+      | BRANCH | LOCATION      | MESSAGE              |
+      | main   | local, remote | parent done          |
+      |        |               | Revert "parent done" |
+      | child  | local, remote | child commit         |
+      | parent | local, remote | parent commit        |
     And Git Town now has the original branch hierarchy

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -6,8 +6,8 @@ Feature: handle merge conflicts between feature branch and main branch
       | BRANCH | LOCATION      | MESSAGE            | FILE NAME            | FILE CONTENT        |
       | main   | remote        | main commit        | conflicting_file     | main content        |
       | alpha  | local, remote | alpha commit       | feature1_file        | alpha content       |
-      | beta   | local         | beta local commit  | conflicting_file     | beta local content  |
-      |        | remote        | beta remote commit | feature2_remote_file | beta remote content |
+      | beta   | local         | local beta commit  | conflicting_file     | local beta content  |
+      |        | remote        | remote beta commit | feature2_remote_file | remote beta content |
       | gamma  | remote        | gamma commit       | feature3_file        | gamma content       |
     And I am on the "main" branch
     And my workspace has an uncommitted file
@@ -42,7 +42,7 @@ Feature: handle merge conflicts between feature branch and main branch
     Then it runs the commands
       | BRANCH | COMMAND                                        |
       | beta   | git merge --abort                              |
-      |        | git reset --hard {{ sha 'beta local commit' }} |
+      |        | git reset --hard {{ sha 'local beta commit' }} |
       |        | git checkout alpha                             |
       | alpha  | git checkout main                              |
       | main   | git stash pop                                  |
@@ -55,22 +55,22 @@ Feature: handle merge conflicts between feature branch and main branch
       | alpha  | local, remote | alpha commit                   |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into alpha |
-      | beta   | local         | beta local commit              |
-      |        | remote        | beta remote commit             |
+      | beta   | local         | local beta commit              |
+      |        | remote        | remote beta commit             |
       | gamma  | remote        | gamma commit                   |
     And my repo still has these committed files
       | BRANCH | NAME             | CONTENT            |
       | main   | conflicting_file | main content       |
       | alpha  | conflicting_file | main content       |
       |        | feature1_file    | alpha content      |
-      | beta   | conflicting_file | beta local content |
+      | beta   | conflicting_file | local beta content |
 
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
       | BRANCH | COMMAND                                        |
       | beta   | git merge --abort                              |
-      |        | git reset --hard {{ sha 'beta local commit' }} |
+      |        | git reset --hard {{ sha 'local beta commit' }} |
       |        | git checkout gamma                             |
       | gamma  | git merge --no-edit origin/gamma               |
       |        | git merge --no-edit main                       |
@@ -87,8 +87,8 @@ Feature: handle merge conflicts between feature branch and main branch
       | alpha  | local, remote | alpha commit                   |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into alpha |
-      | beta   | local         | beta local commit              |
-      |        | remote        | beta remote commit             |
+      | beta   | local         | local beta commit              |
+      |        | remote        | remote beta commit             |
       | gamma  | local, remote | gamma commit                   |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into gamma |
@@ -97,7 +97,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | main   | conflicting_file | main content       |
       | alpha  | conflicting_file | main content       |
       |        | feature1_file    | alpha content      |
-      | beta   | conflicting_file | beta local content |
+      | beta   | conflicting_file | local beta content |
       | gamma  | conflicting_file | main content       |
       |        | feature3_file    | gamma content      |
 
@@ -136,7 +136,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | alpha  | conflicting_file     | main content        |
       |        | feature1_file        | alpha content       |
       | beta   | conflicting_file     | resolved content    |
-      |        | feature2_remote_file | beta remote content |
+      |        | feature2_remote_file | remote beta content |
       | gamma  | conflicting_file     | main content        |
       |        | feature3_file        | gamma content       |
 

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -6,8 +6,8 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT        |
       | main   | remote        | main commit        | main_file        | main content        |
       | alpha  | local, remote | alpha commit       | feature1_file    | alpha content       |
-      | beta   | local         | beta local commit  | conflicting_file | beta local content  |
-      |        | remote        | beta remote commit | conflicting_file | beta remote content |
+      | beta   | local         | local beta commit  | conflicting_file | local beta content  |
+      |        | remote        | remote beta commit | conflicting_file | remote beta content |
       | gamma  | local, remote | gamma commit       | feature3_file    | gamma content       |
     And I am on the "main" branch
     And my workspace has an uncommitted file
@@ -52,15 +52,15 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | alpha  | local, remote | alpha commit                   |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into alpha |
-      | beta   | local         | beta local commit              |
-      |        | remote        | beta remote commit             |
+      | beta   | local         | local beta commit              |
+      |        | remote        | remote beta commit             |
       | gamma  | local, remote | gamma commit                   |
     And my repo now has these committed files
       | BRANCH | NAME             | CONTENT            |
       | main   | main_file        | main content       |
       | alpha  | feature1_file    | alpha content      |
       |        | main_file        | main content       |
-      | beta   | conflicting_file | beta local content |
+      | beta   | conflicting_file | local beta content |
       | gamma  | feature3_file    | gamma content      |
 
   Scenario: skip
@@ -83,8 +83,8 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | alpha  | local, remote | alpha commit                   |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into alpha |
-      | beta   | local         | beta local commit              |
-      |        | remote        | beta remote commit             |
+      | beta   | local         | local beta commit              |
+      |        | remote        | remote beta commit             |
       | gamma  | local, remote | gamma commit                   |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into gamma |
@@ -93,7 +93,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | main   | main_file        | main content       |
       | alpha  | feature1_file    | alpha content      |
       |        | main_file        | main content       |
-      | beta   | conflicting_file | beta local content |
+      | beta   | conflicting_file | local beta content |
       | gamma  | feature3_file    | gamma content      |
       |        | main_file        | main content       |
 

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -4,8 +4,8 @@ Feature: handle rebase conflicts between main branch and its tracking branch
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE            | FILE NAME        | FILE CONTENT        |
-      | main    | local    | main local commit  | conflicting_file | main local content  |
-      |         | remote   | main remote commit | conflicting_file | main remote content |
+      | main    | local    | local main commit  | conflicting_file | local main content  |
+      |         | remote   | remote main commit | conflicting_file | remote main content |
       | feature | local    | feature commit     | feature_file     | feature content     |
     And I am on the "main" branch
     And my workspace has an uncommitted file

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -6,8 +6,8 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        | FILE CONTENT               |
       | main        | remote        | main commit               | main_file        | main content               |
       | perennial-1 | local, remote | perennial-1 commit        | peren1_file      | perennial-1 content        |
-      | perennial-2 | local         | perennial-2 local commit  | conflicting_file | perennial-2 local content  |
-      |             | remote        | perennial-2 remote commit | conflicting_file | perennial-2 remote content |
+      | perennial-2 | local         | local perennial-2 commit  | conflicting_file | local perennial-2 content  |
+      |             | remote        | remote perennial-2 commit | conflicting_file | remote perennial-2 content |
       | perennial-3 | local, remote | perennial-3 commit        | peren3_file      | perennial-3 content        |
     And I am on the "main" branch
     And my workspace has an uncommitted file
@@ -48,8 +48,8 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       | BRANCH      | LOCATION      | MESSAGE                   |
       | main        | local, remote | main commit               |
       | perennial-1 | local, remote | perennial-1 commit        |
-      | perennial-2 | local         | perennial-2 local commit  |
-      |             | remote        | perennial-2 remote commit |
+      | perennial-2 | local         | local perennial-2 commit  |
+      |             | remote        | remote perennial-2 commit |
       | perennial-3 | local, remote | perennial-3 commit        |
 
   Scenario: skip
@@ -68,8 +68,8 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       | BRANCH      | LOCATION      | MESSAGE                   |
       | main        | local, remote | main commit               |
       | perennial-1 | local, remote | perennial-1 commit        |
-      | perennial-2 | local         | perennial-2 local commit  |
-      |             | remote        | perennial-2 remote commit |
+      | perennial-2 | local         | local perennial-2 commit  |
+      |             | remote        | remote perennial-2 commit |
       | perennial-3 | local, remote | perennial-3 commit        |
 
   Scenario: continue without resolving the conflicts

--- a/features/sync/all_branches/sync_all_branches.feature
+++ b/features/sync/all_branches/sync_all_branches.feature
@@ -8,8 +8,8 @@ Feature: sync all feature branches
       | main       | remote        | main commit              |
       | alpha      | local, remote | alpha commit             |
       | beta       | local, remote | beta commit              |
-      | production | local         | production local commit  |
-      |            | remote        | production remote commit |
+      | production | local         | local production commit  |
+      |            | remote        | remote production commit |
       | qa         | local         | qa local commit          |
       |            | remote        | qa remote commit         |
     And I am on the "alpha" branch

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the current feature branch and its tracking br
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | feature | local    | local conflicting commit  | conflicting_file | local conflicting content  |
-      |         | remote   | remote conflicting commit | conflicting_file | remote conflicting content |
+      | feature | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |         | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the main branch and its tracking branch
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | main   | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |        | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder.feature
@@ -3,10 +3,10 @@ Feature: sync inside a folder that doesn't exist on the main branch
   Background:
     Given my repo has the feature branches "alpha" and "beta"
     And my repo contains the commits
-      | BRANCH | LOCATION      | MESSAGE             | FILE NAME        |
-      | main   | local, remote | main commit         | main_file        |
-      | alpha  | local, remote | folder commit       | new_folder/file1 |
-      | beta   | local, remote | beta feature commit | file2            |
+      | BRANCH | LOCATION      | MESSAGE       | FILE NAME        |
+      | main   | local, remote | main commit   | main_file        |
+      | alpha  | local, remote | folder commit | new_folder/file1 |
+      | beta   | local, remote | beta commit   | file2            |
     And I am on the "alpha" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all" in the "new_folder" folder
@@ -39,6 +39,6 @@ Feature: sync inside a folder that doesn't exist on the main branch
       | alpha  | local, remote | folder commit                  |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into alpha |
-      | beta   | local, remote | beta feature commit            |
+      | beta   | local, remote | beta commit                    |
       |        |               | main commit                    |
       |        |               | Merge branch 'main' into beta  |

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -5,9 +5,9 @@ Feature: sync inside a folder that doesn't exist on the main branch
     And my repo contains the commits
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
-      | current | local         | conflicting feature commit | conflicting_file | feature content |
+      | current | local         | conflicting current commit | conflicting_file | current content |
       |         |               | folder commit              | new_folder/file1 |                 |
-      | other   | local, remote | other feature commit       | file2            |                 |
+      | other   | local, remote | other commit               | file2            |                 |
     And I am on the "current" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all" in the "new_folder" folder
@@ -76,11 +76,11 @@ Feature: sync inside a folder that doesn't exist on the main branch
     And my repo now has the commits
       | BRANCH  | LOCATION      | MESSAGE                          |
       | main    | local, remote | conflicting main commit          |
-      | current | local, remote | conflicting feature commit       |
+      | current | local, remote | conflicting current commit       |
       |         |               | folder commit                    |
       |         |               | conflicting main commit          |
       |         |               | Merge branch 'main' into current |
-      | other   | local, remote | other feature commit             |
+      | other   | local, remote | other commit                     |
       |         |               | conflicting main commit          |
       |         |               | Merge branch 'main' into other   |
     And my repo still has these committed files

--- a/features/sync/current_branch/feature_branch/features/local_repo.feature
+++ b/features/sync/current_branch/feature_branch/features/local_repo.feature
@@ -4,9 +4,9 @@ Feature: sync the current feature branch (without a tracking branch or remote re
     Given my repo does not have a remote origin
     And my repo has a local feature branch "feature"
     And my repo contains the commits
-      | BRANCH  | LOCATION | MESSAGE              |
-      | main    | local    | local main commit    |
-      | feature | local    | local feature commit |
+      | BRANCH  | LOCATION | MESSAGE        |
+      | main    | local    | main commit    |
+      | feature | local    | feature commit |
     And I am on the "feature" branch
     When I run "git-town sync"
 
@@ -18,7 +18,7 @@ Feature: sync the current feature branch (without a tracking branch or remote re
     And I am still on the "feature" branch
     And my repo now has the commits
       | BRANCH  | LOCATION | MESSAGE                          |
-      | main    | local    | local main commit                |
-      | feature | local    | local feature commit             |
-      |         |          | local main commit                |
+      | main    | local    | main commit                      |
+      | feature | local    | feature commit                   |
+      |         |          | main commit                      |
       |         |          | Merge branch 'main' into feature |

--- a/features/sync/current_branch/feature_branch/features/nested_feature_branches.feature
+++ b/features/sync/current_branch/feature_branch/features/nested_feature_branches.feature
@@ -4,13 +4,13 @@ Feature: nested feature branches
     Given my repo has a feature branch "parent"
     And my repo has a feature branch "child" as a child of "parent"
     And my repo contains the commits
-      | BRANCH | LOCATION | MESSAGE                      |
-      | main   | local    | local main commit            |
-      |        | remote   | remote main commit           |
-      | parent | local    | local parent feature commit  |
-      |        | remote   | remote parent feature commit |
-      | child  | local    | local child feature commit   |
-      |        | remote   | remote child feature commit  |
+      | BRANCH | LOCATION | MESSAGE              |
+      | main   | local    | local main commit    |
+      |        | remote   | remote main commit   |
+      | parent | local    | local parent commit  |
+      |        | remote   | remote parent commit |
+      | child  | local    | local child commit   |
+      |        | remote   | remote child commit  |
     And I am on the "child" branch
     When I run "git-town sync"
     Then it runs the commands
@@ -33,18 +33,18 @@ Feature: nested feature branches
       | BRANCH | LOCATION      | MESSAGE                                                  |
       | main   | local, remote | remote main commit                                       |
       |        |               | local main commit                                        |
-      | child  | local, remote | local child feature commit                               |
-      |        |               | remote child feature commit                              |
+      | child  | local, remote | local child commit                                       |
+      |        |               | remote child commit                                      |
       |        |               | Merge remote-tracking branch 'origin/child' into child   |
-      |        |               | local parent feature commit                              |
-      |        |               | remote parent feature commit                             |
+      |        |               | local parent commit                                      |
+      |        |               | remote parent commit                                     |
       |        |               | Merge remote-tracking branch 'origin/parent' into parent |
       |        |               | remote main commit                                       |
       |        |               | local main commit                                        |
       |        |               | Merge branch 'main' into parent                          |
       |        |               | Merge branch 'parent' into child                         |
-      | parent | local, remote | local parent feature commit                              |
-      |        |               | remote parent feature commit                             |
+      | parent | local, remote | local parent commit                                      |
+      |        |               | remote parent commit                                     |
       |        |               | Merge remote-tracking branch 'origin/parent' into parent |
       |        |               | remote main commit                                       |
       |        |               | local main commit                                        |

--- a/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     Given I am on the "main" branch
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | main   | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |        | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
     And my workspace has an uncommitted file
     When I run "git-town sync"
 

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -4,8 +4,8 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     Given my repo has the perennial branches "production" and "qa"
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | qa     | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | qa     | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |        | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
     And I am on the "qa" branch
     And my workspace has an uncommitted file
     When I run "git-town sync"

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -5,8 +5,8 @@ Feature: warn about unfinished prompt asking the user how to proceed
     Given my repo has a feature branch "feature"
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main   | local    | conflicting local commit  | conflicting_file | local conflicting content  |
-      |        | remote   | conflicting remote commit | conflicting_file | remote conflicting content |
+      | main   | local    | conflicting local commit  | conflicting_file | conflicting local content  |
+      |        | remote   | conflicting remote commit | conflicting_file | conflicting remote content |
     And I am on the "feature" branch
     And my workspace has an uncommitted file
     And I run "git-town sync"


### PR DESCRIPTION
Some commit messages contain historically grown cruft that makes them unnecessarily long. This PR cleans that up to improve readability.