### PR TITLE
Output raw bytes from subprocess

### DIFF
--- a/src/subshell/backend_runner.go
+++ b/src/subshell/backend_runner.go
@@ -2,6 +2,7 @@ package subshell
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -32,11 +33,10 @@ func (r BackendRunner) Run(executable string, args ...string) (string, error) {
 	if err != nil {
 		err = ErrorDetails(executable, args, err, outputBytes)
 	}
-	output := strings.TrimSpace(stripansi.Strip(string(outputBytes)))
-	if r.Verbose && output != "" {
-		fmt.Println(output)
+	if r.Verbose && len(outputBytes) > 0 {
+		os.Stdout.Write(outputBytes)
 	}
-	return output, err
+	return strings.TrimSpace(stripansi.Strip(string(outputBytes))), err
 }
 
 // RunMany runs all given commands in current directory.

--- a/test/subshell/test_runner.go
+++ b/test/subshell/test_runner.go
@@ -228,12 +228,11 @@ func (r *TestRunner) RunWith(opts *Options, cmd string, args ...string) (string,
 	exitCode := subProcess.ProcessState.ExitCode()
 	if r.Debug {
 		fmt.Println(filepath.Base(r.WorkingDir), ">", cmd, strings.Join(args, " "))
-		fmt.Println(output.String())
+		os.Stdout.Write(output.Bytes())
 		if err != nil {
 			fmt.Printf("ERROR: %v\n", err)
 		}
 	}
-
 	if exitCode != 0 {
 		err = fmt.Errorf("process \"%s %s\" failed with code %d, output:\n%s", cmd, strings.Join(args, " "), exitCode, output.String())
 	}


### PR DESCRIPTION
When debug mode is enabled, it's faster and more accurate to output the raw bytes captured from the subprocess rather than the sanitized and trimmed string.