### PR TITLE
Fix docs for pull-branch-strategy parameters

### DIFF
--- a/website/src/commands/pull-branch-strategy.md
+++ b/website/src/commands/pull-branch-strategy.md
@@ -8,4 +8,5 @@ branches.
 ### Variations
 
 - without an argument, displays the current branch strategy
-- with `rebase` or `merge`, set the branch strategy
+- with `rebase`, set the pull branch strategy to rebase
+- with `merge`, set the pull branch strategy to merge

--- a/website/src/commands/pull-branch-strategy.md
+++ b/website/src/commands/pull-branch-strategy.md
@@ -7,5 +7,5 @@ branches.
 
 ### Variations
 
-- without an argument, displays the existing perennial branches
-- the `update` subcommand displays UI to set the perennial branches
+- without an argument, displays the current branch strategy
+- with `rebase` or `merge`, set the branch strategy


### PR DESCRIPTION
Seems the original docs were copy-pasted from the perennial branches command