### PR TITLE
Fix go vet error reported using Go 1.18.

### DIFF
--- a/src/cli/dryrun.go
+++ b/src/cli/dryrun.go
@@ -10,7 +10,7 @@ import (
 func PrintDryRunMessage() {
 	_, err := color.New(color.FgBlue).Print(dryRunMessage)
 	if err != nil {
-		fmt.Println(dryRunMessage)
+		fmt.Print(dryRunMessage)
 	}
 }
 


### PR DESCRIPTION
Error: Println arg list ends with redundant newline

If the extra newline is preferred, let me know and I'll update this patch to keep it.