### PR TITLE
Extract run methods from commands

### DIFF
--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -18,19 +18,23 @@ func abortCmd(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, hasGitVersion, isRepository, isConfigured),
 		Short:   "Aborts the last run git-town command",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runState, err := runstate.Load(repo)
-			if err != nil {
-				return fmt.Errorf("cannot load previous run state: %w", err)
-			}
-			if runState == nil || !runState.IsUnfinished() {
-				return fmt.Errorf("nothing to abort")
-			}
-			abortRunState := runState.CreateAbortRunState()
-			connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
-			if err != nil {
-				return err
-			}
-			return runstate.Execute(&abortRunState, repo, connector)
+			return runAbort(repo)
 		},
 	}
+}
+
+func runAbort(repo *git.ProdRepo) error {
+	runState, err := runstate.Load(repo)
+	if err != nil {
+		return fmt.Errorf("cannot load previous run state: %w", err)
+	}
+	if runState == nil || !runState.IsUnfinished() {
+		return fmt.Errorf("nothing to abort")
+	}
+	abortRunState := runState.CreateAbortRunState()
+	connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
+	if err != nil {
+		return err
+	}
+	return runstate.Execute(&abortRunState, repo, connector)
 }

--- a/src/cmd/aliases.go
+++ b/src/cmd/aliases.go
@@ -25,15 +25,19 @@ Does not overwrite existing aliases.
 
 This can conflict with other tools that also define Git aliases.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			switch strings.ToLower(args[0]) {
-			case "add":
-				return addAliases(repo)
-			case "remove":
-				return removeAliases(repo)
-			}
-			return fmt.Errorf(`invalid argument %q. Please provide either "add" or "remove"`, args[0])
+			return runAliases(args, repo)
 		},
 	}
