### PR TITLE
Simplify configuration steps

### DIFF
--- a/features/append/features/new_branch_push_flag.feature
+++ b/features/append/features/new_branch_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push the new branch to origin
 
   Background:
-    Given the "new-branch-push-flag" configuration is "true"
+    Given the "new-branch-push-flag" setting is "true"
     And the commits
       | BRANCH | LOCATION | MESSAGE     |
       | main   | origin   | main commit |

--- a/features/append/features/new_branch_push_flag.feature
+++ b/features/append/features/new_branch_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push the new branch to origin
 
   Background:
-    Given the new-branch-push-flag configuration is "true"
+    Given the "new-branch-push-flag" configuration is "true"
     And the commits
       | BRANCH | LOCATION | MESSAGE     |
       | main   | origin   | main commit |

--- a/features/append/features/new_branch_push_flag.feature
+++ b/features/append/features/new_branch_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push the new branch to the remote
 
   Background:
-    Given the new-branch-push-flag configuration is true
+    Given the new-branch-push-flag configuration is "true"
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE     |
       | main   | remote   | main commit |

--- a/features/append/features/offline.feature
+++ b/features/append/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: append in offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And my repo has a feature branch "existing"
     And the commits
       | BRANCH   | LOCATION      | MESSAGE         |

--- a/features/config/setup.feature
+++ b/features/config/setup.feature
@@ -28,4 +28,4 @@ Feature: enter Git Town configuration
       | PROMPT                                     | ANSWER        |
       | Please specify the main development branch | [DOWN][ENTER] |
     Then the main branch is now "main"
-    And my repo still has no perennial branches
+    And there are still no perennial branches

--- a/features/config/setup.feature
+++ b/features/config/setup.feature
@@ -28,4 +28,4 @@ Feature: enter Git Town configuration
       | PROMPT                                     | ANSWER        |
       | Please specify the main development branch | [DOWN][ENTER] |
     Then the main branch is now "main"
-    And my repo now has no perennial branches
+    And my repo still has no perennial branches

--- a/features/hack/features/new_branch_push_flag.feature
+++ b/features/hack/features/new_branch_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push the new branch
 
   Background:
-    Given the new-branch-push-flag configuration is "true"
+    Given the "new-branch-push-flag" configuration is "true"
     And the commits
       | BRANCH | LOCATION | MESSAGE       |
       | main   | origin   | origin commit |

--- a/features/hack/features/new_branch_push_flag.feature
+++ b/features/hack/features/new_branch_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push the new branch
 
   Background:
-    Given the new-branch-push-flag configuration is true
+    Given the new-branch-push-flag configuration is "true"
     And my repo contains the commits
       | BRANCH | LOCATION | MESSAGE       |
       | main   | remote   | remote commit |

--- a/features/hack/features/new_branch_push_flag.feature
+++ b/features/hack/features/new_branch_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push the new branch
 
   Background:
-    Given the "new-branch-push-flag" configuration is "true"
+    Given the "new-branch-push-flag" setting is "true"
     And the commits
       | BRANCH | LOCATION | MESSAGE       |
       | main   | origin   | origin commit |

--- a/features/hack/features/offline.feature
+++ b/features/hack/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And the commits
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And my repo has the feature branches "feature" and "other"
     And the commits
       | BRANCH  | LOCATION      | MESSAGE        |

--- a/features/kill/supplied_branch/edge_cases/remote_branch_when_offline.feature
+++ b/features/kill/supplied_branch/edge_cases/remote_branch_when_offline.feature
@@ -1,7 +1,7 @@
 Feature: does not kill a remote branch in offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And the origin has a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION | MESSAGE        |

--- a/features/main_branch/display.feature
+++ b/features/main_branch/display.feature
@@ -1,7 +1,7 @@
 Feature: display the main branch configuration
 
   Scenario: not configured
-    Given the main branch is not configured
+    Given the main branch is not set
     When I run "git-town main-branch"
     Then it prints:
       """

--- a/features/main_branch/display.feature
+++ b/features/main_branch/display.feature
@@ -1,7 +1,7 @@
 Feature: display the main branch configuration
 
   Scenario: not configured
-    Given my repo doesn't have a main branch configured
+    Given the main branch is not set
     When I run "git-town main-branch"
     Then it prints:
       """

--- a/features/main_branch/display.feature
+++ b/features/main_branch/display.feature
@@ -1,7 +1,7 @@
 Feature: display the main branch configuration
 
   Scenario: not configured
