### PR TITLE
Allow TODO comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - gocognit # we keep track of this via code reviews
     - goconst # tests contain a ton of hard-coded test strings, for example branch names
     - gocyclo # we keep track of this via code reviews
+    - godox # we allow TODO comments
     - golint # deprecated
     - gomnd # tests contain hard-coded test data that wouldn't make sense to extract into constants
     - ifshort # this enforces less readable code


### PR DESCRIPTION
They are helpful with tracking areas to clean up without polluting the public issue tracker with small-scale chores.