### PR TITLE
Rename ancestry to lineage

### DIFF
--- a/features/append/append.feature
+++ b/features/append/append.feature
@@ -28,7 +28,7 @@ Feature: append a new feature branch to an existing feature branch
       | BRANCH   | LOCATION      | MESSAGE         |
       | existing | local, origin | existing commit |
       | new      | local         | existing commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT   |
       | existing | main     |
       | new      | existing |

--- a/features/append/edge_cases/on_main_branch.feature
+++ b/features/append/edge_cases/on_main_branch.feature
@@ -24,7 +24,7 @@ Feature: on the main branch
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |
       | new    | local         | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 

--- a/features/append/edge_cases/unknown_parent.feature
+++ b/features/append/edge_cases/unknown_parent.feature
@@ -5,7 +5,7 @@ Feature: ask for missing parent branch information
     When I run "git-town append new" and answer the prompts:
       | PROMPT                                        | ANSWER  |
       | Please specify the parent branch of 'feature' | [ENTER] |
-    Then this branch hierarchy exists now
+    Then this branch lineage exists now
       | BRANCH  | PARENT  |
       | feature | main    |
       | new     | feature |

--- a/features/append/features/local_repo.feature
+++ b/features/append/features/local_repo.feature
@@ -22,7 +22,7 @@ Feature: in a local repo
     And now these commits exist
       | BRANCH   | LOCATION | MESSAGE         |
       | existing | local    | existing commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT |
       | existing | main   |
       | new      | main   |

--- a/features/append/features/on_perennial_branch.feature
+++ b/features/append/features/on_perennial_branch.feature
@@ -20,7 +20,7 @@ Feature: append to a perennial branch
       | BRANCH     | LOCATION      | MESSAGE           |
       | new        | local         | production commit |
       | production | local, origin | production commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT     |
       | new    | production |
 

--- a/features/append/features/push_hook.feature
+++ b/features/append/features/push_hook.feature
@@ -22,7 +22,7 @@ Feature: auto-push the new branch to origin without running Git push hooks
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |
       | new    | local, origin | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 
@@ -41,6 +41,6 @@ Feature: auto-push the new branch to origin without running Git push hooks
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |
       | new    | local, origin | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |

--- a/features/append/features/push_new_branches.feature
+++ b/features/append/features/push_new_branches.feature
@@ -21,7 +21,7 @@ Feature: auto-push the new branch to origin
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |
       | new    | local, origin | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -53,7 +53,7 @@ Feature: show the configuration
         GitLab token: (not set)
         Gitea token: (not set)
 
-      Branch Ancestry:
+      Branch Lineage:
         main
           alpha
             child

--- a/features/diff_parent/current_branch/edge_cases/unknown_parent.feature
+++ b/features/diff_parent/current_branch/edge_cases/unknown_parent.feature
@@ -9,6 +9,6 @@ Feature: ask for missing parent
     Then it runs the commands
       | BRANCH  | COMMAND                |
       | feature | git diff main..feature |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH  | PARENT |
       | feature | main   |

--- a/features/diff_parent/supplied_branch/edge_cases/unknown_parent.feature
+++ b/features/diff_parent/supplied_branch/edge_cases/unknown_parent.feature
@@ -10,6 +10,6 @@ Feature: ask for missing parent
     Then it runs the commands
       | BRANCH | COMMAND                |
       | main   | git diff main..feature |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH  | PARENT |
       | feature | main   |

--- a/features/hack/edge_cases/in_committed_subfolder.feature
+++ b/features/hack/edge_cases/in_committed_subfolder.feature
@@ -17,7 +17,7 @@ Feature: inside a committed subfolder that exists only on the current feature br
       |          | git checkout new         |
     And the current branch is now "new"
     And now the initial commits exist
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT |
       | existing | main   |
       | new      | main   |

--- a/features/hack/edge_cases/in_uncommitted_subfolder.feature
+++ b/features/hack/edge_cases/in_uncommitted_subfolder.feature
@@ -25,7 +25,7 @@ Feature: inside an uncommitted subfolder on the current feature branch
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |
       | new    | local         | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT |
       | existing | main   |
       | new      | main   |

