### PR TITLE
Use the same Go version in all CI workflows

### DIFF
--- a/.github/workflows/lint_unit.yml
+++ b/.github/workflows/lint_unit.yml
@@ -17,10 +17,11 @@ jobs:
         go-version: 1.16
     - uses: dprint/check@v2.0
     - run: go version
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.43
+    - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+    # - name: golangci-lint
+    #   uses: golangci/golangci-lint-action@v2
+    #   with:
+    #     version: v1.43
     - name: ShellCheck
       uses: ludeeus/action-shellcheck@1.1.0
       with:

--- a/.github/workflows/lint_unit.yml
+++ b/.github/workflows/lint_unit.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         go-version: 1.16
     - uses: dprint/check@v2.0
+    - run: go version
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:

--- a/.github/workflows/lint_unit.yml
+++ b/.github/workflows/lint_unit.yml
@@ -16,8 +16,12 @@ jobs:
       with:
         go-version: 1.16
     - uses: dprint/check@v2.0
-    - run: go version
     - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+    # NOTE: Downloading golangci-lint binaries doesn't work as of 2022-05-15.
+    #       A likely cause is that this binary is compiled with the wrong version of Go.
+    #       Installing from source does work since it uses the native Go toolchain on this machine.
+    # TODO: re-enable downloading the binary once the changes introduced in Go 1.18 stabilize
+    #       and the ecosystem has caught up with them.
     # - name: golangci-lint
     #   uses: golangci/golangci-lint-action@v2
     #   with:

--- a/.github/workflows/lint_unit.yml
+++ b/.github/workflows/lint_unit.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
     - uses: dprint/check@v2.0
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This page helps you get started hacking on the Git Town codebase.
 
 ## setup
 
-1. install [Go](https://golang.org) version 1.18
+1. install [Go](https://golang.org) version 1.16
 2. install [Make](https://www.gnu.org/software/make)
    - Mac and Linux users have this out of the box
    - Windows users can install

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This page helps you get started hacking on the Git Town codebase.
 
 ## setup
 
-1. install [Go](https://golang.org) version 1.16 or higher
+1. install [Go](https://golang.org) version 1.18
 2. install [Make](https://www.gnu.org/software/make)
    - Mac and Linux users have this out of the box
    - Windows users can install


### PR DESCRIPTION
The `lint_unit` workflow was using the default Go version while the `cuke` workflow was hard-coded to v1.16. This PR hardcodes `lint_unit` to 1.16 as well.