### PR TITLE
Simplify Lineage implementation

### DIFF
--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -123,13 +123,13 @@ func (gt *GitTown) IsPerennialBranch(branch string) bool {
 
 // LoadLineage provides the Lineage for the given Git repo.
 func (gt *GitTown) Lineage() Lineage {
-	parents := Lineage{}
+	lineage := Lineage{}
 	for _, key := range gt.LocalConfigKeysMatching(`^git-town-branch\..*\.parent$`) {
 		child := strings.TrimSuffix(strings.TrimPrefix(key, "git-town-branch."), ".parent")
 		parent := gt.LocalConfigValue(key)
-		parents[child] = parent
+		lineage[child] = parent
 	}
-	return parents
+	return lineage
 }
 
 // MainBranch provides the name of the main branch.

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -123,13 +123,13 @@ func (gt *GitTown) IsPerennialBranch(branch string) bool {
 
 // LoadLineage provides the Lineage for the given Git repo.
 func (gt *GitTown) Lineage() *Lineage {
-	parents := map[string]string{}
+	parents := Lineage{}
 	for _, key := range gt.LocalConfigKeysMatching(`^git-town-branch\..*\.parent$`) {
 		child := strings.TrimSuffix(strings.TrimPrefix(key, "git-town-branch."), ".parent")
 		parent := gt.LocalConfigValue(key)
 		parents[child] = parent
 	}
-	return &Lineage{parents}
+	return &parents
 }
 
 // MainBranch provides the name of the main branch.

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -122,14 +122,14 @@ func (gt *GitTown) IsPerennialBranch(branch string) bool {
 }
 
 // LoadLineage provides the Lineage for the given Git repo.
-func (gt *GitTown) Lineage() *Lineage {
+func (gt *GitTown) Lineage() Lineage {
 	parents := Lineage{}
 	for _, key := range gt.LocalConfigKeysMatching(`^git-town-branch\..*\.parent$`) {
 		child := strings.TrimSuffix(strings.TrimPrefix(key, "git-town-branch."), ".parent")
 		parent := gt.LocalConfigValue(key)
 		parents[child] = parent
 	}
-	return &parents
+	return parents
 }
 
 // MainBranch provides the name of the main branch.

--- a/src/config/lineage.go
+++ b/src/config/lineage.go
@@ -83,7 +83,3 @@ func (l *Lineage) Roots() []string {
 	sort.Strings(roots)
 	return roots
 }
-
-func (l *Lineage) SetParent(branch, parent string) {
-	(*l)[branch] = parent
-}

--- a/src/config/lineage.go
+++ b/src/config/lineage.go
@@ -7,17 +7,15 @@ import (
 )
 
 // Lineage encapsulates all data and functionality around parent branches.
-type Lineage struct {
-	// branch --> its parent
-	Entries map[string]string
-}
+// branch --> its parent
+type Lineage map[string]string
 
 // Ancestors provides the names of all parent branches of the branch with the given name.
 func (l *Lineage) Ancestors(branch string) []string {
 	current := branch
 	result := []string{}
 	for {
-		parent, found := l.Entries[current]
+		parent, found := (*l)[current]
 		if !found {
 			return result
 		}
@@ -29,7 +27,7 @@ func (l *Lineage) Ancestors(branch string) []string {
 // Children provides the names of all branches that have the given branch as their parent.
 func (l *Lineage) Children(branch string) []string {
 	result := []string{}
-	for child, parent := range l.Entries {
+	for child, parent := range *l {
 		if parent == branch {
 			result = append(result, child)
 		}
@@ -40,7 +38,7 @@ func (l *Lineage) Children(branch string) []string {
 
 // HasParents returns whether or not the given branch has at least one parent.
 func (l *Lineage) HasParents(branch string) bool {
-	for child := range l.Entries {
+	for child := range *l {
 		if child == branch {
 			return true
 		}
@@ -52,7 +50,7 @@ func (l *Lineage) HasParents(branch string) bool {
 func (l *Lineage) IsAncestor(ancestor, other string) bool {
 	current := other
 	for {
-		parent, found := l.Entries[current]
+		parent, found := (*l)[current]
 		if !found {
 			return false
 		}
@@ -65,7 +63,7 @@ func (l *Lineage) IsAncestor(ancestor, other string) bool {
 
 // Parent provides the name of the parent branch for the given branch or nil if the branch has no parent.
 func (l *Lineage) Parent(branch string) string {
-	for child, parent := range l.Entries {
+	for child, parent := range *l {
 		if child == branch {
 			return parent
 		}
@@ -76,8 +74,8 @@ func (l *Lineage) Parent(branch string) string {
 // Roots provides the branches with children and no parents.
 func (l *Lineage) Roots() []string {
 	roots := []string{}
-	for _, parent := range l.Entries {
-		_, ok := l.Entries[parent]
+	for _, parent := range *l {
+		_, ok := (*l)[parent]
 		if !ok && !stringslice.Contains(roots, parent) {
 			roots = append(roots, parent)
 		}
@@ -87,5 +85,5 @@ func (l *Lineage) Roots() []string {
 }
 
 func (l *Lineage) SetParent(branch, parent string) {
-	l.Entries[branch] = parent
+	(*l)[branch] = parent
 }

--- a/src/config/lineage.go
+++ b/src/config/lineage.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Lineage encapsulates all data and functionality around parent branches.
-// branch --> its parent
+// branch --> its parent.
 type Lineage map[string]string
 
 // Ancestors provides the names of all parent branches of the branch with the given name.

--- a/src/config/lineage.go
+++ b/src/config/lineage.go
@@ -11,11 +11,11 @@ import (
 type Lineage map[string]string
 
 // Ancestors provides the names of all parent branches of the branch with the given name.
-func (l *Lineage) Ancestors(branch string) []string {
+func (l Lineage) Ancestors(branch string) []string {
 	current := branch
 	result := []string{}
 	for {
-		parent, found := (*l)[current]
+		parent, found := l[current]
 		if !found {
 			return result
 		}
@@ -25,9 +25,9 @@ func (l *Lineage) Ancestors(branch string) []string {
 }
 
 // Children provides the names of all branches that have the given branch as their parent.
-func (l *Lineage) Children(branch string) []string {
+func (l Lineage) Children(branch string) []string {
 	result := []string{}
-	for child, parent := range *l {
+	for child, parent := range l {
 		if parent == branch {
 			result = append(result, child)
 		}
@@ -37,8 +37,8 @@ func (l *Lineage) Children(branch string) []string {
 }
 
 // HasParents returns whether or not the given branch has at least one parent.
-func (l *Lineage) HasParents(branch string) bool {
-	for child := range *l {
+func (l Lineage) HasParents(branch string) bool {
+	for child := range l {
 		if child == branch {
 			return true
 		}
@@ -47,10 +47,10 @@ func (l *Lineage) HasParents(branch string) bool {
 }
 
 // IsAncestor indicates whether the given branch is an ancestor of the other given branch.
-func (l *Lineage) IsAncestor(ancestor, other string) bool {
+func (l Lineage) IsAncestor(ancestor, other string) bool {
 	current := other
 	for {
-		parent, found := (*l)[current]
+		parent, found := l[current]
 		if !found {
 			return false
 		}
@@ -62,8 +62,8 @@ func (l *Lineage) IsAncestor(ancestor, other string) bool {
 }
 
 // Parent provides the name of the parent branch for the given branch or nil if the branch has no parent.
-func (l *Lineage) Parent(branch string) string {
-	for child, parent := range *l {
+func (l Lineage) Parent(branch string) string {
+	for child, parent := range l {
 		if child == branch {
 			return parent
 		}
@@ -72,10 +72,10 @@ func (l *Lineage) Parent(branch string) string {
 }
 
 // Roots provides the branches with children and no parents.
-func (l *Lineage) Roots() []string {
+func (l Lineage) Roots() []string {
 	roots := []string{}
-	for _, parent := range *l {
-		_, ok := (*l)[parent]
+	for _, parent := range l {
+		_, ok := l[parent]
 		if !ok && !stringslice.Contains(roots, parent) {
 			roots = append(roots, parent)
 		}

--- a/src/config/lineage_test.go
+++ b/src/config/lineage_test.go
@@ -7,10 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newLineage() config.Lineage {
-	return config.Lineage{}
-}
-
 func TestAncestry(t *testing.T) {
 	t.Parallel()
 
@@ -18,7 +14,7 @@ func TestAncestry(t *testing.T) {
 		t.Parallel()
 		t.Run("multiple ancestors", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["three"] = "two"
 			ancestry["two"] = "one"
 			ancestry["one"] = "main"
@@ -28,7 +24,7 @@ func TestAncestry(t *testing.T) {
 		})
 		t.Run("one ancestor", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["one"] = "main"
 			have := ancestry.Ancestors("one")
 			want := []string{"main"}
@@ -36,7 +32,7 @@ func TestAncestry(t *testing.T) {
 		})
 		t.Run("no ancestors", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["one"] = "main"
 			have := ancestry.Ancestors("two")
 			want := []string{}
@@ -48,7 +44,7 @@ func TestAncestry(t *testing.T) {
 		t.Parallel()
 		t.Run("multiple children", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["beta1"] = "alpha"
 			ancestry["beta2"] = "alpha"
 			have := ancestry.Children("alpha")
@@ -57,7 +53,7 @@ func TestAncestry(t *testing.T) {
 		})
 		t.Run("child has children", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["beta"] = "alpha"
 			ancestry["gamma"] = "beta"
 			have := ancestry.Children("alpha")
@@ -66,7 +62,7 @@ func TestAncestry(t *testing.T) {
 		})
 		t.Run("empty", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			have := ancestry.Children("alpha")
 			want := []string{}
 			assert.Equal(t, want, have)
@@ -77,13 +73,13 @@ func TestAncestry(t *testing.T) {
 		t.Parallel()
 		t.Run("has a parent", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["beta"] = "alpha"
 			assert.True(t, ancestry.HasParents("beta"))
 		})
 		t.Run("has no parent", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			assert.False(t, ancestry.HasParents("foo"))
 		})
 	})
@@ -91,7 +87,7 @@ func TestAncestry(t *testing.T) {
 	t.Run("IsAncestor", func(t *testing.T) {
 		t.Run("greatgrandparent", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["four"] = "three"
 			ancestry["three"] = "two"
 			ancestry["two"] = "one"
@@ -99,19 +95,19 @@ func TestAncestry(t *testing.T) {
 		})
 		t.Run("direct parent", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["two"] = "one"
 			assert.True(t, ancestry.IsAncestor("one", "two"))
 		})
 		t.Run("child", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["two"] = "one"
 			assert.False(t, ancestry.IsAncestor("two", "one"))
 		})
 		t.Run("not related", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["two"] = "one"
 			ancestry["three"] = "one"
 			assert.False(t, ancestry.IsAncestor("two", "three"))
@@ -122,13 +118,13 @@ func TestAncestry(t *testing.T) {
 		t.Parallel()
 		t.Run("has parent", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["two"] = "one"
 			assert.Equal(t, "one", ancestry.Parent("two"))
 		})
 		t.Run("has no parent", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			assert.Equal(t, "", ancestry.Parent("foo"))
 		})
 	})
@@ -137,7 +133,7 @@ func TestAncestry(t *testing.T) {
 		t.Parallel()
 		t.Run("multiple roots with nested child branches", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["two"] = "one"
 			ancestry["one"] = "main"
 			ancestry["beta"] = "alpha"
@@ -150,7 +146,7 @@ func TestAncestry(t *testing.T) {
 		})
 		t.Run("no nested branches", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			ancestry["one"] = "main"
 			ancestry["alpha"] = "main"
 			have := ancestry.Roots()
@@ -159,7 +155,7 @@ func TestAncestry(t *testing.T) {
 		})
 		t.Run("empty", func(t *testing.T) {
 			t.Parallel()
-			ancestry := newLineage()
+			ancestry := config.Lineage{}
 			have := ancestry.Roots()
 			want := []string{}
 			assert.Equal(t, want, have)

--- a/src/config/lineage_test.go
+++ b/src/config/lineage_test.go
@@ -19,9 +19,9 @@ func TestAncestry(t *testing.T) {
 		t.Run("multiple ancestors", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("three", "two")
-			ancestry.SetParent("two", "one")
-			ancestry.SetParent("one", "main")
+			ancestry["three"] = "two"
+			ancestry["two"] = "one"
+			ancestry["one"] = "main"
 			have := ancestry.Ancestors("three")
 			want := []string{"main", "one", "two"}
 			assert.Equal(t, want, have)
@@ -29,7 +29,7 @@ func TestAncestry(t *testing.T) {
 		t.Run("one ancestor", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("one", "main")
+			ancestry["one"] = "main"
 			have := ancestry.Ancestors("one")
 			want := []string{"main"}
 			assert.Equal(t, want, have)
@@ -37,7 +37,7 @@ func TestAncestry(t *testing.T) {
 		t.Run("no ancestors", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("one", "main")
+			ancestry["one"] = "main"
 			have := ancestry.Ancestors("two")
 			want := []string{}
 			assert.Equal(t, want, have)
@@ -49,8 +49,8 @@ func TestAncestry(t *testing.T) {
 		t.Run("multiple children", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("beta1", "alpha")
-			ancestry.SetParent("beta2", "alpha")
+			ancestry["beta1"] = "alpha"
+			ancestry["beta2"] = "alpha"
 			have := ancestry.Children("alpha")
 			want := []string{"beta1", "beta2"}
 			assert.Equal(t, want, have)
@@ -58,8 +58,8 @@ func TestAncestry(t *testing.T) {
 		t.Run("child has children", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("beta", "alpha")
-			ancestry.SetParent("gamma", "beta")
+			ancestry["beta"] = "alpha"
+			ancestry["gamma"] = "beta"
 			have := ancestry.Children("alpha")
 			want := []string{"beta"}
 			assert.Equal(t, want, have)
@@ -78,7 +78,7 @@ func TestAncestry(t *testing.T) {
 		t.Run("has a parent", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("beta", "alpha")
+			ancestry["beta"] = "alpha"
 			assert.True(t, ancestry.HasParents("beta"))
 		})
 		t.Run("has no parent", func(t *testing.T) {
@@ -92,28 +92,28 @@ func TestAncestry(t *testing.T) {
 		t.Run("greatgrandparent", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("four", "three")
-			ancestry.SetParent("three", "two")
-			ancestry.SetParent("two", "one")
+			ancestry["four"] = "three"
+			ancestry["three"] = "two"
+			ancestry["two"] = "one"
 			assert.True(t, ancestry.IsAncestor("one", "four"))
 		})
 		t.Run("direct parent", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("two", "one")
+			ancestry["two"] = "one"
 			assert.True(t, ancestry.IsAncestor("one", "two"))
 		})
 		t.Run("child", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("two", "one")
+			ancestry["two"] = "one"
 			assert.False(t, ancestry.IsAncestor("two", "one"))
 		})
 		t.Run("not related", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("two", "one")
-			ancestry.SetParent("three", "one")
+			ancestry["two"] = "one"
+			ancestry["three"] = "one"
 			assert.False(t, ancestry.IsAncestor("two", "three"))
 		})
 	})
@@ -123,7 +123,7 @@ func TestAncestry(t *testing.T) {
 		t.Run("has parent", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("two", "one")
+			ancestry["two"] = "one"
 			assert.Equal(t, "one", ancestry.Parent("two"))
 		})
 		t.Run("has no parent", func(t *testing.T) {
@@ -138,12 +138,12 @@ func TestAncestry(t *testing.T) {
 		t.Run("multiple roots with nested child branches", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("two", "one")
-			ancestry.SetParent("one", "main")
-			ancestry.SetParent("beta", "alpha")
-			ancestry.SetParent("alpha", "main")
-			ancestry.SetParent("hotfix1", "prod")
-			ancestry.SetParent("hotfix2", "prod")
+			ancestry["two"] = "one"
+			ancestry["one"] = "main"
+			ancestry["beta"] = "alpha"
+			ancestry["alpha"] = "main"
+			ancestry["hotfix1"] = "prod"
+			ancestry["hotfix2"] = "prod"
 			have := ancestry.Roots()
 			want := []string{"main", "prod"}
 			assert.Equal(t, want, have)
@@ -151,8 +151,8 @@ func TestAncestry(t *testing.T) {
 		t.Run("no nested branches", func(t *testing.T) {
 			t.Parallel()
 			ancestry := newLineage()
-			ancestry.SetParent("one", "main")
-			ancestry.SetParent("alpha", "main")
+			ancestry["one"] = "main"
+			ancestry["alpha"] = "main"
 			have := ancestry.Roots()
 			want := []string{"main"}
 			assert.Equal(t, want, have)

--- a/src/config/lineage_test.go
+++ b/src/config/lineage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newLineage() config.Lineage {
-	return config.Lineage{map[string]string{}}
+	return config.Lineage{}
 }
 
 func TestAncestry(t *testing.T) {

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -487,7 +487,7 @@ func (bc *BackendCommands) RemoveOutdatedConfiguration() error {
 	if err != nil {
 		return err
 	}
-	for child, parent := range bc.Config.Lineage().Entries {
+	for child, parent := range *bc.Config.Lineage() {
 		hasChildBranch := stringslice.Contains(branches, child)
 		hasParentBranch := stringslice.Contains(branches, parent)
 		if !hasChildBranch || !hasParentBranch {

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -487,7 +487,7 @@ func (bc *BackendCommands) RemoveOutdatedConfiguration() error {
 	if err != nil {
 		return err
 	}
-	for child, parent := range *bc.Config.Lineage() {
+	for child, parent := range bc.Config.Lineage() {
 		hasChildBranch := stringslice.Contains(branches, child)
 		hasParentBranch := stringslice.Contains(branches, parent)
 		if !hasChildBranch || !hasParentBranch {

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -41,13 +41,13 @@ func (r *TestCommands) BranchHierarchyTable() datatable.DataTable {
 	r.Config.Reload()
 	parentBranchMap := r.Config.Lineage()
 	result.AddRow("BRANCH", "PARENT")
-	childBranches := make([]string, 0, len(*parentBranchMap))
-	for child := range *parentBranchMap {
+	childBranches := make([]string, 0, len(parentBranchMap))
+	for child := range parentBranchMap {
 		childBranches = append(childBranches, child)
 	}
 	sort.Strings(childBranches)
 	for _, child := range childBranches {
-		result.AddRow(child, (*parentBranchMap)[child])
+		result.AddRow(child, (parentBranchMap)[child])
 	}
 	return result
 }

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -47,7 +47,7 @@ func (r *TestCommands) BranchHierarchyTable() datatable.DataTable {
 	}
 	sort.Strings(childBranches)
 	for _, child := range childBranches {
-		result.AddRow(child, (parentBranchMap)[child])
+		result.AddRow(child, parentBranchMap[child])
 	}
 	return result
 }

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -39,15 +39,15 @@ func (r *TestCommands) AddSubmodule(url string) {
 func (r *TestCommands) BranchHierarchyTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	r.Config.Reload()
-	parentBranchMap := r.Config.Lineage().Entries
+	parentBranchMap := r.Config.Lineage()
 	result.AddRow("BRANCH", "PARENT")
-	childBranches := make([]string, 0, len(parentBranchMap))
-	for child := range parentBranchMap {
+	childBranches := make([]string, 0, len(*parentBranchMap))
+	for child := range *parentBranchMap {
 		childBranches = append(childBranches, child)
 	}
 	sort.Strings(childBranches)
 	for _, child := range childBranches {
-		result.AddRow(child, parentBranchMap[child])
+		result.AddRow(child, (*parentBranchMap)[child])
 	}
 	return result
 }

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -413,7 +413,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^no branch hierarchy exists now$`, func() error {
 		if state.fixture.DevRepo.Config.HasBranchInformation() {
-			branchInfo := state.fixture.DevRepo.Config.Lineage().Entries
+			branchInfo := state.fixture.DevRepo.Config.Lineage()
 			return fmt.Errorf("unexpected Git Town branch hierarchy information: %+v", branchInfo)
 		}
 		return nil


### PR DESCRIPTION
It consists only of a single field, so the type can be the type of that field directly. Also getting rid of unnecessary mutability.