### PR TITLE
Fix aliases install docs

### DIFF
--- a/website/src/quick-configuration.md
+++ b/website/src/quick-configuration.md
@@ -11,10 +11,10 @@ its commands that make them feel like native Git commands, i.e. allow you to run
 for example `git hack` instead of `git town hack`. To enable this feature:
 
 ```
-git town install aliases true
+git town install aliases add
 ```
 
-To remove these aliases, run `git town install aliases false`.
+To remove these aliases, run `git town install aliases remove`.
 
 ## API access to your hosting provider
 


### PR DESCRIPTION
I tried running `git town install aliases true/false` but learned that this has been changed to `git town install aliases add/remove`, so I figured I'd update the docs. 😄 