### PR TITLE
Polish scenario titles

### DIFF
--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -47,7 +47,7 @@ Feature: conflicts between the main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: conflicts between the main branch and its tracking branch
       | main   | conflicting_file | resolved content |
       | new    | conflicting_file | resolved content |
 
-  Scenario: resolve the conflict, finish the rebase, and continue
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -38,7 +38,7 @@ Feature: conflicts between the main branch and its tracking branch
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflicts
     When I run "git-town continue"
     Then it prints the error:
       """
@@ -47,7 +47,7 @@ Feature: conflicts between the main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continue after resolving the conflicts but not finishing the rebase
+  Scenario: resolve the conflicts and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: conflicts between the main branch and its tracking branch
       | main   | conflicting_file | resolved content |
       | new    | conflicting_file | resolved content |
 
-  Scenario: continue after resolving the conflicts and finishing the rebase
+  Scenario: resolve the conflicts, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -38,7 +38,7 @@ Feature: conflicts between the main branch and its tracking branch
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continue with unresolved conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it prints the error:
       """
@@ -47,7 +47,7 @@ Feature: conflicts between the main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: resolve the conflicts and continue
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: conflicts between the main branch and its tracking branch
       | main   | conflicting_file | resolved content |
       | new    | conflicting_file | resolved content |
 
-  Scenario: resolve the conflicts, finish the rebase, and continue
+  Scenario: resolve the conflict, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
+++ b/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
@@ -37,7 +37,7 @@ Feature: conflicts between uncommitted changes and the main branch
       """
     And I am still on the "new" branch
 
-  Scenario: resolve the conflict and abort
+  Scenario: resolve and abort
     Given I resolve the conflict in "conflicting_file"
     When I run "git-town abort"
     Then it runs the commands
@@ -60,7 +60,7 @@ Feature: conflicts between uncommitted changes and the main branch
       you must resolve the conflicts before continuing
       """
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs no commands
@@ -71,7 +71,7 @@ Feature: conflicts between uncommitted changes and the main branch
       | new    | local         | conflicting commit | conflicting_file | main content |
     And my workspace now contains the file "conflicting_file" with content "resolved content"
 
-  Scenario: resolve the conflict and undo undoes the hack but cannot get back to the original branch due to merge conflicts
+  Scenario: resolve and undo undoes the hack but cannot get back to the original branch due to merge conflicts
     Given I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     When I run "git-town undo"

--- a/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
+++ b/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
@@ -26,7 +26,7 @@ Feature: conflicts between uncommitted changes and the main branch
       """
     And the file "conflicting_file" contains unresolved conflicts
 
-  Scenario: abort with unresolved conflicts fails due to unresolved merge conflicts
+  Scenario: abort with unresolved conflict fails due to unresolved merge conflicts
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH | COMMAND           |

--- a/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
+++ b/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
@@ -26,7 +26,7 @@ Feature: conflicts between uncommitted changes and the main branch
       """
     And the file "conflicting_file" contains unresolved conflicts
 
-  Scenario: abort without resolving the conflicts fails due to unresolved merge conflicts
+  Scenario: abort with unresolved conflicts fails due to unresolved merge conflicts
     When I run "git-town abort"
     Then it runs the commands
       | BRANCH | COMMAND           |
