### PR TITLE
Enforce complete data in all steps

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,11 @@ issues:
     - linters:
         - ireturn
       text: (github.com/git-town/git-town/v9/src/hosting.Connector|github.com/git-town/git-town/v9/src/steps.Step)
-    - text: Step is missing field EmptyStep
+    - text: Steps? is missing field EmptyStep
+      linters:
+        - exhaustruct
+    - path: src/runstate/jsonstep.go
+      text: is missing field
       linters:
         - exhaustruct
     - text: (mockConfig|Options|Cmd)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,7 @@ issues:
       linters:
         - ireturn
     - path: src/hosting/gitea
-      text: missing in (ListOptions|ListPullRequestsOptions|PRBranchInfo|Token)
+      text: missing in (List.*Options|PRBranchInfo|Token)
       linters:
         - exhaustruct
     - path: src/hosting/github.go
@@ -82,7 +82,7 @@ issues:
       linters:
         - exhaustruct
     - path: src/hosting/gitlab.go
-      text: missing in (AcceptMergeRequestOptions|Client|ListProjectMergeRequestsOptions|UpdateMergeRequestOptions)
+      text: missing in (.*Options|Client)
       linters:
         - exhaustruct
     - path: src/hosting/gitlab_test.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,7 +63,7 @@ issues:
     - text: Steps? is missing field EmptyStep
       linters:
         - exhaustruct
-    - path: src/runstate/jsonstep.go
+    - path: src/runstate/jsonstep.go # ignore all missing fields in jsonstep.go since those are intentional
       text: is missing field
       linters:
         - exhaustruct

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,7 @@ issues:
       text: is missing field
       linters:
         - exhaustruct
-    - text: (mockConfig|Options)
+    - text: (mockConfig)
       linters:
         - exhaustruct
     - path: src/cache/cache.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,7 @@ issues:
       text: is missing field
       linters:
         - exhaustruct
-    - text: (mockConfig|Options|Cmd)
+    - text: (mockConfig|Options)
       linters:
         - exhaustruct
     - path: src/cache/cache.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,10 @@ issues:
     - linters:
         - ireturn
       text: (github.com/git-town/git-town/v9/src/hosting.Connector|github.com/git-town/git-town/v9/src/steps.Step)
-    - text: (mockConfig|EmptyStep|Options|Cmd)
+    - text: Step is missing field EmptyStep
+      linters:
+        - exhaustruct
+    - text: (mockConfig|Options|Cmd)
       linters:
         - exhaustruct
     - path: src/cache/cache.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,7 @@ issues:
       text: is missing field
       linters:
         - exhaustruct