-    Given the main branch is not set
+    Given the main branch is not configured
     When I run "git-town main-branch"
     Then it prints:
       """

--- a/features/main_branch/update.feature
+++ b/features/main_branch/update.feature
@@ -1,7 +1,7 @@
 Feature: configure the main branch
 
   Scenario: not configured
-    Given the main branch is not configured
+    Given the main branch is not set
     When I run "git-town main-branch main"
     Then it prints no output
     And the main branch is now "main"

--- a/features/main_branch/update.feature
+++ b/features/main_branch/update.feature
@@ -1,7 +1,7 @@
 Feature: configure the main branch
 
   Scenario: not configured
-    Given my repo doesn't have a main branch configured
+    Given the main branch is not set
     When I run "git-town main-branch main"
     Then it prints no output
     And the main branch is now "main"

--- a/features/main_branch/update.feature
+++ b/features/main_branch/update.feature
@@ -1,7 +1,7 @@
 Feature: configure the main branch
 
   Scenario: not configured
-    Given the main branch is not set
+    Given the main branch is not configured
     When I run "git-town main-branch main"
     Then it prints no output
     And the main branch is now "main"

--- a/features/new-branch-push-flag/display.feature
+++ b/features/new-branch-push-flag/display.feature
@@ -15,7 +15,7 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario Outline: local setting
-    Given the new-branch-push-flag configuration is "<VALUE>"
+    Given the "new-branch-push-flag" configuration is "<VALUE>"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -27,7 +27,7 @@ Feature: display the new-branch-push-flag setting
       | false |
 
   Scenario Outline: global setting
-    Given the global new-branch-push-flag configuration is "<VALUE>"
+    Given the global "new-branch-push-flag" configuration is "<VALUE>"
     When I run "git-town new-branch-push-flag --global"
     Then it prints:
       """
@@ -40,7 +40,7 @@ Feature: display the new-branch-push-flag setting
       | false |
 
   Scenario: global set, local not set
-    Given the global new-branch-push-flag configuration is "true"
+    Given the global "new-branch-push-flag" configuration is "true"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -48,8 +48,8 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario: global and local set
-    Given the global new-branch-push-flag configuration is "true"
-    And the new-branch-push-flag configuration is "false"
+    Given the global "new-branch-push-flag" configuration is "true"
+    And the "new-branch-push-flag" configuration is "false"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -57,7 +57,7 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario: invalid value
-    Given the new-branch-push-flag configuration is "zonk"
+    Given the "new-branch-push-flag" configuration is "zonk"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """

--- a/features/new-branch-push-flag/display.feature
+++ b/features/new-branch-push-flag/display.feature
@@ -15,7 +15,7 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario Outline: local setting
-    Given the "new-branch-push-flag" configuration is "<VALUE>"
+    Given the "new-branch-push-flag" setting is "<VALUE>"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -27,7 +27,7 @@ Feature: display the new-branch-push-flag setting
       | false |
 
   Scenario Outline: global setting
-    Given the global "new-branch-push-flag" configuration is "<VALUE>"
+    Given the global "new-branch-push-flag" setting is "<VALUE>"
     When I run "git-town new-branch-push-flag --global"
     Then it prints:
       """
@@ -40,7 +40,7 @@ Feature: display the new-branch-push-flag setting
       | false |
 
   Scenario: global set, local not set
-    Given the global "new-branch-push-flag" configuration is "true"
+    Given the global "new-branch-push-flag" setting is "true"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -48,8 +48,8 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario: global and local set
-    Given the global "new-branch-push-flag" configuration is "true"
-    And the "new-branch-push-flag" configuration is "false"
+    Given the global "new-branch-push-flag" setting is "true"
+    And the "new-branch-push-flag" setting is "false"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -57,7 +57,7 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario: invalid value
-    Given the "new-branch-push-flag" configuration is "zonk"
+    Given the "new-branch-push-flag" setting is "zonk"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """

--- a/features/new-branch-push-flag/display.feature
+++ b/features/new-branch-push-flag/display.feature
@@ -15,7 +15,7 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario Outline: local setting
-    Given the new-branch-push-flag configuration is <VALUE>
+    Given the new-branch-push-flag configuration is "<VALUE>"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -27,7 +27,7 @@ Feature: display the new-branch-push-flag setting
       | false |
 
   Scenario Outline: global setting
-    Given the global new-branch-push-flag configuration is <VALUE>
+    Given the global new-branch-push-flag configuration is "<VALUE>"
     When I run "git-town new-branch-push-flag --global"
     Then it prints:
       """
@@ -40,7 +40,7 @@ Feature: display the new-branch-push-flag setting
       | false |
 
   Scenario: global set, local not set
-    Given the global new-branch-push-flag configuration is true
+    Given the global new-branch-push-flag configuration is "true"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """
@@ -48,8 +48,8 @@ Feature: display the new-branch-push-flag setting
       """
 
   Scenario: global and local set