@@ -37,7 +37,7 @@ Feature: conflicts between uncommitted changes and the main branch
       """
     And I am still on the "new" branch
 
-  Scenario: abort after resolving the conflicts undoes the hack and indicates the merge conflict in the uncommitted file
+  Scenario: resolve the conflict and abort
     Given I resolve the conflict in "conflicting_file"
     When I run "git-town abort"
     Then it runs the commands
@@ -53,14 +53,14 @@ Feature: conflicts between uncommitted changes and the main branch
     And my repo is left with my original commits
     And my workspace now contains the file "conflicting_file" with content "resolved content"
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it prints the error:
       """
       you must resolve the conflicts before continuing
       """
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs no commands
@@ -71,7 +71,7 @@ Feature: conflicts between uncommitted changes and the main branch
       | new    | local         | conflicting commit | conflicting_file | main content |
     And my workspace now contains the file "conflicting_file" with content "resolved content"
 
-  Scenario: undo after resolving the conflicts undoes the hack but cannot get back to the original branch due to merge conflicts
+  Scenario: resolve the conflict and undo undoes the hack but cannot get back to the original branch due to merge conflicts
     Given I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     When I run "git-town undo"

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -38,7 +38,7 @@ Feature: merge conflict
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -49,7 +49,7 @@ Feature: merge conflict
     And my repo still has a merge in progress
 
   @skipWindows
-  Scenario: continue after resolving conflicts
+  Scenario: resolve the conflict and continue
     Given I resolve the conflict in "conflicting_file"
     When I run "git-town continue"
     Then it runs the commands
@@ -74,7 +74,7 @@ Feature: merge conflict
       | feature | conflicting_file | resolved content |
 
   @skipWindows
-  Scenario: continue after resolving conflicts and committing
+  Scenario: resolve the conflict, commit, and continue
     Given I resolve the conflict in "conflicting_file"
     When I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -49,7 +49,7 @@ Feature: merge conflict
     And my repo still has a merge in progress
 
   @skipWindows
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     Given I resolve the conflict in "conflicting_file"
     When I run "git-town continue"
     Then it runs the commands
@@ -74,7 +74,7 @@ Feature: merge conflict
       | feature | conflicting_file | resolved content |
 
   @skipWindows
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     Given I resolve the conflict in "conflicting_file"
     When I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/shared/run_outside_repo.feature
+++ b/features/shared/run_outside_repo.feature
@@ -1,4 +1,4 @@
-Feature: require running inside a Git repository
+Feature: require a Git repository
 
   Scenario Outline:
     Given my workspace is currently not a Git repo

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -42,7 +42,7 @@ Feature: handle conflicts between the shipped branch and the main branch
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
     And Git Town still has the original branch hierarchy
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -64,7 +64,7 @@ Feature: handle conflicts between the shipped branch and the main branch
       |        |               | feature done            | conflicting_file | resolved content |
     And Git Town now has no branch hierarchy information
 
-  Scenario: continue after resolving the conflicts and committing
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -42,7 +42,7 @@ Feature: handle conflicts between the shipped branch and the main branch
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
     And Git Town still has the original branch hierarchy
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -64,7 +64,7 @@ Feature: handle conflicts between the shipped branch and the main branch
       |        |               | feature done            | conflicting_file | resolved content |
     And Git Town now has no branch hierarchy information
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -37,7 +37,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -59,7 +59,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
       | main   | local, remote | feature done | conflicting_file |
     And Git Town now has no branch hierarchy information
 
-  Scenario: continue after resolving the conflicts and committing
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -37,7 +37,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -59,7 +59,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
       | main   | local, remote | feature done | conflicting_file |
     And Git Town now has no branch hierarchy information
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -61,7 +61,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       |        |               | feature done              |
     And Git Town now has no branch hierarchy information
 
-  Scenario: resolve the conflict, finish the rebase, and continue
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -61,7 +61,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       |        |               | feature done              |
     And Git Town now has no branch hierarchy information
 
-  Scenario: continue after resolving the conflicts and continuing the rebase
+  Scenario: resolve the conflict, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -48,7 +48,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | feature | local         | conflicting feature commit |
     And Git Town still has the original branch hierarchy
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -75,7 +75,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | BRANCH | PARENT |
       | other  | main   |
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
@@ -92,7 +92,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
     And I am now on the "other" branch
     And my workspace still contains my uncommitted file
 
-  Scenario: resolve the conflict, continue, and undo
+  Scenario: resolve, continue, and undo
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     And I run "git-town undo"

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -48,7 +48,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | feature | local         | conflicting feature commit |
     And Git Town still has the original branch hierarchy
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -75,7 +75,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | BRANCH | PARENT |
       | other  | main   |
 
-  Scenario: continue after resolving the conflicts and comitting
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
@@ -92,7 +92,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
     And I am now on the "other" branch
     And my workspace still contains my uncommitted file
 
-  Scenario: undo after continue
+  Scenario: resolve the conflict, continue, and undo
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     And I run "git-town undo"

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -43,7 +43,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       | BRANCH | PARENT |
       | other  | main   |
 
-  Scenario: continue after resolving the conflicts and comitting
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
@@ -88,7 +88,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And I am now on the "other" branch
     And my workspace still contains my uncommitted file
 
-  Scenario: undo after continue
+  Scenario: resolve the conflict, continue, and undo
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     And I run "git-town undo"

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -43,7 +43,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       | BRANCH | PARENT |
       | other  | main   |
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"
@@ -88,7 +88,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And I am now on the "other" branch
     And my workspace still contains my uncommitted file
 
-  Scenario: resolve the conflict, continue, and undo
+  Scenario: resolve, continue, and undo
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     And I run "git-town undo"

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -40,7 +40,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -72,7 +72,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | BRANCH | PARENT |
       | other  | main   |
 
-  Scenario: resolve the conflict, finish the rebase, and continue
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"
@@ -92,7 +92,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | other   | git stash pop                      |
     And I am now on the "other" branch
 
-  Scenario: resolve the conflict, continue, and undo
+  Scenario: resolve, continue, and undo
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     And I run "git-town undo"

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -40,7 +40,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo is left with my original commits
     And Git Town still has the original branch hierarchy
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -72,7 +72,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | BRANCH | PARENT |
       | other  | main   |
 
-  Scenario: continue after resolving the conflicts and continuing the rebase
+  Scenario: resolve the conflict, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"
@@ -92,7 +92,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | other   | git stash pop                      |
     And I am now on the "other" branch
 
-  Scenario: undo after continue
+  Scenario: resolve the conflict, continue, and undo
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     And I run "git-town undo"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -97,7 +97,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file | main content  |
       |        | feature2_file    | gamma content |
 
-  Scenario: continue with resolved conflict
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -108,7 +108,7 @@ Feature: handle merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -135,7 +135,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file | main content     |
       |        | feature2_file    | gamma content    |
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -97,7 +97,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file | main content  |
       |        | feature2_file    | gamma content |
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with resolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -108,7 +108,7 @@ Feature: handle merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -135,7 +135,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file | main content     |
       |        | feature2_file    | gamma content    |
 
-  Scenario: continue after resolving the conflicts and committing
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -88,7 +88,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -111,7 +111,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
       | gamma  | conflicting_file | main content     |
       |        | feature3_file    | gamma content    |
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -77,7 +77,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
       | gamma  | conflicting_file | main content  |
       |        | feature3_file    | gamma content |
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -88,7 +88,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -111,7 +111,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
       | gamma  | conflicting_file | main content     |
       |        | feature3_file    | gamma content    |
 
-  Scenario: continue after resolving the conflicts and committing
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -101,7 +101,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file | main content       |
       |        | feature3_file    | gamma content      |
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -112,7 +112,7 @@ Feature: handle merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -140,7 +140,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file     | main content        |
       |        | feature3_file        | gamma content       |
 
-  Scenario: continue after resolving the conflicts and committing
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -112,7 +112,7 @@ Feature: handle merge conflicts between feature branch and main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -140,7 +140,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file     | main content        |
       |        | feature3_file        | gamma content       |
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -108,7 +108,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -137,7 +137,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | gamma  | feature3_file    | gamma content    |
       |        | main_file        | main content     |
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -97,7 +97,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | gamma  | feature3_file    | gamma content      |
       |        | main_file        | main content       |
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -108,7 +108,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -137,7 +137,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | gamma  | feature3_file    | gamma content    |
       |        | main_file        | main content     |
 
-  Scenario: continue after resolving the conflicts and committing
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -36,7 +36,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
 
-  Scenario: continue with resolved conflict
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -46,7 +46,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       | feature | conflicting_file | resolved content |
       |         | feature_file     | feature content  |
 
-  Scenario: resolve the conflict, finished the rebase, and continue
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -36,7 +36,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
     And my workspace has the uncommitted file again
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with resolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -46,7 +46,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -70,7 +70,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       | feature | conflicting_file | resolved content |
       |         | feature_file     | feature content  |
 
-  Scenario: continue after resolving the conflicts and continuing the rebase
+  Scenario: resolve the conflict, finished the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -82,7 +82,7 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -99,7 +99,7 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And my workspace has the uncommitted file again
     And there is no rebase in progress anymore
 
-  Scenario: resolve the conflict, finish the rebase, and continue
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -72,7 +72,7 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       |        | remote        | remote beta commit |
       | gamma  | local, remote | gamma commit       |
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -82,7 +82,7 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -99,7 +99,7 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And my workspace has the uncommitted file again
     And there is no rebase in progress anymore
 
-  Scenario: continue after resolving the conflicts and continuing the rebase
+  Scenario: resolve the conflict, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -48,7 +48,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -59,7 +59,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -76,7 +76,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continue after resolving the conflicts resulting in no changes
+  Scenario: resolve the conflicts so that there are no changes and continue
     When I resolve the conflict in "conflicting_file" with "feature content"
     And I run "git-town continue"
     Then it runs the commands
@@ -93,7 +93,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content    |
       | feature | conflicting_file | feature content |
 
-  Scenario: continue after resolving the conflicts and comitting
+  Scenario: resolve the conflict, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -59,7 +59,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -76,7 +76,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
-  Scenario: resolve the conflict resulting in no changes and continue
+  Scenario: resolve resulting in no changes and continue
     When I resolve the conflict in "conflicting_file" with "feature content"
     And I run "git-town continue"
     Then it runs the commands
@@ -93,7 +93,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content    |
       | feature | conflicting_file | feature content |
 
-  Scenario: resolve the conflict, commit, and continue
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -76,7 +76,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
-  Scenario: resolve the conflicts so that there are no changes and continue
+  Scenario: resolve the conflict resulting in no changes and continue
     When I resolve the conflict in "conflicting_file" with "feature content"
     And I run "git-town continue"
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -38,7 +38,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -49,7 +49,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve the conflict and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -65,7 +65,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | conflicting_file | main content     |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continue after resolving the conflicts and comitting
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -49,7 +49,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: resolve the conflict and continue
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -51,7 +51,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
       |         | remote        | feature commit             | feature_file     | feature content |
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -62,7 +62,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -80,7 +80,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | feature | conflicting_file | resolved content |
       |         | feature_file     | feature content  |
 
-  Scenario: continue after resolving the conflicts and comitting
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -43,7 +43,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -54,7 +54,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
@@ -71,7 +71,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
       | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continue after resolving the conflicts and committing
+  Scenario: resolve, commit, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git commit --no-edit"
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -38,7 +38,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -48,7 +48,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my repo still has a rebase in progress
     And my uncommitted file is stashed
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -69,7 +69,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | main    | conflicting_file | resolved content |
       | feature | conflicting_file | resolved content |
 
-  Scenario: continue after resolving the conflicts and continuing the rebase
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -44,7 +44,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continue with resolved conflict
+  Scenario: continue with unresolved conflict
     When I run "git-town continue" in the "new_folder" folder
     Then it runs no commands
     And it prints the error:

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -44,7 +44,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
     And there is no merge in progress
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with resolved conflict
     When I run "git-town continue" in the "new_folder" folder
     Then it runs no commands
     And it prints the error:
@@ -55,7 +55,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
     And my uncommitted file is stashed
     And my repo still has a merge in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" in the "new_folder" folder
     Then it runs the commands

--- a/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -35,7 +35,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -45,7 +45,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -61,7 +61,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
       | BRANCH | NAME             | CONTENT          |
       | main   | conflicting_file | resolved content |
 
-  Scenario: continue after resolving the conflicts and continuing the rebase
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -37,7 +37,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     And there is no rebase in progress anymore
     And my repo is left with my original commits
 
-  Scenario: continue without resolving the conflicts
+  Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
     And it prints the error:
@@ -47,7 +47,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     And my uncommitted file is stashed
     And my repo still has a rebase in progress
 
-  Scenario: continue after resolving the conflicts
+  Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
@@ -64,7 +64,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
       | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |
 
-  Scenario: continue after resolving the conflicts and continuing the rebase
+  Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -1,5 +1,5 @@
 @skipWindows
-Feature: warn about unfinished prompt asking the user how to proceed
+Feature: warn user about previous operation
 
   Background:
     Given my repo has a feature branch "feature"

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -16,7 +16,7 @@ Feature: warn user about previous operation
       To continue after having resolved conflicts, run "git-town continue".
       """
 
