### PR TITLE
More fine-grained Git version check

### DIFF
--- a/features/shared/invalid_git_version.feature
+++ b/features/shared/invalid_git_version.feature
@@ -9,35 +9,35 @@ Feature: require minimum Git version
       """
 
     Examples:
-      | COMMAND              |
-      | aliases true         |
-      | append               |
-      | config               |
-      | diff-parent          |
-      | hack                 |
-      | kill                 |
-      | main_branch          |
-      | push-new-branches    |
-      | new-pull-request     |
-      | offline              |
-      | perennial-branches   |
-      | prepend              |
-      | prune-branches       |
-      | pull-branch-strategy |
-      | rename-branch        |
-      | repo                 |
-      | set-parent           |
-      | ship                 |
-      | sync                 |
+      | COMMAND                     |
+      | aliases true                |
+      | append foo                  |
+      | config                      |
+      | config main-branch          |
+      | config push-new-branches    |
+      | config offline              |
+      | config perennial-branches   |
+      | config pull-branch-strategy |
+      | diff-parent                 |
+      | hack foo                    |
+      | kill                        |
+      | new-pull-request            |
+      | prepend foo                 |
+      | prune-branches              |
+      | rename-branch foo           |
+      | repo                        |
+      | set-parent                  |
+      | ship                        |
+      | sync                        |
 
-  @this
   Scenario Outline: not requiring Git
     Given Git has version "2.6.2"
     When I run "git-town <COMMAND>"
     Then it runs no commands
 
     Examples:
-      | COMMAND |
-      |         |
-      | help    |
-      | version |
+      | COMMAND          |
+      |                  |
+      | completions bash |
+      | help             |
+      | version          |

--- a/features/shared/invalid_git_version.feature
+++ b/features/shared/invalid_git_version.feature
@@ -10,13 +10,11 @@ Feature: require minimum Git version
 
     Examples:
       | COMMAND              |
-      |                      |
       | aliases true         |
       | append               |
       | config               |
       | diff-parent          |
       | hack                 |
-      | help                 |
       | kill                 |
       | main_branch          |
       | push-new-branches    |
@@ -31,4 +29,15 @@ Feature: require minimum Git version
       | set-parent           |
       | ship                 |
       | sync                 |
-      | version              |
+
+  @this
+  Scenario Outline: not requiring Git
+    Given Git has version "2.6.2"
+    When I run "git-town <COMMAND>"
+    Then it runs no commands
+
+    Examples:
+      | COMMAND |
+      |         |
+      | help    |
+      | version |

--- a/features/shared/run_outside_repo.feature
+++ b/features/shared/run_outside_repo.feature
@@ -1,3 +1,4 @@
+@this
 Feature: require a Git repository
 
   Scenario Outline:

--- a/features/shared/run_outside_repo.feature
+++ b/features/shared/run_outside_repo.feature
@@ -1,4 +1,3 @@
-@this
 Feature: require a Git repository
 
   Scenario Outline:

--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -34,11 +34,13 @@ func abortCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			ec := runstate.ErrorChecker{}
-			ec.Check(validateGitVersion(repo))
-			ec.Check(ValidateIsRepository(repo))
-			ec.Check(validateIsConfigured(repo))
-			return ec.Err
+			if err := validateGitVersion(repo); err != nil {
+				return err
+			}
+			if err := ValidateIsRepository(repo); err != nil {
+				return err
+			}
+			return validateIsConfigured(repo)
 		},
 		GroupID: "errors",
 	}

--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -34,10 +34,11 @@ func abortCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := ValidateIsRepository(repo); err != nil {
-				return err
-			}
-			return validateIsConfigured(repo)
+			ec := runstate.ErrorChecker{}
+			ec.Check(validateGitVersion(repo))
+			ec.Check(ValidateIsRepository(repo))
+			ec.Check(validateIsConfigured(repo))
+			return ec.Err
 		},
 		GroupID: "errors",
 	}

--- a/src/cmd/aliases.go
+++ b/src/cmd/aliases.go
@@ -37,7 +37,10 @@ This can conflict with other tools that also define Git aliases.`,
 				cli.Exit(fmt.Errorf(`invalid argument %q. Please provide either "add" or "remove"`, args[0]))
 			}
 		},
-		Args:    cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateGitVersion(repo)
+		},
 		GroupID: "setup",
 	}
 }

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -40,6 +40,9 @@ See "sync" for information regarding upstream remotes.`,
 		},
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); err != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -52,6 +52,9 @@ func configCmd(repo *git.ProdRepo) *cobra.Command {
 			}
 		},
 		Args: cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return ValidateIsRepository(repo)
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return validateGitVersion(repo)
 		},

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -52,8 +52,8 @@ func configCmd(repo *git.ProdRepo) *cobra.Command {
 			}
 		},
 		Args: cobra.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return ValidateIsRepository(repo)
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateGitVersion(repo)
 		},
 		GroupID: "setup",
 	}

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -40,6 +40,9 @@ func continueCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); err != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/core.go
+++ b/src/cmd/core.go
@@ -38,13 +38,6 @@ func Execute() {
 	debugFlag := false
 	repo := git.NewProdRepo(&debugFlag)
 	rootCmd := RootCmd(&repo, &debugFlag)
-	majorVersion, minorVersion, err := repo.Silent.Version()
-	if err != nil {
-		cli.Exit(err)
-	}
-	if !IsAcceptableGitVersion(majorVersion, minorVersion) {
-		cli.Exit(errors.New("this app requires Git 2.7.0 or higher"))
-	}
 	color.NoColor = false // Prevent color from auto disable
 	if err := rootCmd.Execute(); err != nil {
 		cli.Exit(err)
@@ -99,6 +92,17 @@ and it allows you to perform many common Git operations faster and easier.`,
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.PersistentFlags().BoolVar(debugFlag, "debug", false, "Print all Git commands run under the hood")
 	return &rootCmd
+}
+
+func validateGitVersion(repo *git.ProdRepo) error {
+	majorVersion, minorVersion, err := repo.Silent.Version()
+	if err != nil {
+		cli.Exit(err)
+	}
+	if !IsAcceptableGitVersion(majorVersion, minorVersion) {
+		cli.Exit(errors.New("this app requires Git 2.7.0 or higher"))
+	}
+	return nil
 }
 
 // IsAcceptableGitVersion indicates whether the given Git version works for Git Town.

--- a/src/cmd/core.go
+++ b/src/cmd/core.go
@@ -97,10 +97,10 @@ and it allows you to perform many common Git operations faster and easier.`,
 func validateGitVersion(repo *git.ProdRepo) error {
 	majorVersion, minorVersion, err := repo.Silent.Version()
 	if err != nil {
-		cli.Exit(err)
+		return err
 	}
 	if !IsAcceptableGitVersion(majorVersion, minorVersion) {
-		cli.Exit(errors.New("this app requires Git 2.7.0 or higher"))
+		return errors.New("this app requires Git 2.7.0 or higher")
 	}
 	return nil
 }

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -30,7 +30,7 @@ Exits with error code 1 if the given branch is a perennial branch or the main br
 		},
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			err := ValidateIsRepository(repo)

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -30,6 +30,9 @@ Exits with error code 1 if the given branch is a perennial branch or the main br
 		},
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			err := ValidateIsRepository(repo)
 			if err != nil {
 				return err

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -41,6 +41,9 @@ See "sync" for information regarding upstream remotes.`,
 		},
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -41,7 +41,7 @@ See "sync" for information regarding upstream remotes.`,
 		},
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -36,6 +36,9 @@ Does not delete perennial branches nor the main branch.`,
 		},
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -36,7 +36,7 @@ Does not delete perennial branches nor the main branch.`,
 		},
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -57,7 +57,7 @@ where hostname matches what is in your ssh config file.`, config.CodeHostingDriv
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -57,6 +57,9 @@ where hostname matches what is in your ssh config file.`, config.CodeHostingDriv
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -44,7 +44,7 @@ See "sync" for upstream remote options.
 		},
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -44,6 +44,9 @@ See "sync" for upstream remote options.
 		},
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -33,7 +33,7 @@ This usually means the branch was shipped or killed on another machine.`,
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -33,6 +33,9 @@ This usually means the branch was shipped or killed on another machine.`,
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -50,7 +50,7 @@ When run on a perennial branch
 		},
 		Args: cobra.RangeArgs(1, 2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -50,6 +50,9 @@ When run on a perennial branch
 		},
 		Args: cobra.RangeArgs(1, 2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -38,7 +38,7 @@ where HOSTNAME matches what is in your ssh config file.`, config.CodeHostingDriv
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -38,6 +38,9 @@ where HOSTNAME matches what is in your ssh config file.`, config.CodeHostingDriv
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -38,6 +38,9 @@ func setParentCommand(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -38,7 +38,7 @@ func setParentCommand(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -66,6 +66,9 @@ and Git Town will leave it up to your origin server to delete the remote branch.
 		},
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -66,7 +66,7 @@ and Git Town will leave it up to your origin server to delete the remote branch.
 		},
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -32,7 +32,7 @@ func skipCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -32,6 +32,9 @@ func skipCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -25,6 +25,9 @@ func statusCommand(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			return ValidateIsRepository(repo)
 		},
 		GroupID: "errors",

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -25,7 +25,7 @@ func statusCommand(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			return ValidateIsRepository(repo)

--- a/src/cmd/status_reset.go
+++ b/src/cmd/status_reset.go
@@ -22,7 +22,7 @@ func resetRunstateCommand(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			return ValidateIsRepository(repo)

--- a/src/cmd/status_reset.go
+++ b/src/cmd/status_reset.go
@@ -22,6 +22,9 @@ func resetRunstateCommand(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			return ValidateIsRepository(repo)
 		},
 	}

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -31,7 +31,7 @@ func switchCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -31,6 +31,9 @@ func switchCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -53,7 +53,7 @@ You can disable this by running "git config %s false".`, config.SyncUpstreamKey)
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -53,6 +53,9 @@ You can disable this by running "git config %s false".`, config.SyncUpstreamKey)
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -29,6 +29,9 @@ func undoCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateGitVersion(repo); repo != nil {
+				return err
+			}
 			if err := ValidateIsRepository(repo); err != nil {
 				return err
 			}

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -29,7 +29,7 @@ func undoCmd(repo *git.ProdRepo) *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateGitVersion(repo); repo != nil {
+			if err := validateGitVersion(repo); err != nil {
 				return err
 			}
 			if err := ValidateIsRepository(repo); err != nil {


### PR DESCRIPTION
Enforces Git versions only for the commands that need them.