--- a/features/hack/edge_cases/main_branch_subfolder.feature
+++ b/features/hack/edge_cases/main_branch_subfolder.feature
@@ -25,7 +25,7 @@ Feature: in a subfolder on the main branch
       | BRANCH | LOCATION      | MESSAGE       |
       | main   | local, origin | folder commit |
       | new    | local         | folder commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 

--- a/features/hack/edge_cases/unconfigured.feature
+++ b/features/hack/edge_cases/unconfigured.feature
@@ -16,7 +16,7 @@ Feature: missing configuration
       |        | git checkout feature     |
     And the main branch is now "main"
     And the current branch is now "feature"
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH  | PARENT |
       | feature | main   |
 

--- a/features/hack/features/custom_parent.feature
+++ b/features/hack/features/custom_parent.feature
@@ -17,7 +17,7 @@ Feature: customize the parent for the new feature branch
       |          | git branch new existing     |
       |          | git checkout new            |
     And the current branch is now "new"
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT   |
       | existing | main     |
       | new      | existing |
@@ -30,6 +30,6 @@ Feature: customize the parent for the new feature branch
       | existing | git branch -D new         |
       |          | git push origin :existing |
     And the current branch is now "existing"
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT |
       | existing | main   |

--- a/features/hack/features/local_repo.feature
+++ b/features/hack/features/local_repo.feature
@@ -23,7 +23,7 @@ Feature: local repo
       | BRANCH | LOCATION | MESSAGE     |
       | main   | local    | main commit |
       | new    | local    | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT |
       | existing | main   |
       | new      | main   |
@@ -40,6 +40,6 @@ Feature: local repo
     And the current branch is now "existing"
     And the uncommitted file still exists
     And now the initial commits exist
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT |
       | existing | main   |

--- a/features/hack/features/offline.feature
+++ b/features/hack/features/offline.feature
@@ -23,7 +23,7 @@ Feature: offline mode
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |
       | new    | local         | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 

--- a/features/hack/features/push_new_branches.feature
+++ b/features/hack/features/push_new_branches.feature
@@ -21,7 +21,7 @@ Feature: auto-push the new branch
       | BRANCH | LOCATION      | MESSAGE       |
       | main   | local, origin | origin commit |
       | new    | local, origin | origin commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 

--- a/features/hack/features/push_new_branches_no_verify.feature
+++ b/features/hack/features/push_new_branches_no_verify.feature
@@ -22,7 +22,7 @@ Feature: auto-push the new branch without running Git push hooks
       | BRANCH | LOCATION      | MESSAGE       |
       | main   | local, origin | origin commit |
       | new    | local, origin | origin commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 
@@ -41,6 +41,6 @@ Feature: auto-push the new branch without running Git push hooks
       | BRANCH | LOCATION      | MESSAGE       |
       | main   | local, origin | origin commit |
       | new    | local, origin | origin commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |

--- a/features/hack/on_feature_branch.feature
+++ b/features/hack/on_feature_branch.feature
@@ -27,7 +27,7 @@ Feature: on the main branch
       | main     | local, origin | main commit     |
       | existing | local         | existing commit |
       | new      | local         | main commit     |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH   | PARENT |
       | existing | main   |
       | new      | main   |

--- a/features/hack/on_main_branch.feature
+++ b/features/hack/on_main_branch.feature
@@ -24,7 +24,7 @@ Feature: on a feature branch
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |
       | new    | local         | main commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 

--- a/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
@@ -27,7 +27,7 @@ Feature: the branch to kill has a deleted tracking branch
     And the branches are now
       | REPOSITORY    | BRANCHES    |
       | local, origin | main, other |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/kill/current_branch/features/local_repo.feature
+++ b/features/kill/current_branch/features/local_repo.feature
@@ -25,7 +25,7 @@ Feature: in a local repo
     And now these commits exist
       | BRANCH | LOCATION | MESSAGE      |
       | other  | local    | other commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -28,7 +28,7 @@ Feature: offline mode
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | origin        | feature commit |
       | other   | local, origin | other commit   |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/kill/current_branch/features/parent_branch.feature
