### PR TITLE
Update Regex for hostname extraction to support more ssh usernames

### DIFF
--- a/features/new-pull-request/bitbucket.feature
+++ b/features/new-pull-request/bitbucket.feature
@@ -21,6 +21,11 @@ Feature: Bitbucket support
       | git@bitbucket.org/git-town/git-town                  |
       | ssh://git@bitbucket.org/git-town/git-town.git        |
       | ssh://git@bitbucket.org/git-town/git-town            |
+      | username@bitbucket.org/git-town/git-town.git              |
+      | username@bitbucket.org/git-town/git-town                  |
+      | ssh://username@bitbucket.org/git-town/git-town.git        |
+      | ssh://username@bitbucket.org/git-town/git-town            |
+
 
   Scenario Outline: origin includes path that looks like a URL
     Given the current branch is a feature branch "feature"

--- a/features/repo/bitbucket.feature
+++ b/features/repo/bitbucket.feature
@@ -20,3 +20,8 @@ Feature: Bitbucket
       | git@bitbucket.org/git-town/git-town                  |
       | ssh://git@bitbucket.org/git-town/git-town.git        |
       | ssh://git@bitbucket.org/git-town/git-town            |
+      | username@bitbucket.org/git-town/git-town.git              |
+      | username@bitbucket.org/git-town/git-town                  |
+      | ssh://username@bitbucket.org/git-town/git-town.git        |
+      | ssh://username@bitbucket.org/git-town/git-town            |
+

--- a/src/giturl/url.go
+++ b/src/giturl/url.go
@@ -8,7 +8,7 @@ import (
 
 // Host provides the hostname contained within the given Git hosting URL.
 func Host(url string) string {
-	hostnameRegex := regexp.MustCompile("(^[^:]*://([^@]*@)?|git@)([^/:]+).*")
+	hostnameRegex := regexp.MustCompile("(^[^:]*://([^@]*@)?|[^@]*@)([^/:]+).*")
 	matches := hostnameRegex.FindStringSubmatch(url)
 	if matches == nil {
 		return ""

--- a/src/giturl/url_test.go
+++ b/src/giturl/url_test.go
@@ -11,6 +11,7 @@ func TestHost(t *testing.T) {
 	t.Parallel()
 	tests := map[string]string{
 		"git@github.com:git-town/git-town.git":                 "github.com",
+		"username@bitbucket.org:git-town/git-town.git":         "bitbucket.org",
 		"https://github.com/git-town/git-town.git":             "github.com",
 		"https://user@github.com/git-town/git-town.git":        "github.com",
 		"https://user:secret@github.com/git-town/git-town.git": "github.com",
@@ -25,6 +26,7 @@ func TestRepo(t *testing.T) {
 	t.Parallel()
 	tests := map[string]string{
 		"git@github.com:git-town/git-town.git":                 "git-town/git-town",
+		"username@bitbucket.org:git-town/git-town.git":         "git-town/git-town",
 		"https://github.com/git-town/git-town.git":             "git-town/git-town",
 		"https://user@github.com/git-town/git-town.git":        "git-town/git-town",
 		"https://user:secret@github.com/git-town/git-town.git": "git-town/git-town",

--- a/src/hosting/bitbucket_test.go
+++ b/src/hosting/bitbucket_test.go
@@ -28,3 +28,14 @@ func TestLoadBitbucket_customHostName(t *testing.T) {
 	assert.Equal(t, "Bitbucket", driver.HostingServiceName())
 	assert.Equal(t, "https://bitbucket.org/git-town/git-town", driver.RepositoryURL())
 }
+
+//nolint:paralleltest  // mocks HTTP
+func TestLoadBitbucket_customUserName(t *testing.T) {
+	driver := hosting.NewBitbucketDriver(mockConfig{
+		hostingService: "bitbucket",
+		originURL:      "username@bitbucket.org:git-town/git-town.git",
+	}, nil)
+	assert.NotNil(t, driver)
+	assert.Equal(t, "Bitbucket", driver.HostingServiceName())
+	assert.Equal(t, "https://bitbucket.org/git-town/git-town", driver.RepositoryURL())
+}


### PR DESCRIPTION
Add support for using other usernames than `git` for ssh urls.
For example, Bitbucket added support for using
`your-username@bitbucket.org` as a repository url quite a while back.

See for an explanation when this might be needed:
https://bitbucket.org/blog/better-support-multiple-ssh-keys

The regex change itself is rather basic, we could also use a more elaborate
regex to match the user name, such as: https://github.com/shinnn/github-username-regex#githubusernameregex