+}
+
+func runAliases(args []string, repo *git.ProdRepo) error {
+	switch strings.ToLower(args[0]) {
+	case "add":
+		return addAliases(repo)
+	case "remove":
+		return removeAliases(repo)
+	}
+	return fmt.Errorf(`invalid argument %q. Please provide either "add" or "remove"`, args[0])
 }
 
 func addAliases(repo *git.ProdRepo) error {

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -26,18 +26,22 @@ and brings over all uncommitted changes to the new feature branch.
 
 See "sync" for information regarding upstream remotes.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determineAppendConfig(args, repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := appendStepList(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("append", stepList)
-			return runstate.Execute(runState, repo, nil)
+			return runAppend(args, repo)
 		},
 	}
+}
+
+func runAppend(args []string, repo *git.ProdRepo) error {
+	config, err := determineAppendConfig(args, repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := appendStepList(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("append", stepList)
+	return runstate.Execute(runState, repo, nil)
 }
 
 type appendConfig struct {

--- a/src/cmd/completions.go
+++ b/src/cmd/completions.go
@@ -47,28 +47,32 @@ To load autocompletions for Powershell, run this command:
 To load completions for each session, add the above line to your PowerShell profile.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			completionType, err := NewCompletionType(args[0])
-			if err != nil {
-				return err
-			}
-			switch completionType {
-			case CompletionTypeBash:
-				return rootCmd.GenBashCompletion(os.Stdout)
-			case CompletionTypeZsh:
-				if completionsNoDescFlag {
-					return rootCmd.GenZshCompletionNoDesc(os.Stdout)
-				}
-				return rootCmd.GenZshCompletion(os.Stdout)
-			case CompletionTypeFish:
-				return rootCmd.GenFishCompletion(os.Stdout, !completionsNoDescFlag)
-			case CompletionTypePowershell:
-				return rootCmd.GenPowerShellCompletion(os.Stdout)
-			}
-			return fmt.Errorf("unknown argument: %q", args[0])
+			return runCompletions(args, completionsNoDescFlag, rootCmd)
 		},
 	}
 	completionsCmd.Flags().BoolVar(&completionsNoDescFlag, "no-descriptions", false, "disable completions description for shells that support it")
 	return &completionsCmd
+}
+
+func runCompletions(args []string, completionsNoDescFlag bool, rootCmd *cobra.Command) error {
+	completionType, err := NewCompletionType(args[0])
+	if err != nil {
+		return err
+	}
+	switch completionType {
+	case CompletionTypeBash:
+		return rootCmd.GenBashCompletion(os.Stdout)
+	case CompletionTypeZsh:
+		if completionsNoDescFlag {
+			return rootCmd.GenZshCompletionNoDesc(os.Stdout)
+		}
+		return rootCmd.GenZshCompletion(os.Stdout)
+	case CompletionTypeFish:
+		return rootCmd.GenFishCompletion(os.Stdout, !completionsNoDescFlag)
+	case CompletionTypePowershell:
+		return rootCmd.GenPowerShellCompletion(os.Stdout)
+	}
+	return fmt.Errorf("unknown argument: %q", args[0])
 }
 
 // CompletionType defines the valid shells for which Git Town can create auto-completions.

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -19,42 +19,7 @@ func configCmd(repo *git.ProdRepo) *cobra.Command {
 		PersistentPreRunE: ensure(repo, hasGitVersion),
 		Short:             "Displays your Git Town configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ec := runstate.ErrorChecker{}
-			pushNewBranches := ec.Bool(repo.Config.ShouldNewBranchPush())
-			pushHook := ec.Bool(repo.Config.PushHook())
-			isOffline := ec.Bool(repo.Config.IsOffline())
-			deleteOrigin := ec.Bool(repo.Config.ShouldShipDeleteOriginBranch())
-			pullBranchStrategy := ec.PullBranchStrategy(repo.Config.PullBranchStrategy())
-			shouldSyncUpstream := ec.Bool(repo.Config.ShouldSyncUpstream())
-			syncStrategy := ec.SyncStrategy(repo.Config.SyncStrategy())
-			hostingService := ec.HostingService(repo.Config.HostingService())
-			if ec.Err != nil {
-				return ec.Err
-			}
-			fmt.Println()
-			cli.PrintHeader("Branches")
-			cli.PrintEntry("main branch", cli.StringSetting(repo.Config.MainBranch()))
-			cli.PrintEntry("perennial branches", cli.StringSetting(strings.Join(repo.Config.PerennialBranches(), ", ")))
-			fmt.Println()
-			cli.PrintHeader("Configuration")
-			cli.PrintEntry("offline", cli.BoolSetting(isOffline))
-			cli.PrintEntry("pull branch strategy", string(pullBranchStrategy))
-			cli.PrintEntry("run pre-push hook", cli.BoolSetting(pushHook))
-			cli.PrintEntry("push new branches", cli.BoolSetting(pushNewBranches))
-			cli.PrintEntry("ship removes the remote branch", cli.BoolSetting(deleteOrigin))
-			cli.PrintEntry("sync strategy", string(syncStrategy))
-			cli.PrintEntry("sync with upstream", cli.BoolSetting(shouldSyncUpstream))
-			fmt.Println()
-			cli.PrintHeader("Hosting")
-			cli.PrintEntry("hosting service override", cli.StringSetting(string(hostingService)))
-			cli.PrintEntry("GitHub token", cli.StringSetting(repo.Config.GitHubToken()))
-			cli.PrintEntry("GitLab token", cli.StringSetting(repo.Config.GitLabToken()))
-			cli.PrintEntry("Gitea token", cli.StringSetting(repo.Config.GiteaToken()))
-			fmt.Println()
-			if repo.Config.MainBranch() != "" {
-				cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(repo.Config))
-			}
-			return nil
+			return runConfig(repo)
 		},
 	}
 	configCmd.AddCommand(mainbranchConfigCmd(repo))
