### PR TITLE
Standardize Git Town configuration steps

### DIFF
--- a/features/config/reset.feature
+++ b/features/config/reset.feature
@@ -7,6 +7,6 @@ Feature: reset the configuration
     Then Git Town is no longer configured for this repo
 
   Scenario: no configuration
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town config reset"
     Then Git Town is no longer configured for this repo

--- a/features/config/reset.feature
+++ b/features/config/reset.feature
@@ -4,9 +4,9 @@ Feature: reset the configuration
     Given the main branch is "main"
     And the perennial branches are "qa" and "staging"
     When I run "git-town config reset"
-    Then Git Town is no longer configured for this repo
+    Then Git Town is no longer configured
 
   Scenario: no configuration
     Given Git Town is not configured
     When I run "git-town config reset"
-    Then Git Town is no longer configured for this repo
+    Then Git Town is no longer configured

--- a/features/config/setup.feature
+++ b/features/config/setup.feature
@@ -14,7 +14,7 @@ Feature: enter Git Town configuration
 
   Scenario: unconfigured
     Given my repo has the branches "dev" and "production"
-    And I haven't configured Git Town yet
+    And Git Town is not configured
     When I run "git-town config setup" and answer the prompts:
       | PROMPT                                     | ANSWER                      |
       | Please specify the main development branch | [DOWN][ENTER]               |
@@ -23,7 +23,7 @@ Feature: enter Git Town configuration
     And the perennial branches are now "dev" and "production"
 
   Scenario: don't ask for perennial branches if no branches that could be perennial exist
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town config setup" and answer the prompts:
       | PROMPT                                     | ANSWER        |
       | Please specify the main development branch | [DOWN][ENTER] |

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -41,7 +41,7 @@ Feature: show the configuration
       """
 
   Scenario: no configuration data
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town config"
     Then it prints:
       """

--- a/features/hack/edge_cases/unconfigured.feature
+++ b/features/hack/edge_cases/unconfigured.feature
@@ -2,7 +2,7 @@
 Feature: missing configuration
 
   Background: running unconfigured
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town hack feature" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |

--- a/features/help/edge_cases/unconfigured.feature
+++ b/features/help/edge_cases/unconfigured.feature
@@ -1,7 +1,7 @@
 Feature: show help even if the current repo misses configuration
 
   Scenario Outline:
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "<COMMAND>"
     Then it prints:
       """

--- a/features/kill/current_branch/edge_cases/unconfigured.feature
+++ b/features/kill/current_branch/edge_cases/unconfigured.feature
@@ -2,7 +2,7 @@
 Feature: ask for missing configuration
 
   Scenario:
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town kill" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |

--- a/features/new-pull-request/edge_cases/unconfigured.feature
+++ b/features/new-pull-request/edge_cases/unconfigured.feature
@@ -2,7 +2,7 @@
 Feature: ask for missing configuration
 
   Scenario: run unconfigured
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And my computer has the "open" tool installed
     When I run "git-town new-pull-request" and answer the prompts:

--- a/features/new-pull-request/features/self_hosted.feature
+++ b/features/new-pull-request/features/self_hosted.feature
@@ -5,7 +5,7 @@ Feature: self-hosted service
     And my computer has the "open" tool installed
     And my repo has a feature branch "feature"
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
-    And my repo has "git-town.code-hosting-driver" set to "<DRIVER>"
+    And Git Town's local "git-town.code-hosting-driver" setting is "<DRIVER>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
     Then "open" launches a new pull request with this url in my browser:

--- a/features/new-pull-request/features/self_hosted.feature
+++ b/features/new-pull-request/features/self_hosted.feature
@@ -5,7 +5,7 @@ Feature: self-hosted service
     And my computer has the "open" tool installed
     And my repo has a feature branch "feature"
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
-    And Git Town's local "git-town.code-hosting-driver" setting is "<DRIVER>"
+    And Git Town's local "code-hosting-driver" setting is "<DRIVER>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
     Then "open" launches a new pull request with this url in my browser:

--- a/features/new-pull-request/features/ssh_identity.feature
+++ b/features/new-pull-request/features/ssh_identity.feature
@@ -5,7 +5,7 @@ Feature: use a SSH identity
     And my computer has the "open" tool installed
     And my repo has a feature branch "feature"
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
-    And my repo has "git-town.code-hosting-origin-hostname" set to "<ORIGIN_HOSTNAME>"
+    And Git Town's local "git-town.code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
     Then "open" launches a new pull request with this url in my browser:

--- a/features/new-pull-request/features/ssh_identity.feature
+++ b/features/new-pull-request/features/ssh_identity.feature
@@ -5,7 +5,7 @@ Feature: use a SSH identity
     And my computer has the "open" tool installed
     And my repo has a feature branch "feature"
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
-    And Git Town's local "git-town.code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
+    And Git Town's local "code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
     Then "open" launches a new pull request with this url in my browser:

--- a/features/offline/display.feature
+++ b/features/offline/display.feature
@@ -16,7 +16,7 @@ Feature: display the current offline status
       """
 
   Scenario: invalid value
