### PR TITLE
Remove BackendRunner from FrontendCommands

### DIFF
--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -60,7 +60,7 @@ func repo(debug bool) error {
 	if connector == nil {
 		return hosting.UnsupportedServiceError()
 	}
-	browser.Open(connector.RepositoryURL(), run.Frontend.Frontend, run.Backend.BackendRunner)
+	browser.Open(connector.RepositoryURL(), run.Frontend, run.Backend.BackendRunner)
 	run.Stats.PrintAnalysis()
 	return nil
 }

--- a/src/execute/load_prod_runner.go
+++ b/src/execute/load_prod_runner.go
@@ -17,17 +17,15 @@ func LoadProdRunner(args LoadArgs) (prodRunner git.ProdRunner, exit bool, err er
 	}
 	backendRunner := NewBackendRunner(nil, args.Debug, stats)
 	config := git.NewRepoConfig(backendRunner)
-	backendCommands := git.BackendCommands{
-		BackendRunner: backendRunner,
-		Config:        &config,
-	}
 	prodRunner = git.ProdRunner{
-		Config:  config,
-		Backend: backendCommands,
+		Config: config,
+		Backend: git.BackendCommands{
+			BackendRunner: backendRunner,
+			Config:        &config,
+		},
 		Frontend: git.FrontendCommands{
-			Frontend: NewFrontendRunner(args.OmitBranchNames, args.DryRun, config.CurrentBranchCache, stats),
-			Config:   &config,
-			Backend:  &backendCommands,
+			FrontendRunner: NewFrontendRunner(args.OmitBranchNames, args.DryRun, config.CurrentBranchCache, stats),
+			Config:         &config,
 		},
 		Stats: stats,
 	}

--- a/src/steps/create_proposal_step.go
+++ b/src/steps/create_proposal_step.go
@@ -18,6 +18,6 @@ func (step *CreateProposalStep) Run(run *git.ProdRunner, connector hosting.Conne
 	if err != nil {
 		return err
 	}
-	browser.Open(prURL, run.Frontend.Frontend, run.Backend)
+	browser.Open(prURL, run.Frontend, run.Backend)
 	return nil
 }

--- a/src/validate/is_repository.go
+++ b/src/validate/is_repository.go
@@ -2,6 +2,8 @@ package validate
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/git-town/git-town/v7/src/git"
 )
@@ -12,5 +14,16 @@ func IsRepository(run *git.ProdRunner) error {
 	if !run.Backend.IsRepository() {
 		return errors.New("this is not a Git repository")
 	}
-	return run.Frontend.NavigateToRootIfNecessary()
+	currentDirectory, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cannot get current working directory: %w", err)
+	}
+	gitRootDirectory, err := run.Backend.RootDirectory()
+	if err != nil {
+		return err
+	}
+	if currentDirectory != gitRootDirectory {
+		return run.Frontend.NavigateToDir(gitRootDirectory)
+	}
+	return nil
 }


### PR DESCRIPTION
Keep FrontendCommands focused on running frontend commands. Stuff that needs a BackendRunner gets provided from the callsite.