### PR TITLE
SHA data type

### DIFF
--- a/src/failure/collector_test.go
+++ b/src/failure/collector_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/failure"
 	"github.com/git-town/git-town/v9/src/git"
+	testgit "github.com/git-town/git-town/v9/test/git"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,17 +43,17 @@ func TestCollector(t *testing.T) {
 			syncStatuses := git.BranchesSyncStatus{
 				{
 					Name:         "branch1",
-					InitialSHA:   "",
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 				{
 					Name:         "branch2",
-					InitialSHA:   "",
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			have := fc.BranchesSyncStatus(syncStatuses, nil)

--- a/src/failure/collector_test.go
+++ b/src/failure/collector_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/failure"
 	"github.com/git-town/git-town/v9/src/git"
-	testgit "github.com/git-town/git-town/v9/test/git"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,17 +42,17 @@ func TestCollector(t *testing.T) {
 			syncStatuses := git.BranchesSyncStatus{
 				{
 					Name:         "branch1",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 				{
 					Name:         "branch2",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			have := fc.BranchesSyncStatus(syncStatuses, nil)

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -98,7 +98,7 @@ func ParseVerboseBranchesOutput(output string) (BranchesSyncStatus, string) {
 		}
 		parts := spaceRE.Split(line[2:], 3)
 		branchName := parts[0]
-		sha := parts[1]
+		sha := SHA{parts[1]}
 		remoteText := parts[2]
 		if line[0] == '*' && branchName != "(no" { // "(no" is what we get when a rebase is active, in which case no branch is checked out
 			checkedoutBranch = branchName
@@ -114,7 +114,7 @@ func ParseVerboseBranchesOutput(output string) (BranchesSyncStatus, string) {
 				InitialSHA:   sha,
 				SyncStatus:   syncStatus,
 				TrackingName: trackingBranchName,
-				TrackingSHA:  "", // will be added later
+				TrackingSHA:  SHA{""}, // will be added later
 			})
 		}
 	}
@@ -253,7 +253,7 @@ func (bc *BackendCommands) currentBranchDuringRebase() (string, error) {
 }
 
 // CurrentSha provides the SHA of the currently checked out branch/commit.
-func (bc *BackendCommands) CurrentSha() (string, error) {
+func (bc *BackendCommands) CurrentSha() (SHA, error) {
 	return bc.ShaForBranch("HEAD")
 }
 
@@ -434,12 +434,12 @@ func (bc *BackendCommands) RootDirectory() string {
 }
 
 // ShaForBranch provides the SHA for the local branch with the given name.
-func (bc *BackendCommands) ShaForBranch(name string) (string, error) {
+func (bc *BackendCommands) ShaForBranch(name string) (SHA, error) {
 	output, err := bc.QueryTrim("git", "rev-parse", name)
 	if err != nil {
-		return "", fmt.Errorf(messages.BranchLocalShaProblem, name, err)
+		return SHA{""}, fmt.Errorf(messages.BranchLocalShaProblem, name, err)
 	}
-	return output, nil
+	return SHA{output}, nil
 }
 
 // ShouldPushBranch returns whether the local branch with the given name

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -437,7 +437,7 @@ func (bc *BackendCommands) RootDirectory() string {
 func (bc *BackendCommands) ShaForBranch(name string) (SHA, error) {
 	output, err := bc.QueryTrim("git", "rev-parse", name)
 	if err != nil {
-		return ErrorSHA(), fmt.Errorf(messages.BranchLocalShaProblem, name, err)
+		return SHA{}, fmt.Errorf(messages.BranchLocalShaProblem, name, err)
 	}
 	return SHA{output}, nil
 }

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -437,7 +437,7 @@ func (bc *BackendCommands) RootDirectory() string {
 func (bc *BackendCommands) ShaForBranch(name string) (SHA, error) {
 	output, err := bc.QueryTrim("git", "rev-parse", name)
 	if err != nil {
-		return SHA{""}, fmt.Errorf(messages.BranchLocalShaProblem, name, err)
+		return ErrorSHA(), fmt.Errorf(messages.BranchLocalShaProblem, name, err)
 	}
 	return SHA{output}, nil
 }

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -240,7 +240,7 @@ func TestBackendCommands(t *testing.T) {
 						InitialSHA:   git.NewSHA("22222222"),
 						SyncStatus:   git.SyncStatusRemoteOnly,
 						TrackingName: "",
-						TrackingSHA:  testgit.ZeroValueSHA(),
+						TrackingSHA:  git.SHA{},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -255,7 +255,7 @@ func TestBackendCommands(t *testing.T) {
 						InitialSHA:   git.NewSHA("01a7eded"),
 						SyncStatus:   git.SyncStatusLocalOnly,
 						TrackingName: "",
-						TrackingSHA:  testgit.ZeroValueSHA(),
+						TrackingSHA:  git.SHA{},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -270,7 +270,7 @@ func TestBackendCommands(t *testing.T) {
 						InitialSHA:   git.NewSHA("01a7eded"),
 						SyncStatus:   git.SyncStatusDeletedAtRemote,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  testgit.ZeroValueSHA(),
+						TrackingSHA:  git.SHA{},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -297,7 +297,7 @@ func TestBackendCommands(t *testing.T) {
 						InitialSHA:   git.NewSHA("22222222"),
 						SyncStatus:   git.SyncStatusRemoteOnly,
 						TrackingName: "",
-						TrackingSHA:  testgit.ZeroValueSHA(),
+						TrackingSHA:  git.SHA{},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -351,7 +351,7 @@ func TestBackendCommands(t *testing.T) {
 					InitialSHA:   git.NewSHA("e4d6bc09"),
 					SyncStatus:   git.SyncStatusDeletedAtRemote,
 					TrackingName: "origin/branch-4",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			have, currentBranch := git.ParseVerboseBranchesOutput(give)

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -170,10 +170,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   git.SHA{"11111111"},
+						InitialSHA:   git.NewSHA("11111111"),
 						SyncStatus:   git.SyncStatusAhead,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  git.SHA{"22222222"},
+						TrackingSHA:  git.NewSHA("22222222"),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -187,10 +187,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   git.SHA{"11111111"},
+						InitialSHA:   git.NewSHA("11111111"),
 						SyncStatus:   git.SyncStatusBehind,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  git.SHA{"22222222"},
+						TrackingSHA:  git.NewSHA("22222222"),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -204,10 +204,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   git.SHA{"11111111"},
+						InitialSHA:   git.NewSHA("11111111"),
 						SyncStatus:   git.SyncStatusAheadAndBehind,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  git.SHA{"22222222"},
+						TrackingSHA:  git.NewSHA("22222222"),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -221,10 +221,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   git.SHA{"11111111"},
+						InitialSHA:   git.NewSHA("11111111"),
 						SyncStatus:   git.SyncStatusUpToDate,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  git.SHA{"11111111"},
+						TrackingSHA:  git.NewSHA("11111111"),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -237,10 +237,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "origin/branch-1",
-						InitialSHA:   git.SHA{"22222222"},
+						InitialSHA:   git.NewSHA("22222222"),
 						SyncStatus:   git.SyncStatusRemoteOnly,
 						TrackingName: "",
-						TrackingSHA:  git.SHA{""},
+						TrackingSHA:  testgit.ZeroValueSHA(),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -252,10 +252,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   git.SHA{"01a7eded"},
+						InitialSHA:   git.NewSHA("01a7eded"),
 						SyncStatus:   git.SyncStatusLocalOnly,
 						TrackingName: "",
-						TrackingSHA:  git.SHA{""},
+						TrackingSHA:  testgit.ZeroValueSHA(),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -267,10 +267,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   git.SHA{"01a7eded"},
+						InitialSHA:   git.NewSHA("01a7eded"),
 						SyncStatus:   git.SyncStatusDeletedAtRemote,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  git.SHA{""},
+						TrackingSHA:  testgit.ZeroValueSHA(),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -287,17 +287,17 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   git.SHA{"11111111"},
+						InitialSHA:   git.NewSHA("11111111"),
 						SyncStatus:   git.SyncStatusUpToDate,
 						TrackingName: "origin/branch-2",
-						TrackingSHA:  git.SHA{"11111111"},
+						TrackingSHA:  git.NewSHA("11111111"),
 					},
 					git.BranchSyncStatus{
 						Name:         "origin/branch-1",
-						InitialSHA:   git.SHA{"22222222"},
+						InitialSHA:   git.NewSHA("22222222"),
 						SyncStatus:   git.SyncStatusRemoteOnly,
 						TrackingName: "",
-						TrackingSHA:  git.SHA{""},
+						TrackingSHA:  testgit.ZeroValueSHA(),
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -320,38 +320,38 @@ func TestBackendCommands(t *testing.T) {
 			want := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "branch-1",
-					InitialSHA:   git.SHA{"01a7eded"},
+					InitialSHA:   git.NewSHA("01a7eded"),
 					SyncStatus:   git.SyncStatusAhead,
 					TrackingName: "origin/branch-1",
-					TrackingSHA:  git.SHA{"307a7bf4"},
+					TrackingSHA:  git.NewSHA("307a7bf4"),
 				},
 				git.BranchSyncStatus{
 					Name:         "branch-2",
-					InitialSHA:   git.SHA{"da796a69"},
+					InitialSHA:   git.NewSHA("da796a69"),
 					SyncStatus:   git.SyncStatusUpToDate,
 					TrackingName: "origin/branch-2",
-					TrackingSHA:  git.SHA{"da796a69"},
+					TrackingSHA:  git.NewSHA("da796a69"),
 				},
 				git.BranchSyncStatus{
 					Name:         "branch-3",
-					InitialSHA:   git.SHA{"f4ebec0a"},
+					InitialSHA:   git.NewSHA("f4ebec0a"),
 					SyncStatus:   git.SyncStatusBehind,
 					TrackingName: "origin/branch-3",
-					TrackingSHA:  git.SHA{"bc39378a"},
+					TrackingSHA:  git.NewSHA("bc39378a"),
 				},
 				git.BranchSyncStatus{
 					Name:         "main",
-					InitialSHA:   git.SHA{"024df944"},
+					InitialSHA:   git.NewSHA("024df944"),
 					SyncStatus:   git.SyncStatusUpToDate,
 					TrackingName: "origin/main",
-					TrackingSHA:  git.SHA{"024df944"},
+					TrackingSHA:  git.NewSHA("024df944"),
 				},
 				git.BranchSyncStatus{
 					Name:         "branch-4",
-					InitialSHA:   git.SHA{"e4d6bc09"},
+					InitialSHA:   git.NewSHA("e4d6bc09"),
 					SyncStatus:   git.SyncStatusDeletedAtRemote,
 					TrackingName: "origin/branch-4",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			have, currentBranch := git.ParseVerboseBranchesOutput(give)

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -170,10 +170,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   "11111111",
+						InitialSHA:   git.SHA{"11111111"},
 						SyncStatus:   git.SyncStatusAhead,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  "22222222",
+						TrackingSHA:  git.SHA{"22222222"},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -187,10 +187,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   "11111111",
+						InitialSHA:   git.SHA{"11111111"},
 						SyncStatus:   git.SyncStatusBehind,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  "22222222",
+						TrackingSHA:  git.SHA{"22222222"},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -204,10 +204,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   "11111111",
+						InitialSHA:   git.SHA{"11111111"},
 						SyncStatus:   git.SyncStatusAheadAndBehind,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  "22222222",
+						TrackingSHA:  git.SHA{"22222222"},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -221,10 +221,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   "11111111",
+						InitialSHA:   git.SHA{"11111111"},
 						SyncStatus:   git.SyncStatusUpToDate,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  "11111111",
+						TrackingSHA:  git.SHA{"11111111"},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -237,10 +237,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "origin/branch-1",
-						InitialSHA:   "22222222",
+						InitialSHA:   git.SHA{"22222222"},
 						SyncStatus:   git.SyncStatusRemoteOnly,
 						TrackingName: "",
-						TrackingSHA:  "",
+						TrackingSHA:  git.SHA{""},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -252,10 +252,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   "01a7eded",
+						InitialSHA:   git.SHA{"01a7eded"},
 						SyncStatus:   git.SyncStatusLocalOnly,
 						TrackingName: "",
-						TrackingSHA:  "",
+						TrackingSHA:  git.SHA{""},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -267,10 +267,10 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   "01a7eded",
+						InitialSHA:   git.SHA{"01a7eded"},
 						SyncStatus:   git.SyncStatusDeletedAtRemote,
 						TrackingName: "origin/branch-1",
-						TrackingSHA:  "",
+						TrackingSHA:  git.SHA{""},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -287,17 +287,17 @@ func TestBackendCommands(t *testing.T) {
 				want := git.BranchesSyncStatus{
 					git.BranchSyncStatus{
 						Name:         "branch-1",
-						InitialSHA:   "11111111",
+						InitialSHA:   git.SHA{"11111111"},
 						SyncStatus:   git.SyncStatusUpToDate,
 						TrackingName: "origin/branch-2",
-						TrackingSHA:  "11111111",
+						TrackingSHA:  git.SHA{"11111111"},
 					},
 					git.BranchSyncStatus{
 						Name:         "origin/branch-1",
-						InitialSHA:   "22222222",
+						InitialSHA:   git.SHA{"22222222"},
 						SyncStatus:   git.SyncStatusRemoteOnly,
 						TrackingName: "",
-						TrackingSHA:  "",
+						TrackingSHA:  git.SHA{""},
 					},
 				}
 				have, _ := git.ParseVerboseBranchesOutput(give)
@@ -320,38 +320,38 @@ func TestBackendCommands(t *testing.T) {
 			want := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "branch-1",
-					InitialSHA:   "01a7eded",
+					InitialSHA:   git.SHA{"01a7eded"},
 					SyncStatus:   git.SyncStatusAhead,
 					TrackingName: "origin/branch-1",
-					TrackingSHA:  "307a7bf4",
+					TrackingSHA:  git.SHA{"307a7bf4"},
 				},
 				git.BranchSyncStatus{
 					Name:         "branch-2",
-					InitialSHA:   "da796a69",
+					InitialSHA:   git.SHA{"da796a69"},
 					SyncStatus:   git.SyncStatusUpToDate,
 					TrackingName: "origin/branch-2",
-					TrackingSHA:  "da796a69",
+					TrackingSHA:  git.SHA{"da796a69"},
 				},
 				git.BranchSyncStatus{
 					Name:         "branch-3",
-					InitialSHA:   "f4ebec0a",
+					InitialSHA:   git.SHA{"f4ebec0a"},
 					SyncStatus:   git.SyncStatusBehind,
 					TrackingName: "origin/branch-3",
-					TrackingSHA:  "bc39378a",
+					TrackingSHA:  git.SHA{"bc39378a"},
 				},
 				git.BranchSyncStatus{
 					Name:         "main",
-					InitialSHA:   "024df944",
+					InitialSHA:   git.SHA{"024df944"},
 					SyncStatus:   git.SyncStatusUpToDate,
 					TrackingName: "origin/main",
-					TrackingSHA:  "024df944",
+					TrackingSHA:  git.SHA{"024df944"},
 				},
 				git.BranchSyncStatus{
 					Name:         "branch-4",
-					InitialSHA:   "e4d6bc09",
+					InitialSHA:   git.SHA{"e4d6bc09"},
 					SyncStatus:   git.SyncStatusDeletedAtRemote,
 					TrackingName: "origin/branch-4",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			have, currentBranch := git.ParseVerboseBranchesOutput(give)

--- a/src/git/branches.go
+++ b/src/git/branches.go
@@ -1,69 +1,12 @@
 package git
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/messages"
 )
-
-// SHA represents a Git SHA as a dedicated data type.
-// This helps avoid stringly-typed code.
-type SHA struct {
-	content string
-}
-
-// NewSHA creates a new SHA instance with the given value.
-// The value is verified for correctness.
-func NewSHA(content string) SHA {
-	if !validateSHA(content) {
-		panic(fmt.Sprintf("%q is not a valid Git SHA", content))
-	}
-	return SHA{content}
-}
-
-// validateSHA indicates whether the given SHA content is a valid Git SHA.
-func validateSHA(content string) bool {
-	if len(content) == 0 {
-		return false
-	}
-	for _, c := range content {
-		if c < '0' || c > 'f' {
-			return false
-		}
-	}
-	return true
-}
-
-// ErrorSHA provides the zero value for a Git SHA, to be used only when returning a SHA that should be ignored because it is returned as part of an error.
-// This is needed because we need to return invalid SHAs from functions that return an error.
-func ErrorSHA() SHA {
-	return SHA{""}
-}
-
-func (s SHA) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.content)
-}
-
-// Implements the fmt.Stringer interface for Git SHAs.
-func (s SHA) String() string { return s.content }
-
-// TruncateTo provides a new SHA instance that contains a shorter checksum.
-func (s SHA) TruncateTo(newLength int) SHA {
-	return SHA{s.content[0:newLength]}
-}
-
-func (s *SHA) UnmarshalJSON(b []byte) error {
-	var t string
-	err := json.Unmarshal(b, &t)
-	if err != nil {
-		return err
-	}
-	*s = SHA{t}
-	return nil
-}
 
 // BranchSyncStatus describes the sync status of a branch in relation to its tracking branch.
 type BranchSyncStatus struct {

--- a/src/git/branches.go
+++ b/src/git/branches.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -11,7 +12,7 @@ import (
 // SHA represents a Git SHA as a dedicated data type.
 // This helps avoid stringly-typed code.
 type SHA struct {
-	Content string
+	content string
 }
 
 // NewSHA creates a new SHA instance with the given value.
@@ -42,12 +43,26 @@ func ErrorSHA() SHA {
 	return SHA{""}
 }
 
+func (s SHA) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.content)
+}
+
 // Implements the fmt.Stringer interface for Git SHAs.
-func (s SHA) String() string { return s.Content }
+func (s SHA) String() string { return s.content }
 
 // TruncateTo provides a new SHA instance that contains a shorter checksum.
 func (s SHA) TruncateTo(newLength int) SHA {
-	return SHA{s.Content[0:newLength]}
+	return SHA{s.content[0:newLength]}
+}
+
+func (s *SHA) UnmarshalJSON(b []byte) error {
+	var t string
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+	*s = SHA{t}
+	return nil
 }
 
 // BranchSyncStatus describes the sync status of a branch in relation to its tracking branch.

--- a/src/git/branches.go
+++ b/src/git/branches.go
@@ -8,6 +8,43 @@ import (
 	"github.com/git-town/git-town/v9/src/messages"
 )
 
+type SHA struct {
+	Content string
+}
+
+func NewSHA(content string) SHA {
+	if !validateSHA(content) {
+		panic(fmt.Sprintf("%q is not a valid Git SHA", content))
+	}
+	return SHA{content}
+}
+
+func validateSHA(content string) bool {
+	if len(content) == 0 {
+		return false
+	}
+	for _, c := range content {
+		if c < '0' || c > 'f' {
+			return false
+		}
+	}
+	return true
+}
+
+// ErrorSHA provides the zero value for a SHA, to be used only when returning a SHA that should be ignored because it is returned as part of an error.
+// This is needed because Go chooses to implement multiple return values instead of sum types.
+func ErrorSHA() SHA {
+	return SHA{""}
+}
+
+// Implements the fmt.Stringer interface.
+func (s SHA) String() string { return s.Content }
+
+// TruncateTo reduces the length of this SHA.
+func (s SHA) TruncateTo(newLength int) SHA {
+	return SHA{s.Content[0:newLength]}
+}
+
 // BranchSyncStatus describes the sync status of a branch in relation to its tracking branch.
 type BranchSyncStatus struct {
 	// Name contains the fully qualified name of the branch,
@@ -15,7 +52,7 @@ type BranchSyncStatus struct {
 	Name string
 
 	// InitialSHA contains the SHA that this branch had before Git Town ran.
-	InitialSHA string
+	InitialSHA SHA
 
 	// SyncStatus of the branch
 	SyncStatus SyncStatus
@@ -24,7 +61,7 @@ type BranchSyncStatus struct {
 	TrackingName string
 
 	// TrackingSHA contains the SHA of the tracking branch before Git Town ran.
-	TrackingSHA string
+	TrackingSHA SHA
 }
 
 func (bi BranchSyncStatus) HasTrackingBranch() bool {

--- a/src/git/branches.go
+++ b/src/git/branches.go
@@ -8,10 +8,14 @@ import (
 	"github.com/git-town/git-town/v9/src/messages"
 )
 
+// SHA represents a Git SHA as a dedicated data type.
+// This helps avoid stringly-typed code.
 type SHA struct {
 	Content string
 }
 
+// NewSHA creates a new SHA instance with the given value.
+// The value is verified for correctness.
 func NewSHA(content string) SHA {
 	if !validateSHA(content) {
 		panic(fmt.Sprintf("%q is not a valid Git SHA", content))
@@ -19,6 +23,7 @@ func NewSHA(content string) SHA {
 	return SHA{content}
 }
 
+// validateSHA indicates whether the given SHA content is a valid Git SHA.
 func validateSHA(content string) bool {
 	if len(content) == 0 {
 		return false
@@ -31,16 +36,16 @@ func validateSHA(content string) bool {
 	return true
 }
 
-// ErrorSHA provides the zero value for a SHA, to be used only when returning a SHA that should be ignored because it is returned as part of an error.
-// This is needed because Go chooses to implement multiple return values instead of sum types.
+// ErrorSHA provides the zero value for a Git SHA, to be used only when returning a SHA that should be ignored because it is returned as part of an error.
+// This is needed because we need to return invalid SHAs from functions that return an error.
 func ErrorSHA() SHA {
 	return SHA{""}
 }
 
-// Implements the fmt.Stringer interface.
+// Implements the fmt.Stringer interface for Git SHAs.
 func (s SHA) String() string { return s.Content }
 
-// TruncateTo reduces the length of this SHA.
+// TruncateTo provides a new SHA instance that contains a shorter checksum.
 func (s SHA) TruncateTo(newLength int) SHA {
 	return SHA{s.Content[0:newLength]}
 }

--- a/src/git/branches_test.go
+++ b/src/git/branches_test.go
@@ -22,10 +22,10 @@ func TestBranch(t *testing.T) {
 		t.Run("local branch", func(t *testing.T) {
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			}
 			have := give.NameWithoutRemote()
 			want := "branch1"
@@ -34,10 +34,10 @@ func TestBranch(t *testing.T) {
 		t.Run("remote branch", func(t *testing.T) {
 			give := git.BranchSyncStatus{
 				Name:         "origin/branch1",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			}
 			have := give.NameWithoutRemote()
 			want := "branch1"
@@ -50,10 +50,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "origin/branch1",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			}
 			have := give.RemoteBranch()
 			want := "origin/branch1"
@@ -63,10 +63,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			}
 			have := give.RemoteBranch()
 			want := ""
@@ -76,10 +76,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusUpToDate,
 				TrackingName: "origin/branch-2",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			}
 			have := give.RemoteBranch()
 			want := "origin/branch-2"
@@ -96,17 +96,17 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		have := bs.BranchNames()
@@ -121,10 +121,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			assert.True(t, bs.HasLocalBranch("one"))
@@ -134,10 +134,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "origin/one",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			assert.False(t, bs.HasLocalBranch("one"))
@@ -147,10 +147,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "origin/one",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			assert.False(t, bs.HasLocalBranch("one"))
@@ -163,17 +163,17 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			assert.True(t, bs.IsKnown("one"))
@@ -184,10 +184,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusUpToDate,
 					TrackingName: "origin/two",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			assert.True(t, bs.IsKnown("origin/two"))
@@ -200,45 +200,45 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "up-to-date",
-				InitialSHA:   "11111111",
+				InitialSHA:   git.SHA{"11111111"},
 				SyncStatus:   git.SyncStatusUpToDate,
 				TrackingName: "origin/up-to-date",
-				TrackingSHA:  "11111111",
+				TrackingSHA:  git.SHA{"11111111"},
 			},
 			git.BranchSyncStatus{
 				Name:         "ahead",
-				InitialSHA:   "11111111",
+				InitialSHA:   git.SHA{"11111111"},
 				SyncStatus:   git.SyncStatusAhead,
 				TrackingName: "origin/ahead",
-				TrackingSHA:  "22222222",
+				TrackingSHA:  git.SHA{"22222222"},
 			},
 			git.BranchSyncStatus{
 				Name:         "behind",
-				InitialSHA:   "111111111",
+				InitialSHA:   git.SHA{"111111111"},
 				SyncStatus:   git.SyncStatusBehind,
 				TrackingName: "origin/behind",
-				TrackingSHA:  "222222222",
+				TrackingSHA:  git.SHA{"222222222"},
 			},
 			git.BranchSyncStatus{
 				Name:         "local-only",
-				InitialSHA:   "11111111",
+				InitialSHA:   git.SHA{"11111111"},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "remote-only",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "deleted-at-remote",
-				InitialSHA:   "11111111111",
+				InitialSHA:   git.SHA{"11111111111"},
 				SyncStatus:   git.SyncStatusDeletedAtRemote,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		want := []string{"up-to-date", "ahead", "behind", "local-only", "deleted-at-remote"}
@@ -251,45 +251,45 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "up-to-date",
-				InitialSHA:   "1111111111",
+				InitialSHA:   git.SHA{"1111111111"},
 				SyncStatus:   git.SyncStatusUpToDate,
 				TrackingName: "origin/up-to-date",
-				TrackingSHA:  "1111111111",
+				TrackingSHA:  git.SHA{"1111111111"},
 			},
 			git.BranchSyncStatus{
 				Name:         "ahead",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusAhead,
 				TrackingName: "origin/ahead",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "behind",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusBehind,
 				TrackingName: "origin/behind",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "local-only",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "remote-only",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "deleted-at-remote",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusDeletedAtRemote,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		have := bs.LocalBranchesWithDeletedTrackingBranches().BranchNames()
@@ -302,17 +302,17 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		assert.Equal(t, "one", bs.Lookup("one").Name)
@@ -325,10 +325,10 @@ func TestBranches(t *testing.T) {
 		t.Run("has a local branch with matching tracking branch", func(t *testing.T) {
 			branch := git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "origin/two",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			}
 			bs := git.BranchesSyncStatus{branch}
 			have := bs.LookupLocalBranchWithTracking("origin/two")
@@ -337,10 +337,10 @@ func TestBranches(t *testing.T) {
 		t.Run("has a local branch with the given name", func(t *testing.T) {
 			bs := git.BranchesSyncStatus{git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			}}
 			have := bs.LookupLocalBranchWithTracking("one")
 			assert.Nil(t, have)
@@ -353,27 +353,27 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			have := bs.Remove("two")
 			want := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   "",
+					InitialSHA:   git.SHA{""},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  "",
+					TrackingSHA:  git.SHA{""},
 				},
 			}
 			assert.Equal(t, want, have)
@@ -384,34 +384,34 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		have := bs.Remove("zonk")
 		want := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		assert.Equal(t, want, have)
@@ -422,48 +422,48 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "three",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "four",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		have, err := bs.Select([]string{"one", "three"})
 		want := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 			git.BranchSyncStatus{
 				Name:         "three",
-				InitialSHA:   "",
+				InitialSHA:   git.SHA{""},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  "",
+				TrackingSHA:  git.SHA{""},
 			},
 		}
 		assert.NoError(t, err)

--- a/src/git/branches_test.go
+++ b/src/git/branches_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v9/src/git"
-	testgit "github.com/git-town/git-town/v9/test/git"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,10 +22,10 @@ func TestBranch(t *testing.T) {
 		t.Run("local branch", func(t *testing.T) {
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			}
 			have := give.NameWithoutRemote()
 			want := "branch1"
@@ -35,10 +34,10 @@ func TestBranch(t *testing.T) {
 		t.Run("remote branch", func(t *testing.T) {
 			give := git.BranchSyncStatus{
 				Name:         "origin/branch1",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			}
 			have := give.NameWithoutRemote()
 			want := "branch1"
@@ -51,10 +50,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "origin/branch1",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			}
 			have := give.RemoteBranch()
 			want := "origin/branch1"
@@ -64,10 +63,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			}
 			have := give.RemoteBranch()
 			want := ""
@@ -77,10 +76,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusUpToDate,
 				TrackingName: "origin/branch-2",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			}
 			have := give.RemoteBranch()
 			want := "origin/branch-2"
@@ -97,17 +96,17 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		have := bs.BranchNames()
@@ -122,10 +121,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			assert.True(t, bs.HasLocalBranch("one"))
@@ -135,10 +134,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "origin/one",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			assert.False(t, bs.HasLocalBranch("one"))
@@ -148,10 +147,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "origin/one",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			assert.False(t, bs.HasLocalBranch("one"))
@@ -164,17 +163,17 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			assert.True(t, bs.IsKnown("one"))
@@ -185,10 +184,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusUpToDate,
 					TrackingName: "origin/two",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			assert.True(t, bs.IsKnown("origin/two"))
@@ -225,21 +224,21 @@ func TestBranches(t *testing.T) {
 				InitialSHA:   git.NewSHA("11111111"),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "remote-only",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "deleted-at-remote",
 				InitialSHA:   git.NewSHA("11111111111"),
 				SyncStatus:   git.SyncStatusDeletedAtRemote,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		want := []string{"up-to-date", "ahead", "behind", "local-only", "deleted-at-remote"}
@@ -259,38 +258,38 @@ func TestBranches(t *testing.T) {
 			},
 			git.BranchSyncStatus{
 				Name:         "ahead",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusAhead,
 				TrackingName: "origin/ahead",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "behind",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusBehind,
 				TrackingName: "origin/behind",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "local-only",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "remote-only",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "deleted-at-remote",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusDeletedAtRemote,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		have := bs.LocalBranchesWithDeletedTrackingBranches().BranchNames()
@@ -303,17 +302,17 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		assert.Equal(t, "one", bs.Lookup("one").Name)
@@ -326,10 +325,10 @@ func TestBranches(t *testing.T) {
 		t.Run("has a local branch with matching tracking branch", func(t *testing.T) {
 			branch := git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "origin/two",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			}
 			bs := git.BranchesSyncStatus{branch}
 			have := bs.LookupLocalBranchWithTracking("origin/two")
@@ -338,10 +337,10 @@ func TestBranches(t *testing.T) {
 		t.Run("has a local branch with the given name", func(t *testing.T) {
 			bs := git.BranchesSyncStatus{git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			}}
 			have := bs.LookupLocalBranchWithTracking("one")
 			assert.Nil(t, have)
@@ -354,27 +353,27 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			have := bs.Remove("two")
 			want := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   testgit.ZeroValueSHA(),
+					InitialSHA:   git.SHA{},
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  testgit.ZeroValueSHA(),
+					TrackingSHA:  git.SHA{},
 				},
 			}
 			assert.Equal(t, want, have)
@@ -385,34 +384,34 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		have := bs.Remove("zonk")
 		want := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		assert.Equal(t, want, have)
@@ -423,48 +422,48 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "three",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "four",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		have, err := bs.Select([]string{"one", "three"})
 		want := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 			git.BranchSyncStatus{
 				Name:         "three",
-				InitialSHA:   testgit.ZeroValueSHA(),
+				InitialSHA:   git.SHA{},
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  testgit.ZeroValueSHA(),
+				TrackingSHA:  git.SHA{},
 			},
 		}
 		assert.NoError(t, err)

--- a/src/git/branches_test.go
+++ b/src/git/branches_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v9/src/git"
+	testgit "github.com/git-town/git-town/v9/test/git"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,10 +23,10 @@ func TestBranch(t *testing.T) {
 		t.Run("local branch", func(t *testing.T) {
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			}
 			have := give.NameWithoutRemote()
 			want := "branch1"
@@ -34,10 +35,10 @@ func TestBranch(t *testing.T) {
 		t.Run("remote branch", func(t *testing.T) {
 			give := git.BranchSyncStatus{
 				Name:         "origin/branch1",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			}
 			have := give.NameWithoutRemote()
 			want := "branch1"
@@ -50,10 +51,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "origin/branch1",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			}
 			have := give.RemoteBranch()
 			want := "origin/branch1"
@@ -63,10 +64,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			}
 			have := give.RemoteBranch()
 			want := ""
@@ -76,10 +77,10 @@ func TestBranch(t *testing.T) {
 			t.Parallel()
 			give := git.BranchSyncStatus{
 				Name:         "branch1",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusUpToDate,
 				TrackingName: "origin/branch-2",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			}
 			have := give.RemoteBranch()
 			want := "origin/branch-2"
@@ -96,17 +97,17 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		have := bs.BranchNames()
@@ -121,10 +122,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			assert.True(t, bs.HasLocalBranch("one"))
@@ -134,10 +135,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "origin/one",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			assert.False(t, bs.HasLocalBranch("one"))
@@ -147,10 +148,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "origin/one",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			assert.False(t, bs.HasLocalBranch("one"))
@@ -163,17 +164,17 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			assert.True(t, bs.IsKnown("one"))
@@ -184,10 +185,10 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusUpToDate,
 					TrackingName: "origin/two",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			assert.True(t, bs.IsKnown("origin/two"))
@@ -200,45 +201,45 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "up-to-date",
-				InitialSHA:   git.SHA{"11111111"},
+				InitialSHA:   git.NewSHA("11111111"),
 				SyncStatus:   git.SyncStatusUpToDate,
 				TrackingName: "origin/up-to-date",
-				TrackingSHA:  git.SHA{"11111111"},
+				TrackingSHA:  git.NewSHA("11111111"),
 			},
 			git.BranchSyncStatus{
 				Name:         "ahead",
-				InitialSHA:   git.SHA{"11111111"},
+				InitialSHA:   git.NewSHA("11111111"),
 				SyncStatus:   git.SyncStatusAhead,
 				TrackingName: "origin/ahead",
-				TrackingSHA:  git.SHA{"22222222"},
+				TrackingSHA:  git.NewSHA("22222222"),
 			},
 			git.BranchSyncStatus{
 				Name:         "behind",
-				InitialSHA:   git.SHA{"111111111"},
+				InitialSHA:   git.NewSHA("111111111"),
 				SyncStatus:   git.SyncStatusBehind,
 				TrackingName: "origin/behind",
-				TrackingSHA:  git.SHA{"222222222"},
+				TrackingSHA:  git.NewSHA("222222222"),
 			},
 			git.BranchSyncStatus{
 				Name:         "local-only",
-				InitialSHA:   git.SHA{"11111111"},
+				InitialSHA:   git.NewSHA("11111111"),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "remote-only",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "deleted-at-remote",
-				InitialSHA:   git.SHA{"11111111111"},
+				InitialSHA:   git.NewSHA("11111111111"),
 				SyncStatus:   git.SyncStatusDeletedAtRemote,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		want := []string{"up-to-date", "ahead", "behind", "local-only", "deleted-at-remote"}
@@ -251,45 +252,45 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "up-to-date",
-				InitialSHA:   git.SHA{"1111111111"},
+				InitialSHA:   git.NewSHA("1111111111"),
 				SyncStatus:   git.SyncStatusUpToDate,
 				TrackingName: "origin/up-to-date",
-				TrackingSHA:  git.SHA{"1111111111"},
+				TrackingSHA:  git.NewSHA("1111111111"),
 			},
 			git.BranchSyncStatus{
 				Name:         "ahead",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusAhead,
 				TrackingName: "origin/ahead",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "behind",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusBehind,
 				TrackingName: "origin/behind",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "local-only",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "remote-only",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusRemoteOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "deleted-at-remote",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusDeletedAtRemote,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		have := bs.LocalBranchesWithDeletedTrackingBranches().BranchNames()
@@ -302,17 +303,17 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		assert.Equal(t, "one", bs.Lookup("one").Name)
@@ -325,10 +326,10 @@ func TestBranches(t *testing.T) {
 		t.Run("has a local branch with matching tracking branch", func(t *testing.T) {
 			branch := git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "origin/two",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			}
 			bs := git.BranchesSyncStatus{branch}
 			have := bs.LookupLocalBranchWithTracking("origin/two")
@@ -337,10 +338,10 @@ func TestBranches(t *testing.T) {
 		t.Run("has a local branch with the given name", func(t *testing.T) {
 			bs := git.BranchesSyncStatus{git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			}}
 			have := bs.LookupLocalBranchWithTracking("one")
 			assert.Nil(t, have)
@@ -353,27 +354,27 @@ func TestBranches(t *testing.T) {
 			bs := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 				git.BranchSyncStatus{
 					Name:         "two",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			have := bs.Remove("two")
 			want := git.BranchesSyncStatus{
 				git.BranchSyncStatus{
 					Name:         "one",
-					InitialSHA:   git.SHA{""},
+					InitialSHA:   testgit.ZeroValueSHA(),
 					SyncStatus:   git.SyncStatusLocalOnly,
 					TrackingName: "",
-					TrackingSHA:  git.SHA{""},
+					TrackingSHA:  testgit.ZeroValueSHA(),
 				},
 			}
 			assert.Equal(t, want, have)
@@ -384,34 +385,34 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		have := bs.Remove("zonk")
 		want := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		assert.Equal(t, want, have)
@@ -422,48 +423,48 @@ func TestBranches(t *testing.T) {
 		bs := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "two",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "three",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "four",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		have, err := bs.Select([]string{"one", "three"})
 		want := git.BranchesSyncStatus{
 			git.BranchSyncStatus{
 				Name:         "one",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 			git.BranchSyncStatus{
 				Name:         "three",
-				InitialSHA:   git.SHA{""},
+				InitialSHA:   testgit.ZeroValueSHA(),
 				SyncStatus:   git.SyncStatusLocalOnly,
 				TrackingName: "",
-				TrackingSHA:  git.SHA{""},
+				TrackingSHA:  testgit.ZeroValueSHA(),
 			},
 		}
 		assert.NoError(t, err)

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -51,12 +51,12 @@ func (fc *FrontendCommands) CheckoutBranch(name string) error {
 }
 
 // CreateRemoteBranch creates a remote branch from the given local SHA.
-func (fc *FrontendCommands) CreateRemoteBranch(localSha, branch string, noPushHook bool) error {
+func (fc *FrontendCommands) CreateRemoteBranch(localSha SHA, branch string, noPushHook bool) error {
 	args := []string{"push"}
 	if noPushHook {
 		args = append(args, "--no-verify")
 	}
-	args = append(args, config.OriginRemote, localSha+":refs/heads/"+branch)
+	args = append(args, config.OriginRemote, localSha.Content+":refs/heads/"+branch)
 	return fc.Run("git", args...)
 }
 
@@ -202,18 +202,18 @@ func (fc *FrontendCommands) RemoveGitAlias(alias config.Alias) error {
 }
 
 // ResetToSha undoes all commits on the current branch all the way until the given SHA.
-func (fc *FrontendCommands) ResetToSha(sha string, hard bool) error {
+func (fc *FrontendCommands) ResetToSha(sha SHA, hard bool) error {
 	args := []string{"reset"}
 	if hard {
 		args = append(args, "--hard")
 	}
-	args = append(args, sha)
+	args = append(args, sha.Content)
 	return fc.Run("git", args...)
 }
 
 // RevertCommit reverts the commit with the given SHA.
-func (fc *FrontendCommands) RevertCommit(sha string) error {
-	return fc.Run("git", "revert", sha)
+func (fc *FrontendCommands) RevertCommit(sha SHA) error {
+	return fc.Run("git", "revert", sha.Content)
 }
 
 // SquashMerge squash-merges the given branch into the current branch.

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -56,7 +56,7 @@ func (fc *FrontendCommands) CreateRemoteBranch(localSha SHA, branch string, noPu
 	if noPushHook {
 		args = append(args, "--no-verify")
 	}
-	args = append(args, config.OriginRemote, localSha.Content+":refs/heads/"+branch)
+	args = append(args, config.OriginRemote, localSha.String()+":refs/heads/"+branch)
 	return fc.Run("git", args...)
 }
 
@@ -207,13 +207,13 @@ func (fc *FrontendCommands) ResetToSha(sha SHA, hard bool) error {
 	if hard {
 		args = append(args, "--hard")
 	}
-	args = append(args, sha.Content)
+	args = append(args, sha.String())
 	return fc.Run("git", args...)
 }
 
 // RevertCommit reverts the commit with the given SHA.
 func (fc *FrontendCommands) RevertCommit(sha SHA) error {
-	return fc.Run("git", "revert", sha.Content)
+	return fc.Run("git", "revert", sha.String())
 }
 
 // SquashMerge squash-merges the given branch into the current branch.

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -41,7 +41,7 @@ func (s SHA) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.content)
 }
 
-// Implements the fmt.Stringer interface for Git SHAs.
+// Implements the fmt.Stringer interface.
 func (s SHA) String() string { return s.content }
 
 // TruncateTo provides a new SHA instance that contains a shorter checksum.

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -22,13 +22,17 @@ func NewSHA(content string) SHA {
 
 // validateSHA indicates whether the given SHA content is a valid Git SHA.
 func validateSHA(content string) bool {
-	if len(content) == 0 {
+	if len(content) < 6 {
 		return false
 	}
 	for _, c := range content {
-		if c < '0' || c > 'f' {
-			return false
+		if c >= '0' && c <= '9' {
+			continue
 		}
+		if c >= 'a' && c <= 'f' {
+			continue
+		}
+		return false
 	}
 	return true
 }

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -55,6 +55,6 @@ func (s *SHA) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	*&s.content = t
+	s.content = t
 	return nil
 }

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// SHA represents a Git SHA as a dedicated data type.
+// This helps avoid stringly-typed code.
+type SHA struct {
+	content string
+}
+
+// NewSHA creates a new SHA instance with the given value.
+// The value is verified for correctness.
+func NewSHA(content string) SHA {
+	if !validateSHA(content) {
+		panic(fmt.Sprintf("%q is not a valid Git SHA", content))
+	}
+	return SHA{content}
+}
+
+// validateSHA indicates whether the given SHA content is a valid Git SHA.
+func validateSHA(content string) bool {
+	if len(content) == 0 {
+		return false
+	}
+	for _, c := range content {
+		if c < '0' || c > 'f' {
+			return false
+		}
+	}
+	return true
+}
+
+// ErrorSHA provides the zero value for a Git SHA, to be used only when returning a SHA that should be ignored because it is returned as part of an error.
+// This is needed because we need to return invalid SHAs from functions that return an error.
+func ErrorSHA() SHA {
+	return SHA{""}
+}
+
+func (s SHA) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.content)
+}
+
+// Implements the fmt.Stringer interface for Git SHAs.
+func (s SHA) String() string { return s.content }
+
+// TruncateTo provides a new SHA instance that contains a shorter checksum.
+func (s SHA) TruncateTo(newLength int) SHA {
+	return SHA{s.content[0:newLength]}
+}
+
+func (s *SHA) UnmarshalJSON(b []byte) error {
+	var t string
+	err := json.Unmarshal(b, &t)
+	if err != nil {
+		return err
+	}
+	*s = SHA{t}
+	return nil
+}

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -55,6 +55,6 @@ func (s *SHA) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	*s = SHA{t}
+	*&s.content = t
 	return nil
 }

--- a/src/git/sha.go
+++ b/src/git/sha.go
@@ -37,12 +37,6 @@ func validateSHA(content string) bool {
 	return true
 }
 
-// ErrorSHA provides the zero value for a Git SHA, to be used only when returning a SHA that should be ignored because it is returned as part of an error.
-// This is needed because we need to return invalid SHAs from functions that return an error.
-func ErrorSHA() SHA {
-	return SHA{""}
-}
-
 func (s SHA) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.content)
 }

--- a/src/git/sha_test.go
+++ b/src/git/sha_test.go
@@ -8,28 +8,35 @@ import (
 )
 
 func ensurePanic(t *testing.T) {
+	t.Helper()
 	if r := recover(); r == nil {
 		t.Errorf("The code did not panic")
 	}
 }
 
 func TestSHA(t *testing.T) {
+	t.Parallel()
 	t.Run("NewSHA", func(t *testing.T) {
+		t.Parallel()
 		t.Run("allows hex characters", func(t *testing.T) {
+			t.Parallel()
 			text := "1234567890abcdef"
 			git.NewSHA(text) // should not panic
 		})
 		t.Run("does not allow empty values", func(t *testing.T) {
+			t.Parallel()
 			defer ensurePanic(t)
 			git.NewSHA("")
 		})
 		t.Run("does not allow non-SHA characters", func(t *testing.T) {
+			t.Parallel()
 			defer ensurePanic(t)
 			git.NewSHA("abc def")
 		})
 	})
 
 	t.Run("Stringer interface", func(t *testing.T) {
+		t.Parallel()
 		sha := git.NewSHA("abcdef")
 		assert.Equal(t, "abcdef", sha.String())
 	})

--- a/src/git/sha_test.go
+++ b/src/git/sha_test.go
@@ -28,10 +28,20 @@ func TestSHA(t *testing.T) {
 			defer ensureDidPanic(t)
 			git.NewSHA("")
 		})
-		t.Run("does not allow non-SHA characters", func(t *testing.T) {
+		t.Run("does not allow spaces", func(t *testing.T) {
 			t.Parallel()
 			defer ensureDidPanic(t)
 			git.NewSHA("abc def")
+		})
+		t.Run("does not allow uppercase characters", func(t *testing.T) {
+			t.Parallel()
+			defer ensureDidPanic(t)
+			git.NewSHA("ABCDEF")
+		})
+		t.Run("does not allow non-hex characters", func(t *testing.T) {
+			t.Parallel()
+			defer ensureDidPanic(t)
+			git.NewSHA("abcdefg")
 		})
 	})
 

--- a/src/git/sha_test.go
+++ b/src/git/sha_test.go
@@ -18,7 +18,7 @@ func TestSHA(t *testing.T) {
 	t.Parallel()
 	t.Run("NewSHA", func(t *testing.T) {
 		t.Parallel()
-		t.Run("allows hex characters", func(t *testing.T) {
+		t.Run("allows lowercase hex characters", func(t *testing.T) {
 			t.Parallel()
 			text := "1234567890abcdef"
 			git.NewSHA(text) // should not panic

--- a/src/git/sha_test.go
+++ b/src/git/sha_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func ensurePanic(t *testing.T) {
+func ensureDidPanic(t *testing.T) {
 	t.Helper()
 	if r := recover(); r == nil {
 		t.Errorf("The code did not panic")
@@ -25,12 +25,12 @@ func TestSHA(t *testing.T) {
 		})
 		t.Run("does not allow empty values", func(t *testing.T) {
 			t.Parallel()
-			defer ensurePanic(t)
+			defer ensureDidPanic(t)
 			git.NewSHA("")
 		})
 		t.Run("does not allow non-SHA characters", func(t *testing.T) {
 			t.Parallel()
-			defer ensurePanic(t)
+			defer ensureDidPanic(t)
 			git.NewSHA("abc def")
 		})
 	})

--- a/src/git/sha_test.go
+++ b/src/git/sha_test.go
@@ -1,0 +1,36 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v9/src/git"
+	"github.com/stretchr/testify/assert"
+)
+
+func ensurePanic(t *testing.T) {
+	if r := recover(); r == nil {
+		t.Errorf("The code did not panic")
+	}
+}
+
+func TestSHA(t *testing.T) {
+	t.Run("NewSHA", func(t *testing.T) {
+		t.Run("allows hex characters", func(t *testing.T) {
+			text := "1234567890abcdef"
+			git.NewSHA(text) // should not panic
+		})
+		t.Run("does not allow empty values", func(t *testing.T) {
+			defer ensurePanic(t)
+			git.NewSHA("")
+		})
+		t.Run("does not allow non-SHA characters", func(t *testing.T) {
+			defer ensurePanic(t)
+			git.NewSHA("abc def")
+		})
+	})
+
+	t.Run("Stringer interface", func(t *testing.T) {
+		sha := git.NewSHA("abcdef")
+		assert.Equal(t, "abcdef", sha.String())
+	})
+}

--- a/src/git/sha_test.go
+++ b/src/git/sha_test.go
@@ -45,7 +45,7 @@ func TestSHA(t *testing.T) {
 		})
 	})
 
-	t.Run("Stringer interface", func(t *testing.T) {
+	t.Run("implements the Stringer interface", func(t *testing.T) {
 		t.Parallel()
 		sha := git.NewSHA("abcdef")
 		assert.Equal(t, "abcdef", sha.String())

--- a/src/hosting/bitbucket.go
+++ b/src/hosting/bitbucket.go
@@ -69,7 +69,7 @@ func (c *BitbucketConnector) RepositoryURL() string {
 }
 
 func (c *BitbucketConnector) SquashMergeProposal(_ int, _ string) (mergeSHA git.SHA, err error) {
-	return git.ErrorSHA(), errors.New(messages.HostingBitBucketNotImplemented)
+	return git.SHA{}, errors.New(messages.HostingBitBucketNotImplemented)
 }
 
 func (c *BitbucketConnector) UpdateProposalTarget(_ int, _ string) error {

--- a/src/hosting/bitbucket.go
+++ b/src/hosting/bitbucket.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/git-town/git-town/v9/src/config"
+	"github.com/git-town/git-town/v9/src/git"
 	"github.com/git-town/git-town/v9/src/giturl"
 	"github.com/git-town/git-town/v9/src/messages"
 )
@@ -58,7 +59,7 @@ func (c *BitbucketConnector) NewProposalURL(branch, parentBranch string) (string
 	if err != nil {
 		return "", fmt.Errorf(messages.ProposalURLProblem, branch, parentBranch, err)
 	}
-	query.Add("source", strings.Join([]string{c.Organization + "/" + c.Repository, branchSha[0:12], branch}, ":"))
+	query.Add("source", strings.Join([]string{c.Organization + "/" + c.Repository, branchSha.TruncateTo(12).String(), branch}, ":"))
 	query.Add("dest", strings.Join([]string{c.Organization + "/" + c.Repository, "", parentBranch}, ":"))
 	return fmt.Sprintf("%s/pull-request/new?%s", c.RepositoryURL(), query.Encode()), nil
 }
@@ -67,8 +68,8 @@ func (c *BitbucketConnector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", c.Hostname, c.Organization, c.Repository)
 }
 
-func (c *BitbucketConnector) SquashMergeProposal(_ int, _ string) (mergeSHA string, err error) {
-	return "", errors.New(messages.HostingBitBucketNotImplemented)
+func (c *BitbucketConnector) SquashMergeProposal(_ int, _ string) (mergeSHA git.SHA, err error) {
+	return git.ErrorSHA(), errors.New(messages.HostingBitBucketNotImplemented)
 }
 
 func (c *BitbucketConnector) UpdateProposalTarget(_ int, _ string) error {

--- a/src/hosting/core.go
+++ b/src/hosting/core.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"github.com/git-town/git-town/v9/src/config"
+	"github.com/git-town/git-town/v9/src/git"
 	"github.com/git-town/git-town/v9/src/giturl"
 )
 
@@ -29,7 +30,7 @@ type Connector interface {
 
 	// SquashMergeProposal squash-merges the proposal with the given number
 	// using the given commit message.
-	SquashMergeProposal(number int, message string) (mergeSHA string, err error)
+	SquashMergeProposal(number int, message string) (mergeSHA git.SHA, err error)
 
 	// NewProposalURL provides the URL of the page
 	// to create a new proposal online.
@@ -99,7 +100,7 @@ type gitTownConfig interface {
 	OriginURL() *giturl.Parts
 }
 
-type ShaForBranchFunc func(string) (string, error)
+type ShaForBranchFunc func(string) (git.SHA, error)
 
 // NewConnector provides an instance of the code hosting connector to use based on the given gitConfig.
 func NewConnector(args NewConnectorArgs) (Connector, error) {

--- a/src/hosting/core_test.go
+++ b/src/hosting/core_test.go
@@ -2,10 +2,9 @@ package hosting_test
 
 import (
 	"github.com/git-town/git-town/v9/src/git"
-	testgit "github.com/git-town/git-town/v9/test/git"
 )
 
 // emptyShaForBranch is a dummy implementation for hosting.ShaForBranchfunc to be used in tests.
 func emptyShaForBranch(string) (git.SHA, error) {
-	return testgit.ZeroValueSHA(), nil
+	return git.SHA{}, nil
 }

--- a/src/hosting/core_test.go
+++ b/src/hosting/core_test.go
@@ -1,6 +1,11 @@
 package hosting_test
 
+import (
+	"github.com/git-town/git-town/v9/src/git"
+	testgit "github.com/git-town/git-town/v9/test/git"
+)
+
 // emptyShaForBranch is a dummy implementation for hosting.ShaForBranchfunc to be used in tests.
-func emptyShaForBranch(string) (string, error) {
-	return "", nil
+func emptyShaForBranch(string) (git.SHA, error) {
+	return testgit.ZeroValueSHA(), nil
 }

--- a/src/hosting/gitea.go
+++ b/src/hosting/gitea.go
@@ -64,7 +64,7 @@ func (c *GiteaConnector) RepositoryURL() string {
 
 func (c *GiteaConnector) SquashMergeProposal(number int, message string) (mergeSha git.SHA, err error) {
 	if number <= 0 {
-		return git.ErrorSHA(), fmt.Errorf(messages.ProposalNoNumberGiven)
+		return git.SHA{}, fmt.Errorf(messages.ProposalNoNumberGiven)
 	}
 	title, body := ParseCommitMessage(message)
 	_, err = c.client.MergePullRequest(c.Organization, c.Repository, int64(number), gitea.MergePullRequestOption{
@@ -73,11 +73,11 @@ func (c *GiteaConnector) SquashMergeProposal(number int, message string) (mergeS
 		Message: body,
 	})
 	if err != nil {
-		return git.ErrorSHA(), err
+		return git.SHA{}, err
 	}
 	pullRequest, err := c.client.GetPullRequest(c.Organization, c.Repository, int64(number))
 	if err != nil {
-		return git.ErrorSHA(), err
+		return git.SHA{}, err
 	}
 	return git.NewSHA(*pullRequest.MergedCommitID), nil
 }

--- a/src/hosting/gitea.go
+++ b/src/hosting/gitea.go
@@ -7,6 +7,7 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/git-town/git-town/v9/src/config"
+	"github.com/git-town/git-town/v9/src/git"
 	"github.com/git-town/git-town/v9/src/giturl"
 	"github.com/git-town/git-town/v9/src/messages"
 	"golang.org/x/oauth2"
@@ -61,9 +62,9 @@ func (c *GiteaConnector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", c.Hostname, c.Organization, c.Repository)
 }
 
-func (c *GiteaConnector) SquashMergeProposal(number int, message string) (mergeSha string, err error) {
+func (c *GiteaConnector) SquashMergeProposal(number int, message string) (mergeSha git.SHA, err error) {
 	if number <= 0 {
-		return "", fmt.Errorf(messages.ProposalNoNumberGiven)
+		return git.ErrorSHA(), fmt.Errorf(messages.ProposalNoNumberGiven)
 	}
 	title, body := ParseCommitMessage(message)
 	_, err = c.client.MergePullRequest(c.Organization, c.Repository, int64(number), gitea.MergePullRequestOption{
@@ -72,13 +73,13 @@ func (c *GiteaConnector) SquashMergeProposal(number int, message string) (mergeS
 		Message: body,
 	})
 	if err != nil {
-		return "", err
+		return git.ErrorSHA(), err
 	}
 	pullRequest, err := c.client.GetPullRequest(c.Organization, c.Repository, int64(number))
 	if err != nil {
-		return "", err
+		return git.ErrorSHA(), err
 	}
-	return *pullRequest.MergedCommitID, nil
+	return git.NewSHA(*pullRequest.MergedCommitID), nil
 }
 
 func (c *GiteaConnector) UpdateProposalTarget(_ int, _ string) error {

--- a/src/hosting/github.go
+++ b/src/hosting/github.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/git-town/git-town/v9/src/config"
+	"github.com/git-town/git-town/v9/src/git"
 	"github.com/git-town/git-town/v9/src/giturl"
 	"github.com/git-town/git-town/v9/src/messages"
 	"github.com/google/go-github/v50/github"
@@ -62,9 +63,9 @@ func (c *GitHubConnector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", c.Hostname, c.Organization, c.Repository)
 }
 
-func (c *GitHubConnector) SquashMergeProposal(number int, message string) (mergeSHA string, err error) {
+func (c *GitHubConnector) SquashMergeProposal(number int, message string) (mergeSHA git.SHA, err error) {
 	if number <= 0 {
-		return "", fmt.Errorf(messages.ProposalNoNumberGiven)
+		return git.ErrorSHA(), fmt.Errorf(messages.ProposalNoNumberGiven)
 	}
 	c.log.Start(messages.HostingGithubMergingViaAPI, number)
 	title, body := ParseCommitMessage(message)
@@ -72,7 +73,7 @@ func (c *GitHubConnector) SquashMergeProposal(number int, message string) (merge
 		MergeMethod: "squash",
 		CommitTitle: title,
 	})
-	sha := result.GetSHA()
+	sha := git.NewSHA(result.GetSHA())
 	if err != nil {
 		c.log.Failed(err)
 		return sha, err

--- a/src/hosting/github.go
+++ b/src/hosting/github.go
@@ -65,7 +65,7 @@ func (c *GitHubConnector) RepositoryURL() string {
 
 func (c *GitHubConnector) SquashMergeProposal(number int, message string) (mergeSHA git.SHA, err error) {
 	if number <= 0 {
-		return git.ErrorSHA(), fmt.Errorf(messages.ProposalNoNumberGiven)
+		return git.SHA{}, fmt.Errorf(messages.ProposalNoNumberGiven)
 	}
 	c.log.Start(messages.HostingGithubMergingViaAPI, number)
 	title, body := ParseCommitMessage(message)

--- a/src/hosting/gitlab.go
+++ b/src/hosting/gitlab.go
@@ -42,7 +42,7 @@ func (c *GitLabConnector) FindProposal(branch, target string) (*Proposal, error)
 
 func (c *GitLabConnector) SquashMergeProposal(number int, message string) (mergeSHA git.SHA, err error) {
 	if number <= 0 {
-		return git.ErrorSHA(), fmt.Errorf(messages.ProposalNoNumberGiven)
+		return git.SHA{}, fmt.Errorf(messages.ProposalNoNumberGiven)
 	}
 	c.log.Start(messages.HostingGitlabMergingViaAPI, number)
 	// the GitLab API wants the full commit message in the body
@@ -54,7 +54,7 @@ func (c *GitLabConnector) SquashMergeProposal(number int, message string) (merge
 	})
 	if err != nil {
 		c.log.Failed(err)
-		return git.ErrorSHA(), err
+		return git.SHA{}, err
 	}
 	c.log.Success()
 	return git.NewSHA(result.SHA), nil

--- a/src/hosting/gitlab.go
+++ b/src/hosting/gitlab.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/git-town/git-town/v9/src/config"
+	"github.com/git-town/git-town/v9/src/git"
 	"github.com/git-town/git-town/v9/src/giturl"
 	"github.com/git-town/git-town/v9/src/messages"
 	"github.com/xanzy/go-gitlab"
@@ -39,9 +40,9 @@ func (c *GitLabConnector) FindProposal(branch, target string) (*Proposal, error)
 	return &proposal, nil
 }
 
-func (c *GitLabConnector) SquashMergeProposal(number int, message string) (mergeSHA string, err error) {
+func (c *GitLabConnector) SquashMergeProposal(number int, message string) (mergeSHA git.SHA, err error) {
 	if number <= 0 {
-		return "", fmt.Errorf(messages.ProposalNoNumberGiven)
+		return git.ErrorSHA(), fmt.Errorf(messages.ProposalNoNumberGiven)
 	}
 	c.log.Start(messages.HostingGitlabMergingViaAPI, number)
 	// the GitLab API wants the full commit message in the body
@@ -53,10 +54,10 @@ func (c *GitLabConnector) SquashMergeProposal(number int, message string) (merge
 	})
 	if err != nil {
 		c.log.Failed(err)
-		return "", err
+		return git.ErrorSHA(), err
 	}
 	c.log.Success()
-	return result.SHA, nil
+	return git.NewSHA(result.SHA), nil
 }
 
 func (c *GitLabConnector) UpdateProposalTarget(number int, target string) error {

--- a/src/runstate/core_test.go
+++ b/src/runstate/core_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/git-town/git-town/v9/src/git"
 	"github.com/git-town/git-town/v9/src/runstate"
 	"github.com/git-town/git-town/v9/src/steps"
 	"github.com/stretchr/testify/assert"
@@ -15,14 +16,14 @@ func TestRunState(t *testing.T) {
 		t.Parallel()
 		runState := &runstate.RunState{
 			AbortStepList: runstate.StepList{
-				List: []steps.Step{&steps.ResetToShaStep{Sha: "abc"}},
+				List: []steps.Step{&steps.ResetToShaStep{Sha: git.NewSHA("abcdef")}},
 			},
 			Command: "sync",
 			RunStepList: runstate.StepList{
-				List: []steps.Step{&steps.ResetToShaStep{Sha: "abc"}},
+				List: []steps.Step{&steps.ResetToShaStep{Sha: git.NewSHA("abcdef")}},
 			},
 			UndoStepList: runstate.StepList{
-				List: []steps.Step{&steps.ResetToShaStep{Sha: "abc"}},
+				List: []steps.Step{&steps.ResetToShaStep{Sha: git.NewSHA("abcdef")}},
 			},
 		}
 		data, err := json.Marshal(runState)

--- a/src/steps/commit_open_changes_step.go
+++ b/src/steps/commit_open_changes_step.go
@@ -11,7 +11,7 @@ import (
 // It does not ask the user for a commit message, but chooses one automatically.
 type CommitOpenChangesStep struct {
 	EmptyStep
-	previousSha string
+	previousSha git.SHA
 }
 
 func (step *CommitOpenChangesStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/connector_merge_proposal_step.go
+++ b/src/steps/connector_merge_proposal_step.go
@@ -16,7 +16,7 @@ type ConnectorMergeProposalStep struct {
 	ProposalMessage           string
 	enteredEmptyCommitMessage bool
 	mergeError                error
-	mergeSha                  string
+	mergeSha                  git.SHA
 	ProposalNumber            int
 }
 

--- a/src/steps/create_remote_branch_step.go
+++ b/src/steps/create_remote_branch_step.go
@@ -10,7 +10,7 @@ type CreateRemoteBranchStep struct {
 	EmptyStep
 	Branch     string
 	NoPushHook bool
-	Sha        string
+	Sha        git.SHA
 }
 
 func (step *CreateRemoteBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/delete_local_branch_step.go
+++ b/src/steps/delete_local_branch_step.go
@@ -12,11 +12,11 @@ type DeleteLocalBranchStep struct {
 	Branch    string
 	Parent    string
 	Force     bool
-	branchSha string
+	branchSha git.SHA
 }
 
 func (step *DeleteLocalBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
-	return []Step{&CreateBranchStep{Branch: step.Branch, StartingPoint: step.branchSha}}, nil
+	return []Step{&CreateBranchStep{Branch: step.Branch, StartingPoint: step.branchSha.String()}}, nil
 }
 
 func (step *DeleteLocalBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/delete_origin_branch_step.go
+++ b/src/steps/delete_origin_branch_step.go
@@ -11,7 +11,7 @@ type DeleteOriginBranchStep struct {
 	Branch     string // name of the branch to delete without the remote name, i.e. "foo" instead of "origin/foo"
 	IsTracking bool
 	NoPushHook bool
-	branchSha  string
+	branchSha  git.SHA
 }
 
 func (step *DeleteOriginBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/merge_step.go
+++ b/src/steps/merge_step.go
@@ -9,7 +9,7 @@ import (
 type MergeStep struct {
 	EmptyStep
 	Branch      string
-	previousSha string
+	previousSha git.SHA
 }
 
 func (step *MergeStep) CreateAbortStep() Step {

--- a/src/steps/rebase_branch_step.go
+++ b/src/steps/rebase_branch_step.go
@@ -10,7 +10,7 @@ import (
 type RebaseBranchStep struct {
 	EmptyStep
 	Branch      string
-	previousSha string
+	previousSha git.SHA
 }
 
 func (step *RebaseBranchStep) CreateAbortStep() Step {

--- a/src/steps/reset_to_sha_step.go
+++ b/src/steps/reset_to_sha_step.go
@@ -10,7 +10,7 @@ import (
 type ResetToShaStep struct {
 	EmptyStep
 	Hard bool
-	Sha  string
+	Sha  git.SHA
 }
 
 func (step *ResetToShaStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/revert_commit_step.go
+++ b/src/steps/revert_commit_step.go
@@ -8,7 +8,7 @@ import (
 // RevertCommitStep reverts the commit with the given sha.
 type RevertCommitStep struct {
 	EmptyStep
-	Sha string
+	Sha git.SHA
 }
 
 func (step *RevertCommitStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/test/git/sha.go
+++ b/test/git/sha.go
@@ -1,0 +1,8 @@
+package git
+
+import "github.com/git-town/git-town/v9/src/git"
+
+// A zero-value SHA to be used as a placeholder in tests.
+func ZeroValueSHA() git.SHA {
+	return git.ErrorSHA()
+}

--- a/test/git/sha.go
+++ b/test/git/sha.go
@@ -1,8 +1,0 @@
-package git
-
-import "github.com/git-town/git-town/v9/src/git"
-
-// A zero-value SHA to be used as a placeholder in tests.
-func ZeroValueSHA() git.SHA {
-	return git.ErrorSHA()
-}


### PR DESCRIPTION
To prevent primitive obsession and stringly typed code, this PR introduces a dedicated type for Git SHAs.