+++ b/features/kill/current_branch/features/parent_branch.feature
@@ -31,7 +31,7 @@ Feature: delete a branch within a branch chain
       | BRANCH | LOCATION      | MESSAGE      |
       | alpha  | local, origin | alpha commit |
       | gamma  | local, origin | gamma commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |
       | gamma  | alpha  |

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -27,7 +27,7 @@ Feature: delete the current feature branch
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | other  | local, origin | other commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -27,7 +27,7 @@ Feature: delete the current branch
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | other  | local, origin | other commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/kill/supplied_branch/features/local_branch.feature
+++ b/features/kill/supplied_branch/features/local_branch.feature
@@ -26,7 +26,7 @@ Feature: local branch
     And now these commits exist
       | BRANCH | LOCATION | MESSAGE      |
       | other  | local    | other commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -25,7 +25,7 @@ Feature: local repository
       | BRANCH | LOCATION | MESSAGE     |
       | main   | local    | main commit |
       | good   | local    | good commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | good   | main   |
 

--- a/features/kill/supplied_branch/features/parent_branch.feature
+++ b/features/kill/supplied_branch/features/parent_branch.feature
@@ -28,7 +28,7 @@ Feature: delete a parent branch
       | BRANCH | LOCATION      | MESSAGE      |
       | alpha  | local, origin | alpha commit |
       | gamma  | local, origin | gamma commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |
       | gamma  | alpha  |

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -26,7 +26,7 @@ Feature: delete another than the current branch
       | BRANCH | LOCATION      | MESSAGE            |
       | main   | local, origin | conflicting commit |
       | good   | local, origin | good commit        |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | good   | main   |
 

--- a/features/prepend/edge_cases/unknown_parent.feature
+++ b/features/prepend/edge_cases/unknown_parent.feature
@@ -12,7 +12,7 @@ Feature: ask for missing parent information
       | main   | git rebase origin/main   |
       |        | git branch new main      |
       |        | git checkout new         |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
       | old    | new    |

--- a/features/prepend/features/offline.feature
+++ b/features/prepend/features/offline.feature
@@ -19,7 +19,7 @@ Feature: offline mode
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE    |
       | old    | local, origin | old commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
       | old    | new    |

--- a/features/prepend/features/push_new_branches.feature
+++ b/features/prepend/features/push_new_branches.feature
@@ -21,7 +21,7 @@ Feature: auto-push new branches
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE        |
       | old    | local, origin | feature commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
       | old    | new    |

--- a/features/prepend/features/push_new_branches_no_verify.feature
+++ b/features/prepend/features/push_new_branches_no_verify.feature
@@ -22,7 +22,7 @@ Feature: auto-push new branches
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE        |
       | old    | local, origin | feature commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
       | old    | new    |
@@ -42,7 +42,7 @@ Feature: auto-push new branches
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE        |
       | old    | local, origin | feature commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
       | old    | new    |

--- a/features/prepend/prepend.feature
+++ b/features/prepend/prepend.feature
@@ -24,7 +24,7 @@ Feature: prepend a branch to a feature branch
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE    |
       | old    | local, origin | old commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | old    | parent |
       | parent | main   |

--- a/features/prune_branches/edge_cases/remote_gone_local_updated.feature
+++ b/features/prune_branches/edge_cases/remote_gone_local_updated.feature
@@ -21,7 +21,7 @@ Feature: remote branch gone, local branch has additional commits
     And the branches are now
       | REPOSITORY    | BRANCHES     |
       | local, origin | main, active |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | active | main   |
 

--- a/features/prune_branches/features/debug.feature
+++ b/features/prune_branches/features/debug.feature
@@ -19,7 +19,7 @@ Feature: display debug statistics
     And the branches are now
       | REPOSITORY    | BRANCHES     |
       | local, origin | main, active |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | active | main   |
 

--- a/features/prune_branches/features/shipped_parent.feature
+++ b/features/prune_branches/features/shipped_parent.feature
@@ -20,7 +20,7 @@ Feature: a parent branch of a local branch was shipped
     And the branches are now
       | REPOSITORY    | BRANCHES    |
       | local, origin | main, child |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | child  | main   |
 

--- a/features/prune_branches/prune_branches.feature
+++ b/features/prune_branches/prune_branches.feature
@@ -22,7 +22,7 @@ Feature: delete branches that were shipped or removed on another machine
     And the branches are now
       | REPOSITORY    | BRANCHES     |
       | local, origin | main, active |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | active | main   |
 

