### PR TITLE
Make the initial branch explicit

### DIFF
--- a/test/repo.go
+++ b/test/repo.go
@@ -41,7 +41,7 @@ func CreateRepo(t *testing.T) Repo {
 func InitRepo(workingDir, homeDir, binDir string) (Repo, error) {
 	result := NewRepo(workingDir, homeDir, binDir)
 	err := result.RunMany([][]string{
-		{"git", "init"},
+		{"git", "init", "--initial-branch=master"},
 		{"git", "config", "--global", "user.name", "user"},
 		{"git", "config", "--global", "user.email", "email@example.com"},
 	})


### PR DESCRIPTION
With the initial branch changing in newer Git versions (from `master` to `main`), our tests can no longer assume a particular setting for the initial branch. We therefore set it to the value expected by the tests.