### PR TITLE
Unify "original" and "initial" concept in specs

### DIFF
--- a/features/append/append.feature
+++ b/features/append/append.feature
@@ -47,5 +47,5 @@ Feature: append a new feature branch to an existing feature branch
       | existing | git stash pop         |
     And I am now on the "existing" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy

--- a/features/append/append.feature
+++ b/features/append/append.feature
@@ -48,4 +48,4 @@ Feature: append a new feature branch to an existing feature branch
     And I am now on the "existing" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy

--- a/features/append/features/local_repo.feature
+++ b/features/append/features/local_repo.feature
@@ -38,6 +38,6 @@ Feature: in a local repo
       | existing | git branch -d new     |
       |          | git stash pop         |
     And I am now on the "existing" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my workspace still contains my uncommitted file
     And my repo now has its initial branches and branch hierarchy

--- a/features/append/features/offline.feature
+++ b/features/append/features/offline.feature
@@ -35,5 +35,5 @@ Feature: append in offline mode
       |          | git checkout main     |
       | main     | git checkout existing |
     And I am now on the "existing" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy

--- a/features/append/features/offline.feature
+++ b/features/append/features/offline.feature
@@ -36,4 +36,4 @@ Feature: append in offline mode
       | main     | git checkout existing |
     And I am now on the "existing" branch
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/append/features/on_perennial_branch.feature
+++ b/features/append/features/on_perennial_branch.feature
@@ -34,4 +34,4 @@ Feature: append to a perennial branch
     And my repo now has the commits
       | BRANCH     | LOCATION      | MESSAGE           |
       | production | local, remote | production commit |
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/hack/edge_cases/in_committed_subfolder.feature
+++ b/features/hack/edge_cases/in_committed_subfolder.feature
@@ -17,7 +17,7 @@ Feature: inside a committed subfolder that exists only on the current feature br
       |          | git branch new main      |
       |          | git checkout new         |
     And I am now on the "new" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town is now aware of this branch hierarchy
       | BRANCH   | PARENT |
       | existing | main   |
@@ -31,5 +31,5 @@ Feature: inside a committed subfolder that exists only on the current feature br
       | main   | git branch -d new     |
       |        | git checkout existing |
     And I am now on the "existing" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy

--- a/features/hack/edge_cases/in_committed_subfolder.feature
+++ b/features/hack/edge_cases/in_committed_subfolder.feature
@@ -32,4 +32,4 @@ Feature: inside a committed subfolder that exists only on the current feature br
       |        | git checkout existing |
     And I am now on the "existing" branch
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/hack/edge_cases/in_uncommitted_subfolder.feature
+++ b/features/hack/edge_cases/in_uncommitted_subfolder.feature
@@ -42,5 +42,5 @@ Feature: inside an uncommitted subfolder on the current feature branch
       |          | git checkout existing |
       | existing | git stash pop         |
     And I am now on the "existing" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy

--- a/features/hack/edge_cases/in_uncommitted_subfolder.feature
+++ b/features/hack/edge_cases/in_uncommitted_subfolder.feature
@@ -43,4 +43,4 @@ Feature: inside an uncommitted subfolder on the current feature branch
       | existing | git stash pop         |
     And I am now on the "existing" branch
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -36,7 +36,7 @@ Feature: conflicts between the main branch and its tracking branch
     And I am now on the "existing" branch
     And my workspace has the uncommitted file again
     And there is no rebase in progress anymore
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
+++ b/features/hack/edge_cases/uncommitted_changes_conflict_with_main.feature
@@ -50,7 +50,7 @@ Feature: conflicts between uncommitted changes and the main branch
       cannot check out branch "existing"
       """
     And I am now on the "main" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my workspace now contains the file "conflicting_file" with content "resolved content"
 
   Scenario: continue with unresolved conflict
@@ -85,5 +85,5 @@ Feature: conflicts between uncommitted changes and the main branch
       cannot check out branch "existing"
       """
     And I am now on the "main" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my workspace now contains the file "conflicting_file" with content "resolved content"

