### PR TITLE
Move EmptyStep composite to bottom

### DIFF
--- a/src/steps/add_to_perennial_branches_step.go
+++ b/src/steps/add_to_perennial_branches_step.go
@@ -8,8 +8,8 @@ import (
 
 // AddToPerennialBranchesStep adds the branch with the given name as a perennial branch.
 type AddToPerennialBranchesStep struct {
-	EmptyStep
 	Branch domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *AddToPerennialBranchesStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/checkout_step.go
+++ b/src/steps/checkout_step.go
@@ -8,9 +8,9 @@ import (
 
 // CheckoutStep checks out a new branch.
 type CheckoutStep struct {
-	EmptyStep
 	Branch         domain.LocalBranchName
 	previousBranch domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *CheckoutStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/commit_open_changes_step.go
+++ b/src/steps/commit_open_changes_step.go
@@ -11,8 +11,8 @@ import (
 // CommitOpenChangesStep commits all open changes as a new commit.
 // It does not ask the user for a commit message, but chooses one automatically.
 type CommitOpenChangesStep struct {
-	EmptyStep
 	previousSha domain.SHA
+	EmptyStep
 }
 
 func (step *CommitOpenChangesStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/connector_merge_proposal_step.go
+++ b/src/steps/connector_merge_proposal_step.go
@@ -11,7 +11,6 @@ import (
 
 // ConnectorMergeProposalStep squash merges the branch with the given name into the current branch.
 type ConnectorMergeProposalStep struct {
-	EmptyStep
 	Branch                    domain.LocalBranchName
 	CommitMessage             string
 	ProposalMessage           string
@@ -19,6 +18,7 @@ type ConnectorMergeProposalStep struct {
 	mergeError                error
 	mergeSha                  domain.SHA
 	ProposalNumber            int
+	EmptyStep
 }
 
 func (step *ConnectorMergeProposalStep) CreateAbortStep() Step {

--- a/src/steps/create_branch_step.go
+++ b/src/steps/create_branch_step.go
@@ -8,9 +8,9 @@ import (
 
 // CreateBranchStep creates a new branch but leaves the current branch unchanged.
 type CreateBranchStep struct {
-	EmptyStep
 	Branch        domain.LocalBranchName
 	StartingPoint domain.Location
+	EmptyStep
 }
 
 func (step *CreateBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/create_proposal_step.go
+++ b/src/steps/create_proposal_step.go
@@ -9,8 +9,8 @@ import (
 
 // CreateProposalStep creates a new pull request for the current branch.
 type CreateProposalStep struct {
-	EmptyStep
 	Branch domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *CreateProposalStep) Run(run *git.ProdRunner, connector hosting.Connector) error {

--- a/src/steps/create_remote_branch_step.go
+++ b/src/steps/create_remote_branch_step.go
@@ -8,10 +8,10 @@ import (
 
 // CreateRemoteBranchStep pushes the current branch up to origin.
 type CreateRemoteBranchStep struct {
-	EmptyStep
 	Branch     domain.LocalBranchName
 	NoPushHook bool
 	Sha        domain.SHA
+	EmptyStep
 }
 
 func (step *CreateRemoteBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -10,9 +10,9 @@ import (
 // CreateTrackingBranchStep pushes the current branch up to origin
 // and marks it as tracking the current branch.
 type CreateTrackingBranchStep struct {
-	EmptyStep
 	Branch     domain.LocalBranchName
 	NoPushHook bool
+	EmptyStep
 }
 
 func (step *CreateTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/delete_local_branch_step.go
+++ b/src/steps/delete_local_branch_step.go
@@ -9,11 +9,11 @@ import (
 // DeleteLocalBranchStep deletes the branch with the given name,
 // optionally in a safe or unsafe way.
 type DeleteLocalBranchStep struct {
-	EmptyStep
 	Branch    domain.LocalBranchName
 	Parent    domain.Location
 	Force     bool
 	branchSha domain.SHA
+	EmptyStep
 }
 
 func (step *DeleteLocalBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/delete_origin_branch_step.go
+++ b/src/steps/delete_origin_branch_step.go
@@ -8,11 +8,11 @@ import (
 
 // DeleteOriginBranchStep deletes the current branch from the origin remote.
 type DeleteOriginBranchStep struct {
-	EmptyStep
 	Branch     domain.LocalBranchName
 	IsTracking bool
 	NoPushHook bool
 	branchSha  domain.SHA
+	EmptyStep
 }
 
 func (step *DeleteOriginBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/delete_parent_branch_step.go
+++ b/src/steps/delete_parent_branch_step.go
@@ -8,9 +8,9 @@ import (
 
 // DeleteParentBranchStep removes the parent branch entry in the Git Town configuration.
 type DeleteParentBranchStep struct {
-	EmptyStep
 	Branch domain.LocalBranchName
 	Parent domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *DeleteParentBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/ensure_has_shippable_changes_step.go
+++ b/src/steps/ensure_has_shippable_changes_step.go
@@ -11,9 +11,9 @@ import (
 
 // EnsureHasShippableChangesStep asserts that the branch has unique changes not on the main branch.
 type EnsureHasShippableChangesStep struct {
-	EmptyStep
 	Branch domain.LocalBranchName
 	Parent domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *EnsureHasShippableChangesStep) CreateAutomaticAbortError() error {

--- a/src/steps/fetch_upstream_step.go
+++ b/src/steps/fetch_upstream_step.go
@@ -9,8 +9,8 @@ import (
 // FetchUpstreamStep brings the Git history of the local repository
 // up to speed with activities that happened in the upstream remote.
 type FetchUpstreamStep struct {
-	EmptyStep
 	Branch domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *FetchUpstreamStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/merge_step.go
+++ b/src/steps/merge_step.go
@@ -8,9 +8,9 @@ import (
 
 // MergeStep merges the branch with the given name into the current branch.
 type MergeStep struct {
-	EmptyStep
 	Branch      domain.BranchName
 	previousSha domain.SHA
+	EmptyStep
 }
 
 func (step *MergeStep) CreateAbortStep() Step {

--- a/src/steps/preserve_checkout_history_step.go
+++ b/src/steps/preserve_checkout_history_step.go
@@ -8,10 +8,10 @@ import (
 
 // PreserveCheckoutHistoryStep does stuff.
 type PreserveCheckoutHistoryStep struct {
-	EmptyStep
 	InitialBranch                     domain.LocalBranchName
 	InitialPreviouslyCheckedOutBranch domain.LocalBranchName
 	MainBranch                        domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *PreserveCheckoutHistoryStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/pull_branch_step.go
+++ b/src/steps/pull_branch_step.go
@@ -8,8 +8,8 @@ import (
 // PullBranchStep updates the branch with the given name with commits from its remote.
 // TODO: rename to PullCurrentBranchStep and remove the "Branch" field.
 type PullBranchStep struct {
-	EmptyStep
 	Branch string
+	EmptyStep
 }
 
 func (step *PullBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -10,12 +10,12 @@ import (
 // PushBranchStep pushes the branch with the given name to the origin remote.
 // Optionally with force.
 type PushBranchStep struct {
-	EmptyStep
 	Branch domain.LocalBranchName
 	// TrackingBranch domain.RemoteBranchName // TODO: populate this with the actual tracking branch name
 	ForceWithLease bool
 	NoPushHook     bool
 	Undoable       bool
+	EmptyStep
 }
 
 func (step *PushBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/rebase_branch_step.go
+++ b/src/steps/rebase_branch_step.go
@@ -9,9 +9,9 @@ import (
 // RebaseBranchStep rebases the current branch
 // against the branch with the given name.
 type RebaseBranchStep struct {
-	EmptyStep
 	Branch      domain.BranchName
 	previousSha domain.SHA
+	EmptyStep
 }
 
 func (step *RebaseBranchStep) CreateAbortStep() Step {

--- a/src/steps/remove_from_perennial_branches_step.go
+++ b/src/steps/remove_from_perennial_branches_step.go
@@ -8,8 +8,8 @@ import (
 
 // RemoveFromPerennialBranchesStep removes the branch with the given name as a perennial branch.
 type RemoveFromPerennialBranchesStep struct {
-	EmptyStep
 	Branch domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *RemoveFromPerennialBranchesStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/reset_to_sha_step.go
+++ b/src/steps/reset_to_sha_step.go
@@ -9,9 +9,9 @@ import (
 // ResetToShaStep undoes all commits on the current branch
 // all the way until the given SHA.
 type ResetToShaStep struct {
-	EmptyStep
 	Hard bool
 	Sha  domain.SHA
+	EmptyStep
 }
 
 func (step *ResetToShaStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/revert_commit_step.go
+++ b/src/steps/revert_commit_step.go
@@ -8,8 +8,8 @@ import (
 
 // RevertCommitStep reverts the commit with the given sha.
 type RevertCommitStep struct {
-	EmptyStep
 	Sha domain.SHA
+	EmptyStep
 }
 
 func (step *RevertCommitStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -9,10 +9,10 @@ import (
 // SetParentStep registers the branch with the given name as a parent
 // of the branch with the other given name.
 type SetParentStep struct {
-	EmptyStep
 	Branch         domain.LocalBranchName
 	ParentBranch   domain.LocalBranchName
 	previousParent domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *SetParentStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {

--- a/src/steps/squash_merge_step.go
+++ b/src/steps/squash_merge_step.go
@@ -12,10 +12,10 @@ import (
 
 // SquashMergeStep squash merges the branch with the given name into the current branch.
 type SquashMergeStep struct {
-	EmptyStep
 	Branch        domain.LocalBranchName
 	CommitMessage string
 	Parent        domain.LocalBranchName
+	EmptyStep
 }
 
 func (step *SquashMergeStep) CreateAbortStep() Step {


### PR DESCRIPTION
It improves readability by putting the more important data first (all steps have the EmptyStep composite) and helps fine-tune the exhaustruct linter.