### PR TITLE
Make coworker steps sound more natural

### DIFF
--- a/features/sync/current_branch/feature_branch/features/two_collaborators.feature
+++ b/features/sync/current_branch/feature_branch/features/two_collaborators.feature
@@ -1,10 +1,10 @@
 Feature: collaborative feature branch syncing
 
   Scenario:
-    Given I am collaborating with a coworker
+    Given a coworker clones the repository
     And my repo has a feature branch "feature"
-    And a coworker fetches updates
-    And a coworker sets the parent branch of "feature" as "main"
+    And the coworker fetches updates
+    And the coworker sets the parent branch of "feature" as "main"
     And my repo contains the commits
       | BRANCH  | LOCATION | MESSAGE         |
       | feature | local    | my commit       |
@@ -26,7 +26,7 @@ Feature: collaborative feature branch syncing
       |         | coworker      | coworker commit |
     And all branches are now synchronized
 
-    Given a coworker is on the "feature" branch
+    Given the coworker is on the "feature" branch
     When a coworker runs "git-town sync"
     Then it runs the commands
       | BRANCH  | COMMAND                            |

--- a/test/steps.go
+++ b/test/steps.go
@@ -77,11 +77,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		}
 	})
 
-	suite.Step(`^a coworker fetches updates$`, func() error {
+	suite.Step(`^the coworker fetches updates$`, func() error {
 		return state.gitEnv.CoworkerRepo.Fetch()
 	})
 
-	suite.Step(`^a coworker is on the "([^"]*)" branch$`, func(branchName string) error {
+	suite.Step(`^the coworker is on the "([^"]*)" branch$`, func(branchName string) error {
 		return state.gitEnv.CoworkerRepo.CheckoutBranch(branchName)
 	})
 
@@ -90,7 +90,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^a coworker sets the parent branch of "([^"]*)" as "([^"]*)"$`, func(childBranch, parentBranch string) error {
+	suite.Step(`^the coworker sets the parent branch of "([^"]*)" as "([^"]*)"$`, func(childBranch, parentBranch string) error {
 		_ = state.gitEnv.CoworkerRepo.Config.SetParentBranch(childBranch, parentBranch)
 		return nil
 	})
@@ -160,7 +160,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^I am collaborating with a coworker$`, func() error {
+	suite.Step(`^a coworker clones the repository$`, func() error {
 		return state.gitEnv.AddCoworkerRepo()
 	})
 


### PR DESCRIPTION
There is only one scenario that uses these steps. It talks about one specific co-worker. After introducing the coworker as "a coworker", subsequent steps should refer to him as "the worker", not "a coworker" again. Alphabetic sorting will be done after all steps are modernized.