--- a/features/rename_branch/edge_cases/offline.feature
+++ b/features/rename_branch/edge_cases/offline.feature
@@ -21,7 +21,7 @@ Feature: offline mode
       | main   | local, origin | main commit |
       | new    | local         | old commit  |
       | old    | origin        | old commit  |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |
 

--- a/features/rename_branch/features/parent_branch.feature
+++ b/features/rename_branch/features/parent_branch.feature
@@ -23,7 +23,7 @@ Feature: rename a parent branch
       | BRANCH | LOCATION      | MESSAGE       |
       | child  | local, origin | child commit  |
       | new    | local, origin | parent commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | child  | new    |
       | new    | main   |

--- a/features/rename_branch/features/perennial_branch.feature
+++ b/features/rename_branch/features/perennial_branch.feature
@@ -32,7 +32,7 @@ Feature: rename a perennial branch
       | BRANCH | LOCATION      | MESSAGE           |
       | hotfix | local, origin | hotfix commit     |
       | new    | local, origin | production commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | hotfix | new    |
 

--- a/features/set_parent_branch/debug.feature
+++ b/features/set_parent_branch/debug.feature
@@ -11,7 +11,7 @@ Feature: display debug statistics
       """
       Ran 11 shell commands.
       """
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | child  | main   |
       | parent | main   |

--- a/features/set_parent_branch/set_parent_branch.feature
+++ b/features/set_parent_branch/set_parent_branch.feature
@@ -16,7 +16,7 @@ Feature: update the parent of a feature branch
     When I run "git-town set-parent" and answer the prompts:
       | PROMPT                                      | ANSWER        |
       | Please specify the parent branch of 'child' | [DOWN][ENTER] |
-    Then this branch hierarchy exists now
+    Then this branch lineage exists now
       | BRANCH | PARENT |
       | child  | main   |
       | parent | main   |
@@ -26,6 +26,6 @@ Feature: update the parent of a feature branch
       | PROMPT                                      | ANSWER      |
       | Please specify the parent branch of 'child' | [UP][ENTER] |
     Then the perennial branches are now "child"
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | parent | main   |

--- a/features/shared/strip_colors.feature
+++ b/features/shared/strip_colors.feature
@@ -8,6 +8,6 @@ Feature: strip colors
     When I run "git-town hack new" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the main development branch | [ENTER] |
-    Then this branch hierarchy exists now
+    Then this branch lineage exists now
       | BRANCH | PARENT |
       | new    | main   |

--- a/features/ship/current_branch/features/parent_branch.feature
+++ b/features/ship/current_branch/features/parent_branch.feature
@@ -29,7 +29,7 @@ Feature: ship a parent branch
       | main   | local, origin | parent done   |
       | child  | local, origin | child commit  |
       | parent | origin        | parent commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | child  | main   |
 

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -75,7 +75,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT     |
       | main   | local, origin | conflicting main commit | conflicting_file | main content     |
       |        |               | feature done            | conflicting_file | resolved content |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -70,7 +70,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, origin | feature done |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -72,7 +72,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And the branches are now
       | REPOSITORY    | BRANCHES    |
       | local, origin | main, other |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/supplied_branch/edge_cases/in_subfolder.feature
@@ -36,7 +36,7 @@ Feature: ship the supplied feature branch from a subfolder
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, origin | feature done |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/remote_only_branch.feature
@@ -39,7 +39,7 @@ Feature: ship a branch that exists only on origin
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, origin | feature done |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 
@@ -67,7 +67,7 @@ Feature: ship a branch that exists only on origin
     And the branches are now
       | REPOSITORY    | BRANCHES             |
       | local, origin | main, feature, other |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH  | PARENT |
       | feature | main   |
       | other   | main   |

--- a/features/ship/supplied_branch/features/commit_message_via_cli.feature
+++ b/features/ship/supplied_branch/features/commit_message_via_cli.feature
@@ -36,7 +36,7 @@ Feature: provide the commit message via a CLI argument
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, origin | feature done |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/features/local_branch.feature
+++ b/features/ship/supplied_branch/features/local_branch.feature
@@ -36,7 +36,7 @@ Feature: ship the supplied feature branch without a tracking branch
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, origin | feature done |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/features/local_repo.feature
+++ b/features/ship/supplied_branch/features/local_repo.feature
@@ -31,7 +31,7 @@ Feature: ship the supplied feature branch in a local repo
     And now these commits exist
       | BRANCH | LOCATION | MESSAGE      |
       | main   | local    | feature done |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/features/parent_branch.feature
