### PR TITLE
Simplify configuration

### DIFF
--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -23,6 +23,7 @@ Feature: enter a parent branch name when prompted
       | alpha  | main   |
       | beta   | alpha  |
 
+  @debug @this
   Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                     | ANSWER      |

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -23,7 +23,6 @@ Feature: enter a parent branch name when prompted
       | alpha  | main   |
       | beta   | alpha  |
 
-  @debug @this
   Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town sync" and answer the prompts:
       | PROMPT                                     | ANSWER      |

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -77,11 +77,10 @@ func runAppend(arg string, debug bool) error {
 }
 
 type appendConfig struct {
-	branchTypes         domain.BranchTypes
+	branches            domain.Branches
 	branchesToSync      domain.BranchInfos
 	hasOpenChanges      bool
 	remotes             config.Remotes
-	initialBranch       domain.LocalBranchName
 	isOffline           bool
 	lineage             config.Lineage
 	mainBranch          domain.LocalBranchName
@@ -139,11 +138,10 @@ func determineAppendConfig(targetBranch domain.LocalBranchName, run *git.ProdRun
 	syncStrategy := fc.SyncStrategy(run.Config.SyncStrategy())
 	shouldSyncUpstream := fc.Bool(run.Config.ShouldSyncUpstream())
 	return &appendConfig{
-		branchTypes:         branches.Types,
+		branches:            branches,
 		branchesToSync:      branchesToSync,
 		hasOpenChanges:      hasOpenChanges,
 		remotes:             remotes,
-		initialBranch:       branches.Initial,
 		isOffline:           isOffline,
 		lineage:             lineage,
 		mainBranch:          mainBranch,
@@ -163,7 +161,7 @@ func appendStepList(config *appendConfig) (runstate.StepList, error) {
 	for _, branch := range config.branchesToSync {
 		syncBranchSteps(&list, syncBranchStepsArgs{
 			branch:             branch,
-			branchTypes:        config.branchTypes,
+			branchTypes:        config.branches.Types,
 			isOffline:          config.isOffline,
 			lineage:            config.lineage,
 			remotes:            config.remotes,
@@ -185,7 +183,7 @@ func appendStepList(config *appendConfig) (runstate.StepList, error) {
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
 		MainBranch:       config.mainBranch,
-		InitialBranch:    config.initialBranch,
+		InitialBranch:    config.branches.Initial,
 		PreviousBranch:   config.previousBranch,
 	})
 	return list.Result()

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -119,13 +119,12 @@ func determineHackConfig(args []string, promptForParent bool, run *git.ProdRunne
 	pullBranchStrategy := fc.PullBranchStrategy(run.Config.PullBranchStrategy())
 	syncStrategy := fc.SyncStrategy(run.Config.SyncStrategy())
 	return &appendConfig{
-		branchTypes:         branches.Types,
+		branches:            branches,
 		branchesToSync:      branchesToSync,
 		targetBranch:        targetBranch,
 		parentBranch:        parentBranch,
 		hasOpenChanges:      hasOpenChanges,
 		remotes:             remotes,
-		initialBranch:       branches.Initial,
 		lineage:             lineage,
 		mainBranch:          mainBranch,
 		shouldNewBranchPush: shouldNewBranchPush,

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -88,12 +88,11 @@ func newPullRequest(debug bool) error {
 }
 
 type newPullRequestConfig struct {
+	branches           domain.Branches
 	branchesToSync     domain.BranchInfos
-	branchTypes        domain.BranchTypes
 	connector          hosting.Connector
 	hasOpenChanges     bool
 	remotes            config.Remotes
-	initialBranch      domain.LocalBranchName
 	isOffline          bool
 	lineage            config.Lineage
 	mainBranch         domain.LocalBranchName
@@ -182,12 +181,11 @@ func determineNewPullRequestConfig(run *git.ProdRunner, isOffline bool) (*newPul
 	branchNamesToSync := lineage.BranchAndAncestors(branches.Initial)
 	branchesToSync, err := branches.All.Select(branchNamesToSync)
 	return &newPullRequestConfig{
-		branchTypes:        branches.Types,
+		branches:           branches,
 		branchesToSync:     branchesToSync,
 		connector:          connector,
 		hasOpenChanges:     hasOpenChanges,
 		remotes:            remotes,
-		initialBranch:      branches.Initial,
 		isOffline:          isOffline,
 		lineage:            lineage,
 		mainBranch:         mainBranch,
@@ -204,7 +202,7 @@ func newPullRequestStepList(config *newPullRequestConfig) (runstate.StepList, er
 	for _, branch := range config.branchesToSync {
 		syncBranchSteps(&list, syncBranchStepsArgs{
 			branch:             branch,
-			branchTypes:        config.branchTypes,
+			branchTypes:        config.branches.Types,
 			remotes:            config.remotes,
 			isOffline:          config.isOffline,
 			lineage:            config.lineage,
@@ -220,9 +218,9 @@ func newPullRequestStepList(config *newPullRequestConfig) (runstate.StepList, er
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
 		MainBranch:       config.mainBranch,
-		InitialBranch:    config.initialBranch,
+		InitialBranch:    config.branches.Initial,
 		PreviousBranch:   config.previousBranch,
 	})
-	list.Add(&steps.CreateProposalStep{Branch: config.initialBranch})
+	list.Add(&steps.CreateProposalStep{Branch: config.branches.Initial})
 	return list.Result()
 }

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -124,13 +124,12 @@ func determineSyncConfig(allFlag bool, run *git.ProdRunner, isOffline bool) (*sy
 	var shouldPushTags bool
 	lineage := run.Config.Lineage()
 	var configUpdated bool
-	branchTypes := branches.Types
 	if allFlag {
 		localBranches := branches.All.LocalBranches()
 		configUpdated, err = validate.KnowsBranchesAncestors(validate.KnowsBranchesAncestorsArgs{
 			AllBranches: localBranches,
 			Backend:     &run.Backend,
-			BranchTypes: branchTypes,
+			BranchTypes: branches.Types,
 			Lineage:     lineage,
 			MainBranch:  mainBranch,
 		})
@@ -154,15 +153,15 @@ func determineSyncConfig(allFlag bool, run *git.ProdRunner, isOffline bool) (*sy
 	}
 	if configUpdated {
 		lineage = run.Config.Lineage() // reload after ancestry change
-		branchTypes = run.Config.BranchTypes()
+		branches.Types = run.Config.BranchTypes()
 	}
 	if !allFlag {
 		branchNamesToSync = domain.LocalBranchNames{branches.Initial}
 		if configUpdated {
 			run.Config.Reload()
-			branchTypes = run.Config.BranchTypes()
+			branches.Types = run.Config.BranchTypes()
 		}
-		shouldPushTags = !branchTypes.IsFeatureBranch(branches.Initial)
+		shouldPushTags = !branches.Types.IsFeatureBranch(branches.Initial)
 	}
 	allBranchNamesToSync := lineage.BranchesAndAncestors(branchNamesToSync)
 	syncStrategy, err := run.Config.SyncStrategy()


### PR DESCRIPTION
Many configuration objects use various fields of `domain.Branches` as separate fields. Given that all these fields are loaded together, it is simpler to consolidate them.