### PR TITLE
More focused unit tests

### DIFF
--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -187,7 +187,9 @@ func TestBackendCommands(t *testing.T) {
 				assert.Equal(t, want, have)
 			})
 			t.Run("recognizes branches that are in sync with their remote branch", func(t *testing.T) {
-				give := `  branch-1                     01a7eded [origin/branch-1] Commit message 1`
+				give := `
+  branch-1                     11111111 [origin/branch-1] Commit message 1
+  remotes/origin/branch-1      11111111 Commit message 1`
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:       "branch-1",

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -200,7 +200,8 @@ func TestBackendCommands(t *testing.T) {
 				assert.Equal(t, want, have)
 			})
 			t.Run("recognizes remote-only branches", func(t *testing.T) {
-				give := `  remotes/origin/branch-1                     01a7eded Commit message 1`
+				give := `
+  remotes/origin/branch-1    22222222 Commit message 2`
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:       "branch-1",

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -133,77 +133,103 @@ func TestBackendCommands(t *testing.T) {
 
 	t.Run("ParseVerboseBranchesOutput", func(t *testing.T) {
 		t.Parallel()
-		t.Run("recognizes branches that are ahead of their remote branch", func(t *testing.T) {
-			give := `* branch-1                     01a7eded [origin/branch-1: ahead 1] Commit message 1`
-			want := git.BranchesSyncStatus{
-				git.BranchSyncStatus{
-					Name:       "branch-1",
-					SyncStatus: git.SyncStatusAhead,
-				},
-			}
-			have, currentBranch := git.ParseVerboseBranchesOutput(give)
-			assert.Equal(t, want, have)
-			assert.Equal(t, "branch-1", currentBranch)
+		t.Run("recognizes the current branch", func(t *testing.T) {
+			t.Run("marker is at the first entry", func(t *testing.T) {
+				give := `
+* branch-1                     01a7eded [origin/branch-1: ahead 1] Commit message 1
+  branch-2                     da796a69 [origin/branch-2] Commit message 2
+  branch-3                     f4ebec0a [origin/branch-3: behind 2] Commit message 3a`[1:]
+				_, currentBranch := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, "branch-1", currentBranch)
+			})
+			t.Run("marker is at the middle entry", func(t *testing.T) {
+				give := `
+  branch-1                     01a7eded [origin/branch-1: ahead 1] Commit message 1
+* branch-2                     da796a69 [origin/branch-2] Commit message 2
+  branch-3                     f4ebec0a [origin/branch-3: behind 2] Commit message 3a`[1:]
+				_, currentBranch := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, "branch-2", currentBranch)
+			})
+			t.Run("marker is at the last entry", func(t *testing.T) {
+				give := `
+  branch-1                     01a7eded [origin/branch-1: ahead 1] Commit message 1
+  branch-2                     da796a69 [origin/branch-2] Commit message 2
+* branch-3                     f4ebec0a [origin/branch-3: behind 2] Commit message 3a`[1:]
+				_, currentBranch := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, "branch-3", currentBranch)
+			})
 		})
-		t.Run("recognizes branches that are behind their remote branch", func(t *testing.T) {
-			give := `* branch-1                     01a7eded [origin/branch-1: behind 2] Commit message 1`
-			want := git.BranchesSyncStatus{
-				git.BranchSyncStatus{
-					Name:       "branch-1",
-					SyncStatus: git.SyncStatusBehind,
-				},
-			}
-			have, currentBranch := git.ParseVerboseBranchesOutput(give)
-			assert.Equal(t, want, have)
-			assert.Equal(t, "branch-1", currentBranch)
-		})
-		t.Run("recognizes branches that are in sync with their remote branch", func(t *testing.T) {
-			give := `* branch-1                     01a7eded [origin/branch-1] Commit message 1`
-			want := git.BranchesSyncStatus{
-				git.BranchSyncStatus{
-					Name:       "branch-1",
-					SyncStatus: git.SyncStatusUpToDate,
-				},
-			}
-			have, currentBranch := git.ParseVerboseBranchesOutput(give)
-			assert.Equal(t, want, have)
-			assert.Equal(t, "branch-1", currentBranch)
-		})
-		t.Run("recognizes remote-only branches", func(t *testing.T) {
-			give := `  remotes/origin/branch-1                     01a7eded Commit message 1`
-			want := git.BranchesSyncStatus{
-				git.BranchSyncStatus{
-					Name:       "branch-1",
-					SyncStatus: git.SyncStatusRemoteOnly,
-				},
-			}
-			have, currentBranch := git.ParseVerboseBranchesOutput(give)
-			assert.Equal(t, want, have)
-			assert.Equal(t, "", currentBranch)
-		})
-		t.Run("recognizes local-only branches", func(t *testing.T) {
-			give := `* branch-1                     01a7eded Commit message 1`
-			want := git.BranchesSyncStatus{
-				git.BranchSyncStatus{
-					Name:       "branch-1",
-					SyncStatus: git.SyncStatusLocalOnly,
-				},
-			}
-			have, currentBranch := git.ParseVerboseBranchesOutput(give)
-			assert.Equal(t, want, have)
-			assert.Equal(t, "branch-1", currentBranch)
-		})
-		t.Run("recognizes branches that got deleted at the remote", func(t *testing.T) {
-			give := `* branch-1                     01a7eded [origin/branch-1: gone] Commit message 1`
-			want := git.BranchesSyncStatus{
-				git.BranchSyncStatus{
-					Name:       "branch-1",
-					SyncStatus: git.SyncStatusDeletedAtRemote,
-				},
-			}
-			have, currentBranch := git.ParseVerboseBranchesOutput(give)
-			assert.Equal(t, want, have)
-			assert.Equal(t, "branch-1", currentBranch)
+		t.Run("recognizes the branch sync status", func(t *testing.T) {
+			t.Run("branch is ahead of its remote branch", func(t *testing.T) {
+				give := `
+  branch-1                     11111111 [origin/branch-1: ahead 1] Commit message 1a
+  remotes/origin/branch-1      22222222 Commit message 1b`[1:]
+				want := git.BranchesSyncStatus{
+					git.BranchSyncStatus{
+						Name:       "branch-1",
+						SyncStatus: git.SyncStatusAhead,
+					},
+				}
+				have, _ := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, want, have)
+			})
+			t.Run("recognizes branches that are behind their remote branch", func(t *testing.T) {
+				give := `
+  branch-1                     11111111 [origin/branch-1: behind 2] Commit message 1
+  remotes/origin/branch-1      22222222 Commit message 1b`[1:]
+				want := git.BranchesSyncStatus{
+					git.BranchSyncStatus{
+						Name:       "branch-1",
+						SyncStatus: git.SyncStatusBehind,
+					},
+				}
+				have, _ := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, want, have)
+			})
+			t.Run("recognizes branches that are in sync with their remote branch", func(t *testing.T) {
+				give := `  branch-1                     01a7eded [origin/branch-1] Commit message 1`
+				want := git.BranchesSyncStatus{
+					git.BranchSyncStatus{
+						Name:       "branch-1",
+						SyncStatus: git.SyncStatusUpToDate,
+					},
+				}
+				have, _ := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, want, have)
+			})
+			t.Run("recognizes remote-only branches", func(t *testing.T) {
+				give := `  remotes/origin/branch-1                     01a7eded Commit message 1`
+				want := git.BranchesSyncStatus{
+					git.BranchSyncStatus{
+						Name:       "branch-1",
+						SyncStatus: git.SyncStatusRemoteOnly,
+					},
+				}
+				have, _ := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, want, have)
+			})
+			t.Run("recognizes local-only branches", func(t *testing.T) {
+				give := `  branch-1                     01a7eded Commit message 1`
+				want := git.BranchesSyncStatus{
+					git.BranchSyncStatus{
+						Name:       "branch-1",
+						SyncStatus: git.SyncStatusLocalOnly,
+					},
+				}
+				have, _ := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, want, have)
+			})
+			t.Run("recognizes branches that got deleted at the remote", func(t *testing.T) {
+				give := `  branch-1                     01a7eded [origin/branch-1: gone] Commit message 1`
+				want := git.BranchesSyncStatus{
+					git.BranchSyncStatus{
+						Name:       "branch-1",
+						SyncStatus: git.SyncStatusDeletedAtRemote,
+					},
+				}
+				have, _ := git.ParseVerboseBranchesOutput(give)
+				assert.Equal(t, want, have)
+			})
 		})
 		t.Run("complex example", func(t *testing.T) {
 			give := `

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -173,7 +173,7 @@ func TestBackendCommands(t *testing.T) {
 				have, _ := git.ParseVerboseBranchesOutput(give)
 				assert.Equal(t, want, have)
 			})
-			t.Run("recognizes branches that are behind their remote branch", func(t *testing.T) {
+			t.Run("branch is behind its remote branch", func(t *testing.T) {
 				give := `
   branch-1                     11111111 [origin/branch-1: behind 2] Commit message 1
   remotes/origin/branch-1      22222222 Commit message 1b`[1:]
@@ -186,7 +186,7 @@ func TestBackendCommands(t *testing.T) {
 				have, _ := git.ParseVerboseBranchesOutput(give)
 				assert.Equal(t, want, have)
 			})
-			t.Run("recognizes branches that are in sync with their remote branch", func(t *testing.T) {
+			t.Run("branch is in sync with its remote branch", func(t *testing.T) {
 				give := `
   branch-1                     11111111 [origin/branch-1] Commit message 1
   remotes/origin/branch-1      11111111 Commit message 1`
@@ -199,7 +199,7 @@ func TestBackendCommands(t *testing.T) {
 				have, _ := git.ParseVerboseBranchesOutput(give)
 				assert.Equal(t, want, have)
 			})
-			t.Run("recognizes remote-only branches", func(t *testing.T) {
+			t.Run("remote-only branch", func(t *testing.T) {
 				give := `
   remotes/origin/branch-1    22222222 Commit message 2`
 				want := git.BranchesSyncStatus{
@@ -211,7 +211,7 @@ func TestBackendCommands(t *testing.T) {
 				have, _ := git.ParseVerboseBranchesOutput(give)
 				assert.Equal(t, want, have)
 			})
-			t.Run("recognizes local-only branches", func(t *testing.T) {
+			t.Run("local-only branch", func(t *testing.T) {
 				give := `  branch-1                     01a7eded Commit message 1`
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
@@ -222,7 +222,7 @@ func TestBackendCommands(t *testing.T) {
 				have, _ := git.ParseVerboseBranchesOutput(give)
 				assert.Equal(t, want, have)
 			})
-			t.Run("recognizes branches that got deleted at the remote", func(t *testing.T) {
+			t.Run("branch is deleted at the remote", func(t *testing.T) {
 				give := `  branch-1                     01a7eded [origin/branch-1: gone] Commit message 1`
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{


### PR DESCRIPTION
The unit tests for ParseVerboseBranchesOutput are starting to get complex. They test a whole array of individual things. This PR splits them up into more focused unit tests where each unit test checks only one aspect.