+++ b/features/ship/supplied_branch/features/parent_branch.feature
@@ -31,7 +31,7 @@ Feature: ship a parent branch
       | main   | local, origin | parent done   |
       | child  | local, origin | child commit  |
       | parent | origin        | parent commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | child  | main   |
 

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -34,7 +34,7 @@ Feature: skip deleting the remote branch when shipping another branch
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, origin | feature done |
       | other  | local         | other commit |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/ship/supplied_branch/ship_supplied_branch.feature
+++ b/features/ship/supplied_branch/ship_supplied_branch.feature
@@ -36,7 +36,7 @@ Feature: ship the supplied feature branch
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE      |
       | main   | local, origin | feature done |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | other  | main   |
 

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -9,7 +9,7 @@ Feature: enter a parent branch name when prompted
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                     | ANSWER  |
       | Please specify the parent branch of 'beta' | [ENTER] |
-    Then this branch hierarchy exists now
+    Then this branch lineage exists now
       | BRANCH | PARENT |
       | beta   | main   |
 
@@ -18,7 +18,7 @@ Feature: enter a parent branch name when prompted
       | PROMPT                                      | ANSWER        |
       | Please specify the parent branch of 'beta'  | [DOWN][ENTER] |
       | Please specify the parent branch of 'alpha' | [ENTER]       |
-    And this branch hierarchy exists now
+    And this branch lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |
       | beta   | alpha  |
@@ -34,7 +34,7 @@ Feature: enter a parent branch name when prompted
       | PROMPT                                      | ANSWER  |
       | Please specify the parent branch of 'alpha' | [ENTER] |
       | Please specify the parent branch of 'beta'  | [ENTER] |
-    Then this branch hierarchy exists now
+    Then this branch lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |
       | beta   | main   |

--- a/src/cli/printable.go
+++ b/src/cli/printable.go
@@ -5,15 +5,15 @@ import (
 	"strings"
 )
 
