### PR TITLE
Shorten perennial branch names

### DIFF
--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -1,14 +1,14 @@
 Feature: handle rebase conflicts between perennial branch and its tracking branch
 
   Background:
-    Given my repo has the perennial branches "perennial-1", "perennial-2", and "perennial-3"
+    Given my repo has the perennial branches "alpha", "beta", and "gamma"
     And my repo contains the commits
-      | BRANCH      | LOCATION      | MESSAGE                   | FILE NAME        | FILE CONTENT               |
-      | main        | remote        | main commit               | main_file        | main content               |
-      | perennial-1 | local, remote | perennial-1 commit        | peren1_file      | perennial-1 content        |
-      | perennial-2 | local         | local perennial-2 commit  | conflicting_file | local perennial-2 content  |
-      |             | remote        | remote perennial-2 commit | conflicting_file | remote perennial-2 content |
-      | perennial-3 | local, remote | perennial-3 commit        | peren3_file      | perennial-3 content        |
+      | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT        |
+      | main   | remote        | main commit        | main_file        | main content        |
+      | alpha  | local, remote | alpha commit       | peren1_file      | alpha content       |
+      | beta   | local         | local beta commit  | conflicting_file | local beta content  |
+      |        | remote        | remote beta commit | conflicting_file | remote beta content |
+      | gamma  | local, remote | gamma commit       | peren3_file      | gamma content       |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"
@@ -16,15 +16,15 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
   Scenario: result
     Then I am not prompted for any parent branches
     And it runs the commands
-      | BRANCH      | COMMAND                       |
-      | main        | git fetch --prune --tags      |
-      |             | git add -A                    |
-      |             | git stash                     |
-      |             | git rebase origin/main        |
-      |             | git checkout perennial-1      |
-      | perennial-1 | git rebase origin/perennial-1 |
-      |             | git checkout perennial-2      |
-      | perennial-2 | git rebase origin/perennial-2 |
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git rebase origin/main   |
+      |        | git checkout alpha       |
+      | alpha  | git rebase origin/alpha  |
+      |        | git checkout beta        |
+      | beta   | git rebase origin/beta   |
     And it prints the error:
       """
       To abort, run "git-town abort".
@@ -37,40 +37,40 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
   Scenario: abort
     When I run "git-town abort"
     Then it runs the commands
-      | BRANCH      | COMMAND                  |
-      | perennial-2 | git rebase --abort       |
-      |             | git checkout perennial-1 |
-      | perennial-1 | git checkout main        |
-      | main        | git stash pop            |
+      | BRANCH | COMMAND            |
+      | beta   | git rebase --abort |
+      |        | git checkout alpha |
+      | alpha  | git checkout main  |
+      | main   | git stash pop      |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo now has the commits
-      | BRANCH      | LOCATION      | MESSAGE                   |
-      | main        | local, remote | main commit               |
-      | perennial-1 | local, remote | perennial-1 commit        |
-      | perennial-2 | local         | local perennial-2 commit  |
-      |             | remote        | remote perennial-2 commit |
-      | perennial-3 | local, remote | perennial-3 commit        |
+      | BRANCH | LOCATION      | MESSAGE            |
+      | main   | local, remote | main commit        |
+      | alpha  | local, remote | alpha commit       |
+      | beta   | local         | local beta commit  |
+      |        | remote        | remote beta commit |
+      | gamma  | local, remote | gamma commit       |
 
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
-      | BRANCH      | COMMAND                       |
-      | perennial-2 | git rebase --abort            |
-      |             | git checkout perennial-3      |
-      | perennial-3 | git rebase origin/perennial-3 |
-      |             | git checkout main             |
-      | main        | git push --tags               |
-      |             | git stash pop                 |
+      | BRANCH | COMMAND                 |
+      | beta   | git rebase --abort      |
+      |        | git checkout gamma      |
+      | gamma  | git rebase origin/gamma |
+      |        | git checkout main       |
+      | main   | git push --tags         |
+      |        | git stash pop           |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
     And my repo now has the commits
-      | BRANCH      | LOCATION      | MESSAGE                   |
-      | main        | local, remote | main commit               |
-      | perennial-1 | local, remote | perennial-1 commit        |
-      | perennial-2 | local         | local perennial-2 commit  |
-      |             | remote        | remote perennial-2 commit |
-      | perennial-3 | local, remote | perennial-3 commit        |
+      | BRANCH | LOCATION      | MESSAGE            |
+      | main   | local, remote | main commit        |
+      | alpha  | local, remote | alpha commit       |
+      | beta   | local         | local beta commit  |
+      |        | remote        | remote beta commit |
+      | gamma  | local, remote | gamma commit       |
 
   Scenario: continue without resolving the conflicts
     When I run "git-town continue"
@@ -86,14 +86,14 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
-      | BRANCH      | COMMAND                       |
-      | perennial-2 | git rebase --continue         |
-      |             | git push                      |
-      |             | git checkout perennial-3      |
-      | perennial-3 | git rebase origin/perennial-3 |
-      |             | git checkout main             |
-      | main        | git push --tags               |
-      |             | git stash pop                 |
+      | BRANCH | COMMAND                 |
+      | beta   | git rebase --continue   |
+      |        | git push                |
+      |        | git checkout gamma      |
+      | gamma  | git rebase origin/gamma |
+      |        | git checkout main       |
+      | main   | git push --tags         |
+      |        | git stash pop           |
     And all branches are now synchronized
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
@@ -104,10 +104,10 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH      | COMMAND                       |
-      | perennial-2 | git push                      |
-      |             | git checkout perennial-3      |
-      | perennial-3 | git rebase origin/perennial-3 |
-      |             | git checkout main             |
-      | main        | git push --tags               |
-      |             | git stash pop                 |
+      | BRANCH | COMMAND                 |
+      | beta   | git push                |
+      |        | git checkout gamma      |
+      | gamma  | git rebase origin/gamma |
+      |        | git checkout main       |
+      | main   | git push --tags         |
+      |        | git stash pop           |

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -5,10 +5,10 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT        |
       | main   | remote        | main commit        | main_file        | main content        |
-      | alpha  | local, remote | alpha commit       | peren1_file      | alpha content       |
+      | alpha  | local, remote | alpha commit       | alpha_file       | alpha content       |
       | beta   | local         | local beta commit  | conflicting_file | local beta content  |
       |        | remote        | remote beta commit | conflicting_file | remote beta content |
-      | gamma  | local, remote | gamma commit       | peren3_file      | gamma content       |
+      | gamma  | local, remote | gamma commit       | gamma_file       | gamma content       |
     And I am on the "main" branch
     And my workspace has an uncommitted file
     When I run "git-town sync --all"


### PR DESCRIPTION
This spec contains only perennial branches so it's clear that they are perennial and we can name them more distinct from each other.