### PR TITLE
Split up the logic around pushing branches

### DIFF
--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -329,7 +329,7 @@ func shipStepList(config *shipConfig, commitMessage string, run *git.ProdRunner)
 			})
 		}
 		// push
-		list.Add(&steps.PushCurrentBranchStep{Branch: config.branchToShip.Name, NoPushHook: false, Undoable: false})
+		list.Add(&steps.PushCurrentBranchStep{CurrentBranch: config.branchToShip.Name, NoPushHook: false, Undoable: false})
 		list.Add(&steps.ConnectorMergeProposalStep{
 			Branch:          config.branchToShip.Name,
 			ProposalNumber:  config.proposal.Number,
@@ -341,7 +341,7 @@ func shipStepList(config *shipConfig, commitMessage string, run *git.ProdRunner)
 		list.Add(&steps.SquashMergeStep{Branch: config.branchToShip.Name, CommitMessage: commitMessage, Parent: config.targetBranch.Name})
 	}
 	if config.remotes.HasOrigin() && !config.isOffline {
-		list.Add(&steps.PushCurrentBranchStep{Branch: config.targetBranch.Name, Undoable: true, NoPushHook: false})
+		list.Add(&steps.PushCurrentBranchStep{CurrentBranch: config.targetBranch.Name, Undoable: true, NoPushHook: false})
 	}
 	// NOTE: when shipping via API, we can always delete the remote branch because:
 	// - we know we have a tracking branch (otherwise there would be no PR to ship via API)

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -329,7 +329,7 @@ func shipStepList(config *shipConfig, commitMessage string, run *git.ProdRunner)
 			})
 		}
 		// push
-		list.Add(&steps.PushBranchStep{Branch: config.branchToShip.Name, NoPushHook: false, Undoable: false})
+		list.Add(&steps.PushCurrentBranchStep{Branch: config.branchToShip.Name, NoPushHook: false, Undoable: false})
 		list.Add(&steps.ConnectorMergeProposalStep{
 			Branch:          config.branchToShip.Name,
 			ProposalNumber:  config.proposal.Number,
@@ -341,7 +341,7 @@ func shipStepList(config *shipConfig, commitMessage string, run *git.ProdRunner)
 		list.Add(&steps.SquashMergeStep{Branch: config.branchToShip.Name, CommitMessage: commitMessage, Parent: config.targetBranch.Name})
 	}
 	if config.remotes.HasOrigin() && !config.isOffline {
-		list.Add(&steps.PushBranchStep{Branch: config.targetBranch.Name, Undoable: true, NoPushHook: false})
+		list.Add(&steps.PushCurrentBranchStep{Branch: config.targetBranch.Name, Undoable: true, NoPushHook: false})
 	}
 	// NOTE: when shipping via API, we can always delete the remote branch because:
 	// - we know we have a tracking branch (otherwise there would be no PR to ship via API)

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -329,7 +329,7 @@ func shipStepList(config *shipConfig, commitMessage string, run *git.ProdRunner)
 			})
 		}
 		// push