@@ -67,4 +32,43 @@ func configCmd(repo *git.ProdRepo) *cobra.Command {
 	configCmd.AddCommand(setupConfigCommand(repo))
 	configCmd.AddCommand(syncStrategyCommand(repo))
 	return configCmd
+}
+
+func runConfig(repo *git.ProdRepo) error {
+	ec := runstate.ErrorChecker{}
+	pushNewBranches := ec.Bool(repo.Config.ShouldNewBranchPush())
+	pushHook := ec.Bool(repo.Config.PushHook())
+	isOffline := ec.Bool(repo.Config.IsOffline())
+	deleteOrigin := ec.Bool(repo.Config.ShouldShipDeleteOriginBranch())
+	pullBranchStrategy := ec.PullBranchStrategy(repo.Config.PullBranchStrategy())
+	shouldSyncUpstream := ec.Bool(repo.Config.ShouldSyncUpstream())
+	syncStrategy := ec.SyncStrategy(repo.Config.SyncStrategy())
+	hostingService := ec.HostingService(repo.Config.HostingService())
+	if ec.Err != nil {
+		return ec.Err
+	}
+	fmt.Println()
+	cli.PrintHeader("Branches")
+	cli.PrintEntry("main branch", cli.StringSetting(repo.Config.MainBranch()))
+	cli.PrintEntry("perennial branches", cli.StringSetting(strings.Join(repo.Config.PerennialBranches(), ", ")))
+	fmt.Println()
+	cli.PrintHeader("Configuration")
+	cli.PrintEntry("offline", cli.BoolSetting(isOffline))
+	cli.PrintEntry("pull branch strategy", string(pullBranchStrategy))
+	cli.PrintEntry("run pre-push hook", cli.BoolSetting(pushHook))
+	cli.PrintEntry("push new branches", cli.BoolSetting(pushNewBranches))
+	cli.PrintEntry("ship removes the remote branch", cli.BoolSetting(deleteOrigin))
+	cli.PrintEntry("sync strategy", string(syncStrategy))
+	cli.PrintEntry("sync with upstream", cli.BoolSetting(shouldSyncUpstream))
+	fmt.Println()
+	cli.PrintHeader("Hosting")
+	cli.PrintEntry("hosting service override", cli.StringSetting(string(hostingService)))
+	cli.PrintEntry("GitHub token", cli.StringSetting(repo.Config.GitHubToken()))
+	cli.PrintEntry("GitLab token", cli.StringSetting(repo.Config.GitLabToken()))
+	cli.PrintEntry("Gitea token", cli.StringSetting(repo.Config.GiteaToken()))
+	fmt.Println()
+	if repo.Config.MainBranch() != "" {
+		cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(repo.Config))
+	}
+	return nil
 }

--- a/src/cmd/config_mainbranch.go
+++ b/src/cmd/config_mainbranch.go
@@ -18,13 +18,17 @@ func mainbranchConfigCmd(repo *git.ProdRepo) *cobra.Command {
 
 The main branch is the Git branch from which new feature branches are cut.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return setMainBranch(args[0], repo)
-			}
-			printMainBranch(repo)
-			return nil
+			return runConfigMainbranch(args, repo)
 		},
 	}
+}
+
+func runConfigMainbranch(args []string, repo *git.ProdRepo) error {
+	if len(args) > 0 {
+		return setMainBranch(args[0], repo)
+	}
+	printMainBranch(repo)
+	return nil
 }
 
 func printMainBranch(repo *git.ProdRepo) {

--- a/src/cmd/config_offline.go
+++ b/src/cmd/config_offline.go
@@ -18,12 +18,16 @@ func offlineCmd(repo *git.ProdRepo) *cobra.Command {
 
 Git Town avoids network operations in offline mode.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return setOfflineStatus(args[0], repo)
-			}
-			return displayOfflineStatus(repo)
+			return runConfigOffline(args, repo)
 		},
 	}
+}
+
+func runConfigOffline(args []string, repo *git.ProdRepo) error {
+	if len(args) > 0 {
+		return setOfflineStatus(args[0], repo)
+	}
+	return displayOfflineStatus(repo)
 }
 
 func displayOfflineStatus(repo *git.ProdRepo) error {

--- a/src/cmd/config_pull_branch_strategy.go
+++ b/src/cmd/config_pull_branch_strategy.go
@@ -19,12 +19,16 @@ The pull branch strategy specifies what strategy to use
 when merging remote tracking branches into local branches
 for the main branch and perennial branches.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return setPullBranchStrategy(args[0], repo)
-			}
-			return displayPullBranchStrategy(repo)
+			return runConfigPullBranchStrategy(args, repo)
 		},
 	}
+}
+
+func runConfigPullBranchStrategy(args []string, repo *git.ProdRepo) error {
+	if len(args) > 0 {
+		return setPullBranchStrategy(args[0], repo)
+	}
+	return displayPullBranchStrategy(repo)
 }
 
 func displayPullBranchStrategy(repo *git.ProdRepo) error {

--- a/src/cmd/config_push_hook.go
+++ b/src/cmd/config_push_hook.go
@@ -20,14 +20,18 @@ func pushHookCommand(repo *git.ProdRepo) *cobra.Command {
 
 Enabled by default. When disabled, Git Town prevents Git's pre-push hook from running.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return setPushHook(args[0], globalFlag, repo)
-			}
-			return printPushHook(globalFlag, repo)
+			return runConfigPushHook(args, globalFlag, repo)
 		},
 	}
 	pushHookCmd.Flags().BoolVar(&globalFlag, "global", false, "Displays or sets the global push hook flag")
 	return &pushHookCmd
