### PR TITLE
Correct merge/rebase typo

### DIFF
--- a/website/src/preferences/sync-strategy.md
+++ b/website/src/preferences/sync-strategy.md
@@ -7,5 +7,5 @@ git-town.sync-strategy <merge|rebase>
 The sync-strategy setting specifies which strategy to use when merging the
 remote of feature branches into their local counterpart. If set to `merge` (the
 default value), it merges the respective tracking branch into its local branch.
-If set to `merge`, it updates local perennial branches by rebasing them against
+If set to `rebase`, it updates local perennial branches by rebasing them against
 their remote branch.


### PR DESCRIPTION
The doc refers to setting this setting to `merge` twice, one should be `rebase`