### PR TITLE
Merge "a coworker" and "the origin" steps

### DIFF
--- a/features/hack/edge_cases/branch_exists.feature
+++ b/features/hack/edge_cases/branch_exists.feature
@@ -14,4 +14,4 @@ Feature: already existing branch
     Examples:
       | LOCATION   |
       | my repo    |
-      | a coworker |
+      | the origin |

--- a/features/rename-branch/edge_cases/destination_branch_exists.feature
+++ b/features/rename-branch/edge_cases/destination_branch_exists.feature
@@ -20,7 +20,7 @@ Feature: destination branch exists
 
   Scenario: destination branch exists remotely
     Given my repo has a feature branch "alpha"
-    And a coworker has a feature branch "beta"
+    And the origin has a feature branch "beta"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE      |
       | alpha  | local, remote | alpha commit |

--- a/features/sync/all_branches/edge_cases/remote_only_branches.feature
+++ b/features/sync/all_branches/edge_cases/remote_only_branches.feature
@@ -2,7 +2,7 @@ Feature: does not sync branches that exist only on the remote
 
   Background:
     Given my repo has a feature branch "mine"
-    And a coworker has a feature branch "other"
+    And the origin has a feature branch "other"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE         |
       | main   | remote        | main commit     |

--- a/test/steps.go
+++ b/test/steps.go
@@ -95,7 +95,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^(?:a coworker|the origin) has a feature branch "([^"]*)"$`, func(branch string) error {
+	suite.Step(`^the origin has a feature branch "([^"]*)"$`, func(branch string) error {
 		state.initialRemoteBranches = append(state.initialRemoteBranches, branch)
 		return state.gitEnv.OriginRepo.CreateBranch(branch, "main")
 	})


### PR DESCRIPTION
These two steps perform the same activity, and never where "a coworker has a feature branch" is used is it actually necessary anymore. Saying that "a coworker has a branch" is also misleading since the branch gets created only in the origin repo, not in a repo local to the coworker.