### PR TITLE
Trim only whitespace of git-remote output

### DIFF
--- a/src/config/git.go
+++ b/src/config/git.go
@@ -14,7 +14,6 @@ type Git struct {
 
 type runner interface {
 	Query(executable string, args ...string) (string, error)
-	QueryTrim(executable string, args ...string) (string, error)
 	Run(executable string, args ...string) error
 }
 

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -151,8 +151,8 @@ func (gt *GitTown) OriginURLString() string {
 	if remote != "" {
 		return remote
 	}
-	output, _ := gt.QueryTrim("git", "remote", "get-url", domain.OriginRemote.String())
-	return output
+	output, _ := gt.Query("git", "remote", "get-url", domain.OriginRemote.String())
+	return strings.TrimSpace(output)
 }
 
 // OriginURL provides the URL for the "origin" remote.


### PR DESCRIPTION
This removes the only use of QueryTrim.