### PR TITLE
Remove cuke-open target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,6 @@ build:  # builds for the current platform
 cuke: build   # runs all end-to-end tests
 	@env LANG=C GOGC=off go test . -v -count=1
 
-cuke-open:  # runs only the currently uncommitted end-to-end tests
-	@git status --porcelain | grep -v '^\s*D ' | sed 's/^\s*\w\s*//' | grep '\.feature' | xargs godog
-#                           remove deleted     remove indicator
-
 cukethis: build   # runs the end-to-end tests that have a @this tag
 	@env LANG=C GOGC=off go test . -v -count=1 -this
 


### PR DESCRIPTION
The godog binary is deprecated and end-to-end tests run so fast now that this is no longer necessary.