+}
+
+func runConfigPushHook(args []string, globalFlag bool, repo *git.ProdRepo) error {
+	if len(args) > 0 {
+		return setPushHook(args[0], globalFlag, repo)
+	}
+	return printPushHook(globalFlag, repo)
 }
 
 func printPushHook(globalFlag bool, repo *git.ProdRepo) error {

--- a/src/cmd/config_push_new_branches.go
+++ b/src/cmd/config_push_new_branches.go
@@ -21,14 +21,18 @@ func pushNewBranchesCommand(repo *git.ProdRepo) *cobra.Command {
 If "push-new-branches" is true, the Git Town commands hack, append, and prepend
 push the new branch to the origin remote.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return setPushNewBranches(args[0], globalFlag, repo)
-			}
-			return printPushNewBranches(globalFlag, repo)
+			return runConfigPushNewBranches(args, globalFlag, repo)
 		},
 	}
 	pushNewBranchesCmd.Flags().BoolVar(&globalFlag, "global", false, "Displays or sets your global new branch push flag")
 	return &pushNewBranchesCmd
+}
+
+func runConfigPushNewBranches(args []string, globalFlag bool, repo *git.ProdRepo) error {
+	if len(args) > 0 {
+		return setPushNewBranches(args[0], globalFlag, repo)
+	}
+	return printPushNewBranches(globalFlag, repo)
 }
 
 func printPushNewBranches(globalFlag bool, repo *git.ProdRepo) error {

--- a/src/cmd/config_reset.go
+++ b/src/cmd/config_reset.go
@@ -12,7 +12,11 @@ func resetConfigCommand(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, isRepository),
 		Short:   "Resets your Git Town configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return repo.Config.RemoveLocalGitConfiguration()
+			return runConfigReset(repo)
 		},
 	}
+}
+
+func runConfigReset(repo *git.ProdRepo) error {
+	return repo.Config.RemoveLocalGitConfiguration()
 }

--- a/src/cmd/config_setup.go
+++ b/src/cmd/config_setup.go
@@ -13,11 +13,15 @@ func setupConfigCommand(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, isRepository),
 		Short:   "Prompts to setup your Git Town configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := validate.EnterMainBranch(repo)
-			if err != nil {
-				return err
-			}
-			return validate.EnterPerennialBranches(repo)
+			return runConfigSetup(repo)
 		},
 	}
+}
+
+func runConfigSetup(repo *git.ProdRepo) error {
+	err := validate.EnterMainBranch(repo)
+	if err != nil {
+		return err
+	}
+	return validate.EnterPerennialBranches(repo)
 }

--- a/src/cmd/config_sync_strategy.go
+++ b/src/cmd/config_sync_strategy.go
@@ -19,14 +19,18 @@ func syncStrategyCommand(repo *git.ProdRepo) *cobra.Command {
 The sync strategy specifies what strategy to use
 when merging remote tracking branches into local feature branches.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return setSyncStrategy(globalFlag, repo, args[0])
-			}
-			return printSyncStrategy(globalFlag, repo)
+			return runConfigSyncStrategy(args, globalFlag, repo)
 		},
 	}
 	syncStrategyCmd.Flags().BoolVar(&globalFlag, "global", false, "Displays or sets the global sync strategy")
 	return &syncStrategyCmd
+}
+
+func runConfigSyncStrategy(args []string, globalFlag bool, repo *git.ProdRepo) error {
+	if len(args) > 0 {
+		return setSyncStrategy(globalFlag, repo, args[0])
+	}
+	return printSyncStrategy(globalFlag, repo)
 }
 
 func printSyncStrategy(globalFlag bool, repo *git.ProdRepo) error {

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -18,25 +18,29 @@ func continueCmd(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, hasGitVersion, isRepository, isConfigured),
 		Short:   "Restarts the last run git-town command after having resolved conflicts",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runState, err := runstate.Load(repo)
-			if err != nil {
-				return fmt.Errorf("cannot load previous run state: %w", err)
-			}
-			if runState == nil || !runState.IsUnfinished() {
-				return fmt.Errorf("nothing to continue")
-			}
-			hasConflicts, err := repo.Silent.HasConflicts()
-			if err != nil {
-				return err
-			}
-			if hasConflicts {
-				return fmt.Errorf("you must resolve the conflicts before continuing")
-			}
-			connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
-			if err != nil {
-				return err
-			}
-			return runstate.Execute(runState, repo, connector)
+			return runContinue(repo)
 		},
 	}
