### PR TITLE
Consistently reload cached state after executing a Git Town command in E2E tests

### DIFF
--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -272,17 +272,20 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^I (?:run|ran) "(.+)"$`, func(command string) error {
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCode(command)
+		state.fixture.DevRepo.Config.Reload()
 		return nil
 	})
 
 	suite.Step(`^I (?:run|ran) "([^"]+)" and answer(?:ed)? the prompts:$`, func(cmd string, input *messages.PickleStepArgument_PickleTable) error {
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCodeWith(cmd, &subshell.Options{Input: helpers.TableToInput(input)})
+		state.fixture.DevRepo.Config.Reload()
 		return nil
 	})
 
 	suite.Step(`^I run "([^"]*)" and close the editor$`, func(cmd string) error {
 		env := append(os.Environ(), "GIT_EDITOR=true")
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCodeWith(cmd, &subshell.Options{Env: env})
+		state.fixture.DevRepo.Config.Reload()
 		return nil
 	})
 
@@ -291,6 +294,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			return err
 		}
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCode(cmd)
+		state.fixture.DevRepo.Config.Reload()
 		return nil
 	})
 
@@ -299,17 +303,20 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			return err
 		}
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCode(cmd)
+		state.fixture.DevRepo.Config.Reload()
 		return nil
 	})
 
 	suite.Step(`^I run "([^"]*)", answer the prompts, and close the next editor:$`, func(cmd string, input *messages.PickleStepArgument_PickleTable) error {
 		env := append(os.Environ(), "GIT_EDITOR=true")
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCodeWith(cmd, &subshell.Options{Env: env, Input: helpers.TableToInput(input)})
+		state.fixture.DevRepo.Config.Reload()
 		return nil
 	})
 
 	suite.Step(`^I run "([^"]+)" in the "([^"]+)" folder$`, func(cmd, folderName string) error {
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCodeWith(cmd, &subshell.Options{Dir: folderName})
+		state.fixture.DevRepo.Config.Reload()
 		return nil
 	})
 
@@ -435,7 +442,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^no branch hierarchy exists now$`, func() error {
-		state.fixture.DevRepo.Config.Reload()
 		if state.fixture.DevRepo.Config.HasBranchInformation() {
 			branchInfo := state.fixture.DevRepo.Config.ParentBranchMap()
 			return fmt.Errorf("unexpected Git Town branch hierarchy information: %+v", branchInfo)
@@ -485,7 +491,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^offline mode is disabled$`, func() error {
-		state.fixture.DevRepo.Config.Reload()
 		isOffline, err := state.fixture.DevRepo.Config.IsOffline()
 		if err != nil {
 			return err
@@ -520,7 +525,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^local setting "([^"]*)" no longer exists$`, func(name string) error {
-		state.fixture.DevRepo.Config.Reload()
 		newValue := state.fixture.DevRepo.Config.LocalConfigValue("git-town." + name)
 		if newValue == "" {
 			return nil
@@ -529,7 +533,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^global setting "([^"]*)" no longer exists$`, func(name string) error {
-		state.fixture.DevRepo.Config.Reload()
 		newValue := state.fixture.DevRepo.Config.GlobalConfigValue("git-town." + name)
 		if newValue == "" {
 			return nil
@@ -538,7 +541,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^setting "([^"]*)" is now "([^"]*)"$`, func(name, want string) error {
-		state.fixture.DevRepo.Config.Reload()
 		have := state.fixture.DevRepo.Config.LocalOrGlobalConfigValue("git-town." + name)
 		if have != want {
 			return fmt.Errorf("expected setting %q to be %q, but was %q", name, want, have)
@@ -547,7 +549,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^local setting "([^"]*)" is now "([^"]*)"$`, func(name, want string) error {
-		state.fixture.DevRepo.Config.Reload()
 		have := state.fixture.DevRepo.Config.LocalConfigValue("git-town." + name)
 		if have != want {
 			return fmt.Errorf("expected local setting %q to be %q, but was %q", name, want, have)
@@ -556,7 +557,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^global setting "([^"]*)" is (?:now|still) "([^"]*)"$`, func(name, want string) error {
-		state.fixture.DevRepo.Config.Reload()
 		have := state.fixture.DevRepo.Config.GlobalConfigValue("git-town." + name)
 		if have != want {
 			return fmt.Errorf("expected global setting %q to be %q, but was %q", name, want, have)
@@ -840,7 +840,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the main branch is now "([^"]+)"$`, func(name string) error {
-		state.fixture.DevRepo.Config.Reload()
 		actual := state.fixture.DevRepo.Config.MainBranch()
 		if actual != name {
 			return fmt.Errorf("expected %q, got %q", name, actual)
@@ -866,7 +865,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the perennial branches are now "([^"]+)"$`, func(name string) error {
-		state.fixture.DevRepo.Config.Reload()
 		actual := state.fixture.DevRepo.Config.PerennialBranches()
 		if len(actual) != 1 {
 			return fmt.Errorf("expected 1 perennial branch, got %q", actual)
@@ -878,7 +876,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^the perennial branches are now "([^"]+)" and "([^"]+)"$`, func(branch1, branch2 string) error {
-		state.fixture.DevRepo.Config.Reload()
 		actual := state.fixture.DevRepo.Config.PerennialBranches()
 		if len(actual) != 2 {
 			return fmt.Errorf("expected 2 perennial branches, got %q", actual)
@@ -943,7 +940,6 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^there are still no perennial branches$`, func() error {
-		state.fixture.DevRepo.Config.Reload()
 		branches := state.fixture.DevRepo.Config.PerennialBranches()
 		if len(branches) > 0 {
 			return fmt.Errorf("expected no perennial branches, got %q", branches)


### PR DESCRIPTION
The current implementation of the E2E tests reloads the Git Town configuration on each step that verifies the configuration. This makes it too easy to forget to reload the configuration and can also cause the configuration to be reloaded multiple times when verifying several config elements. This PR changes the E2E tests to consistently reload the cached Git Town configuration after executing a Git Town command in a subshell.