### PR TITLE
Eliminate redundant TestRunner instances

### DIFF
--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -20,7 +20,7 @@ import (
 
 // TestCommands defines Git commands used only in test code.
 type TestCommands struct {
-	subshell.TestRunner
+	*subshell.TestRunner
 	*prodgit.BackendCommands // TODO: remove this dependency on BackendCommands
 }
 

--- a/test/subshell/test_runner.go
+++ b/test/subshell/test_runner.go
@@ -198,6 +198,14 @@ func (r *TestRunner) QueryWith(opts *Options, cmd string, args ...string) (strin
 
 // QueryWith runs the given command with the given options in this ShellRunner's directory.
 func (r *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string) (string, int, error) {
+	currentBranchText := ""
+	if r.Debug {
+		getBranchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+		getBranchCmd.Dir = r.WorkingDir
+		currentBranch, _ := getBranchCmd.Output()
+		currentBranchText = strings.TrimSpace(string(currentBranch))
+	}
+
 	// create an environment with the temp Overrides directory added to the PATH
 	if opts.Env == nil {
 		opts.Env = os.Environ()
@@ -258,7 +266,7 @@ func (r *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string) (s
 		}
 	}
 	if r.Debug {
-		fmt.Printf("\n\n%s > %s %s\n\n", strings.ToUpper(filepath.Base(r.WorkingDir)), cmd, strings.Join(args, " "))
+		fmt.Printf("\n\n%s@%s > %s %s\n\n", strings.ToUpper(filepath.Base(r.WorkingDir)), currentBranchText, cmd, strings.Join(args, " "))
 		os.Stdout.Write(output.Bytes())
 		if err != nil {
 			fmt.Printf("ERROR: %v\n", err)

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -68,7 +68,7 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 		RemotesCache:       &cache.Strings{},
 	}
 	testCommands := commands.TestCommands{
-		TestRunner:      runner,
+		TestRunner:      &runner,
 		BackendCommands: &backendCommands,
 	}
 	return TestRuntime{
@@ -92,7 +92,7 @@ func CreateGitTown(t *testing.T) TestRuntime {
 
 // Clone creates a clone of the repository managed by this test.Runner into the given directory.
 // The cloned repo uses the same homeDir and binDir as its origin.
-func Clone(original testshell.TestRunner, targetDir string) TestRuntime {
+func Clone(original *testshell.TestRunner, targetDir string) TestRuntime {
 	original.MustRun("git", "clone", original.WorkingDir, targetDir)
 	return New(targetDir, original.HomeDir, original.BinDir)
 }


### PR DESCRIPTION
There were multiple TestRunner instances because Go secretly makes copies under the hood when assigning values. This led to configuration settings not propagating as intended. This results in more consistent output of debug statements.