### PR TITLE
Runner.HasOrigin helper

### DIFF
--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -62,7 +62,7 @@ func createAppendConfig(args []string, repo *git.ProdRepo) (result appendConfig,
 		return result, err
 	}
 	result.targetBranch = args[0]
-	result.hasOrigin, err = repo.Silent.HasRemote("origin")
+	result.hasOrigin, err = repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -69,7 +69,7 @@ func createHackConfig(args []string, repo *git.ProdRepo) (result appendConfig, e
 	if err != nil {
 		return result, err
 	}
-	result.hasOrigin, err = repo.Silent.HasRemote("origin")
+	result.hasOrigin, err = repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -79,7 +79,7 @@ func createKillConfig(args []string, repo *git.ProdRepo) (result killConfig, err
 		}
 		repo.Config.Reload()
 	}
-	hasOrigin, err := repo.Silent.HasRemote("origin")
+	hasOrigin, err := repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -69,7 +69,7 @@ where hostname matches what is in your ssh config file.`,
 }
 
 func createNewPullRequestConfig(repo *git.ProdRepo) (result newPullRequestConfig, err error) {
-	hasOrigin, err := repo.Silent.HasRemote("origin")
+	hasOrigin, err := repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -66,7 +66,7 @@ func createPrependConfig(args []string, repo *git.ProdRepo) (result prependConfi
 		return result, err
 	}
 	result.targetBranch = args[0]
-	result.hasOrigin, err = repo.Silent.HasRemote("origin")
+	result.hasOrigin, err = repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -49,7 +49,7 @@ This usually means the branch was shipped or killed on another machine.`,
 }
 
 func createPruneBranchesConfig(repo *git.ProdRepo) (result pruneBranchesConfig, err error) {
-	hasOrigin, err := repo.Silent.HasRemote("origin")
+	hasOrigin, err := repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -105,7 +105,7 @@ func gitShipConfig(args []string, driver hosting.Driver, repo *git.ProdRepo) (re
 			return result, fmt.Errorf("you have uncommitted changes. Did you mean to commit them before shipping?")
 		}
 	}
-	result.hasOrigin, err = repo.Silent.HasRemote("origin")
+	result.hasOrigin, err = repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}
@@ -209,7 +209,7 @@ func createShipStepList(config shipConfig, repo *git.ProdRepo) (result runstate.
 }
 
 func createPullRequestInfo(branch, parentBranch string, driver hosting.Driver) (result hosting.PullRequestInfo, err error) {
-	hasOrigin, err := prodRepo.Silent.HasRemote("origin")
+	hasOrigin, err := prodRepo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -81,7 +81,7 @@ You can disable this by running "git config git-town.sync-upstream false".`,
 }
 
 func createSyncConfig(repo *git.ProdRepo) (result syncConfig, err error) {
-	result.hasOrigin, err = repo.Silent.HasRemote("origin")
+	result.hasOrigin, err = repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -635,6 +635,11 @@ func (r *Runner) HasRebaseInProgress() (bool, error) {
 	return false, nil
 }
 
+// HasRemote indicates whether this repo has an origin remote.
+func (r *Runner) HasOrigin() (result bool, err error) {
+	return r.HasRemote("origin")
+}
+
 // HasRemote indicates whether this repo has a remote with the given name.
 func (r *Runner) HasRemote(name string) (result bool, err error) {
 	remotes, err := r.Remotes()

--- a/src/git/runner.go
+++ b/src/git/runner.go
@@ -635,7 +635,7 @@ func (r *Runner) HasRebaseInProgress() (bool, error) {
 	return false, nil
 }
 
-// HasRemote indicates whether this repo has an origin remote.
+// HasOrigin indicates whether this repo has an origin remote.
 func (r *Runner) HasOrigin() (result bool, err error) {
 	return r.HasRemote("origin")
 }

--- a/src/git/runner_test.go
+++ b/src/git/runner_test.go
@@ -438,7 +438,7 @@ func TestRunner_HasRemote(t *testing.T) {
 	repoDir := test.CreateTempDir(t)
 	repo, err := origin.Clone(repoDir)
 	assert.NoError(t, err)
-	has, err := repo.Runner.HasRemote("origin")
+	has, err := repo.Runner.HasOrigin()
 	assert.NoError(t, err)
 	assert.True(t, has)
 	has, err = repo.Runner.HasRemote("zonk")

--- a/src/runstate/sync_steps.go
+++ b/src/runstate/sync_steps.go
@@ -10,7 +10,7 @@ import (
 // SyncBranchSteps provides the steps to sync the branch with the given name.
 func SyncBranchSteps(branchName string, pushBranch bool, repo *git.ProdRepo) (result StepList, err error) {
 	isFeature := repo.Config.IsFeatureBranch(branchName)
-	hasRemoteOrigin, err := repo.Silent.HasRemote("origin")
+	hasRemoteOrigin, err := repo.Silent.HasOrigin()
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
HasRemote("origin") is used repeatedly, and uses a magical string on each invocation.