### PR TITLE
Improved merge detection

### DIFF
--- a/src/git/repo.go
+++ b/src/git/repo.go
@@ -623,9 +623,9 @@ func (r *Repo) HasLocalOrOriginBranch(name string) (bool, error) {
 }
 
 // HasMergeInProgress indicates whether this Git repository currently has a merge in progress.
-func (r *Repo) HasMergeInProgress() (bool, error) {
-	_, err := os.Stat(filepath.Join(r.WorkingDir(), ".git", "MERGE_HEAD"))
-	return err == nil, nil
+func (r *Repo) HasMergeInProgress() bool {
+	_, err := r.Run("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
+	return err == nil
 }
 
 // HasOpenChanges indicates whether this repo has open changes.

--- a/src/steps/continue_merge_step.go
+++ b/src/steps/continue_merge_step.go
@@ -16,11 +16,7 @@ func (step *ContinueMergeStep) CreateContinueStep() Step {
 }
 
 func (step *ContinueMergeStep) Run(repo *git.ProdRepo, connector hosting.Connector) error {
-	hasMergeInprogress, err := repo.Silent.HasMergeInProgress()
-	if err != nil {
-		return err
-	}
-	if hasMergeInprogress {
+	if repo.Silent.HasMergeInProgress() {
 		return repo.Logging.CommitNoEdit()
 	}
 	return nil

--- a/test/steps.go
+++ b/test/steps.go
@@ -97,11 +97,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^a merge is now in progress$`, func() error {
-		hasMerge, err := state.gitEnv.DevRepo.HasMergeInProgress()
-		if err != nil {
-			return err
-		}
-		if !hasMerge {
+		if !state.gitEnv.DevRepo.HasMergeInProgress() {
 			return fmt.Errorf("expected merge in progress")
 		}
 		return nil
@@ -435,11 +431,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^no merge is in progress$`, func() error {
-		hasMerge, err := state.gitEnv.DevRepo.HasMergeInProgress()
-		if err != nil {
-			return err
-		}
-		if hasMerge {
+		if state.gitEnv.DevRepo.HasMergeInProgress() {
 			return fmt.Errorf("expected no merge in progress")
 		}
 		return nil


### PR DESCRIPTION
Relies on Git plumbing commands instead of manually checking internal implementation details of Git.