### PR TITLE
Allow named returns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - maintidx # we keep complexity under check with code reviews
     - nakedret # not useful
     - nestif # we keep complexity under check with code reviews
+    - nonamedreturns # they are useful in too many situations
     - nosnakecase # deprecated
     - nlreturn # this forces unnecessary empty lines in function bodies
     - scopelint # deprecated

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -61,7 +61,7 @@ func runSwitch(debug bool) error {
 
 // queryBranch lets the user select a new branch via a visual dialog.
 // Returns the selected branch or nil if the user aborted.
-func queryBranch(currentBranch string, lineage config.Lineage) (selection *string, err error) { //nolint:nonamedreturns
+func queryBranch(currentBranch string, lineage config.Lineage) (selection *string, err error) {
 	entries, err := createEntries(lineage)
 	if err != nil {
 		return nil, err

--- a/src/execute/load_prod_runner.go
+++ b/src/execute/load_prod_runner.go
@@ -14,7 +14,7 @@ type Statistics interface {
 	PrintAnalysis()
 }
 
-func LoadProdRunner(args LoadArgs) (prodRunner git.ProdRunner, exit bool, err error) { //nolint:nonamedreturns // so many return values require names
+func LoadProdRunner(args LoadArgs) (prodRunner git.ProdRunner, exit bool, err error) {
 	var stats Statistics
 	if args.Debug {
 		stats = &statistics.CommandsRun{CommandsCount: 0}

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -549,8 +549,6 @@ func (bc *BackendCommands) TrackingBranch(branch string) string {
 }
 
 // Version indicates whether the needed Git version is installed.
-//
-//nolint:nonamedreturns  // multiple int return values justify using names for return values
 func (bc *BackendCommands) Version() (major int, minor int, err error) {
 	versionRegexp := regexp.MustCompile(`git version (\d+).(\d+).(\d+)`)
 	output, err := bc.Query("git", "version")

--- a/src/hosting/bitbucket.go
+++ b/src/hosting/bitbucket.go
@@ -64,7 +64,6 @@ func (c *BitbucketConnector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", c.Hostname, c.Organization, c.Repository)
 }
 
-//nolint:nonamedreturns
 func (c *BitbucketConnector) SquashMergeProposal(_ int, _ string) (mergeSHA string, err error) {
 	return "", errors.New("shipping pull requests via the Bitbucket API is currently not supported. If you need this functionality, please vote for it by opening a ticket at https://github.com/git-town/git-town/issues")
 }

--- a/src/hosting/gitea.go
+++ b/src/hosting/gitea.go
@@ -59,7 +59,6 @@ func (c *GiteaConnector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", c.Hostname, c.Organization, c.Repository)
 }
 
-//nolint:nonamedreturns  // return value isn't obvious from function name
 func (c *GiteaConnector) SquashMergeProposal(number int, message string) (mergeSha string, err error) {
 	if number <= 0 {
 		return "", fmt.Errorf("no pull request number given")

--- a/src/hosting/github.go
+++ b/src/hosting/github.go
@@ -60,7 +60,6 @@ func (c *GitHubConnector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", c.Hostname, c.Organization, c.Repository)
 }
 
-//nolint:nonamedreturns
 func (c *GitHubConnector) SquashMergeProposal(number int, message string) (mergeSHA string, err error) {
 	if number <= 0 {
 		return "", fmt.Errorf("no pull request number given")
@@ -140,7 +139,6 @@ func parsePullRequest(pullRequest *github.PullRequest) Proposal {
 	}
 }
 
-//nolint:nonamedreturns
 func ParseCommitMessage(message string) (title, body string) {
 	parts := strings.SplitN(message, "\n", 2)
 	title = parts[0]

--- a/src/hosting/gitlab.go
+++ b/src/hosting/gitlab.go
@@ -37,7 +37,6 @@ func (c *GitLabConnector) FindProposal(branch, target string) (*Proposal, error)
 	return &proposal, nil
 }
 
-//nolint:nonamedreturns  // return value isn't obvious from function name
 func (c *GitLabConnector) SquashMergeProposal(number int, message string) (mergeSHA string, err error) {
 	if number <= 0 {
 		return "", fmt.Errorf("no merge request number given")

--- a/src/validate/handle_unfinished_state.go
+++ b/src/validate/handle_unfinished_state.go
@@ -10,8 +10,6 @@ import (
 )
 
 // HandleUnfinishedState checks for unfinished state on disk, handles it, and signals whether to continue execution of the originally intended steps.
-//
-//nolint:nonamedreturns  // return value isn't obvious from function name
 func HandleUnfinishedState(run *git.ProdRunner, connector hosting.Connector) (quit bool, err error) {
 	runState, err := runstate.Load(&run.Backend)
 	if err != nil {

--- a/src/validate/knows_branch_ancestry.go
+++ b/src/validate/knows_branch_ancestry.go
@@ -20,7 +20,7 @@ func KnowsBranchesAncestors(branches []string, backend *git.BackendCommands) err
 }
 
 // KnowsBranchAncestors prompts the user for all unknown ancestors of the given branch.
-func KnowsBranchAncestors(branch, defaultBranch string, backend *git.BackendCommands) (err error) { //nolint:nonamedreturns // return value names are useful here
+func KnowsBranchAncestors(branch, defaultBranch string, backend *git.BackendCommands) (err error) {
 	headerShown := false
 	currentBranch := branch
 	if backend.Config.IsMainBranch(branch) || backend.Config.IsPerennialBranch(branch) {

--- a/test/datatable/data_table.go
+++ b/test/datatable/data_table.go
@@ -53,8 +53,6 @@ func (table *DataTable) columns() [][]string {
 
 // EqualDataTable compares this DataTable instance to the given DataTable.
 // If both are equal it returns an empty string, otherwise a diff printable on the console.
-//
-//nolint:nonamedreturns  // multiple return values with non-obvious meaning
 func (table *DataTable) EqualDataTable(other DataTable) (diff string, errorCount int) {
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(other.String(), table.String(), false)
@@ -66,8 +64,6 @@ func (table *DataTable) EqualDataTable(other DataTable) (diff string, errorCount
 
 // EqualGherkin compares this DataTable instance to the given Gherkin table.
 // If both are equal it returns an empty string, otherwise a diff printable on the console.
-//
-//nolint:nonamedreturns  // multiple return values with non-obvious meaning
 func (table *DataTable) EqualGherkin(other *messages.PickleStepArgument_PickleTable) (diff string, errorCount int) {
 	if len(table.Cells) == 0 {
 		return "your data is empty", 1

--- a/test/ostools/unix.go
+++ b/test/ostools/unix.go
@@ -12,8 +12,6 @@ import (
 // This package contains platform-specific testing tool implementations for Unix-like platforms.
 
 // CallScriptArgs provides the command and arguments to call the given script on Windows.
-//
-//nolint:nonamedreturns  // multiple return values with non-obvious meaning
 func CallScriptArgs(toolPath string) (cmd string, args []string) {
 	return toolPath, []string{}
 }


### PR DESCRIPTION
They are useful in too many situations to ban them outright.