### PR TITLE
Remove unneeded cache invalidation

### DIFF
--- a/src/steps/rebase_branch_step.go
+++ b/src/steps/rebase_branch_step.go
@@ -31,9 +31,5 @@ func (step *RebaseBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) erro
 	if err != nil {
 		return err
 	}
-	err = run.Frontend.Rebase(step.Branch)
-	if err != nil {
-		run.Config.CurrentBranchCache.Invalidate()
-	}
-	return err
+	return run.Frontend.Rebase(step.Branch)
 }


### PR DESCRIPTION
The logic to determine the current branch is now smart enough to recognize a rebase in process and determine the current branch in that situation by itself.