-		list.Add(&steps.PushBranchStep{Branch: config.branchToShip.Name, ForceWithLease: false, NoPushHook: false, Undoable: false})
+		list.Add(&steps.PushBranchStep{Branch: config.branchToShip.Name, NoPushHook: false, Undoable: false})
 		list.Add(&steps.ConnectorMergeProposalStep{
 			Branch:          config.branchToShip.Name,
 			ProposalNumber:  config.proposal.Number,
@@ -341,7 +341,7 @@ func shipStepList(config *shipConfig, commitMessage string, run *git.ProdRunner)
 		list.Add(&steps.SquashMergeStep{Branch: config.branchToShip.Name, CommitMessage: commitMessage, Parent: config.targetBranch.Name})
 	}
 	if config.remotes.HasOrigin() && !config.isOffline {
-		list.Add(&steps.PushBranchStep{Branch: config.targetBranch.Name, Undoable: true, ForceWithLease: false, NoPushHook: false})
+		list.Add(&steps.PushBranchStep{Branch: config.targetBranch.Name, Undoable: true, NoPushHook: false})
 	}
 	// NOTE: when shipping via API, we can always delete the remote branch because:
 	// - we know we have a tracking branch (otherwise there would be no PR to ship via API)

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -254,7 +254,7 @@ func syncBranchSteps(list *runstate.StepListBuilder, args syncBranchStepsArgs) {
 		case !args.branch.HasTrackingBranch():
 			list.Add(&steps.CreateTrackingBranchStep{Branch: args.branch.Name, NoPushHook: false})
 		case !isFeatureBranch:
-			list.Add(&steps.PushCurrentBranchStep{Branch: args.branch.Name, NoPushHook: false, Undoable: false})
+			list.Add(&steps.PushCurrentBranchStep{CurrentBranch: args.branch.Name, NoPushHook: false, Undoable: false})
 		default:
 			pushFeatureBranchSteps(list, args.branch.Name, args.syncStrategy, args.pushHook)
 		}
@@ -327,7 +327,7 @@ func updateCurrentPerennialBranchStep(list *runstate.StepListBuilder, otherBranc
 func pushFeatureBranchSteps(list *runstate.StepListBuilder, branch domain.LocalBranchName, syncStrategy config.SyncStrategy, pushHook bool) {
 	switch syncStrategy {
 	case config.SyncStrategyMerge:
-		list.Add(&steps.PushCurrentBranchStep{Branch: branch, NoPushHook: !pushHook, Undoable: false})
+		list.Add(&steps.PushCurrentBranchStep{CurrentBranch: branch, NoPushHook: !pushHook, Undoable: false})
 	case config.SyncStrategyRebase:
 		list.Add(&steps.ForcePushBranchStep{Branch: branch, NoPushHook: false})
 	default:

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -254,7 +254,7 @@ func syncBranchSteps(list *runstate.StepListBuilder, args syncBranchStepsArgs) {
 		case !args.branch.HasTrackingBranch():
 			list.Add(&steps.CreateTrackingBranchStep{Branch: args.branch.Name, NoPushHook: false})
 		case !isFeatureBranch:
-			list.Add(&steps.PushBranchStep{Branch: args.branch.Name, ForceWithLease: false, NoPushHook: false, Undoable: false})
+			list.Add(&steps.PushBranchStep{Branch: args.branch.Name, NoPushHook: false, Undoable: false})
 		default:
 			pushFeatureBranchSteps(list, args.branch.Name, args.syncStrategy, args.pushHook)
 		}
@@ -327,9 +327,9 @@ func updateCurrentPerennialBranchStep(list *runstate.StepListBuilder, otherBranc
 func pushFeatureBranchSteps(list *runstate.StepListBuilder, branch domain.LocalBranchName, syncStrategy config.SyncStrategy, pushHook bool) {
 	switch syncStrategy {
 	case config.SyncStrategyMerge:
-		list.Add(&steps.PushBranchStep{Branch: branch, NoPushHook: !pushHook, ForceWithLease: false, Undoable: false})
+		list.Add(&steps.PushBranchStep{Branch: branch, NoPushHook: !pushHook, Undoable: false})
 	case config.SyncStrategyRebase:
-		list.Add(&steps.PushBranchStep{Branch: branch, ForceWithLease: true, NoPushHook: false, Undoable: false})
+		list.Add(&steps.ForcePushBranchStep{Branch: branch, NoPushHook: false})
 	default:
 		list.Fail("unknown syncStrategy value: %q", syncStrategy)
 	}

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -254,7 +254,7 @@ func syncBranchSteps(list *runstate.StepListBuilder, args syncBranchStepsArgs) {
 		case !args.branch.HasTrackingBranch():
 			list.Add(&steps.CreateTrackingBranchStep{Branch: args.branch.Name, NoPushHook: false})
 		case !isFeatureBranch:
-			list.Add(&steps.PushBranchStep{Branch: args.branch.Name, NoPushHook: false, Undoable: false})
+			list.Add(&steps.PushCurrentBranchStep{Branch: args.branch.Name, NoPushHook: false, Undoable: false})
 		default:
 			pushFeatureBranchSteps(list, args.branch.Name, args.syncStrategy, args.pushHook)
 		}
@@ -327,7 +327,7 @@ func updateCurrentPerennialBranchStep(list *runstate.StepListBuilder, otherBranc
 func pushFeatureBranchSteps(list *runstate.StepListBuilder, branch domain.LocalBranchName, syncStrategy config.SyncStrategy, pushHook bool) {
 	switch syncStrategy {
 	case config.SyncStrategyMerge:
-		list.Add(&steps.PushBranchStep{Branch: branch, NoPushHook: !pushHook, Undoable: false})
+		list.Add(&steps.PushCurrentBranchStep{Branch: branch, NoPushHook: !pushHook, Undoable: false})
 	case config.SyncStrategyRebase:
 		list.Add(&steps.ForcePushBranchStep{Branch: branch, NoPushHook: false})
 	default:

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -102,6 +102,17 @@ func (fc *FrontendCommands) DeleteLastCommit() error {
 	return fc.Run("git", "reset", "--hard", "HEAD~1")
 }
 
+// PushBranch pushes the branch with the given name to origin.
+func (fc *FrontendCommands) CreateTrackingBranch(branch domain.LocalBranchName, remote domain.Remote, noPushHook bool) error {
+	args := []string{"push"}
+	if noPushHook {
+		args = append(args, "--no-verify")
+	}
+	args = append(args, "-u", remote.String())
+	args = append(args, branch.String())
+	return fc.Run("git", args...)
+}
+
 // DeleteLocalBranch removes the local branch with the given name.
 func (fc *FrontendCommands) DeleteLocalBranch(name domain.LocalBranchName, force bool) error {
 	args := []string{"branch", "-d", name.String()}
@@ -165,17 +176,6 @@ func (fc *FrontendCommands) PushCurrentBranch(noPushHook bool) error {
 	if noPushHook {
 		args = append(args, "--no-verify")
 	}
-	return fc.Run("git", args...)
-}
-
-// PushBranch pushes the branch with the given name to origin.
-func (fc *FrontendCommands) CreateTrackingBranch(branch domain.LocalBranchName, remote domain.Remote, noPushHook bool) error {
-	args := []string{"push"}
-	if noPushHook {
-		args = append(args, "--no-verify")
-	}
-	args = append(args, "-u", remote.String())
-	args = append(args, branch.String())
 	return fc.Run("git", args...)
 }
 

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -169,7 +169,7 @@ func (fc *FrontendCommands) PushCurrentBranch(noPushHook bool) error {
 }
 
 // PushBranch pushes the branch with the given name to origin.
-func (fc *FrontendCommands) PushTrackingBranch(branch domain.LocalBranchName, remote domain.Remote, noPushHook bool) error {
+func (fc *FrontendCommands) CreateTrackingBranch(branch domain.LocalBranchName, remote domain.Remote, noPushHook bool) error {
 	args := []string{"push"}
 	if noPushHook {
 		args = append(args, "--no-verify")

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -159,11 +159,6 @@ func (fc *FrontendCommands) Pull() error {
 	return fc.Run("git", "pull")
 }
 
-type PushArgs struct {
-	Branch     domain.LocalBranchName
-	NoPushHook bool `exhaustruct:"optional"`
-}
-
 // PushBranch pushes the branch with the given name to origin.
 func (fc *FrontendCommands) PushBranch(noPushHook bool) error {
 	args := []string{"push"}
@@ -185,14 +180,10 @@ func (fc *FrontendCommands) PushTrackingBranch(branch domain.LocalBranchName, re
 }
 
 // PushBranch pushes the branch with the given name to origin.
-func (fc *FrontendCommands) ForcePushBranch(options PushArgs) error {
+func (fc *FrontendCommands) ForcePushBranch(noPushHook bool) error {
 	args := []string{"push", "--force-with-lease"}
-	provideBranch := false
-	if options.NoPushHook {
+	if noPushHook {
 		args = append(args, "--no-verify")
-	}
-	if !options.Branch.IsEmpty() && provideBranch {
-		args = append(args, options.Branch.String())
 	}
 	return fc.Run("git", args...)
 }

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -167,12 +167,8 @@ type PushArgs struct {
 // PushBranch pushes the branch with the given name to origin.
 func (fc *FrontendCommands) PushBranch(options PushArgs) error {
 	args := []string{"push"}
-	provideBranch := false
 	if options.NoPushHook {
 		args = append(args, "--no-verify")
-	}
-	if !options.Branch.IsEmpty() && provideBranch {
-		args = append(args, options.Branch.String())
 	}
 	return fc.Run("git", args...)
 }

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -162,7 +162,6 @@ func (fc *FrontendCommands) Pull() error {
 type PushArgs struct {
 	Branch     domain.LocalBranchName
 	NoPushHook bool `exhaustruct:"optional"`
-	Remote     domain.Remote
 }
 
 // PushBranch pushes the branch with the given name to origin.
@@ -172,11 +171,20 @@ func (fc *FrontendCommands) PushBranch(options PushArgs) error {
 	if options.NoPushHook {
 		args = append(args, "--no-verify")
 	}
-	if !options.Remote.IsEmpty() {
-		args = append(args, "-u", options.Remote.String())
-		provideBranch = true
-	}
 	if !options.Branch.IsEmpty() && provideBranch {
+		args = append(args, options.Branch.String())
+	}
+	return fc.Run("git", args...)
+}
+
+// PushBranch pushes the branch with the given name to origin.
+func (fc *FrontendCommands) PushTrackingBranch(options PushArgs, remote domain.Remote) error {
+	args := []string{"push"}
+	if options.NoPushHook {
+		args = append(args, "--no-verify")
+	}
+	args = append(args, "-u", remote.String())
+	if !options.Branch.IsEmpty() {
 		args = append(args, options.Branch.String())
 	}
 	return fc.Run("git", args...)
@@ -188,10 +196,6 @@ func (fc *FrontendCommands) ForcePushBranch(options PushArgs) error {
 	provideBranch := false
 	if options.NoPushHook {
 		args = append(args, "--no-verify")
-	}
-	if !options.Remote.IsEmpty() {
-		args = append(args, "-u", options.Remote.String())
-		provideBranch = true
 	}
 	if !options.Branch.IsEmpty() && provideBranch {
 		args = append(args, options.Branch.String())

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -174,13 +174,13 @@ func (fc *FrontendCommands) PushBranch(noPushHook bool) error {
 }
 
 // PushBranch pushes the branch with the given name to origin.
-func (fc *FrontendCommands) PushTrackingBranch(options PushArgs, remote domain.Remote) error {
+func (fc *FrontendCommands) PushTrackingBranch(branch domain.LocalBranchName, remote domain.Remote, noPushHook bool) error {
 	args := []string{"push"}
-	if options.NoPushHook {
+	if noPushHook {
 		args = append(args, "--no-verify")
 	}
 	args = append(args, "-u", remote.String())
-	args = append(args, options.Branch.String())
+	args = append(args, branch.String())
 	return fc.Run("git", args...)
 }
 

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -159,8 +159,8 @@ func (fc *FrontendCommands) Pull() error {
 	return fc.Run("git", "pull")
 }
 
-// PushBranch pushes the branch with the given name to origin.
-func (fc *FrontendCommands) PushBranch(noPushHook bool) error {
+// PushCurrentBranch pushes the current branch to its tracking branch.
+func (fc *FrontendCommands) PushCurrentBranch(noPushHook bool) error {
 	args := []string{"push"}
 	if noPushHook {
 		args = append(args, "--no-verify")

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -165,9 +165,9 @@ type PushArgs struct {
 }
 
 // PushBranch pushes the branch with the given name to origin.
-func (fc *FrontendCommands) PushBranch(options PushArgs) error {
+func (fc *FrontendCommands) PushBranch(noPushHook bool) error {
 	args := []string{"push"}
-	if options.NoPushHook {
+	if noPushHook {
 		args = append(args, "--no-verify")
 	}
 	return fc.Run("git", args...)

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -160,10 +160,9 @@ func (fc *FrontendCommands) Pull() error {
 }
 
 type PushArgs struct {
-	Branch         domain.LocalBranchName
-	ForceWithLease bool `exhaustruct:"optional"`
-	NoPushHook     bool `exhaustruct:"optional"`
-	Remote         domain.Remote
+	Branch     domain.LocalBranchName
+	NoPushHook bool `exhaustruct:"optional"`
+	Remote     domain.Remote
 }
 
 // PushBranch pushes the branch with the given name to origin.
@@ -173,8 +172,22 @@ func (fc *FrontendCommands) PushBranch(options PushArgs) error {
 	if options.NoPushHook {
 		args = append(args, "--no-verify")
 	}
-	if options.ForceWithLease {
-		args = append(args, "--force-with-lease")
+	if !options.Remote.IsEmpty() {
+		args = append(args, "-u", options.Remote.String())
+		provideBranch = true
+	}
+	if !options.Branch.IsEmpty() && provideBranch {
+		args = append(args, options.Branch.String())
+	}
+	return fc.Run("git", args...)
+}
+
+// PushBranch pushes the branch with the given name to origin.
+func (fc *FrontendCommands) ForcePushBranch(options PushArgs) error {
+	args := []string{"push", "--force-with-lease"}
+	provideBranch := false
+	if options.NoPushHook {
+		args = append(args, "--no-verify")
 	}
 	if !options.Remote.IsEmpty() {
 		args = append(args, "-u", options.Remote.String())

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -180,9 +180,7 @@ func (fc *FrontendCommands) PushTrackingBranch(options PushArgs, remote domain.R
 		args = append(args, "--no-verify")
 	}
 	args = append(args, "-u", remote.String())
-	if !options.Branch.IsEmpty() {
-		args = append(args, options.Branch.String())
-	}
+	args = append(args, options.Branch.String())
 	return fc.Run("git", args...)
 }
 

--- a/src/runstate/jsonstep.go
+++ b/src/runstate/jsonstep.go
@@ -93,8 +93,8 @@ func DetermineStep(stepType string) steps.Step {
 		return &steps.PullBranchStep{}
 	case "*PushBranchAfterCurrentBranchSteps":
 		return &steps.PushBranchAfterCurrentBranchSteps{}
-	case "*PushBranchStep":
-		return &steps.PushBranchStep{}
+	case "*PushCurrentBranchStep":
+		return &steps.PushCurrentBranchStep{}
 	case "*PushTagsStep":
 		return &steps.PushTagsStep{}
 	case "*RebaseBranchStep":

--- a/src/runstate/jsonstep.go
+++ b/src/runstate/jsonstep.go
@@ -83,6 +83,8 @@ func DetermineStep(stepType string) steps.Step {
 		return &steps.EnsureHasShippableChangesStep{}
 	case "*FetchUpstreamStep":
 		return &steps.FetchUpstreamStep{}
+	case "*ForcePushBranchStep":
+		return &steps.ForcePushBranchStep{}
 	case "*MergeStep":
 		return &steps.MergeStep{}
 	case "*PreserveCheckoutHistoryStep":

--- a/src/runstate/persistence_test.go
+++ b/src/runstate/persistence_test.go
@@ -97,7 +97,7 @@ func TestSanitizePath(t *testing.T) {
 					},
 					&steps.PullBranchStep{Branch: "branch"},
 					&steps.PushBranchAfterCurrentBranchSteps{},
-					&steps.PushBranchStep{
+					&steps.PushCurrentBranchStep{
 						Branch:     domain.NewLocalBranchName("branch"),
 						NoPushHook: true,
 						Undoable:   true,
@@ -299,7 +299,7 @@ func TestSanitizePath(t *testing.T) {
         "NoPushHook": true,
         "Undoable": true
       },
-      "type": "*PushBranchStep"
+      "type": "*PushCurrentBranchStep"
     },
     {
       "data": {},

--- a/src/runstate/persistence_test.go
+++ b/src/runstate/persistence_test.go
@@ -85,6 +85,10 @@ func TestSanitizePath(t *testing.T) {
 					&steps.FetchUpstreamStep{
 						Branch: domain.NewLocalBranchName("branch"),
 					},
+					&steps.ForcePushBranchStep{
+						Branch:     domain.NewLocalBranchName("branch"),
+						NoPushHook: true,
+					},
 					&steps.MergeStep{Branch: domain.NewBranchName("branch")},
 					&steps.PreserveCheckoutHistoryStep{
 						InitialBranch:                     domain.NewLocalBranchName("initial-branch"),
@@ -94,10 +98,9 @@ func TestSanitizePath(t *testing.T) {
 					&steps.PullBranchStep{Branch: "branch"},
 					&steps.PushBranchAfterCurrentBranchSteps{},
 					&steps.PushBranchStep{
-						Branch:         domain.NewLocalBranchName("branch"),
-						ForceWithLease: true,
-						NoPushHook:     true,
-						Undoable:       true,
+						Branch:     domain.NewLocalBranchName("branch"),
+						NoPushHook: true,
+						Undoable:   true,
 					},
 					&steps.PushTagsStep{},
 					&steps.RebaseBranchStep{Branch: domain.NewBranchName("branch")},
@@ -261,6 +264,13 @@ func TestSanitizePath(t *testing.T) {
     },
     {
       "data": {
+        "Branch": "branch",
+        "NoPushHook": true
+      },
+      "type": "*ForcePushBranchStep"
+    },
+    {
+      "data": {
         "Branch": "branch"
       },
       "type": "*MergeStep"
@@ -286,7 +296,6 @@ func TestSanitizePath(t *testing.T) {
     {
       "data": {
         "Branch": "branch",
-        "ForceWithLease": true,
         "NoPushHook": true,
         "Undoable": true
       },

--- a/src/runstate/persistence_test.go
+++ b/src/runstate/persistence_test.go
@@ -98,9 +98,9 @@ func TestSanitizePath(t *testing.T) {
 					&steps.PullBranchStep{Branch: "branch"},
 					&steps.PushBranchAfterCurrentBranchSteps{},
 					&steps.PushCurrentBranchStep{
-						Branch:     domain.NewLocalBranchName("branch"),
-						NoPushHook: true,
-						Undoable:   true,
+						CurrentBranch: domain.NewLocalBranchName("branch"),
+						NoPushHook:    true,
+						Undoable:      true,
 					},
 					&steps.PushTagsStep{},
 					&steps.RebaseBranchStep{Branch: domain.NewBranchName("branch")},
@@ -295,7 +295,7 @@ func TestSanitizePath(t *testing.T) {
     },
     {
       "data": {
-        "Branch": "branch",
+        "CurrentBranch": "branch",
         "NoPushHook": true,
         "Undoable": true
       },

--- a/src/runstate/runstate.go
+++ b/src/runstate/runstate.go
@@ -33,7 +33,7 @@ func (runState *RunState) AddPushBranchStepAfterCurrentBranchSteps(backend *git.
 			if err != nil {
 				return err
 			}
-			runState.RunStepList.Prepend(&steps.PushBranchStep{Branch: currentBranch, NoPushHook: false, Undoable: false})
+			runState.RunStepList.Prepend(&steps.PushCurrentBranchStep{Branch: currentBranch, NoPushHook: false, Undoable: false})
 			runState.RunStepList.PrependList(popped)
 			break
 		}

--- a/src/runstate/runstate.go
+++ b/src/runstate/runstate.go
@@ -33,7 +33,7 @@ func (runState *RunState) AddPushBranchStepAfterCurrentBranchSteps(backend *git.
 			if err != nil {
 				return err
 			}
-			runState.RunStepList.Prepend(&steps.PushCurrentBranchStep{Branch: currentBranch, NoPushHook: false, Undoable: false})
+			runState.RunStepList.Prepend(&steps.PushCurrentBranchStep{CurrentBranch: currentBranch, NoPushHook: false, Undoable: false})
 			runState.RunStepList.PrependList(popped)
 			break
 		}

--- a/src/runstate/runstate.go
+++ b/src/runstate/runstate.go
@@ -33,7 +33,7 @@ func (runState *RunState) AddPushBranchStepAfterCurrentBranchSteps(backend *git.
 			if err != nil {
 				return err
 			}
-			runState.RunStepList.Prepend(&steps.PushBranchStep{Branch: currentBranch, ForceWithLease: false, NoPushHook: false, Undoable: false})
+			runState.RunStepList.Prepend(&steps.PushBranchStep{Branch: currentBranch, NoPushHook: false, Undoable: false})
 			runState.RunStepList.PrependList(popped)
 			break
 		}

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -19,9 +19,8 @@ func (step *CreateTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([
 }
 
 func (step *CreateTrackingBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
-	return run.Frontend.PushBranch(git.PushArgs{
+	return run.Frontend.PushTrackingBranch(git.PushArgs{
 		Branch:     step.Branch,
 		NoPushHook: step.NoPushHook,
-		Remote:     domain.OriginRemote,
-	})
+	}, domain.OriginRemote)
 }

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -19,5 +19,5 @@ func (step *CreateTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([
 }
 
 func (step *CreateTrackingBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
-	return run.Frontend.PushTrackingBranch(step.Branch, domain.OriginRemote, step.NoPushHook)
+	return run.Frontend.CreateTrackingBranch(step.Branch, domain.OriginRemote, step.NoPushHook)
 }

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -19,8 +19,5 @@ func (step *CreateTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([
 }
 
 func (step *CreateTrackingBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
-	return run.Frontend.PushTrackingBranch(git.PushArgs{
-		Branch:     step.Branch,
-		NoPushHook: step.NoPushHook,
-	}, domain.OriginRemote)
+	return run.Frontend.PushTrackingBranch(step.Branch, domain.OriginRemote, step.NoPushHook)
 }

--- a/src/steps/force_push_branch_step.go
+++ b/src/steps/force_push_branch_step.go
@@ -1,0 +1,30 @@
+package steps
+
+import (
+	"github.com/git-town/git-town/v9/src/domain"
+	"github.com/git-town/git-town/v9/src/git"
+	"github.com/git-town/git-town/v9/src/hosting"
+)
+
+// PushBranchStep pushes the branch with the given name to the origin remote.
+// Optionally with force.
+type ForcePushBranchStep struct {
+	Branch     domain.LocalBranchName
+	NoPushHook bool
+	EmptyStep
+}
+
+func (step *ForcePushBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
+	return []Step{&SkipCurrentBranchSteps{}}, nil
+}
+
+func (step *ForcePushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
+	shouldPush, err := run.Backend.ShouldPushBranch(step.Branch, step.Branch.RemoteName()) // TODO: look this up in a git.Branches struct that needs to get injected here somehow
+	if err != nil {
+		return err
+	}
+	if !shouldPush && !run.Config.DryRun {
+		return nil
+	}
+	return run.Frontend.ForcePushBranch(step.NoPushHook)
+}

--- a/src/steps/force_push_branch_step.go
+++ b/src/steps/force_push_branch_step.go
@@ -6,8 +6,7 @@ import (
 	"github.com/git-town/git-town/v9/src/hosting"
 )
 
-// PushBranchStep pushes the branch with the given name to the origin remote.
-// Optionally with force.
+// ForcePushBranchStep force-pushes the branch with the given name to the origin remote.
 type ForcePushBranchStep struct {
 	Branch     domain.LocalBranchName
 	NoPushHook bool

--- a/src/steps/force_push_branch_step.go
+++ b/src/steps/force_push_branch_step.go
@@ -18,7 +18,7 @@ func (step *ForcePushBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step
 }
 
 func (step *ForcePushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
-	shouldPush, err := run.Backend.ShouldPushBranch(step.Branch, step.Branch.RemoteName()) // TODO: look this up in a git.Branches struct that needs to get injected here somehow
+	shouldPush, err := run.Backend.ShouldPushBranch(step.Branch, step.Branch.RemoteName())
 	if err != nil {
 		return err
 	}

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -11,9 +11,8 @@ import (
 type PushBranchStep struct {
 	Branch domain.LocalBranchName
 	// TrackingBranch domain.RemoteBranchName // TODO: populate this with the actual tracking branch name
-	ForceWithLease bool
-	NoPushHook     bool
-	Undoable       bool
+	NoPushHook bool
+	Undoable   bool
 	EmptyStep
 }
 
@@ -35,9 +34,6 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	currentBranch, err := run.Backend.CurrentBranch()
 	if err != nil {
 		return err
-	}
-	if step.ForceWithLease {
-		return run.Frontend.ForcePushBranch(step.NoPushHook)
 	}
 	remote := remote(currentBranch, step.Branch)
 	if remote == domain.NoRemote {

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -40,14 +40,20 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 		return run.Frontend.ForcePushBranch(git.PushArgs{
 			Branch:     step.Branch,
 			NoPushHook: step.NoPushHook,
-			Remote:     remote(currentBranch, step.Branch),
+			// Remote:     remote(currentBranch, step.Branch),
 		})
 	}
-	return run.Frontend.PushBranch(git.PushArgs{
+	remote := remote(currentBranch, step.Branch)
+	if remote == domain.NoRemote {
+		return run.Frontend.PushBranch(git.PushArgs{
+			Branch:     step.Branch,
+			NoPushHook: step.NoPushHook,
+		})
+	}
+	return run.Frontend.PushTrackingBranch(git.PushArgs{
 		Branch:     step.Branch,
 		NoPushHook: step.NoPushHook,
-		Remote:     remote(currentBranch, step.Branch),
-	})
+	}, remote)
 }
 
 // provides the name of the remote to push to.

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -31,12 +31,5 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	if !shouldPush && !run.Config.DryRun {
 		return nil
 	}
-	currentBranch, err := run.Backend.CurrentBranch()
-	if err != nil {
-		return err
-	}
-	if currentBranch == step.Branch {
-		return run.Frontend.PushCurrentBranch(step.NoPushHook)
-	}
-	return run.Frontend.CreateTrackingBranch(step.Branch, domain.OriginRemote, step.NoPushHook)
+	return run.Frontend.PushCurrentBranch(step.NoPushHook)
 }

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -43,7 +43,7 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	if remote == domain.NoRemote {
 		return run.Frontend.PushCurrentBranch(step.NoPushHook)
 	}
-	return run.Frontend.PushTrackingBranch(step.Branch, remote, step.NoPushHook)
+	return run.Frontend.CreateTrackingBranch(step.Branch, remote, step.NoPushHook)
 }
 
 // provides the name of the remote to push to.

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -47,10 +47,7 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	if remote == domain.NoRemote {
 		return run.Frontend.PushBranch(step.NoPushHook)
 	}
-	return run.Frontend.PushTrackingBranch(git.PushArgs{
-		Branch:     step.Branch,
-		NoPushHook: step.NoPushHook,
-	}, remote)
+	return run.Frontend.PushTrackingBranch(step.Branch, remote, step.NoPushHook)
 }
 
 // provides the name of the remote to push to.

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -41,7 +41,7 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	}
 	remote := remote(currentBranch, step.Branch)
 	if remote == domain.NoRemote {
-		return run.Frontend.PushBranch(step.NoPushHook)
+		return run.Frontend.PushCurrentBranch(step.NoPushHook)
 	}
 	return run.Frontend.PushTrackingBranch(step.Branch, remote, step.NoPushHook)
 }

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -45,10 +45,7 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	}
 	remote := remote(currentBranch, step.Branch)
 	if remote == domain.NoRemote {
-		return run.Frontend.PushBranch(git.PushArgs{
-			Branch:     step.Branch,
-			NoPushHook: step.NoPushHook,
-		})
+		return run.Frontend.PushBranch(step.NoPushHook)
 	}
 	return run.Frontend.PushTrackingBranch(git.PushArgs{
 		Branch:     step.Branch,

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -37,11 +37,7 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 		return err
 	}
 	if step.ForceWithLease {
-		return run.Frontend.ForcePushBranch(git.PushArgs{
-			Branch:     step.Branch,
-			NoPushHook: step.NoPushHook,
-			// Remote:     remote(currentBranch, step.Branch),
-		})
+		return run.Frontend.ForcePushBranch(step.NoPushHook)
 	}
 	remote := remote(currentBranch, step.Branch)
 	if remote == domain.NoRemote {

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -36,11 +36,17 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	if err != nil {
 		return err
 	}
+	if step.ForceWithLease {
+		return run.Frontend.ForcePushBranch(git.PushArgs{
+			Branch:     step.Branch,
+			NoPushHook: step.NoPushHook,
+			Remote:     remote(currentBranch, step.Branch),
+		})
+	}
 	return run.Frontend.PushBranch(git.PushArgs{
-		Branch:         step.Branch,
-		ForceWithLease: step.ForceWithLease,
-		NoPushHook:     step.NoPushHook,
-		Remote:         remote(currentBranch, step.Branch),
+		Branch:     step.Branch,
+		NoPushHook: step.NoPushHook,
+		Remote:     remote(currentBranch, step.Branch),
 	})
 }
 

--- a/src/steps/push_branch_step.go
+++ b/src/steps/push_branch_step.go
@@ -35,18 +35,8 @@ func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error 
 	if err != nil {
 		return err
 	}
-	remote := remote(currentBranch, step.Branch)
-	if remote == domain.NoRemote {
+	if currentBranch == step.Branch {
 		return run.Frontend.PushCurrentBranch(step.NoPushHook)
 	}
-	return run.Frontend.CreateTrackingBranch(step.Branch, remote, step.NoPushHook)
-}
-
-// provides the name of the remote to push to.
-func remote(currentBranch, stepBranch domain.LocalBranchName) domain.Remote {
-	// TODO: how does this comparison of whether the branch in the step is the current branch make sense when deciding whether to push to origin or not?
-	if currentBranch == stepBranch {
-		return domain.NoRemote
-	}
-	return domain.OriginRemote
+	return run.Frontend.CreateTrackingBranch(step.Branch, domain.OriginRemote, step.NoPushHook)
 }

--- a/src/steps/push_current_branch_step.go
+++ b/src/steps/push_current_branch_step.go
@@ -22,7 +22,7 @@ func (step *PushCurrentBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]St
 }
 
 func (step *PushCurrentBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
-	shouldPush, err := run.Backend.ShouldPushBranch(step.CurrentBranch, step.CurrentBranch.RemoteName()) // TODO: look this up in a git.Branches struct that needs to get injected here somehow
+	shouldPush, err := run.Backend.ShouldPushBranch(step.CurrentBranch, step.CurrentBranch.RemoteName())
 	if err != nil {
 		return err
 	}

--- a/src/steps/push_current_branch_step.go
+++ b/src/steps/push_current_branch_step.go
@@ -6,9 +6,9 @@ import (
 	"github.com/git-town/git-town/v9/src/hosting"
 )
 
-// PushBranchStep pushes the branch with the given name to the origin remote.
+// PushCurrentBranchStep pushes the branch with the given name to the origin remote.
 // Optionally with force.
-type PushBranchStep struct {
+type PushCurrentBranchStep struct {
 	Branch domain.LocalBranchName
 	// TrackingBranch domain.RemoteBranchName // TODO: populate this with the actual tracking branch name
 	NoPushHook bool
@@ -16,14 +16,14 @@ type PushBranchStep struct {
 	EmptyStep
 }
 
-func (step *PushBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
+func (step *PushCurrentBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
 	if step.Undoable {
 		return []Step{&PushBranchAfterCurrentBranchSteps{}}, nil
 	}
 	return []Step{&SkipCurrentBranchSteps{}}, nil
 }
 
-func (step *PushBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
+func (step *PushCurrentBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
 	shouldPush, err := run.Backend.ShouldPushBranch(step.Branch, step.Branch.RemoteName()) // TODO: look this up in a git.Branches struct that needs to get injected here somehow
 	if err != nil {
 		return err

--- a/src/steps/push_current_branch_step.go
+++ b/src/steps/push_current_branch_step.go
@@ -9,10 +9,9 @@ import (
 // PushCurrentBranchStep pushes the branch with the given name to the origin remote.
 // Optionally with force.
 type PushCurrentBranchStep struct {
-	Branch domain.LocalBranchName
-	// TrackingBranch domain.RemoteBranchName // TODO: populate this with the actual tracking branch name
-	NoPushHook bool
-	Undoable   bool
+	CurrentBranch domain.LocalBranchName
+	NoPushHook    bool
+	Undoable      bool
 	EmptyStep
 }
 
@@ -24,7 +23,7 @@ func (step *PushCurrentBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]St
 }
 
 func (step *PushCurrentBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {
-	shouldPush, err := run.Backend.ShouldPushBranch(step.Branch, step.Branch.RemoteName()) // TODO: look this up in a git.Branches struct that needs to get injected here somehow
+	shouldPush, err := run.Backend.ShouldPushBranch(step.CurrentBranch, step.CurrentBranch.RemoteName()) // TODO: look this up in a git.Branches struct that needs to get injected here somehow
 	if err != nil {
 		return err
 	}

--- a/src/steps/push_current_branch_step.go
+++ b/src/steps/push_current_branch_step.go
@@ -6,8 +6,7 @@ import (
 	"github.com/git-town/git-town/v9/src/hosting"
 )
 
-// PushCurrentBranchStep pushes the branch with the given name to the origin remote.
-// Optionally with force.
+// PushCurrentBranchStep pushes the current branch to its existing tracking branch.
 type PushCurrentBranchStep struct {
 	CurrentBranch domain.LocalBranchName
 	NoPushHook    bool


### PR DESCRIPTION
The logic around pushing branches is pretty complex with several code paths. This is an indicator that this logic implements several distinct functionalities. This PR separates these functionalities into several vastly simplified implementations.