-    Given the offline configuration is accidentally set to "zonk"
+    Given Git Town's local "offline" setting is "zonk"
     When I run "git-town offline"
     Then it prints:
       """

--- a/features/prune-branches/edge_cases/unconfigured.feature
+++ b/features/prune-branches/edge_cases/unconfigured.feature
@@ -2,7 +2,7 @@
 Feature: ask for missing configuration
 
   Scenario: run unconfigured
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town prune-branches" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |

--- a/features/repo/edge_cases/unconfigured.feature
+++ b/features/repo/edge_cases/unconfigured.feature
@@ -2,7 +2,7 @@
 Feature: ask for missing configuration
 
   Scenario: unconfigured
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     And my repo's origin is "https://github.com/git-town/git-town.git"
     And my computer has the "open" tool installed
     When I run "git-town repo" and answer the prompts:

--- a/features/repo/features/self_hosted.feature
+++ b/features/repo/features/self_hosted.feature
@@ -4,7 +4,7 @@ Feature: self hosted servie
   Scenario Outline:
     Given my computer has the "open" tool installed
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
-    And my repo has "git-town.code-hosting-driver" set to "<DRIVER>"
+    And Git Town's local "git-town.code-hosting-driver" setting is "<DRIVER>"
     When I run "git-town repo"
     Then "open" launches a new pull request with this url in my browser:
       """

--- a/features/repo/features/self_hosted.feature
+++ b/features/repo/features/self_hosted.feature
@@ -4,7 +4,7 @@ Feature: self hosted servie
   Scenario Outline:
     Given my computer has the "open" tool installed
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
-    And Git Town's local "git-town.code-hosting-driver" setting is "<DRIVER>"
+    And Git Town's local "code-hosting-driver" setting is "<DRIVER>"
     When I run "git-town repo"
     Then "open" launches a new pull request with this url in my browser:
       """

--- a/features/repo/features/ssh_identity.feature
+++ b/features/repo/features/ssh_identity.feature
@@ -4,7 +4,7 @@ Feature: use an SSH identity
   Scenario Outline:
     Given my computer has the "open" tool installed
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
-    And my repo has "git-town.code-hosting-origin-hostname" set to "<ORIGIN_HOSTNAME>"
+    And Git Town's local "git-town.code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
     When I run "git-town repo"
     Then "open" launches a new pull request with this url in my browser:
       """

