### PR TITLE
Accelerate end-to-end tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func TestGodog(t *testing.T) {
 		FeatureContext(s)
 	}, godog.Options{
 		Format:      "progress",
-		Concurrency: runtime.NumCPU(),
+		Concurrency: runtime.NumCPU() * 4,
 		Strict:      true,
 		Paths:       []string{"features/"},
 		Tags:        tags,


### PR DESCRIPTION
On my machine the 4x setting seems to be the best compromise. It shaves 4.7% or 2 seconds off the end-to-end test suite.

1x: 43s
2x: 42s
4x: 41s
6x: 41s