-  Scenario: attempt to sync again and choosing to quit
+  Scenario: sync again and quit
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER  |
       | Please choose how to proceed | [ENTER] |
@@ -27,7 +27,7 @@ Feature: warn user about previous operation
       """
     And my uncommitted file is stashed
 
-  Scenario: attempt to sync again and choosing to continue without resolving conflicts
+  Scenario: sync again and continue with unresolved conflict
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER        |
       | Please choose how to proceed | [DOWN][ENTER] |
@@ -38,7 +38,7 @@ Feature: warn user about previous operation
       """
     And my uncommitted file is stashed
 
-  Scenario: attempt to sync again and choosing to continue after resolving conflicts
+  Scenario: resolve, sync again, and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town sync", answer the prompts, and close the next editor:
       | PROMPT                       | ANSWER        |
@@ -54,7 +54,7 @@ Feature: warn user about previous operation
       |         | git stash pop                      |
     And all branches are now synchronized
 
-  Scenario: attempt to sync again and choosing to abort
+  Scenario: sync again and abort
     When I run "git-town sync" and answer the prompts:
       | PROMPT                       | ANSWER              |
       | Please choose how to proceed | [DOWN][DOWN][ENTER] |
@@ -65,7 +65,7 @@ Feature: warn user about previous operation
       | feature | git stash pop        |
     And my repo is left with my original commits
 
-  Scenario: run another command after manually aborting
+  Scenario: manually abort the rebase and run another command still shows warning about unfinished command
     When I run "git rebase --abort"
     And I run "git checkout feature"
     And I run "git stash pop"
@@ -81,7 +81,7 @@ Feature: warn user about previous operation
       |         | git checkout main              |
       | main    | git branch -D feature          |
 
-  Scenario: does not report unfinished state after abort
+  Scenario: abort and run another command
     When I run "git-town abort"
     And I run "git-town kill"
     Then it does not print "You have an unfinished `sync` command that ended on the `main` branch now."

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -1,5 +1,5 @@
 @skipWindows
-Feature: warn user about previous operation
+Feature: warn the user about an unfinished operation
 
   Background:
     Given my repo has a feature branch "feature"


### PR DESCRIPTION
The scenario titles have accumulated some grammatical cruft over the years. This PR simplifies them, uses active language, and gets them closer to the recommended "The one where we ..." format. The titles are intentionally short, more details about who does what exactly are in the body of the scenario.