### PR TITLE
Use the TestRunner for all test shell commands

### DIFF
--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/acarl005/stripansi"
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/test/fixture"
 	"github.com/git-town/git-town/v9/test/git"
@@ -118,6 +119,7 @@ func TestTestCommands(t *testing.T) {
 		assert.NoError(t, err)
 		output, err := runtime.BackendRunner.Query("git-town", "config")
 		assert.NoError(t, err)
+		output = stripansi.Strip(output)
 		has := strings.Contains(output, "Branch Lineage:\n  main\n    f1\n      f1a")
 		if !has {
 			fmt.Printf("unexpected output: %s", output)

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -52,13 +52,13 @@ func Initialize(workingDir, homeDir, binDir string) (TestRuntime, error) {
 // newRuntime provides a new test.Runner instance working in the given directory.
 // The directory must contain an existing Git repo.
 func New(workingDir, homeDir, binDir string) TestRuntime {
-	mockingRunner := testshell.TestRunner{
+	runner := testshell.TestRunner{
 		WorkingDir: workingDir,
 		HomeDir:    homeDir,
 		BinDir:     binDir,
 	}
 	config := git.RepoConfig{
-		GitTown:            config.NewGitTown(&mockingRunner),
+		GitTown:            config.NewGitTown(&runner),
 		CurrentBranchCache: &cache.String{},
 		DryRun:             false,
 		IsRepoCache:        &cache.Bool{},
@@ -67,11 +67,11 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 		RootDirCache:       &cache.String{},
 	}
 	backendCommands := git.BackendCommands{
-		BackendRunner: &mockingRunner,
+		BackendRunner: &runner,
 		Config:        &config,
 	}
 	testCommands := commands.TestCommands{
-		TestRunner:      mockingRunner,
+		TestRunner:      runner,
 		BackendCommands: &backendCommands,
 	}
 	return TestRuntime{

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/git-town/git-town/v9/src/cache"
 	"github.com/git-town/git-town/v9/src/config"
-	"github.com/git-town/git-town/v9/src/execute"
 	"github.com/git-town/git-town/v9/src/git"
-	prodshell "github.com/git-town/git-town/v9/src/subshell"
 	"github.com/git-town/git-town/v9/test/commands"
 	testshell "github.com/git-town/git-town/v9/test/subshell"
 	"github.com/stretchr/testify/assert"
@@ -69,7 +67,7 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 		RootDirCache:       &cache.String{},
 	}
 	backendCommands := git.BackendCommands{
-		BackendRunner: prodshell.BackendRunner{Dir: &workingDir, Verbose: false, Stats: &execute.NoStatistics{}},
+		BackendRunner: &mockingRunner,
 		Config:        &config,
 	}
 	testCommands := commands.TestCommands{


### PR DESCRIPTION
Some tests used the production BackendRunner to run subshell commands. This might be a possible cause for #2274. This PR makes all tests use only TestRunner instances, which should run Git operations in tests in the appropriate test environment.