--- a/features/hack/features/offline.feature
+++ b/features/hack/features/offline.feature
@@ -38,5 +38,5 @@ Feature: offline mode
       |        | git stash pop     |
     And I am now on the "main" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has no branch hierarchy information

--- a/features/hack/on_feature_branch.feature
+++ b/features/hack/on_feature_branch.feature
@@ -48,4 +48,4 @@ Feature: on the main branch
       | BRANCH   | LOCATION      | MESSAGE         |
       | main     | local, remote | main commit     |
       | existing | local         | existing commit |
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -32,5 +32,5 @@ Feature: delete a local branch
       | local  | git reset {{ sha 'local commit' }}        |
     And I am now on the "local" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/features/local_repo.feature
+++ b/features/kill/current_branch/features/local_repo.feature
@@ -38,5 +38,5 @@ Feature: in a local repo
       | feature | git reset {{ sha 'feature commit' }}          |
     And I am now on the "feature" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -41,5 +41,5 @@ Feature: offline mode
       | feature | git reset {{ sha 'feature commit' }}          |
     And I am now on the "feature" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/features/parent_branch.feature
+++ b/features/kill/current_branch/features/parent_branch.feature
@@ -46,5 +46,5 @@ Feature: delete a branch within a branch chain
       |        | git push -u origin beta                 |
     And I am now on the "beta" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -41,5 +41,5 @@ Feature: delete the current feature branch
       |         | git push -u origin current                    |
     And I am now on the "current" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -41,5 +41,5 @@ Feature: delete the current branch
       |         | git push -u origin current                    |
     And I am now on the "current" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/features/local_branch.feature
+++ b/features/kill/supplied_branch/features/local_branch.feature
@@ -39,5 +39,5 @@ Feature: local branch
       | dead   | git reset {{ sha 'dead commit' }}       |
     And I am now on the "dead" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -42,5 +42,5 @@ Feature: local repository
       |        | git stash pop                             |
     And I am still on the "good" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/features/parent_branch.feature
+++ b/features/kill/supplied_branch/features/parent_branch.feature
@@ -41,5 +41,5 @@ Feature: delete a parent branch
       |        | git push -u origin beta                 |
     And I am now on the "gamma" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -38,5 +38,5 @@ Feature: delete another than the current branch
       |        | git push -u origin dead                     |
     And I am still on the "good" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/new-pull-request/edge_cases/conflict.feature
+++ b/features/new-pull-request/edge_cases/conflict.feature
@@ -36,7 +36,7 @@ Feature: merge conflict
       | main    | git checkout feature |
     And I am still on the "feature" branch
     And there is no merge in progress
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/prepend/features/hack_push_flag.feature
+++ b/features/prepend/features/hack_push_flag.feature
@@ -36,5 +36,5 @@ Feature: auto-push new branches
       | main   | git branch -d new    |
       |        | git checkout old     |
     And I am now on the "old" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy

--- a/features/prepend/features/hack_push_flag.feature
+++ b/features/prepend/features/hack_push_flag.feature
@@ -37,4 +37,4 @@ Feature: auto-push new branches
       |        | git checkout old     |
     And I am now on the "old" branch
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -33,5 +33,5 @@ Feature: offline mode
       | main   | git branch -d new |
       |        | git checkout old  |
     And I am now on the "old" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -34,4 +34,4 @@ Feature: offline mode
       |        | git checkout old  |
     And I am now on the "old" branch
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/prepend/prepend.feature
+++ b/features/prepend/prepend.feature
@@ -43,4 +43,4 @@ Feature: prepend a branch to a feature branch
     And I am now on the "old" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/prepend/prepend.feature
+++ b/features/prepend/prepend.feature
@@ -42,5 +42,5 @@ Feature: prepend a branch to a feature branch
       | old    | git stash pop        |
     And I am now on the "old" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy

