### PR TITLE
Make test framework set up commits correctly

### DIFF
--- a/features/append/features/push_new_branches.feature
+++ b/features/append/features/push_new_branches.feature
@@ -8,6 +8,7 @@ Feature: auto-push the new branch to origin
     And the current branch is "main"
     When I run "git-town append new"
 
+  @this
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/append/features/push_new_branches.feature
+++ b/features/append/features/push_new_branches.feature
@@ -8,7 +8,6 @@ Feature: auto-push the new branch to origin
     And the current branch is "main"
     When I run "git-town append new"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -1,7 +1,7 @@
 Feature: ship-delete-remote-branch disabled
 
   Background:
-    Given the current branch is a local feature branch "feature"
+    Given the current branch is a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, origin | feature commit |

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -1,7 +1,7 @@
 Feature: handle merge conflicts between feature branch and main branch
 
   Background:
-    Given the local feature branches "alpha", "beta", and "gamma"
+    Given the feature branches "alpha", "beta", and "gamma"
     And the commits
       | BRANCH | LOCATION      | MESSAGE      | FILE NAME        | FILE CONTENT  |
       | main   | origin        | main commit  | conflicting_file | main content  |

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -171,7 +171,7 @@ func (env *Fixture) CreateCommits(commits []git.Commit) {
 				env.DevRepo.CreateCommit(commit)
 			case "local, origin":
 				env.DevRepo.CreateCommit(commit)
-				env.DevRepo.PushBranchToRemote(commit.Branch, config.OriginRemote)
+				env.DevRepo.PushBranch()
 			case "origin":
 				env.OriginRepo.CreateCommit(commit)
 			case "upstream":


### PR DESCRIPTION
The old implementation was secretly changing tracking branch names.