### PR TITLE
Split DeleteOriginBranchStep

### DIFF
--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -161,7 +161,7 @@ func killStepList(config *killConfig) (runstate.StepList, error) {
 // killFeatureBranch kills the given feature branch everywhere it exists (locally and remotely).
 func killFeatureBranch(list *runstate.StepList, config killConfig) {
 	if config.targetBranch.HasTrackingBranch() && config.isOnline() {
-		list.Append(&steps.DeleteOriginBranchStep{Branch: config.targetBranch.Name, IsTracking: true, NoPushHook: config.noPushHook})
+		list.Append(&steps.DeleteTrackingBranchStep{Branch: config.targetBranch.Name, NoPushHook: config.noPushHook})
 	}
 	if config.initialBranch == config.targetBranch.Name {
 		if config.hasOpenChanges {

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -174,7 +174,7 @@ func renameBranchStepList(config *renameBranchConfig) (runstate.StepList, error)
 	}
 	if config.oldBranch.HasTrackingBranch() && !config.isOffline {
 		result.Append(&steps.CreateTrackingBranchStep{Branch: config.newBranch, NoPushHook: config.noPushHook})
-		result.Append(&steps.DeleteOriginBranchStep{Branch: config.oldBranch.Name, IsTracking: true, NoPushHook: false})
+		result.Append(&steps.DeleteTrackingBranchStep{Branch: config.oldBranch.Name, NoPushHook: false})
 	}
 	result.Append(&steps.DeleteLocalBranchStep{Branch: config.oldBranch.Name, Parent: config.mainBranch.Location(), Force: false})
 	err := result.Wrap(runstate.WrapOptions{

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -349,7 +349,7 @@ func shipStepList(config *shipConfig, commitMessage string, run *git.ProdRunner)
 	// - we know we are online
 	if config.canShipViaAPI || (config.branchToShip.HasTrackingBranch() && len(config.childBranches) == 0 && !config.isOffline) {
 		if config.deleteOriginBranch {
-			list.Add(&steps.DeleteOriginBranchStep{Branch: config.branchToShip.Name, IsTracking: true, NoPushHook: false})
+			list.Add(&steps.DeleteTrackingBranchStep{Branch: config.branchToShip.Name, NoPushHook: false})
 		}
 	}
 	list.Add(&steps.DeleteLocalBranchStep{Branch: config.branchToShip.Name, Parent: config.mainBranch.Location(), Force: false})

--- a/src/runstate/jsonstep.go
+++ b/src/runstate/jsonstep.go
@@ -73,6 +73,8 @@ func DetermineStep(stepType string) steps.Step {
 		return &steps.DeleteOriginBranchStep{}
 	case "*DeleteParentBranchStep":
 		return &steps.DeleteParentBranchStep{}
+	case "*DeleteTrackingBranchStep":
+		return &steps.DeleteTrackingBranchStep{}
 	case "*DiscardOpenChangesStep":
 		return &steps.DiscardOpenChangesStep{}
 	case "*EmptyStep":

--- a/src/runstate/persistence_test.go
+++ b/src/runstate/persistence_test.go
@@ -67,12 +67,15 @@ func TestSanitizePath(t *testing.T) {
 					},
 					&steps.DeleteOriginBranchStep{
 						Branch:     domain.NewLocalBranchName("branch"),
-						IsTracking: true,
 						NoPushHook: true,
 					},
 					&steps.DeleteParentBranchStep{
 						Branch: domain.NewLocalBranchName("branch"),
 						Parent: domain.NewLocalBranchName("parent"),
+					},
+					&steps.DeleteTrackingBranchStep{
+						Branch:     domain.NewLocalBranchName("branch"),
+						NoPushHook: true,
 					},
 					&steps.DiscardOpenChangesStep{},
 					&steps.EnsureHasShippableChangesStep{
@@ -221,7 +224,6 @@ func TestSanitizePath(t *testing.T) {
     {
       "data": {
         "Branch": "branch",
-        "IsTracking": true,
         "NoPushHook": true
       },
       "type": "*DeleteOriginBranchStep"
@@ -232,6 +234,13 @@ func TestSanitizePath(t *testing.T) {
         "Parent": "parent"
       },
       "type": "*DeleteParentBranchStep"
+    },
+    {
+      "data": {
+        "Branch": "branch",
+        "NoPushHook": true
+      },
+      "type": "*DeleteTrackingBranchStep"
     },
     {
       "data": {},

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -15,7 +15,7 @@ type CreateTrackingBranchStep struct {
 }
 
 func (step *CreateTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
-	return []Step{&DeleteOriginBranchStep{Branch: step.Branch, IsTracking: false, NoPushHook: false}}, nil
+	return []Step{&DeleteOriginBranchStep{Branch: step.Branch, NoPushHook: false}}, nil
 }
 
 func (step *CreateTrackingBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {

--- a/src/steps/delete_local_branch_step.go
+++ b/src/steps/delete_local_branch_step.go
@@ -6,8 +6,7 @@ import (
 	"github.com/git-town/git-town/v9/src/hosting"
 )
 
-// DeleteLocalBranchStep deletes the branch with the given name,
-// optionally in a safe or unsafe way.
+// DeleteLocalBranchStep deletes the branch with the given name.
 type DeleteLocalBranchStep struct {
 	Branch    domain.LocalBranchName
 	Parent    domain.Location

--- a/src/steps/delete_tracking_branch_step.go
+++ b/src/steps/delete_tracking_branch_step.go
@@ -1,0 +1,22 @@
+package steps
+
+import (
+	"github.com/git-town/git-town/v9/src/domain"
+	"github.com/git-town/git-town/v9/src/git"
+	"github.com/git-town/git-town/v9/src/hosting"
+)
+
+// DeleteTrackingBranchStep deletes the tracking branch of the given local branch.
+type DeleteTrackingBranchStep struct {
+	Branch     domain.LocalBranchName
+	NoPushHook bool
+	EmptyStep
+}
+
+func (step *DeleteTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
+	return []Step{&CreateTrackingBranchStep{Branch: step.Branch, NoPushHook: step.NoPushHook}}, nil
+}
+
+func (step *DeleteTrackingBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
+	return run.Frontend.DeleteRemoteBranch(step.Branch)
+}


### PR DESCRIPTION
This step really is two separate steps merged at the hip. Splitting them removes alternative code paths from the implementation.