--- a/features/rename-branch/edge_cases/offline.feature
+++ b/features/rename-branch/edge_cases/offline.feature
@@ -34,5 +34,5 @@ Feature: offline mode
       |        | git checkout old                      |
       | old    | git branch -D new                     |
     And I am now on the "old" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/rename-branch/features/parent_branch.feature
+++ b/features/rename-branch/features/parent_branch.feature
@@ -39,5 +39,5 @@ Feature: rename a parent branch
       |        | git checkout parent                         |
       | parent | git branch -D new                           |
     And I am now on the "parent" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/rename-branch/features/perennial_branch.feature
+++ b/features/rename-branch/features/perennial_branch.feature
@@ -49,5 +49,5 @@ Feature: rename a perennial branch
       | production | git branch -D new                                   |
     And I am now on the "production" branch
     And the perennial branches are now "production"
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/set-parent-branch/set_parent_branch.feature
+++ b/features/set-parent-branch/set_parent_branch.feature
@@ -10,7 +10,7 @@ Feature: update the parent of a feature branch
     When I run "git-town set-parent-branch" and answer the prompts:
       | PROMPT                                      | ANSWER  |
       | Please specify the parent branch of 'child' | [ENTER] |
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: select another branch
     When I run "git-town set-parent-branch" and answer the prompts:

--- a/features/ship/current_branch/edge_cases/child_branch.feature
+++ b/features/ship/current_branch/edge_cases/child_branch.feature
@@ -22,7 +22,7 @@ Feature: does not ship a child branch
       please ship "alpha" first
       """
     And I am still on the "gamma" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy
 
   Scenario: undo
@@ -33,5 +33,5 @@ Feature: does not ship a child branch
       nothing to undo
       """
     And I am still on the "gamma" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/current_branch/edge_cases/default_commit_message.feature
+++ b/features/ship/current_branch/edge_cases/default_commit_message.feature
@@ -30,7 +30,7 @@ Feature: must provide a commit message
       """
     And I am still on the "feature" branch
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: undo
     When I run "git-town undo"
@@ -40,4 +40,4 @@ Feature: must provide a commit message
       """
     And I am still on the "feature" branch
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy

--- a/features/ship/current_branch/edge_cases/default_commit_message.feature
+++ b/features/ship/current_branch/edge_cases/default_commit_message.feature
@@ -29,7 +29,7 @@ Feature: must provide a commit message
       aborted because commit exited with error
       """
     And I am still on the "feature" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy
 
   Scenario: undo
@@ -39,5 +39,5 @@ Feature: must provide a commit message
       nothing to undo
       """
     And I am still on the "feature" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy

--- a/features/ship/current_branch/edge_cases/empty_branch.feature
+++ b/features/ship/current_branch/edge_cases/empty_branch.feature
@@ -26,7 +26,7 @@ Feature: does not ship an empty branch
       the branch "empty-feature" has no shippable changes
       """
     And I am still on the "empty-feature" branch
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: undo
     When I run "git-town undo"
@@ -40,4 +40,4 @@ Feature: does not ship an empty branch
       | BRANCH        | LOCATION      | MESSAGE        |
       | main          | local, remote | main commit    |
       | empty-feature | local         | feature commit |
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy

--- a/features/ship/current_branch/edge_cases/empty_commit_message.feature
+++ b/features/ship/current_branch/edge_cases/empty_commit_message.feature
@@ -30,7 +30,7 @@ Feature: abort the ship by empty commit message
       aborted because commit exited with error
       """
     And I am still on the "feature" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy
 
   Scenario: undo