+}
+
+func runContinue(repo *git.ProdRepo) error {
+	runState, err := runstate.Load(repo)
+	if err != nil {
+		return fmt.Errorf("cannot load previous run state: %w", err)
+	}
+	if runState == nil || !runState.IsUnfinished() {
+		return fmt.Errorf("nothing to continue")
+	}
+	hasConflicts, err := repo.Silent.HasConflicts()
+	if err != nil {
+		return err
+	}
+	if hasConflicts {
+		return fmt.Errorf("you must resolve the conflicts before continuing")
+	}
+	connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
+	if err != nil {
+		return err
+	}
+	return runstate.Execute(runState, repo, connector)
 }

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -21,13 +21,17 @@ Works on either the current branch or the branch name provided.
 
 Exits with error code 1 if the given branch is a perennial branch or the main branch.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determineDiffParentConfig(args, repo)
-			if err != nil {
-				return err
-			}
-			return repo.Logging.DiffParent(config.branch, config.parentBranch)
+			return runDiffParent(args, repo)
 		},
 	}
+}
+
+func runDiffParent(args []string, repo *git.ProdRepo) error {
+	config, err := determineDiffParentConfig(args, repo)
+	if err != nil {
+		return err
+	}
+	return repo.Logging.DiffParent(config.branch, config.parentBranch)
 }
 
 type diffParentConfig struct {

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -27,20 +27,24 @@ and brings over all uncommitted changes to the new feature branch.
 
 See "sync" for information regarding upstream remotes.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determineHackConfig(args, promptForParentFlag, repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := appendStepList(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("hack", stepList)
-			return runstate.Execute(runState, repo, nil)
+			return runHack(args, promptForParentFlag, repo)
 		},
 	}
 	hackCmd.Flags().BoolVarP(&promptForParentFlag, "prompt", "p", false, "Prompt for the parent branch")
 	return &hackCmd
+}
+
+func runHack(args []string, promptForParentFlag bool, repo *git.ProdRepo) error {
+	config, err := determineHackConfig(args, promptForParentFlag, repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := appendStepList(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("hack", stepList)
+	return runstate.Execute(runState, repo, nil)
 }
 
 func determineHackConfig(args []string, promptForParent bool, repo *git.ProdRepo) (*appendConfig, error) {

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -21,18 +21,22 @@ func killCommand(repo *git.ProdRepo) *cobra.Command {
 Deletes the current or provided branch from the local and origin repositories.
 Does not delete perennial branches nor the main branch.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determineKillConfig(args, repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := killStepList(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("kill", stepList)
-			return runstate.Execute(runState, repo, nil)
+			return runKill(args, repo)
 		},
 	}
+}
+
+func runKill(args []string, repo *git.ProdRepo) error {
+	config, err := determineKillConfig(args, repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := killStepList(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("kill", stepList)
+	return runstate.Execute(runState, repo, nil)
 }
 
 type killConfig struct {

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -37,25 +37,29 @@ When using SSH identities, this command needs to be configured with
 "git config %s <hostname>"
 where hostname matches what is in your ssh config file.`, config.CodeHostingDriverKey, config.CodeHostingOriginHostnameKey),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determineNewPullRequestConfig(repo)
-			if err != nil {
-				return err
-			}
-			connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
-			if err != nil {
-				return err
-			}
-			if connector == nil {
-				return hosting.UnsupportedServiceError()
-			}
-			stepList, err := newPullRequestStepList(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("new-pull-request", stepList)
-			return runstate.Execute(runState, repo, connector)
+			return runNewPullRequest(repo)
 		},
 	}
+}
+
+func runNewPullRequest(repo *git.ProdRepo) error {
+	config, err := determineNewPullRequestConfig(repo)
+	if err != nil {
+		return err
+	}
+	connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
+	if err != nil {
+		return err
+	}
+	if connector == nil {
+		return hosting.UnsupportedServiceError()
+	}
+	stepList, err := newPullRequestStepList(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("new-pull-request", stepList)
+	return runstate.Execute(runState, repo, connector)
 }
 
 type newPullRequestConfig struct {

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -29,18 +29,22 @@ and brings over all uncommitted changes to the new feature branch.
 See "sync" for upstream remote options.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determinePrependConfig(args, repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := prependStepList(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("prepend", stepList)
-			return runstate.Execute(runState, repo, nil)
+			return runPrepend(args, repo)
 		},
 	}
+}
+
+func runPrepend(args []string, repo *git.ProdRepo) error {
+	config, err := determinePrependConfig(args, repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := prependStepList(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("prepend", stepList)
+	return runstate.Execute(runState, repo, nil)
 }
 
 type prependConfig struct {

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -18,18 +18,22 @@ func pruneBranchesCommand(repo *git.ProdRepo) *cobra.Command {
 Deletes branches whose tracking branch no longer exists from the local repository.
 This usually means the branch was shipped or killed on another machine.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determinePruneBranchesConfig(repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := pruneBranchesStepList(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("prune-branches", stepList)
-			return runstate.Execute(runState, repo, nil)
+			return runPruneBranches(repo)
 		},
 	}
+}
+
+func runPruneBranches(repo *git.ProdRepo) error {
+	config, err := determinePruneBranchesConfig(repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := pruneBranchesStepList(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("prune-branches", stepList)
+	return runstate.Execute(runState, repo, nil)
 }
 
 type pruneBranchesConfig struct {

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -35,20 +35,24 @@ When run on a perennial branch
 - confirm with the "-f" option
 - registers the new perennial branch name in the local Git Town configuration`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := determineRenameBranchConfig(args, forceFlag, repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := renameBranchStepList(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("rename-branch", stepList)
-			return runstate.Execute(runState, repo, nil)
+			return runRenameBranch(args, forceFlag, repo)
 		},
 	}
 	renameBranchCmd.Flags().BoolVar(&forceFlag, "force", false, "Force rename of perennial branch")
 	return renameBranchCmd
+}
+
+func runRenameBranch(args []string, forceFlag bool, repo *git.ProdRepo) error {
+	config, err := determineRenameBranchConfig(args, forceFlag, repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := renameBranchStepList(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("rename-branch", stepList)
+	return runstate.Execute(runState, repo, nil)
 }
 
 type renameBranchConfig struct {

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -29,15 +29,19 @@ When using SSH identities, run
 "git config %s <HOSTNAME>"
 where HOSTNAME matches what is in your ssh config file.`, config.CodeHostingDriverKey, config.CodeHostingOriginHostnameKey),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
-			if err != nil {
-				return err
-			}
-			if connector == nil {
-				return hosting.UnsupportedServiceError()
-			}
-			browser.Open(connector.RepositoryURL(), repo.LoggingRunner)
-			return nil
+			return runRepo(repo)
 		},
 	}
+}
+
+func runRepo(repo *git.ProdRepo) error {
+	connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
+	if err != nil {
+		return err
+	}
+	if connector == nil {
+		return hosting.UnsupportedServiceError()
+	}
+	browser.Open(connector.RepositoryURL(), repo.LoggingRunner)
+	return nil
 }

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -17,22 +17,26 @@ func setParentCommand(repo *git.ProdRepo) *cobra.Command {
 		Short:   "Prompts to set the parent branch for the current branch",
 		Long:    `Prompts to set the parent branch for the current branch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			currentBranch, err := repo.Silent.CurrentBranch()
-			if err != nil {
-				return err
-			}
-			if !repo.Config.IsFeatureBranch(currentBranch) {
-				return errors.New("only feature branches can have parent branches")
-			}
-			defaultParentBranch := repo.Config.ParentBranch(currentBranch)
-			if defaultParentBranch == "" {
-				defaultParentBranch = repo.Config.MainBranch()
-			}
-			err = repo.Config.RemoveParentBranch(currentBranch)
-			if err != nil {
-				return err
-			}
-			return validate.KnowsBranchAncestry(currentBranch, defaultParentBranch, repo)
+			return runSetParent(repo)
 		},
 	}
+}
+
+func runSetParent(repo *git.ProdRepo) error {
+	currentBranch, err := repo.Silent.CurrentBranch()
+	if err != nil {
+		return err
+	}
+	if !repo.Config.IsFeatureBranch(currentBranch) {
+		return errors.New("only feature branches can have parent branches")
+	}
+	defaultParentBranch := repo.Config.ParentBranch(currentBranch)
+	if defaultParentBranch == "" {
+		defaultParentBranch = repo.Config.MainBranch()
+	}
+	err = repo.Config.RemoveParentBranch(currentBranch)
+	if err != nil {
+		return err
+	}
+	return validate.KnowsBranchAncestry(currentBranch, defaultParentBranch, repo)
 }

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -49,24 +49,28 @@ GitHub's feature to automatically delete head branches,
 run "git config %s false"
 and Git Town will leave it up to your origin server to delete the remote branch.`, config.GithubTokenKey, config.ShipDeleteRemoteBranchKey),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
-			if err != nil {
-				return err
-			}
-			config, err := determineShipConfig(args, connector, repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := shipStepList(config, commitMessage, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("ship", stepList)
-			return runstate.Execute(runState, repo, connector)
+			return runShip(repo, args, commitMessage)
 		},
 	}
 	shipCmd.Flags().StringVarP(&commitMessage, "message", "m", "", "Specify the commit message for the squash commit")
 	return &shipCmd
+}
+
+func runShip(repo *git.ProdRepo, args []string, commitMessage string) error {
+	connector, err := hosting.NewConnector(repo.Config, &repo.Silent, cli.PrintConnectorAction)
+	if err != nil {
+		return err
+	}
+	config, err := determineShipConfig(args, connector, repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := shipStepList(config, commitMessage, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("ship", stepList)
+	return runstate.Execute(runState, repo, connector)
 }
 
 type shipConfig struct {

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -16,18 +16,22 @@ func skipCmd(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, hasGitVersion, isRepository, isConfigured),
 		Short:   "Restarts the last run git-town command by skipping the current branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runState, err := runstate.Load(repo)
-			if err != nil {
-				return fmt.Errorf("cannot load previous run state: %w", err)
-			}
-			if runState == nil || !runState.IsUnfinished() {
-				return fmt.Errorf("nothing to skip")
-			}
-			if !runState.UnfinishedDetails.CanSkip {
-				return fmt.Errorf("cannot skip branch that resulted in conflicts")
-			}
-			skipRunState := runState.CreateSkipRunState()
-			return runstate.Execute(&skipRunState, repo, nil)
+			return runSkip(repo)
 		},
 	}
+}
+
+func runSkip(repo *git.ProdRepo) error {
+	runState, err := runstate.Load(repo)
+	if err != nil {
+		return fmt.Errorf("cannot load previous run state: %w", err)
+	}
+	if runState == nil || !runState.IsUnfinished() {
+		return fmt.Errorf("nothing to skip")
+	}
+	if !runState.UnfinishedDetails.CanSkip {
+		return fmt.Errorf("cannot skip branch that resulted in conflicts")
+	}
+	skipRunState := runState.CreateSkipRunState()
+	return runstate.Execute(&skipRunState, repo, nil)
 }

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -19,16 +19,20 @@ func statusCommand(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, hasGitVersion, isRepository),
 		Short:   "Displays or resets the current suspended Git Town command",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := loadDisplayStatusConfig(repo)
-			if err != nil {
-				return err
-			}
-			displayStatus(*config)
-			return nil
+			return runStatus(repo)
 		},
 	}
 	cmd.AddCommand(resetRunstateCommand(repo))
 	return cmd
+}
+
+func runStatus(repo *git.ProdRepo) error {
+	config, err := loadDisplayStatusConfig(repo)
+	if err != nil {
+		return err
+	}
+	displayStatus(*config)
+	return nil
 }
 
 type displayStatusConfig struct {

--- a/src/cmd/status_reset.go
+++ b/src/cmd/status_reset.go
@@ -15,12 +15,16 @@ func resetRunstateCommand(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, hasGitVersion, isRepository),
 		Short:   "Resets the current suspended Git Town command",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := runstate.Delete(repo)
-			if err != nil {
-				return err
-			}
-			fmt.Println("Runstate file deleted.")
-			return nil
+			return runStatusReset(repo)
 		},
 	}
+}
+
+func runStatusReset(repo *git.ProdRepo) error {
+	err := runstate.Delete(repo)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Runstate file deleted.")
+	return nil
 }

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -16,23 +16,27 @@ func switchCmd(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, hasGitVersion, isRepository, isConfigured),
 		Short:   "Displays the local branches visually and allows switching between them",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			currentBranch, err := repo.Silent.CurrentBranch()
-			if err != nil {
-				return err
-			}
-			newBranch, err := queryBranch(currentBranch, repo)
-			if err != nil {
-				return err
-			}
-			if newBranch != nil && *newBranch != currentBranch {
-				err = repo.Silent.CheckoutBranch(*newBranch)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			return runSwitch(repo)
 		},
 	}
+}
+
+func runSwitch(repo *git.ProdRepo) error {
+	currentBranch, err := repo.Silent.CurrentBranch()
+	if err != nil {
+		return err
+	}
+	newBranch, err := queryBranch(currentBranch, repo)
+	if err != nil {
+		return err
+	}
+	if newBranch != nil && *newBranch != currentBranch {
+		err = repo.Silent.CheckoutBranch(*newBranch)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // queryBranch lets the user select a new branch via a visual dialog.

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -39,35 +39,39 @@ If the repository contains an "upstream" remote,
 syncs the main branch with its upstream counterpart.
 You can disable this by running "git config %s false".`, config.SyncUpstreamKey),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if dryRunFlag {
-				currentBranch, err := repo.Silent.CurrentBranch()
-				if err != nil {
-					return err
-				}
-				repo.DryRun.Activate(currentBranch)
-			}
-			exit, err := validate.HandleUnfinishedState(repo, nil)
-			if err != nil {
-				return err
-			}
-			if exit {
-				os.Exit(0)
-			}
-			config, err := determineSyncConfig(allFlag, repo)
-			if err != nil {
-				return err
-			}
-			stepList, err := syncBranchesSteps(config, repo)
-			if err != nil {
-				return err
-			}
-			runState := runstate.New("sync", stepList)
-			return runstate.Execute(runState, repo, nil)
+			return runSync(dryRunFlag, repo, allFlag)
 		},
 	}
 	syncCmd.Flags().BoolVar(&allFlag, "all", false, "Sync all local branches")
 	syncCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Print the commands but don't run them")
 	return &syncCmd
+}
+
+func runSync(dryRunFlag bool, repo *git.ProdRepo, allFlag bool) error {
+	if dryRunFlag {
+		currentBranch, err := repo.Silent.CurrentBranch()
+		if err != nil {
+			return err
+		}
+		repo.DryRun.Activate(currentBranch)
+	}
+	exit, err := validate.HandleUnfinishedState(repo, nil)
+	if err != nil {
+		return err
+	}
+	if exit {
+		os.Exit(0)
+	}
+	config, err := determineSyncConfig(allFlag, repo)
+	if err != nil {
+		return err
+	}
+	stepList, err := syncBranchesSteps(config, repo)
+	if err != nil {
+		return err
+	}
+	runState := runstate.New("sync", stepList)
+	return runstate.Execute(runState, repo, nil)
 }
 
 type syncConfig struct {

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -16,15 +16,19 @@ func undoCmd(repo *git.ProdRepo) *cobra.Command {
 		PreRunE: ensure(repo, hasGitVersion, isRepository, isConfigured),
 		Short:   "Undoes the last run git-town command",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runState, err := runstate.Load(repo)
-			if err != nil {
-				return fmt.Errorf("cannot load previous run state: %w", err)
-			}
-			if runState == nil || runState.IsUnfinished() {
-				return fmt.Errorf("nothing to undo")
-			}
-			undoRunState := runState.CreateUndoRunState()
-			return runstate.Execute(&undoRunState, repo, nil)
+			return runUndo(repo)
 		},
 	}
+}
+
+func runUndo(repo *git.ProdRepo) error {
+	runState, err := runstate.Load(repo)
+	if err != nil {
+		return fmt.Errorf("cannot load previous run state: %w", err)
+	}
+	if runState == nil || runState.IsUnfinished() {
+		return fmt.Errorf("nothing to undo")
+	}
+	undoRunState := runState.CreateUndoRunState()
+	return runstate.Execute(&undoRunState, repo, nil)
 }


### PR DESCRIPTION
This separates the concerns of defining Cobra commands and running the business logic for those commands. It also makes the business logic available as a Go function that could potentially be called directly from tests.