### PR TITLE
Update GitLab merge request URL

### DIFF
--- a/features/new_pull_request/features/self_hosted.feature
+++ b/features/new_pull_request/features/self_hosted.feature
@@ -17,4 +17,4 @@ Feature: self-hosted service
       | bitbucket | https://self-hosted/git-town/git-town/pull-request/new?dest=git-town%2Fgit-town%3A%3Amain&source=git-town%2Fgit-town%.*%3Afeature       |
       | github    | https://self-hosted/git-town/git-town/compare/feature?expand=1                                                                          |
       | gitea     | https://self-hosted/git-town/git-town/compare/main...feature                                                                            |
-      | gitlab    | https://self-hosted/git-town/git-town/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main |
+      | gitlab    | https://self-hosted/git-town/git-town/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main |

--- a/features/new_pull_request/features/ssh_identity.feature
+++ b/features/new_pull_request/features/ssh_identity.feature
@@ -16,4 +16,4 @@ Feature: use a SSH identity
       | ORIGIN_HOSTNAME | PULL_REQUEST_URL                                                                                                                       |
       | bitbucket.org   | https://bitbucket.org/git-town/git-town/pull-request/new?dest=git-town%2Fgit-town%3A%3Amain&source=git-town%2Fgit-town%.*%3Afeature    |
       | github.com      | https://github.com/git-town/git-town/compare/feature?expand=1                                                                          |
-      | gitlab.com      | https://gitlab.com/git-town/git-town/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main |
+      | gitlab.com      | https://gitlab.com/git-town/git-town/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main |

--- a/features/new_pull_request/gitlab.feature
+++ b/features/new_pull_request/gitlab.feature
@@ -15,9 +15,9 @@ Feature: GitLab support
 
     Examples:
       | REPO ORIGIN                                  | BROWSER URL                                                                                                                                    |
-      | https://gitlab.com/kadu/kadu.git             | https://gitlab.com/kadu/kadu/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main                 |
-      | git@gitlab.com:kadu/kadu.git                 | https://gitlab.com/kadu/kadu/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main                 |
-      | git@gitlab.com:gitlab-com/www-gitlab-com.git | https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main |
+      | https://gitlab.com/kadu/kadu.git             | https://gitlab.com/kadu/kadu/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main                 |
+      | git@gitlab.com:kadu/kadu.git                 | https://gitlab.com/kadu/kadu/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main                 |
+      | git@gitlab.com:gitlab-com/www-gitlab-com.git | https://gitlab.com/gitlab-com/www-gitlab-com/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main |
 
   Scenario: nested feature branch with known parent
     Given a feature branch "parent"
@@ -27,5 +27,5 @@ Feature: GitLab support
     When I run "git-town new-pull-request"
     Then "open" launches a new pull request with this url in my browser:
       """
-      https://gitlab.com/kadu/kadu/merge_requests/new?merge_request%5Bsource_branch%5D=child&merge_request%5Btarget_branch%5D=parent
+      https://gitlab.com/kadu/kadu/-/merge_requests/new?merge_request%5Bsource_branch%5D=child&merge_request%5Btarget_branch%5D=parent
       """

--- a/src/hosting/gitlab.go
+++ b/src/hosting/gitlab.go
@@ -127,7 +127,7 @@ func (c *GitLabConfig) NewProposalURL(branch, parentBranch string) (string, erro
 	query := url.Values{}
 	query.Add("merge_request[source_branch]", branch)
 	query.Add("merge_request[target_branch]", parentBranch)
-	return fmt.Sprintf("%s/merge_requests/new?%s", c.RepositoryURL(), query.Encode()), nil
+	return fmt.Sprintf("%s/-/merge_requests/new?%s", c.RepositoryURL(), query.Encode()), nil
 }
 
 func (c *GitLabConfig) RepositoryURL() string {

--- a/src/hosting/gitlab_test.go
+++ b/src/hosting/gitlab_test.go
@@ -10,11 +10,11 @@ import (
 const (
 	projectPathEnc  = `git-town%2Fgit-town`
 	gitlabRoot      = "https://gitlab.com/api/v4"
-	gitlabCurrOpen  = gitlabRoot + "/projects/" + projectPathEnc + "/merge_requests?source_branch=feature&state=opened&target_branch=main"
-	gitlabChildOpen = gitlabRoot + "/projects/" + projectPathEnc + "/merge_requests?state=opened&target_branch=feature"
-	gitlabMR2       = gitlabRoot + "/projects/" + projectPathEnc + "/merge_requests/2"
-	gitlabMR3       = gitlabRoot + "/projects/" + projectPathEnc + "/merge_requests/3"
-	gitlabMR1Merge  = gitlabRoot + "/projects/" + projectPathEnc + "/merge_requests/1/merge"
+	gitlabCurrOpen  = gitlabRoot + "/projects/" + projectPathEnc + "/-/merge_requests?source_branch=feature&state=opened&target_branch=main"
+	gitlabChildOpen = gitlabRoot + "/projects/" + projectPathEnc + "/-/merge_requests?state=opened&target_branch=feature"
+	gitlabMR2       = gitlabRoot + "/projects/" + projectPathEnc + "/-/merge_requests/2"
+	gitlabMR3       = gitlabRoot + "/projects/" + projectPathEnc + "/-/merge_requests/3"
+	gitlabMR1Merge  = gitlabRoot + "/projects/" + projectPathEnc + "/-/merge_requests/1/merge"
 )
 
 func TestNewGitlabConnector(t *testing.T) {
@@ -94,17 +94,17 @@ func TestGitlabConnector(t *testing.T) {
 			"top-level branch": {
 				branch: "feature",
 				parent: "main",
-				want:   "https://gitlab.com/organization/repo/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main",
+				want:   "https://gitlab.com/organization/repo/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature&merge_request%5Btarget_branch%5D=main",
 			},
 			"nested branch": {
 				branch: "feature-3",
 				parent: "feature-2",
-				want:   "https://gitlab.com/organization/repo/merge_requests/new?merge_request%5Bsource_branch%5D=feature-3&merge_request%5Btarget_branch%5D=feature-2",
+				want:   "https://gitlab.com/organization/repo/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature-3&merge_request%5Btarget_branch%5D=feature-2",
 			},
 			"special characters in branch name": {
 				branch: "feature-#",
 				parent: "main",
-				want:   "https://gitlab.com/organization/repo/merge_requests/new?merge_request%5Bsource_branch%5D=feature-%23&merge_request%5Btarget_branch%5D=main",
+				want:   "https://gitlab.com/organization/repo/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature-%23&merge_request%5Btarget_branch%5D=main",
 			},
 		}
 		for name, test := range tests {


### PR DESCRIPTION
GitLab versions 16.x and later removed the redirect that was in place for the URL that Git Town currently uses, which will break the functionality to open new pull/merge requests. The new URL has been in place since (at least) GitLab version 15.x, so this change is backwards-compatible. I was not able to access GitLab installations older than that.

GitLab 16.x is rolled out partially already on GitLab.com, and will be fully rolled out in the next days, which will break Git Town for all users of GitLab.com starting Tuesday.