-// BranchAncestryConfig defines the configuration values needed by the `cli` package.
-type BranchAncestryConfig interface {
-	BranchAncestryRoots() []string
+// BranchLineageConfig defines the configuration values needed by the `cli` package.
+type BranchLineageConfig interface {
+	BranchLineageRoots() []string
 	ChildBranches(string) []string
 }
 
-// PrintableBranchAncestry provides the branch ancestry in CLI printable format.
-func PrintableBranchAncestry(config BranchAncestryConfig) string {
-	roots := config.BranchAncestryRoots()
+// PrintableBranchLineage provides the branch lineage in CLI printable format.
+func PrintableBranchLineage(config BranchLineageConfig) string {
+	roots := config.BranchLineageRoots()
 	trees := make([]string, len(roots))
 	for r, root := range roots {
 		trees[r] = PrintableBranchTree(root, config)
@@ -22,7 +22,7 @@ func PrintableBranchAncestry(config BranchAncestryConfig) string {
 }
 
 // PrintableBranchTree returns a user printable branch tree.
-func PrintableBranchTree(branch string, config BranchAncestryConfig) string {
+func PrintableBranchTree(branch string, config BranchLineageConfig) string {
 	result := branch
 	childBranches := config.ChildBranches(branch)
 	sort.Strings(childBranches)

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -92,7 +92,7 @@ func determineAppendConfig(targetBranch string, run *git.ProdRunner) (*appendCon
 	if hasTargetBranch {
 		fc.Fail("a branch named %q already exists", targetBranch)
 	}
-	fc.Check(validate.KnowsBranchAncestry(parentBranch, run.Config.MainBranch(), &run.Backend))
+	fc.Check(validate.KnowsBranchAncestors(parentBranch, run.Config.MainBranch(), &run.Backend))
 	ancestorBranches := run.Config.AncestorBranches(parentBranch)
 	return &appendConfig{
 		ancestorBranches:    ancestorBranches,

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -83,7 +83,7 @@ func runConfig(debug bool) error {
 	cli.PrintEntry("Gitea token", cli.StringSetting(run.Config.GiteaToken()))
 	fmt.Println()
 	if run.Config.MainBranch() != "" {
-		cli.PrintLabelAndValue("Branch Ancestry", cli.PrintableBranchAncestry(run.Config))
+		cli.PrintLabelAndValue("Branch Lineage", cli.PrintableBranchLineage(run.Config))
 	}
 	return nil
 }

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -86,7 +86,7 @@ func determineDiffParentConfig(args []string, run *git.ProdRunner) (*diffParentC
 	if !run.Config.IsFeatureBranch(branch) {
 		return nil, fmt.Errorf("you can only diff-parent feature branches")
 	}
-	err = validate.KnowsBranchAncestry(branch, run.Config.MainBranch(), &run.Backend)
+	err = validate.KnowsBranchAncestors(branch, run.Config.MainBranch(), &run.Backend)
 	if err != nil {
 		return nil, err
 	}

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -99,7 +99,7 @@ func determineParentBranch(targetBranch string, promptForParent bool, run *git.P
 		if err != nil {
 			return "", err
 		}
-		err = validate.KnowsBranchAncestry(parentBranch, run.Config.MainBranch(), &run.Backend)
+		err = validate.KnowsBranchAncestors(parentBranch, run.Config.MainBranch(), &run.Backend)
 		if err != nil {
 			return "", err
 		}

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -91,7 +91,7 @@ func determineKillConfig(args []string, run *git.ProdRunner) (*killConfig, error
 		return nil, err
 	}
 	if isTargetBranchLocal {
-		err = validate.KnowsBranchAncestry(targetBranch, mainBranch, &run.Backend)
+		err = validate.KnowsBranchAncestors(targetBranch, mainBranch, &run.Backend)
 		if err != nil {
 			return nil, err
 		}

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -102,7 +102,7 @@ func determineNewPullRequestConfig(run *git.ProdRunner) (*newPullRequestConfig, 
 	if err != nil {
 		return nil, err
 	}
-	err = validate.KnowsBranchAncestry(initialBranch, run.Config.MainBranch(), &run.Backend)
+	err = validate.KnowsBranchAncestors(initialBranch, run.Config.MainBranch(), &run.Backend)
 	if err != nil {
 		return nil, err
 	}

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -106,7 +106,7 @@ func determinePrependConfig(args []string, run *git.ProdRunner) (*prependConfig,
 	if !run.Config.IsFeatureBranch(initialBranch) {
 		return nil, fmt.Errorf("the branch %q is not a feature branch. Only feature branches can have parent branches", initialBranch)
 	}
-	err = validate.KnowsBranchAncestry(initialBranch, run.Config.MainBranch(), &run.Backend)
+	err = validate.KnowsBranchAncestors(initialBranch, run.Config.MainBranch(), &run.Backend)
 	if err != nil {
 		return nil, err
 	}

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -56,7 +56,7 @@ func setParent(debug bool) error {
 	} else {
 		existingParent = run.Config.MainBranch()
 	}
-	err = validate.KnowsBranchAncestry(currentBranch, existingParent, &run.Backend)
+	err = validate.KnowsBranchAncestors(currentBranch, existingParent, &run.Backend)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -159,7 +159,7 @@ func determineShipConfig(args []string, connector hosting.Connector, run *git.Pr
 	if !run.Config.IsFeatureBranch(branchToShip) {
 		return nil, fmt.Errorf("the branch %q is not a feature branch. Only feature branches can be shipped", branchToShip)
 	}
-	err = validate.KnowsBranchAncestry(branchToShip, mainBranch, &run.Backend)
+	err = validate.KnowsBranchAncestors(branchToShip, mainBranch, &run.Backend)
 	if err != nil {
 		return nil, err
 	}

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -71,7 +71,7 @@ func queryBranch(currentBranch string, run *git.ProdRunner) (selection *string, 
 func createEntries(run *git.ProdRunner) (dialog.ModalEntries, error) {
 	entries := dialog.ModalEntries{}
 	var err error
-	for _, root := range run.Config.BranchAncestryRoots() {
+	for _, root := range run.Config.BranchLineageRoots() {
 		entries, err = addEntryAndChildren(entries, root, 0, run)
 		if err != nil {
 			return nil, err

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -112,14 +112,14 @@ func determineSyncConfig(allFlag bool, run *git.ProdRunner) (*syncConfig, error)
 		if err != nil {
 			return nil, err
 		}
-		err = validate.KnowsBranchesAncestry(branches, &run.Backend)
+		err = validate.KnowsBranchesAncestors(branches, &run.Backend)
 		if err != nil {
 			return nil, err
 		}
 		branchesToSync = branches
 		shouldPushTags = true
 	} else {
-		err = validate.KnowsBranchAncestry(initialBranch, run.Config.MainBranch(), &run.Backend)
+		err = validate.KnowsBranchAncestors(initialBranch, run.Config.MainBranch(), &run.Backend)
 		if err != nil {
 			return nil, err
 		}

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -53,8 +53,8 @@ func (gt *GitTown) AncestorBranches(branch string) []string {
 	}
 }
 
-// BranchAncestryRoots provides the branches with children and no parents.
-func (gt *GitTown) BranchAncestryRoots() []string {
+// BranchLineageRoots provides the branches with children and no parents.
+func (gt *GitTown) BranchLineageRoots() []string {
 	parentMap := gt.ParentBranchMap()
 	roots := []string{}
 	for _, parent := range parentMap {

--- a/src/validate/knows_branch_ancestry.go
+++ b/src/validate/knows_branch_ancestry.go
@@ -5,13 +5,13 @@ import (
 	"github.com/git-town/git-town/v9/src/git"
 )
 
-// KnowsBranchesAncestry asserts that the entire ancestry for all given branches
+// KnowsBranchesAncestors asserts that the entire lineage for all given branches
 // is known to Git Town.
-// Missing ancestry information is queried from the user.
-func KnowsBranchesAncestry(branches []string, backend *git.BackendCommands) error {
+// Prompts missing lineage information from the user.
+func KnowsBranchesAncestors(branches []string, backend *git.BackendCommands) error {
 	mainBranch := backend.Config.MainBranch()
 	for _, branch := range branches {
-		err := KnowsBranchAncestry(branch, mainBranch, backend)
+		err := KnowsBranchAncestors(branch, mainBranch, backend)
 		if err != nil {
 			return err
 		}
@@ -19,8 +19,8 @@ func KnowsBranchesAncestry(branches []string, backend *git.BackendCommands) erro
 	return nil
 }
 
-// KnowsBranchAncestry prompts the user for all unknown ancestors of the given branch.
-func KnowsBranchAncestry(branch, defaultBranch string, backend *git.BackendCommands) (err error) { //nolint:nonamedreturns // return value names are useful here
+// KnowsBranchAncestors prompts the user for all unknown ancestors of the given branch.
+func KnowsBranchAncestors(branch, defaultBranch string, backend *git.BackendCommands) (err error) { //nolint:nonamedreturns // return value names are useful here
 	headerShown := false
 	currentBranch := branch
 	if backend.Config.IsMainBranch(branch) || backend.Config.IsPerennialBranch(branch) || backend.Config.HasParentBranch(branch) {

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -118,7 +118,7 @@ func TestTestCommands(t *testing.T) {
 		assert.NoError(t, err)
 		output, err := runtime.BackendRunner.Query("git-town", "config")
 		assert.NoError(t, err)
-		has := strings.Contains(output, "Branch Ancestry:\n  main\n    f1\n      f1a")
+		has := strings.Contains(output, "Branch Lineage:\n  main\n    f1\n      f1a")
 		if !has {
 			fmt.Printf("unexpected output: %s", output)
 		}

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -979,7 +979,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return nil
 	})
 
-	suite.Step(`^this branch hierarchy exists now$`, func(input *messages.PickleStepArgument_PickleTable) error {
+	suite.Step(`^this branch lineage exists now$`, func(input *messages.PickleStepArgument_PickleTable) error {
 		table := state.fixture.DevRepo.BranchHierarchyTable()
 		diff, errCount := table.EqualGherkin(input)
 		if errCount > 0 {

--- a/website/src/nested-feature-branches.md
+++ b/website/src/nested-feature-branches.md
@@ -117,7 +117,7 @@ git sync
 ```
 
 Because we created the branches with `git append`, Git Town knows about the
-branch ancestry and [git sync](commands/sync.md) can update all branches in the
+branch lineage and [git sync](commands/sync.md) can update all branches in the
 right order. It updates the `main` branch, merges `main` into branch 1. Then it
 merges branch 1 into branch 2 and branch 2 into branch 3.
 


### PR DESCRIPTION
Ancestry implies only ancestors. Git Town is also concerned with children. Lineage seems a better fit.