-    - text: (mockConfig)
+    - text: (cobra.Command|subshell.Options|gitea.*Options|github.*Options|gitlab.*Options|godog.Options) is missing fields?
       linters:
         - exhaustruct
     - path: src/cache/cache.go

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -103,7 +103,7 @@ func pruneBranchesStepList(config *pruneBranchesConfig) (runstate.StepList, erro
 		if config.branches.Types.IsPerennialBranch(branchWithDeletedRemote) {
 			result.Append(&steps.RemoveFromPerennialBranchesStep{Branch: branchWithDeletedRemote})
 		}
-		result.Append(&steps.DeleteLocalBranchStep{Branch: branchWithDeletedRemote, Parent: config.mainBranch.Location()})
+		result.Append(&steps.DeleteLocalBranchStep{Branch: branchWithDeletedRemote, Parent: config.mainBranch.Location(), Force: false})
 	}
 	err := result.Wrap(runstate.WrapOptions{
 		RunInGitRoot:     false,

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -174,9 +174,9 @@ func renameBranchStepList(config *renameBranchConfig) (runstate.StepList, error)
 	}
 	if config.oldBranch.HasTrackingBranch() && !config.isOffline {
 		result.Append(&steps.CreateTrackingBranchStep{Branch: config.newBranch, NoPushHook: config.noPushHook})
-		result.Append(&steps.DeleteOriginBranchStep{Branch: config.oldBranch.Name, IsTracking: true})
+		result.Append(&steps.DeleteOriginBranchStep{Branch: config.oldBranch.Name, IsTracking: true, NoPushHook: false})
 	}
-	result.Append(&steps.DeleteLocalBranchStep{Branch: config.oldBranch.Name, Parent: config.mainBranch.Location()})
+	result.Append(&steps.DeleteLocalBranchStep{Branch: config.oldBranch.Name, Parent: config.mainBranch.Location(), Force: false})
 	err := result.Wrap(runstate.WrapOptions{
 		RunInGitRoot:     false,
 		StashOpenChanges: false,

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -252,9 +252,9 @@ func syncBranchSteps(list *runstate.StepListBuilder, args syncBranchStepsArgs) {
 	if args.pushBranch && args.remotes.HasOrigin() && !args.isOffline {
 		switch {
 		case !args.branch.HasTrackingBranch():
-			list.Add(&steps.CreateTrackingBranchStep{Branch: args.branch.Name})
+			list.Add(&steps.CreateTrackingBranchStep{Branch: args.branch.Name, NoPushHook: false})
 		case !isFeatureBranch:
-			list.Add(&steps.PushBranchStep{Branch: args.branch.Name})
+			list.Add(&steps.PushBranchStep{Branch: args.branch.Name, ForceWithLease: false, NoPushHook: false, Undoable: false})
 		default:
 			pushFeatureBranchSteps(list, args.branch.Name, args.syncStrategy, args.pushHook)
 		}
@@ -327,9 +327,9 @@ func updateCurrentPerennialBranchStep(list *runstate.StepListBuilder, otherBranc
 func pushFeatureBranchSteps(list *runstate.StepListBuilder, branch domain.LocalBranchName, syncStrategy config.SyncStrategy, pushHook bool) {
 	switch syncStrategy {
 	case config.SyncStrategyMerge:
-		list.Add(&steps.PushBranchStep{Branch: branch, NoPushHook: !pushHook})
+		list.Add(&steps.PushBranchStep{Branch: branch, NoPushHook: !pushHook, ForceWithLease: false, Undoable: false})
 	case config.SyncStrategyRebase:
-		list.Add(&steps.PushBranchStep{Branch: branch, ForceWithLease: true})
+		list.Add(&steps.PushBranchStep{Branch: branch, ForceWithLease: true, NoPushHook: false, Undoable: false})
 	default:
 		list.Fail("unknown syncStrategy value: %q", syncStrategy)
 	}

--- a/src/runstate/core_test.go
+++ b/src/runstate/core_test.go
@@ -16,7 +16,7 @@ func TestRunState(t *testing.T) {
 		t.Parallel()
 		runState := &runstate.RunState{
 			AbortStepList: runstate.StepList{
-				List: []steps.Step{&steps.ResetToShaStep{Sha: domain.NewSHA("abcdef")}},
+				List: []steps.Step{&steps.ResetToShaStep{Sha: domain.NewSHA("abcdef"), Hard: false}},
 			},
 			Command: "sync",
 			RunStepList: runstate.StepList{

--- a/src/runstate/core_test.go
+++ b/src/runstate/core_test.go
@@ -20,10 +20,10 @@ func TestRunState(t *testing.T) {
 			},
 			Command: "sync",
 			RunStepList: runstate.StepList{
-				List: []steps.Step{&steps.ResetToShaStep{Sha: domain.NewSHA("abcdef")}},
+				List: []steps.Step{&steps.ResetToShaStep{Sha: domain.NewSHA("abcdef"), Hard: false}},
 			},
 			UndoStepList: runstate.StepList{
-				List: []steps.Step{&steps.ResetToShaStep{Sha: domain.NewSHA("abcdef")}},
+				List: []steps.Step{&steps.ResetToShaStep{Sha: domain.NewSHA("abcdef"), Hard: false}},
 			},
 		}
 		data, err := json.Marshal(runState)

--- a/src/runstate/persistence_test.go
+++ b/src/runstate/persistence_test.go
@@ -63,6 +63,7 @@ func TestSanitizePath(t *testing.T) {
 					&steps.DeleteLocalBranchStep{
 						Branch: domain.NewLocalBranchName("branch"),
 						Parent: domain.NewLocalBranchName("parent").Location(),
+						Force:  false,
 					},
 					&steps.DeleteOriginBranchStep{
 						Branch:     domain.NewLocalBranchName("branch"),

--- a/src/runstate/runstate.go
+++ b/src/runstate/runstate.go
@@ -33,7 +33,7 @@ func (runState *RunState) AddPushBranchStepAfterCurrentBranchSteps(backend *git.
 			if err != nil {
 				return err
 			}
-			runState.RunStepList.Prepend(&steps.PushBranchStep{Branch: currentBranch})
+			runState.RunStepList.Prepend(&steps.PushBranchStep{Branch: currentBranch, ForceWithLease: false, NoPushHook: false, Undoable: false})
 			runState.RunStepList.PrependList(popped)
 			break
 		}

--- a/src/steps/checkout_step.go
+++ b/src/steps/checkout_step.go
@@ -9,7 +9,7 @@ import (
 // CheckoutStep checks out a new branch.
 type CheckoutStep struct {
 	Branch         domain.LocalBranchName
-	previousBranch domain.LocalBranchName
+	previousBranch domain.LocalBranchName `exhaustruct:"optional"`
 	EmptyStep
 }
 

--- a/src/steps/commit_open_changes_step.go
+++ b/src/steps/commit_open_changes_step.go
@@ -16,7 +16,7 @@ type CommitOpenChangesStep struct {
 }
 
 func (step *CommitOpenChangesStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
-	return []Step{&ResetToShaStep{Sha: step.previousSha}}, nil
+	return []Step{&ResetToShaStep{Sha: step.previousSha, Hard: false}}, nil
 }
 
 func (step *CommitOpenChangesStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -15,7 +15,7 @@ type CreateTrackingBranchStep struct {
 }
 
 func (step *CreateTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
-	return []Step{&DeleteOriginBranchStep{Branch: step.Branch}}, nil
+	return []Step{&DeleteOriginBranchStep{Branch: step.Branch, IsTracking: false, NoPushHook: false}}, nil
 }
 
 func (step *CreateTrackingBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/delete_local_branch_step.go
+++ b/src/steps/delete_local_branch_step.go
@@ -12,7 +12,7 @@ type DeleteLocalBranchStep struct {
 	Branch    domain.LocalBranchName
 	Parent    domain.Location
 	Force     bool
-	branchSha domain.SHA
+	branchSha domain.SHA `exhaustruct:"optional"`
 	EmptyStep
 }
 

--- a/src/steps/delete_origin_branch_step.go
+++ b/src/steps/delete_origin_branch_step.go
@@ -11,7 +11,7 @@ type DeleteOriginBranchStep struct {
 	Branch     domain.LocalBranchName
 	IsTracking bool
 	NoPushHook bool
-	branchSha  domain.SHA
+	branchSha  domain.SHA `exhaustruct:"optional"`
 	EmptyStep
 }
 

--- a/src/steps/set_parent_branch_step.go
+++ b/src/steps/set_parent_branch_step.go
@@ -11,7 +11,7 @@ import (
 type SetParentStep struct {
 	Branch         domain.LocalBranchName
 	ParentBranch   domain.LocalBranchName
-	previousParent domain.LocalBranchName
+	previousParent domain.LocalBranchName `exhaustruct:"optional"`
 	EmptyStep
 }
 


### PR DESCRIPTION
The linter had a misconfiguration that made it ignore most step instances. This was a vector for bugs and caused a good amount of avoidable manual debugging.