-    Given the global new-branch-push-flag configuration is true
-    And the new-branch-push-flag configuration is false
+    Given the global new-branch-push-flag configuration is "true"
+    And the new-branch-push-flag configuration is "false"
     When I run "git-town new-branch-push-flag"
     Then it prints:
       """

--- a/features/new-branch-push-flag/update.feature
+++ b/features/new-branch-push-flag/update.feature
@@ -2,7 +2,7 @@ Feature: set the new-branch-push-flag
 
   Scenario Outline: local setting
     When I run "git-town new-branch-push-flag <GIVE>"
-    Then the "new-branch-push-flag" configuration is now "<WANT>"
+    Then the "new-branch-push-flag" setting is now "<WANT>"
 
     Examples:
       | GIVE  | WANT  |
@@ -22,7 +22,7 @@ Feature: set the new-branch-push-flag
 
   Scenario Outline: global setting
     When I run "git-town new-branch-push-flag --global <GIVE>"
-    Then the "new-branch-push-flag" configuration is now "<WANT>"
+    Then the "new-branch-push-flag" setting is now "<WANT>"
 
     Examples:
       | GIVE  | WANT  |

--- a/features/new-branch-push-flag/update.feature
+++ b/features/new-branch-push-flag/update.feature
@@ -2,7 +2,7 @@ Feature: set the new-branch-push-flag
 
   Scenario Outline: local setting
     When I run "git-town new-branch-push-flag <GIVE>"
-    Then the new-branch-push-flag configuration is now "<WANT>"
+    Then the "new-branch-push-flag" configuration is now "<WANT>"
 
     Examples:
       | GIVE  | WANT  |
@@ -22,7 +22,7 @@ Feature: set the new-branch-push-flag
 
   Scenario Outline: global setting
     When I run "git-town new-branch-push-flag --global <GIVE>"
-    Then the new-branch-push-flag configuration is now "<WANT>"
+    Then the "new-branch-push-flag" configuration is now "<WANT>"
 
     Examples:
       | GIVE  | WANT  |

--- a/features/new-branch-push-flag/update.feature
+++ b/features/new-branch-push-flag/update.feature
@@ -2,7 +2,7 @@ Feature: set the new-branch-push-flag
 
   Scenario Outline: local setting
     When I run "git-town new-branch-push-flag <GIVE>"
-    Then the new-branch-push-flag configuration is now <WANT>
+    Then the new-branch-push-flag configuration is now "<WANT>"
 
     Examples:
       | GIVE  | WANT  |
@@ -22,7 +22,7 @@ Feature: set the new-branch-push-flag
 
   Scenario Outline: global setting
     When I run "git-town new-branch-push-flag --global <GIVE>"
-    Then the new-branch-push-flag configuration is now <WANT>
+    Then the new-branch-push-flag configuration is now "<WANT>"
 
     Examples:
       | GIVE  | WANT  |

--- a/features/new-pull-request/features/offline.feature
+++ b/features/new-pull-request/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Scenario:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     When I run "git-town new-pull-request"
     Then it prints the error:
       """

--- a/features/new-pull-request/features/self_hosted.feature
+++ b/features/new-pull-request/features/self_hosted.feature
@@ -5,7 +5,7 @@ Feature: self-hosted service
     And my computer has the "open" tool installed
     And my repo has a feature branch "feature"
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
-    And Git Town's local "code-hosting-driver" setting is "<DRIVER>"
+    And the "code-hosting-driver" setting is "<DRIVER>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
     Then "open" launches a new pull request with this url in my browser:

--- a/features/new-pull-request/features/ssh_identity.feature
+++ b/features/new-pull-request/features/ssh_identity.feature
@@ -5,7 +5,7 @@ Feature: use a SSH identity
     And my computer has the "open" tool installed
     And my repo has a feature branch "feature"
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
-    And Git Town's local "code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
+    And the "code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
     And I am on the "feature" branch
     When I run "git-town new-pull-request"
     Then "open" launches a new pull request with this url in my browser:

--- a/features/offline/display.feature
+++ b/features/offline/display.feature
@@ -8,7 +8,7 @@ Feature: display the current offline status
       """
 
   Scenario: enabled
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     When I run "git-town offline"
     Then it prints:
       """

--- a/features/offline/display.feature
+++ b/features/offline/display.feature
@@ -8,11 +8,19 @@ Feature: display the current offline status
       """
 
   Scenario: enabled
-    Given offline mode is enabled
+    Given the "offline" setting is "true"
     When I run "git-town offline"
     Then it prints:
       """
       true
+      """
+
+  Scenario: disabled
+    Given the "offline" setting is "false"
+    When I run "git-town offline"
+    Then it prints:
+      """
+      false
       """
 
   Scenario: invalid value

--- a/features/offline/display.feature
+++ b/features/offline/display.feature
@@ -16,7 +16,7 @@ Feature: display the current offline status
       """
 
   Scenario: invalid value
-    Given Git Town's "offline" setting is "zonk"
+    Given the "offline" setting is "zonk"
     When I run "git-town offline"
     Then it prints:
       """

--- a/features/offline/display.feature
+++ b/features/offline/display.feature
@@ -16,7 +16,7 @@ Feature: display the current offline status
       """
 
   Scenario: invalid value
