### PR TITLE
Commit messages without underscores

### DIFF
--- a/features/append/append.feature
+++ b/features/append/append.feature
@@ -4,7 +4,7 @@ Feature: append a new feature branch to an existing feature branch
     Given my repo has a feature branch "existing"
     And my repo contains the commits
       | BRANCH   | LOCATION      | MESSAGE         |
-      | existing | local, remote | existing_commit |
+      | existing | local, remote | existing commit |
     And I am on the "existing" branch
     And my workspace has an uncommitted file
     When I run "git-town append new"
@@ -27,8 +27,8 @@ Feature: append a new feature branch to an existing feature branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH   | LOCATION      | MESSAGE         |
-      | existing | local, remote | existing_commit |
-      | new      | local         | existing_commit |
+      | existing | local, remote | existing commit |
+      | new      | local         | existing commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH   | PARENT   |
       | existing | main     |

--- a/features/append/edge_cases/on_main_branch.feature
+++ b/features/append/edge_cases/on_main_branch.feature
@@ -3,7 +3,7 @@ Feature: on the main branch
   Background:
     Given my repo contains the commits
       | BRANCH | LOCATION | MESSAGE     |
-      | main   | remote   | main_commit |
+      | main   | remote   | main commit |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town append new"
@@ -22,8 +22,8 @@ Feature: on the main branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |
-      | main   | local, remote | main_commit |
-      | new    | local         | main_commit |
+      | main   | local, remote | main commit |
+      | new    | local         | main commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | new    | main   |
@@ -41,5 +41,5 @@ Feature: on the main branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |
-      | main   | local, remote | main_commit |
+      | main   | local, remote | main commit |
     And Git Town now has no branch hierarchy information

--- a/features/append/features/local_repo.feature
+++ b/features/append/features/local_repo.feature
@@ -5,7 +5,7 @@ Feature: in a local repo
     And my repo does not have a remote origin
     And my repo contains the commits
       | BRANCH   | LOCATION | MESSAGE         |
-      | existing | local    | existing_commit |
+      | existing | local    | existing commit |
     And I am on the "existing" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new"
@@ -22,7 +22,7 @@ Feature: in a local repo
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH   | LOCATION | MESSAGE         |
-      | existing | local    | existing_commit |
+      | existing | local    | existing commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH   | PARENT |
       | existing | main   |

--- a/features/append/features/new_branch_push_flag.feature
+++ b/features/append/features/new_branch_push_flag.feature
@@ -4,7 +4,7 @@ Feature: auto-push the new branch to the remote
     Given the new-branch-push-flag configuration is true
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE     |
-      | main   | remote   | main_commit |
+      | main   | remote   | main commit |
     And I am on the "main" branch
     When I run "git-town append new"
 
@@ -19,8 +19,8 @@ Feature: auto-push the new branch to the remote
     And I am now on the "new" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |
-      | main   | local, remote | main_commit |
-      | new    | local, remote | main_commit |
+      | main   | local, remote | main commit |
+      | new    | local, remote | main commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | new    | main   |
@@ -35,5 +35,5 @@ Feature: auto-push the new branch to the remote
     And I am now on the "main" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |
-      | main   | local, remote | main_commit |
+      | main   | local, remote | main commit |
     And Git Town now has no branch hierarchy information

--- a/features/append/features/on_perennial_branch.feature
+++ b/features/append/features/on_perennial_branch.feature
@@ -4,7 +4,7 @@ Feature: append to a perennial branch
     Given my repo has the perennial branches "qa" and "production"
     And my repo contains the commits
       | BRANCH     | LOCATION | MESSAGE           |
-      | production | remote   | production_commit |
+      | production | remote   | production commit |
     And I am on the "production" branch
     When I run "git-town append new"
 
@@ -18,8 +18,8 @@ Feature: append to a perennial branch
     And I am now on the "new" branch
     And my repo now has the commits
       | BRANCH     | LOCATION      | MESSAGE           |
-      | new        | local         | production_commit |
-      | production | local, remote | production_commit |
+      | new        | local         | production commit |
+      | production | local, remote | production commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT     |
       | new    | production |
@@ -33,5 +33,5 @@ Feature: append to a perennial branch
     And I am now on the "production" branch
     And my repo now has the commits
       | BRANCH     | LOCATION      | MESSAGE           |
-      | production | local, remote | production_commit |
+      | production | local, remote | production commit |
     And Git Town now has the original branch hierarchy

--- a/features/hack/on_main_branch.feature
+++ b/features/hack/on_main_branch.feature
@@ -3,7 +3,7 @@ Feature: on a feature branch
   Background:
     Given my repo contains the commits
       | BRANCH | LOCATION | MESSAGE     |
-      | main   | remote   | main_commit |
+      | main   | remote   | main commit |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town hack new"
@@ -22,8 +22,8 @@ Feature: on a feature branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |
-      | main   | local, remote | main_commit |
-      | new    | local         | main_commit |
+      | main   | local, remote | main commit |
+      | new    | local         | main commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | new    | main   |
@@ -40,5 +40,5 @@ Feature: on a feature branch
     And I am now on the "main" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE     |
-      | main   | local, remote | main_commit |
+      | main   | local, remote | main commit |
     And Git Town now has no branch hierarchy information

--- a/features/prepend/features/hack_push_flag.feature
+++ b/features/prepend/features/hack_push_flag.feature
@@ -5,7 +5,7 @@ Feature: auto-push new branches
     And my repo has a feature branch "old"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE        |
-      | old    | local, remote | feature_commit |
+      | old    | local, remote | feature commit |
     And I am on the "old" branch
     When I run "git-town prepend new"
 
@@ -21,7 +21,7 @@ Feature: auto-push new branches
     And I am now on the "new" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE        |
-      | old    | local, remote | feature_commit |
+      | old    | local, remote | feature commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | new    | main   |

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -5,7 +5,7 @@ Feature: offline mode
     And my repo has a feature branch "old"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE    |
-      | old    | local, remote | old_commit |
+      | old    | local, remote | old commit |
     And I am on the "old" branch
     When I run "git-town prepend new"
 
@@ -19,7 +19,7 @@ Feature: offline mode
     And I am now on the "new" branch
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE    |
-      | old    | local, remote | old_commit |
+      | old    | local, remote | old commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | new    | main   |

--- a/features/prepend/prepend.feature
+++ b/features/prepend/prepend.feature
@@ -4,7 +4,7 @@ Feature: prepend a branch to a feature branch
     Given my repo has a feature branch "old"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE    |
-      | old    | local, remote | old_commit |
+      | old    | local, remote | old commit |
     And I am on the "old" branch
     And my workspace has an uncommitted file
     When I run "git-town prepend parent"
@@ -24,7 +24,7 @@ Feature: prepend a branch to a feature branch
     And my workspace still contains my uncommitted file
     And my repo now has the commits
       | BRANCH | LOCATION      | MESSAGE    |
-      | old    | local, remote | old_commit |
+      | old    | local, remote | old commit |
     And Git Town is now aware of this branch hierarchy
       | BRANCH | PARENT |
       | old    | parent |


### PR DESCRIPTION
We use underscores in filenames to make them more readable. Some of these underscores have snuck into commit messages. This PR cleans that up.