@@ -40,5 +40,5 @@ Feature: abort the ship by empty commit message
       nothing to undo
       """
     And I am still on the "feature" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -40,7 +40,7 @@ Feature: handle conflicts between the shipped branch and the main branch
       | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
       | main    | local, remote | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -35,7 +35,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
     And I am still on the "feature" branch
     And there is no merge in progress
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
       | main    | git checkout feature |
     And I am still on the "feature" branch
     And there is no merge in progress
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -32,7 +32,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And I am still on the "feature" branch
     And there is no rebase in progress anymore
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -31,7 +31,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       |        | git checkout feature |
     And I am still on the "feature" branch
     And there is no rebase in progress anymore
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue

--- a/features/ship/current_branch/features/coworker_branch.feature
+++ b/features/ship/current_branch/features/coworker_branch.feature
@@ -67,4 +67,4 @@ Feature: ship a coworker's feature branch
       | main    | local, remote | feature done          |
       |         |               | Revert "feature done" |
       | feature | local, remote | coworker commit       |
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/ship/current_branch/features/offline.feature
+++ b/features/ship/current_branch/features/offline.feature
@@ -39,5 +39,5 @@ Feature: offline mode
       | main    | git reset --hard {{ sha 'Initial commit' }}   |
       |         | git checkout feature                          |
     And I am now on the "feature" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And my repo now has its initial branches and branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -46,7 +46,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | BRANCH  | LOCATION      | MESSAGE                    |
       | main    | local, remote | conflicting main commit    |
       | feature | local         | conflicting feature commit |
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -40,7 +40,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And I am now on the "other" branch
     And my workspace still contains my uncommitted file
     And there is no merge in progress
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -41,7 +41,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And my workspace still contains my uncommitted file
     And there is no merge in progress
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -37,7 +37,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And I am still on the "other" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress anymore
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -38,7 +38,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress anymore
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"

--- a/features/ship/supplied_branch/edge_cases/empty_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_branch.feature
@@ -31,7 +31,7 @@ Feature: does not ship empty feature branches
       """
     And I am still on the "other" branch
     And my workspace still contains my uncommitted file
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: undo
     When I run "git-town undo"
@@ -45,4 +45,4 @@ Feature: does not ship empty feature branches
       | BRANCH | LOCATION      | MESSAGE        |
       | main   | local, remote | main commit    |
       | empty  | local         | feature commit |
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
@@ -38,7 +38,7 @@ Feature: abort the ship via empty commit message
     And I am still on the "other" branch
     And my workspace still contains my uncommitted file
     And my repo is left with my original commits
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy
 
   Scenario: undo
     When I run "git-town undo"
@@ -52,4 +52,4 @@ Feature: abort the ship via empty commit message
       | BRANCH  | LOCATION      | MESSAGE        |
       | main    | local, remote | main commit    |
       | feature | local         | feature commit |
-    And Git Town still has the original branch hierarchy
+    And Git Town still has the initial branch hierarchy

--- a/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
@@ -37,7 +37,7 @@ Feature: abort the ship via empty commit message
       """
     And I am still on the "other" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town still has the initial branch hierarchy
 
   Scenario: undo

--- a/features/ship/supplied_branch/features/child_branch.feature
+++ b/features/ship/supplied_branch/features/child_branch.feature
@@ -22,7 +22,7 @@ Feature: does not ship a child branch
       please ship "alpha" first
       """
     And I am now on the "alpha" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy
 
   Scenario: undo
@@ -33,5 +33,5 @@ Feature: does not ship a child branch
       nothing to undo
       """
     And I am still on the "alpha" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And Git Town now has the initial branch hierarchy

--- a/features/ship/supplied_branch/features/child_branch.feature
+++ b/features/ship/supplied_branch/features/child_branch.feature
@@ -23,7 +23,7 @@ Feature: does not ship a child branch
       """
     And I am now on the "alpha" branch
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy
 
   Scenario: undo
     When I run "git-town undo"