-    Given Git Town's local "offline" setting is "zonk"
+    Given Git Town's "offline" setting is "zonk"
     When I run "git-town offline"
     Then it prints:
       """

--- a/features/offline/update.feature
+++ b/features/offline/update.feature
@@ -3,12 +3,12 @@ Feature: change offline mode
   Scenario: enable
     Given the "offline" setting is "false"
     When I run "git-town offline true"
-    Then Git Town's "offline" setting is now "true"
+    Then the "offline" setting is now "true"
 
   Scenario: disable
     Given the "offline" setting is "true"
     When I run "git-town offline false"
-    Then Git Town's "offline" setting is now "false"
+    Then the "offline" setting is now "false"
 
   Scenario: invalid value
     Given the "offline" setting is "false"
@@ -17,4 +17,4 @@ Feature: change offline mode
       """
       invalid argument: "zonk". Please provide either "true" or "false"
       """
-    And Git Town's "offline" setting is still "false"
+    And the "offline" setting is still "false"

--- a/features/offline/update.feature
+++ b/features/offline/update.feature
@@ -2,12 +2,14 @@ Feature: change offline mode
 
   Scenario: enable
     When I run "git-town offline true"
-    Then offline mode is enabled
+    Then Git Town's "offline" setting is now "true"
+    And Git Town is now in offline mode
 
   Scenario: disable
     Given Git Town is in offline mode
     When I run "git-town offline false"
-    Then offline mode is disabled
+    Then Git Town's "offline" setting is now "false"
+    And Git Town is no longer in offline mode
 
   Scenario: invalid value
     When I run "git-town offline zonk"
@@ -15,3 +17,4 @@ Feature: change offline mode
       """
       invalid argument: "zonk". Please provide either "true" or "false"
       """
+    And Git Town is no longer in offline mode

--- a/features/offline/update.feature
+++ b/features/offline/update.feature
@@ -1,20 +1,20 @@
 Feature: change offline mode
 
   Scenario: enable
+    Given Git Town's "offline" setting is "false"
     When I run "git-town offline true"
     Then Git Town's "offline" setting is now "true"
-    And Git Town is now in offline mode
 
   Scenario: disable
-    Given Git Town is in offline mode
+    Given Git Town's "offline" setting is "true"
     When I run "git-town offline false"
     Then Git Town's "offline" setting is now "false"
-    And Git Town is no longer in offline mode
 
   Scenario: invalid value
+    Given Git Town's "offline" setting is "false"
     When I run "git-town offline zonk"
     Then it prints the error:
       """
       invalid argument: "zonk". Please provide either "true" or "false"
       """
-    And Git Town is no longer in offline mode
+    And Git Town's "offline" setting is still "false"

--- a/features/offline/update.feature
+++ b/features/offline/update.feature
@@ -1,17 +1,17 @@
 Feature: change offline mode
 
   Scenario: enable
-    Given Git Town's "offline" setting is "false"
+    Given the "offline" setting is "false"
     When I run "git-town offline true"
     Then Git Town's "offline" setting is now "true"
 
   Scenario: disable
-    Given Git Town's "offline" setting is "true"
+    Given the "offline" setting is "true"
     When I run "git-town offline false"
     Then Git Town's "offline" setting is now "false"
 
   Scenario: invalid value
-    Given Git Town's "offline" setting is "false"
+    Given the "offline" setting is "false"
     When I run "git-town offline zonk"
     Then it prints the error:
       """

--- a/features/prepend/features/hack_push_flag.feature
+++ b/features/prepend/features/hack_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push new branches
 
   Background:
-    Given the new-branch-push-flag configuration is "true"
+    Given the "new-branch-push-flag" configuration is "true"
     And my repo has a feature branch "old"
     And the commits
       | BRANCH | LOCATION      | MESSAGE        |

--- a/features/prepend/features/hack_push_flag.feature
+++ b/features/prepend/features/hack_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push new branches
 
   Background:
-    Given the "new-branch-push-flag" configuration is "true"
+    Given the "new-branch-push-flag" setting is "true"
     And my repo has a feature branch "old"
     And the commits
       | BRANCH | LOCATION      | MESSAGE        |

--- a/features/prepend/features/hack_push_flag.feature
+++ b/features/prepend/features/hack_push_flag.feature
@@ -1,7 +1,7 @@
 Feature: auto-push new branches
 
   Background:
-    Given the new-branch-push-flag configuration is true
+    Given the new-branch-push-flag configuration is "true"
     And my repo has a feature branch "old"
     And my repo contains the commits
       | BRANCH | LOCATION      | MESSAGE        |

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And my repo has a feature branch "old"
     And the commits
       | BRANCH | LOCATION      | MESSAGE    |

--- a/features/prune-branches/features/offline.feature
+++ b/features/prune-branches/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Scenario: try to prune branches in offline mode
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     When I run "git-town prune-branches"
     Then it prints the error:
       """

--- a/features/pull_branch_strategy/display.feature
+++ b/features/pull_branch_strategy/display.feature
@@ -8,7 +8,7 @@ Feature: display the currently configured pull_branch_strategy
       """
 
   Scenario Outline:
-    Given the "pull-branch-strategy" configuration is "<VALUE>"
+    Given the "pull-branch-strategy" setting is "<VALUE>"
     When I run "git-town pull-branch-strategy"
     Then it prints:
       """

--- a/features/pull_branch_strategy/display.feature
+++ b/features/pull_branch_strategy/display.feature
@@ -8,7 +8,7 @@ Feature: display the currently configured pull_branch_strategy
       """
 
   Scenario Outline:
-    Given the pull-branch-strategy configuration is "<VALUE>"
+    Given the "pull-branch-strategy" configuration is "<VALUE>"
     When I run "git-town pull-branch-strategy"
     Then it prints:
       """

--- a/features/pull_branch_strategy/update.feature
+++ b/features/pull_branch_strategy/update.feature
@@ -2,7 +2,7 @@ Feature: configure the pull_branch_strategy
 
   Scenario Outline:
     When I run "git-town pull-branch-strategy <VALUE>"
-    Then the "pull-branch-strategy" configuration is now "<VALUE>"
+    Then the "pull-branch-strategy" setting is now "<VALUE>"
 
     Examples:
       | VALUE  |

--- a/features/pull_branch_strategy/update.feature
+++ b/features/pull_branch_strategy/update.feature
@@ -2,7 +2,7 @@ Feature: configure the pull_branch_strategy
 
   Scenario Outline:
     When I run "git-town pull-branch-strategy <VALUE>"
-    Then the pull-branch-strategy configuration is now "<VALUE>"
+    Then the "pull-branch-strategy" configuration is now "<VALUE>"
 
     Examples:
       | VALUE  |

--- a/features/rename-branch/edge_cases/offline.feature
+++ b/features/rename-branch/edge_cases/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And my repo has a feature branch "old"
     And the commits
       | BRANCH | LOCATION      | MESSAGE     |

--- a/features/repo/edge_cases/offline.feature
+++ b/features/repo/edge_cases/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Scenario: try to prune branches in offline mode
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     When I run "git-town repo"
     Then it prints the error:
       """

--- a/features/repo/features/self_hosted.feature
+++ b/features/repo/features/self_hosted.feature
@@ -4,7 +4,7 @@ Feature: self hosted servie
   Scenario Outline:
     Given my computer has the "open" tool installed
     And my repo's origin is "git@self-hosted:git-town/git-town.git"
-    And Git Town's local "code-hosting-driver" setting is "<DRIVER>"
+    And the "code-hosting-driver" setting is "<DRIVER>"
     When I run "git-town repo"
     Then "open" launches a new pull request with this url in my browser:
       """

--- a/features/repo/features/ssh_identity.feature
+++ b/features/repo/features/ssh_identity.feature
@@ -4,7 +4,7 @@ Feature: use an SSH identity
   Scenario Outline:
     Given my computer has the "open" tool installed
     And my repo's origin is "git@my-ssh-identity:git-town/git-town.git"
-    And Git Town's local "code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
+    And the "code-hosting-origin-hostname" setting is "<ORIGIN_HOSTNAME>"
     When I run "git-town repo"
     Then "open" launches a new pull request with this url in my browser:
       """

--- a/features/shared/strip_colors.feature
+++ b/features/shared/strip_colors.feature
@@ -3,7 +3,7 @@ Feature: strip colors
 
   Scenario: colors are stripped from the output of git commands run internally
     Given Git Town is not configured
-    And Git Town's local "color.ui" setting is "always"
+    And the "color.ui" setting is "always"
     And I am on the "main" branch
     When I run "git-town hack new-feature" and answer the prompts:
       | PROMPT                                     | ANSWER  |

--- a/features/ship/current_branch/edge_cases/unconfigured.feature
+++ b/features/ship/current_branch/edge_cases/unconfigured.feature
@@ -7,7 +7,6 @@ Feature: ask for missing configuration information
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
     And the main branch is now "main"
