### PR TITLE
Return the correct exit code when ignoring subshell output

### DIFF
--- a/test/subshell/test_runner.go
+++ b/test/subshell/test_runner.go
@@ -249,7 +249,7 @@ func (r *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string) (s
 		}
 	}
 	if opts.IgnoreOutput {
-		return "", 0, err
+		return "", exitCode, err
 	}
 	return strings.TrimSpace(output.String()), exitCode, err
 }


### PR DESCRIPTION
Even when ignoring subshell output, it should still return the correct exit code. `Run*` methods ignore the subshell output but rely on the exit code being correct.