### PR TITLE
Simplify the fetch in test code

### DIFF
--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -9,7 +9,7 @@ import (
 type DeleteParentBranchStep struct {
 	EmptyStep
 	Branch string
-	Parent string // TODO: make public and populate as part of creating this step
+	Parent string
 }
 
 func (step *DeleteParentBranchStep) CreateUndoStep(backend *git.BackendCommands) (Step, error) {

--- a/src/steps/fetch_upstream_step.go
+++ b/src/steps/fetch_upstream_step.go
@@ -12,7 +12,6 @@ type FetchUpstreamStep struct {
 	Branch string
 }
 
-// TODO: is this used?
 func (step *FetchUpstreamStep) Run(run *git.ProdRunner, connector hosting.Connector) error {
 	return run.Frontend.FetchUpstream(step.Branch)
 }

--- a/test/commit.go
+++ b/test/commit.go
@@ -5,7 +5,6 @@ import (
 )
 
 // Commit describes a Git commit.
-// TODO: move into the "test" package.
 type Commit struct {
 	Author      string `exhaustruct:"optional"`
 	Branch      string

--- a/test/runner.go
+++ b/test/runner.go
@@ -50,7 +50,6 @@ func initRunner(workingDir, homeDir, binDir string) (Runner, error) {
 
 // newRunner provides a new test.Runner instance working in the given directory.
 // The directory must contain an existing Git repo.
-// TODO: inline this method.
 func newRunner(workingDir, homeDir, binDir string) Runner {
 	mockingRunner := MockingRunner{
 		workingDir: workingDir,

--- a/test/test_commands.go
+++ b/test/test_commands.go
@@ -241,7 +241,7 @@ func (r *testCommands) DeleteMainBranchConfiguration() error {
 
 // Fetch retrieves the updates from the origin repo.
 func (r *testCommands) Fetch() error {
-	_, err := r.Run("git", "fetch", "--prune", "--tags") // TODO: remove --prune or --tags here?
+	_, err := r.Run("git", "fetch")
 	return err
 }
 


### PR DESCRIPTION
Don't fetch tags or pruned branches when setting up the test fixture.