@@ -34,4 +34,4 @@ Feature: does not ship a child branch
       """
     And I am still on the "alpha" branch
     And my repo is left with my original commits
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/ship/supplied_branch/features/parent_branch.feature
+++ b/features/ship/supplied_branch/features/parent_branch.feature
@@ -53,4 +53,4 @@ Feature: ship a parent branch
       |        |               | Revert "parent done" |
       | child  | local, remote | child commit         |
       | parent | local, remote | parent commit        |
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -60,4 +60,4 @@ Feature: skip deleting the remote branch when shipping another branch
       | REPOSITORY | BRANCHES             |
       | local      | main, feature, other |
       | remote     | main, other          |
-    And Git Town now has the original branch hierarchy
+    And Git Town now has the initial branch hierarchy

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -43,7 +43,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
       | main   | git stash pop                             |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
     And there is no merge in progress
 
   Scenario: skip

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -34,7 +34,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       |        | git stash pop      |
     And I am now on the "main" branch
     And my workspace has the uncommitted file again
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -36,7 +36,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And I am still on the "feature" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -41,7 +41,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
     And there is no merge in progress
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -36,7 +36,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And I am still on the "feature" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress anymore
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/sync/current_branch/feature_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/deleted_tracking_branch.feature
@@ -20,4 +20,4 @@ Feature: restores deleted tracking branch
       |         | git push -u origin feature |
     And all branches are now synchronized
     And I am still on the "feature" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits

--- a/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/edge_cases/inside_subfolder_with_conflict.feature
@@ -42,7 +42,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
     And I am still on the "current" branch
     And my workspace has the uncommitted file again
     And there is no merge in progress
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue" in the "new_folder" folder

--- a/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -33,7 +33,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     And I am still on the "main" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress anymore
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/sync/current_branch/main_branch/features/local_repo.feature
+++ b/features/sync/current_branch/main_branch/features/local_repo.feature
@@ -11,4 +11,4 @@ Feature: sync the main branch in a local repo
   Scenario: result
     Then it runs no commands
     And I am still on the "main" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -35,7 +35,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
     And there is no rebase in progress anymore
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: continue with unresolved conflict
     When I run "git-town continue"

--- a/features/sync/current_branch/perennial_branch/features/local_repo.feature
+++ b/features/sync/current_branch/perennial_branch/features/local_repo.feature
@@ -20,4 +20,4 @@ Feature: sync the current perennial branch (without remote repo)
     And all branches are now synchronized
     And I am still on the "qa" branch
     And my workspace still contains my uncommitted file
-    And my repo is left with my original commits
+    And my repo is left with my initial commits

--- a/features/sync/features/dry_run.feature
+++ b/features/sync/features/dry_run.feature
@@ -23,4 +23,4 @@ Feature: dry run
       |         | git merge --no-edit main           |
       |         | git push                           |
     And I am still on the "feature" branch
-    And my repo is left with my original commits
+    And my repo is left with my initial commits

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -63,7 +63,7 @@ Feature: warn the user about an unfinished operation
       | main    | git rebase --abort   |
       |         | git checkout feature |
       | feature | git stash pop        |
-    And my repo is left with my original commits
+    And my repo is left with my initial commits
 
   Scenario: manually abort the rebase and run another command still shows warning about unfinished command
     When I run "git rebase --abort"

--- a/test/steps.go
+++ b/test/steps.go
@@ -146,7 +146,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town (?:now|still) has the original branch hierarchy$`, func() error {
+	suite.Step(`^Git Town (?:now|still) has the initial branch hierarchy$`, func() error {
 		have := state.gitEnv.DevRepo.BranchHierarchyTable()
 		state.initialBranchHierarchy.Sort()
 		diff, errCnt := have.EqualDataTable(state.initialBranchHierarchy)

--- a/test/steps.go
+++ b/test/steps.go
@@ -565,7 +565,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.PushBranchToOrigin(branch)
 	})
 
-	suite.Step(`^my repo is left with my original commits$`, func() error {
+	suite.Step(`^my repo is left with my initial commits$`, func() error {
 		return compareExistingCommits(state, state.initialCommits)
 	})
 


### PR DESCRIPTION
The feature specs define the concepts of "original" (as in "original commits" and "original branch hierarchy") and "initial (as in "initial branches" and "initial branches and branch hierarchy"). Both concepts are synonymous. This PR removes the concept of "original" in favor of using "initial" consistently.