--- a/features/repo/features/ssh_identity.feature
+++ b/features/repo/features/ssh_identity.feature
@@ -4,7 +4,7 @@ Feature: use an SSH identity
   Scenario Outline:
     Given my computer has the "open" tool installed
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
-    And Git Town's local "git-town.code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
+    And Git Town's local "code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
     When I run "git-town repo"
     Then "open" launches a new pull request with this url in my browser:
       """

--- a/features/shared/strip_colors.feature
+++ b/features/shared/strip_colors.feature
@@ -3,7 +3,7 @@ Feature: strip colors
 
   Scenario: colors are stripped from the output of git commands run internally
     Given Git Town is not configured
-    And my repo has "color.ui" set to "always"
+    And Git Town's "color.ui" setting is "always"
     And I am on the "main" branch
     When I run "git-town hack new-feature" and answer the prompts:
       | PROMPT                                     | ANSWER  |

--- a/features/shared/strip_colors.feature
+++ b/features/shared/strip_colors.feature
@@ -2,7 +2,7 @@
 Feature: strip colors
 
   Scenario: colors are stripped from the output of git commands run internally
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     And my repo has "color.ui" set to "always"
     And I am on the "main" branch
     When I run "git-town hack new-feature" and answer the prompts:

--- a/features/shared/strip_colors.feature
+++ b/features/shared/strip_colors.feature
@@ -3,7 +3,7 @@ Feature: strip colors
 
   Scenario: colors are stripped from the output of git commands run internally
     Given Git Town is not configured
-    And Git Town's "color.ui" setting is "always"
+    And Git Town's local "color.ui" setting is "always"
     And I am on the "main" branch
     When I run "git-town hack new-feature" and answer the prompts:
       | PROMPT                                     | ANSWER  |

--- a/features/ship/current_branch/edge_cases/unconfigured.feature
+++ b/features/ship/current_branch/edge_cases/unconfigured.feature
@@ -2,7 +2,7 @@
 Feature: ask for missing configuration information
 
   Scenario: unconfigured
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town ship" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -6,7 +6,7 @@ Feature: ship-delete-remote-branch disabled
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |
     And I am on the "feature" branch
-    And Git Town's local "git-town.ship-delete-remote-branch" setting is "false"
+    And Git Town's local "ship-delete-remote-branch" setting is "false"
     When I run "git-town ship -m 'feature done'"
     And the remote deletes the "feature" branch
 

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -6,7 +6,7 @@ Feature: ship-delete-remote-branch disabled
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, remote | feature commit |
     And I am on the "feature" branch
-    And my repo has "git-town.ship-delete-remote-branch" set to "false"
+    And Git Town's local "git-town.ship-delete-remote-branch" setting is "false"
     When I run "git-town ship -m 'feature done'"
     And the remote deletes the "feature" branch
 

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -7,7 +7,7 @@ Feature: skip deleting the remote branch when shipping another branch
       | feature | local, remote | feature commit |
       | other   | local         | other commit   |
     And I am on the "other" branch
-    And Git Town's local "git-town.ship-delete-remote-branch" setting is "false"
+    And Git Town's local "ship-delete-remote-branch" setting is "false"
     When I run "git-town ship feature -m 'feature done'"
     And the remote deletes the "feature" branch
 

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -7,7 +7,7 @@ Feature: skip deleting the remote branch when shipping another branch
       | feature | local, remote | feature commit |
       | other   | local         | other commit   |
     And I am on the "other" branch
-    And my repo has "git-town.ship-delete-remote-branch" set to "false"
+    And Git Town's local "git-town.ship-delete-remote-branch" setting is "false"
     When I run "git-town ship feature -m 'feature done'"
     And the remote deletes the "feature" branch
 

--- a/features/sync/current_branch/main_branch/features/upstream.feature
+++ b/features/sync/current_branch/main_branch/features/upstream.feature
@@ -30,7 +30,7 @@ Feature: on the main branch with a upstream remote
       |        | remote   | remote commit   |
       |        | upstream | upstream commit |
     And I am on the "main" branch
-    And Git Town's local "git-town.sync-upstream" setting is false
+    And Git Town's local "sync-upstream" setting is false
     When I run "git-town sync"
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/sync/current_branch/main_branch/features/upstream.feature
+++ b/features/sync/current_branch/main_branch/features/upstream.feature
@@ -30,7 +30,7 @@ Feature: on the main branch with a upstream remote
       |        | remote   | remote commit   |
       |        | upstream | upstream commit |
     And I am on the "main" branch
-    And my repo has "git-town.sync-upstream" set to false
+    And Git Town's local "git-town.sync-upstream" setting is false
     When I run "git-town sync"
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/sync/features/unconfigured.feature
+++ b/features/sync/features/unconfigured.feature
@@ -2,7 +2,7 @@
 Feature: ask for missing configuration information
 
   Scenario: run unconfigured
-    Given I haven't configured Git Town yet
+    Given Git Town is not configured
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |

--- a/test/steps.go
+++ b/test/steps.go
@@ -437,7 +437,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.Config.SetColorUI(value)
 	})
 
-	suite.Step(`^my repo has "git-town.code-hosting-driver" set to "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "git-town.code-hosting-driver" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingDriver(value)
 	})
 

--- a/test/steps.go
+++ b/test/steps.go
@@ -200,7 +200,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^I haven't configured Git Town yet$`, func() error {
+	suite.Step(`^Git Town is not configured$`, func() error {
 		err := state.gitEnv.DevRepo.Config.DeletePerennialBranchConfiguration()
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -433,19 +433,15 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.AddUpstream()
 	})
 
-	suite.Step(`^my repo has "color\.ui" set to "([^"]*)"$`, func(value string) error {
-		return state.gitEnv.DevRepo.Config.SetColorUI(value)
-	})
-
 	suite.Step(`^Git Town's local "git-town.code-hosting-driver" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingDriver(value)
 	})
 
-	suite.Step(`^my repo has "git-town.code-hosting-origin-hostname" set to "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "git-town.code-hosting-origin-hostname" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingOriginHostname(value)
 	})
 
-	suite.Step(`^my repo has "git-town.ship-delete-remote-branch" set to "(true|false)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "git-town.ship-delete-remote-branch" setting is "(true|false)"$`, func(value string) error {
 		parsed, err := strconv.ParseBool(value)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -433,7 +433,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.AddUpstream()
 	})
 
-	suite.Step(`^Git Town's "color\.ui" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "color.ui" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetColorUI(value)
 	})
 

--- a/test/steps.go
+++ b/test/steps.go
@@ -882,7 +882,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the offline configuration is accidentally set to "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "offline" setting is "([^"]*)"$`, func(value string) error {
 		_, err := state.gitEnv.DevRepo.Config.SetGlobalConfigValue("git-town.offline", value)
 		return err
 	})

--- a/test/steps.go
+++ b/test/steps.go
@@ -437,15 +437,15 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.Config.SetColorUI(value)
 	})
 
-	suite.Step(`^Git Town's local "git-town.code-hosting-driver" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "code-hosting-driver" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingDriver(value)
 	})
 
-	suite.Step(`^Git Town's local "git-town.code-hosting-origin-hostname" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "code-hosting-origin-hostname" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingOriginHostname(value)
 	})
 
-	suite.Step(`^Git Town's local "git-town.ship-delete-remote-branch" setting is "(true|false)"$`, func(value string) error {
+	suite.Step(`^Git Town's local "ship-delete-remote-branch" setting is "(true|false)"$`, func(value string) error {
 		parsed, err := strconv.ParseBool(value)
 		if err != nil {
 			return err
@@ -454,7 +454,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town's local "git-town.sync-upstream" setting is (true|false)$`, func(text string) error {
+	suite.Step(`^Git Town's local "sync-upstream" setting is (true|false)$`, func(text string) error {
 		value, err := strconv.ParseBool(text)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -115,7 +115,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.Config.SetOffline(true)
 	})
 
-	suite.Step(`^Git Town is no longer configured for this repo$`, func() error {
+	suite.Step(`^Git Town is no longer configured$`, func() error {
 		res, err := state.gitEnv.DevRepo.HasGitTownConfigNow()
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -433,6 +433,10 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.AddUpstream()
 	})
 
+	suite.Step(`^Git Town's "color\.ui" setting is "([^"]*)"$`, func(value string) error {
+		return state.gitEnv.DevRepo.Config.SetColorUI(value)
+	})
+
 	suite.Step(`^Git Town's local "git-town.code-hosting-driver" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingDriver(value)
 	})

--- a/test/steps.go
+++ b/test/steps.go
@@ -450,7 +450,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repo has "git-town.sync-upstream" set to (true|false)$`, func(text string) error {
+	suite.Step(`^Git Town's local "git-town.sync-upstream" setting is (true|false)$`, func(text string) error {
 		value, err := strconv.ParseBool(text)
 		if err != nil {
 			return err


### PR DESCRIPTION
This uses the proper subject (Git Town) in the step that defines whether it is configured or not. We now have these matching steps:

```
Git Town is in offline mode
Git Town is no longer configured
Git Town is not configured
Git Town's local "code-hosting-driver" setting is "([^"]*)"
Git Town's local "code-hosting-origin-hostname" setting is "([^"]*)"        
Git Town's local "ship-delete-remote-branch" setting is "(true|false)"  
Git Town's local "sync-upstream" setting is (true|false)        
Git Town's local "color.ui" setting is "([^"]*)"        
Git Town's local "offline" setting is "([^"]*)"                            

