### PR TITLE
Update Powershell autocompletion command

### DIFF
--- a/website/src/commands/completion.md
+++ b/website/src/commands/completion.md
@@ -33,5 +33,5 @@ git-town completion fish | source
 To install autocompletions for Powershell, run this command:
 
 ```
-git-town completion powershell | source
+Invoke-Expression -Command $(git-town completion powershell | Out-String)
 ```


### PR DESCRIPTION
`source` seems to have been copy-pasted from the bash examples. Outputting the completions to a string and running them with `Invoke-Expression` has worked for me in PowerShell.