-    And my repo now has no perennial branches
     And it prints the error:
       """
       the branch "main" is not a feature branch. Only feature branches can be shipped

--- a/features/ship/current_branch/features/offline.feature
+++ b/features/ship/current_branch/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And my repo has a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION      | MESSAGE        |

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -6,7 +6,7 @@ Feature: ship-delete-remote-branch disabled
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, origin | feature commit |
     And I am on the "feature" branch
-    And Git Town's local "ship-delete-remote-branch" setting is "false"
+    And the "ship-delete-remote-branch" setting is "false"
     When I run "git-town ship -m 'feature done'"
     And origin deletes the "feature" branch
 

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -7,7 +7,7 @@ Feature: skip deleting the remote branch when shipping another branch
       | feature | local, origin | feature commit |
       | other   | local         | other commit   |
     And I am on the "other" branch
-    And Git Town's local "ship-delete-remote-branch" setting is "false"
+    And the "ship-delete-remote-branch" setting is "false"
     When I run "git-town ship feature -m 'feature done'"
     And origin deletes the "feature" branch
 

--- a/features/sync/current_branch/feature_branch/features/offline.feature
+++ b/features/sync/current_branch/feature_branch/features/offline.feature
@@ -1,7 +1,7 @@
 Feature: offline mode
 
   Background:
-    Given Git Town is in offline mode
+    Given offline mode is enabled
     And my repo has a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION | MESSAGE               |

--- a/features/sync/current_branch/feature_branch/features/pull_branch_strategy.feature
+++ b/features/sync/current_branch/feature_branch/features/pull_branch_strategy.feature
@@ -1,7 +1,7 @@
 Feature: with pull-branch-strategy set to "merge"
 
   Background:
-    Given the "pull-branch-strategy" configuration is "merge"
+    Given the "pull-branch-strategy" setting is "merge"
     And my repo has a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION | MESSAGE               |

--- a/features/sync/current_branch/feature_branch/features/pull_branch_strategy.feature
+++ b/features/sync/current_branch/feature_branch/features/pull_branch_strategy.feature
@@ -1,7 +1,7 @@
 Feature: with pull-branch-strategy set to "merge"
 
   Background:
-    Given the pull-branch-strategy configuration is "merge"
+    Given the "pull-branch-strategy" configuration is "merge"
     And my repo has a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION | MESSAGE               |

--- a/features/sync/current_branch/main_branch/features/upstream.feature
+++ b/features/sync/current_branch/main_branch/features/upstream.feature
@@ -30,7 +30,7 @@ Feature: on the main branch with an upstream repo
       |        | origin   | origin commit   |
       |        | upstream | upstream commit |
     And I am on the "main" branch
-    And Git Town's local "sync-upstream" setting is false
+    And the "sync-upstream" setting is false
     When I run "git-town sync"
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/test/steps.go
+++ b/test/steps.go
@@ -375,7 +375,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the main branch is not configured$`, func() error {
+	suite.Step(`^the main branch is not set$`, func() error {
 		return state.gitEnv.DevRepo.DeleteMainBranchConfiguration()
 	})
 

--- a/test/steps.go
+++ b/test/steps.go
@@ -433,19 +433,19 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.AddUpstream()
 	})
 
-	suite.Step(`^Git Town's local "color.ui" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^the "color.ui" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetColorUI(value)
 	})
 
-	suite.Step(`^Git Town's local "code-hosting-driver" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^the "code-hosting-driver" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingDriver(value)
 	})
 
-	suite.Step(`^Git Town's local "code-hosting-origin-hostname" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^the "code-hosting-origin-hostname" setting is "([^"]*)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetCodeHostingOriginHostname(value)
 	})
 
-	suite.Step(`^Git Town's local "ship-delete-remote-branch" setting is "(true|false)"$`, func(value string) error {
+	suite.Step(`^the "ship-delete-remote-branch" setting is "(true|false)"$`, func(value string) error {
 		parsed, err := strconv.ParseBool(value)
 		if err != nil {
 			return err
@@ -454,7 +454,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town's local "sync-upstream" setting is (true|false)$`, func(text string) error {
+	suite.Step(`^the "sync-upstream" setting is (true|false)$`, func(text string) error {
 		value, err := strconv.ParseBool(text)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -939,11 +939,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.CheckoutBranch("-")
 	})
 
-	suite.Step(`^the pull-branch-strategy configuration is "(merge|rebase)"$`, func(value string) error {
+	suite.Step(`^the "pull-branch-strategy" configuration is "(merge|rebase)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetPullBranchStrategy(value)
 	})
 
-	suite.Step(`^the pull-branch-strategy configuration is now "(merge|rebase)"$`, func(want string) error {
+	suite.Step(`^the "pull-branch-strategy" configuration is now "(merge|rebase)"$`, func(want string) error {
 		state.gitEnv.DevRepo.Config.Reload()
 		have := state.gitEnv.DevRepo.Config.PullBranchStrategy()
 		if have != want {

--- a/test/steps.go
+++ b/test/steps.go
@@ -558,7 +558,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	suite.Step(`^my repo has a perennial branch "([^"]+)"`, func(branch string) error {
 		err := state.gitEnv.DevRepo.CreatePerennialBranches(branch)
 		if err != nil {
-			return fmt.Errorf("cannot create perennial branches: %w", err)
+			return fmt.Errorf("cannot create perennial branch: %w", err)
 		}
 		state.initialLocalBranches = append(state.initialLocalBranches, branch)
 		state.initialRemoteBranches = append(state.initialRemoteBranches, branch)

--- a/test/steps.go
+++ b/test/steps.go
@@ -375,7 +375,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^my repo doesn't have a main branch configured$`, func() error {
+	suite.Step(`^the main branch is not set$`, func() error {
 		return state.gitEnv.DevRepo.DeleteMainBranchConfiguration()
 	})
 
@@ -775,22 +775,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town is no longer in offline mode$`, func() error {
-		state.gitEnv.DevRepo.Config.Reload()
-		if state.gitEnv.DevRepo.Config.IsOffline() {
-			return fmt.Errorf("expected to not be offline but am")
-		}
-		return nil
-	})
-
-	suite.Step(`^Git Town is now in offline mode$`, func() error {
-		state.gitEnv.DevRepo.Config.Reload()
-		if !state.gitEnv.DevRepo.Config.IsOffline() {
-			return fmt.Errorf("expected to be offline but am not")
-		}
-		return nil
-	})
-
 	suite.Step(`^the "([^"]*)" branch gets deleted on the remote$`, func(name string) error {
 		state.initialRemoteBranches = stringslice.Remove(state.initialRemoteBranches, name)
 		return state.gitEnv.OriginRepo.RemoveBranch(name)
@@ -887,7 +871,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return err
 	})
 
-	suite.Step(`^Git Town's "offline" setting is now "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's "offline" setting is (?:now|still) "([^"]*)"$`, func(value string) error {
 		want, err := strconv.ParseBool(value)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -814,12 +814,13 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the global new-branch-push-flag configuration is (true|false)$`, func(text string) error {
+	suite.Step(`^the (global )?new-branch-push-flag configuration is (true|false)$`, func(globalText string, text string) error {
+		global := globalText != ""
 		b, err := strconv.ParseBool(text)
 		if err != nil {
 			return err
 		}
-		_ = state.gitEnv.DevRepo.Config.SetNewBranchPush(b, true)
+		_ = state.gitEnv.DevRepo.Config.SetNewBranchPush(b, global)
 		return nil
 	})
 
@@ -834,14 +835,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			return fmt.Errorf("expected %q, got %q", name, actual)
 		}
 		return nil
-	})
-
-	suite.Step(`^the new-branch-push-flag configuration is (true|false)$`, func(value string) error {
-		b, err := strconv.ParseBool(value)
-		if err != nil {
-			return err
-		}
-		return state.gitEnv.DevRepo.Config.SetNewBranchPush(b, false)
 	})
 
 	suite.Step(`^the new-branch-push-flag configuration is "([^"]*)"$`, func(value string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -939,11 +939,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return state.gitEnv.DevRepo.CheckoutBranch("-")
 	})
 
-	suite.Step(`^the "pull-branch-strategy" configuration is "(merge|rebase)"$`, func(value string) error {
+	suite.Step(`^the "pull-branch-strategy" setting is "(merge|rebase)"$`, func(value string) error {
 		return state.gitEnv.DevRepo.Config.SetPullBranchStrategy(value)
 	})
 
-	suite.Step(`^the "pull-branch-strategy" configuration is now "(merge|rebase)"$`, func(want string) error {
+	suite.Step(`^the "pull-branch-strategy" setting is now "(merge|rebase)"$`, func(want string) error {
 		state.gitEnv.DevRepo.Config.Reload()
 		have := state.gitEnv.DevRepo.Config.PullBranchStrategy()
 		if have != want {

--- a/test/steps.go
+++ b/test/steps.go
@@ -875,7 +875,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return err
 	})
 
-	suite.Step(`^Git Town's "offline" setting is (?:now|still) "([^"]*)"$`, func(value string) error {
+	suite.Step(`^the "offline" setting is (?:now|still) "([^"]*)"$`, func(value string) error {
 		want, err := strconv.ParseBool(value)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -375,7 +375,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the main branch is not set$`, func() error {
+	suite.Step(`^the main branch is not configured$`, func() error {
 		return state.gitEnv.DevRepo.DeleteMainBranchConfiguration()
 	})
 
@@ -825,10 +825,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^the main branch is "([^"]+)"$`, func(name string) error {
 		return state.gitEnv.DevRepo.Config.SetMainBranch(name)
-	})
-
-	suite.Step(`^the main branch is not configured$`, func() error {
-		return state.gitEnv.DevRepo.DeleteMainBranchConfiguration()
 	})
 
 	suite.Step(`^the main branch is now "([^"]+)"$`, func(name string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -870,7 +870,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town's "offline" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^the "offline" setting is "([^"]*)"$`, func(value string) error {
 		_, err := state.gitEnv.DevRepo.Config.SetGlobalConfigValue("git-town.offline", value)
 		return err
 	})

--- a/test/steps.go
+++ b/test/steps.go
@@ -843,7 +843,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the (global )?"new-branch-push-flag" configuration is "([^"]*)"$`, func(global string, value string) error {
+	suite.Step(`^the (global )?"new-branch-push-flag" setting is "([^"]*)"$`, func(global string, value string) error {
 		setGlobal := global != ""
 		if value == "true" || value == "false" {
 			b, err := strconv.ParseBool(value)
@@ -857,7 +857,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return err
 	})
 
-	suite.Step(`^the "new-branch-push-flag" configuration is now "(true|false)"$`, func(text string) error {
+	suite.Step(`^the "new-branch-push-flag" setting is now "(true|false)"$`, func(text string) error {
 		want, err := strconv.ParseBool(text)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -111,7 +111,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town is in offline mode$`, func() error {
+	suite.Step(`^offline mode is enabled$`, func() error {
 		return state.gitEnv.DevRepo.Config.SetOffline(true)
 	})
 
@@ -569,7 +569,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return compareExistingCommits(state, state.initialCommits)
 	})
 
-	suite.Step(`^my repo now has no perennial branches$`, func() error {
+	suite.Step(`^there are still no perennial branches$`, func() error {
 		state.gitEnv.DevRepo.Config.Reload()
 		branches := state.gitEnv.DevRepo.Config.PerennialBranches()
 		if len(branches) > 0 {

--- a/test/steps.go
+++ b/test/steps.go
@@ -843,7 +843,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the (global )?new-branch-push-flag configuration is "([^"]*)"$`, func(global string, value string) error {
+	suite.Step(`^the (global )?"new-branch-push-flag" configuration is "([^"]*)"$`, func(global string, value string) error {
 		setGlobal := global != ""
 		if value == "true" || value == "false" {
 			b, err := strconv.ParseBool(value)
@@ -857,7 +857,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return err
 	})
 
-	suite.Step(`^the new-branch-push-flag configuration is now "(true|false)"$`, func(text string) error {
+	suite.Step(`^the "new-branch-push-flag" configuration is now "(true|false)"$`, func(text string) error {
 		want, err := strconv.ParseBool(text)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -814,16 +814,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the (global )?new-branch-push-flag configuration is (true|false)$`, func(globalText string, text string) error {
-		global := globalText != ""
-		b, err := strconv.ParseBool(text)
-		if err != nil {
-			return err
-		}
-		_ = state.gitEnv.DevRepo.Config.SetNewBranchPush(b, global)
-		return nil
-	})
-
 	suite.Step(`^the main branch is "([^"]+)"$`, func(name string) error {
 		return state.gitEnv.DevRepo.Config.SetMainBranch(name)
 	})
@@ -837,7 +827,16 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^the new-branch-push-flag configuration is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^the (global )?new-branch-push-flag configuration is "([^"]*)"$`, func(global string, value string) error {
+		setGlobal := global != ""
+		if value == "true" || value == "false" {
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return err
+			}
+			_ = state.gitEnv.DevRepo.Config.SetNewBranchPush(b, setGlobal)
+			return nil
+		}
 		_, err := state.gitEnv.DevRepo.Config.SetLocalConfigValue("git-town.new-branch-push-flag", value)
 		return err
 	})

--- a/test/steps.go
+++ b/test/steps.go
@@ -841,7 +841,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return err
 	})
 
-	suite.Step(`^the new-branch-push-flag configuration is now (true|false)$`, func(text string) error {
+	suite.Step(`^the new-branch-push-flag configuration is now "(true|false)"$`, func(text string) error {
 		want, err := strconv.ParseBool(text)
 		if err != nil {
 			return err

--- a/test/steps.go
+++ b/test/steps.go
@@ -775,7 +775,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^offline mode is disabled$`, func() error {
+	suite.Step(`^Git Town is no longer in offline mode$`, func() error {
 		state.gitEnv.DevRepo.Config.Reload()
 		if state.gitEnv.DevRepo.Config.IsOffline() {
 			return fmt.Errorf("expected to not be offline but am")
@@ -783,7 +783,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^offline mode is enabled$`, func() error {
+	suite.Step(`^Git Town is now in offline mode$`, func() error {
 		state.gitEnv.DevRepo.Config.Reload()
 		if !state.gitEnv.DevRepo.Config.IsOffline() {
 			return fmt.Errorf("expected to be offline but am not")
@@ -885,6 +885,19 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	suite.Step(`^Git Town's "offline" setting is "([^"]*)"$`, func(value string) error {
 		_, err := state.gitEnv.DevRepo.Config.SetGlobalConfigValue("git-town.offline", value)
 		return err
+	})
+
+	suite.Step(`^Git Town's "offline" setting is now "([^"]*)"$`, func(value string) error {
+		want, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		state.gitEnv.DevRepo.Config.Reload()
+		have := state.gitEnv.DevRepo.Config.IsOffline()
+		if have != want {
+			return fmt.Errorf("expected %t but have %t", want, have)
+		}
+		return nil
 	})
 
 	suite.Step(`^the perennial branches are "([^"]+)"$`, func(name string) error {

--- a/test/steps.go
+++ b/test/steps.go
@@ -882,7 +882,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^Git Town's local "offline" setting is "([^"]*)"$`, func(value string) error {
+	suite.Step(`^Git Town's "offline" setting is "([^"]*)"$`, func(value string) error {
 		_, err := state.gitEnv.DevRepo.Config.SetGlobalConfigValue("git-town.offline", value)
 		return err
 	})


### PR DESCRIPTION
- surrounds all configuration names and values in double-quotes so that they are properly highlighted
- removes pointless "Git Town" as subject. All these specs are about Git Town. Cucumber specs are meant to be read by trained people already familiar with Git Town to some degree. The specs should get straight to the point and not explain that "new-branch-push-flag" is a Git Town setting.