### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/test/envvars/prepend_path_test.go
+++ b/test/envvars/prepend_path_test.go
@@ -1,6 +1,7 @@
 package envvars_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/git-town/git-town/v9/test/envvars"
@@ -11,10 +12,17 @@ func TestPrependPath(t *testing.T) {
 	t.Parallel()
 	t.Run("already contains the given path", func(t *testing.T) {
 		t.Parallel()
-		give := []string{"ONE=1", "PATH=alpha:beta", "THREE=3"}
+		var give []string
+		var want []string
+		if runtime.GOOS == "windows" {
+			give = []string{"ONE=1", "PATH=alpha;beta", "THREE=3"}
+			want = []string{"ONE=1", "PATH=gamma;alpha;beta", "THREE=3"}
+		} else {
+			give = []string{"ONE=1", "PATH=alpha:beta", "THREE=3"}
+			want = []string{"ONE=1", "PATH=gamma:alpha:beta", "THREE=3"}
+		}
 		have := envvars.PrependPath(give, "gamma")
-		want := []string{"ONE=1", "PATH=gamma:alpha:beta", "THREE=3"}
-		assert.Equal(t, have, want)
+		assert.Equal(t, want, have)
 	})
 
 	t.Run("does not contain the given path", func(t *testing.T) {
@@ -22,6 +30,6 @@ func TestPrependPath(t *testing.T) {
 		give := []string{"ONE=1", "TWO=2"}
 		have := envvars.PrependPath(give, "alpha")
 		want := []string{"ONE=1", "TWO=2", "PATH=alpha"}
-		assert.Equal(t, have, want)
+		assert.Equal(t, want, have)
 	})
 }


### PR DESCRIPTION
Windows uses a different format for the PATH environment variable.