### PR TITLE
Document OAuth scopes for GitHub access tokens

### DIFF
--- a/website/src/preferences/github-token.md
+++ b/website/src/preferences/github-token.md
@@ -4,10 +4,11 @@
 git-town.github-token=<token>
 ```
 
-To interact with the GitHub API in your name, Git Town needs a
+To interact with the GitHub API when [shipping](../commands/ship.md), Git Town
+needs a
 [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 with the `repo` scope. You can create one at
 https://github.com/settings/tokens/new. When you have created the token, run
-`git config git-town.github-token <token>` (where `<token>` gets replaced with
-the content of your GitHub access token) inside your code repository to store it
-in the Git Town configuration for the current repository.
+`git config git-town.github-token <token>` (where `<token>` is replaced with the
+content of your GitHub access token) inside your code repository to store it in
+the Git Town configuration for the current repository.

--- a/website/src/preferences/github-token.md
+++ b/website/src/preferences/github-token.md
@@ -5,7 +5,9 @@ git-town.github-token=<token>
 ```
 
 To interact with the GitHub API in your name, Git Town needs a
-[personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
-After your create your token, run `git config git-town.github-token <token>`
-inside your code repository to store it in the Git Town configuration for the
-current repository.
+[personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+with the `repo` scope. You can create one at
+https://github.com/settings/tokens/new. When you have created the token, run
+`git config git-town.github-token <token>` (where `<token>` gets replaced with
+the content of your GitHub access token) inside your code repository to store it
+in the Git Town configuration for the current repository.


### PR DESCRIPTION
Currently people don't know what token to create.