### PR TITLE
Remove Go-specifics from persistence format

### DIFF
--- a/src/runstate/core.go
+++ b/src/runstate/core.go
@@ -18,5 +18,5 @@ type UnfinishedRunStateDetails struct {
 }
 
 func isCheckoutStep(step steps.Step) bool {
-	return typeName(step) == "*CheckoutStep"
+	return typeName(step) == "CheckoutStep"
 }

--- a/src/runstate/execute.go
+++ b/src/runstate/execute.go
@@ -17,11 +17,11 @@ func Execute(args ExecuteArgs) error {
 		if step == nil {
 			return finished(args)
 		}
-		if typeName(step) == "*SkipCurrentBranchSteps" {
+		if typeName(step) == "SkipCurrentBranchSteps" {
 			args.RunState.SkipCurrentBranchSteps()
 			continue
 		}
-		if typeName(step) == "*PushBranchAfterCurrentBranchSteps" {
+		if typeName(step) == "PushBranchAfterCurrentBranchSteps" {
 			err := args.RunState.AddPushBranchStepAfterCurrentBranchSteps(&args.Run.Backend)
 			if err != nil {
 				return err

--- a/src/runstate/jsonstep.go
+++ b/src/runstate/jsonstep.go
@@ -43,79 +43,79 @@ func (j *JSONStep) UnmarshalJSON(b []byte) error {
 
 func DetermineStep(stepType string) steps.Step {
 	switch stepType {
-	case "*AbortMergeStep":
+	case "AbortMergeStep":
 		return &steps.AbortMergeStep{}
-	case "*AbortRebaseStep":
+	case "AbortRebaseStep":
 		return &steps.AbortRebaseStep{}
-	case "*AddToPerennialBranchesStep":
+	case "AddToPerennialBranchesStep":
 		return &steps.AddToPerennialBranchesStep{}
-	case "*CheckoutStep":
+	case "CheckoutStep":
 		return &steps.CheckoutStep{}
-	case "*CommitOpenChangesStep":
+	case "CommitOpenChangesStep":
 		return &steps.CommitOpenChangesStep{}
-	case "*ConnectorMergeProposalStep":
+	case "ConnectorMergeProposalStep":
 		return &steps.ConnectorMergeProposalStep{}
-	case "*ContinueMergeStep":
+	case "ContinueMergeStep":
 		return &steps.ContinueMergeStep{}
-	case "*ContinueRebaseStep":
+	case "ContinueRebaseStep":
 		return &steps.ContinueRebaseStep{}
-	case "*CreateBranchStep":
+	case "CreateBranchStep":
 		return &steps.CreateBranchStep{}
-	case "*CreateProposalStep":
+	case "CreateProposalStep":
 		return &steps.CreateProposalStep{}
-	case "*CreateRemoteBranchStep":
+	case "CreateRemoteBranchStep":
 		return &steps.CreateRemoteBranchStep{}
-	case "*CreateTrackingBranchStep":
+	case "CreateTrackingBranchStep":
 		return &steps.CreateTrackingBranchStep{}
-	case "*DeleteLocalBranchStep":
+	case "DeleteLocalBranchStep":
 		return &steps.DeleteLocalBranchStep{}
-	case "*DeleteParentBranchStep":
+	case "DeleteParentBranchStep":
 		return &steps.DeleteParentBranchStep{}
-	case "*DeleteRemoteBranchStep":
+	case "DeleteRemoteBranchStep":
 		return &steps.DeleteRemoteBranchStep{}
-	case "*DeleteTrackingBranchStep":
+	case "DeleteTrackingBranchStep":
 		return &steps.DeleteTrackingBranchStep{}
-	case "*DiscardOpenChangesStep":
+	case "DiscardOpenChangesStep":
 		return &steps.DiscardOpenChangesStep{}
-	case "*EmptyStep":
+	case "EmptyStep":
 		return &steps.EmptyStep{}
-	case "*EnsureHasShippableChangesStep":
+	case "EnsureHasShippableChangesStep":
 		return &steps.EnsureHasShippableChangesStep{}
-	case "*FetchUpstreamStep":
+	case "FetchUpstreamStep":
 		return &steps.FetchUpstreamStep{}
-	case "*ForcePushBranchStep":
+	case "ForcePushBranchStep":
 		return &steps.ForcePushBranchStep{}
-	case "*MergeStep":
+	case "MergeStep":
 		return &steps.MergeStep{}
-	case "*PreserveCheckoutHistoryStep":
+	case "PreserveCheckoutHistoryStep":
 		return &steps.PreserveCheckoutHistoryStep{}
-	case "*PullBranchStep":
+	case "PullBranchStep":
 		return &steps.PullBranchStep{}
-	case "*PushBranchAfterCurrentBranchSteps":
+	case "PushBranchAfterCurrentBranchSteps":
 		return &steps.PushBranchAfterCurrentBranchSteps{}
-	case "*PushCurrentBranchStep":
+	case "PushCurrentBranchStep":
 		return &steps.PushCurrentBranchStep{}
-	case "*PushTagsStep":
+	case "PushTagsStep":
 		return &steps.PushTagsStep{}
-	case "*RebaseBranchStep":
+	case "RebaseBranchStep":
 		return &steps.RebaseBranchStep{}
-	case "*RemoveFromPerennialBranchesStep":
+	case "RemoveFromPerennialBranchesStep":
 		return &steps.RemoveFromPerennialBranchesStep{}
-	case "*ResetCurrentBranchToSHAStep":
+	case "ResetCurrentBranchToSHAStep":
 		return &steps.ResetCurrentBranchToSHAStep{}
-	case "*RestoreOpenChangesStep":
+	case "RestoreOpenChangesStep":
 		return &steps.RestoreOpenChangesStep{}
-	case "*RevertCommitStep":
+	case "RevertCommitStep":
 		return &steps.RevertCommitStep{}
-	case "*SetParentStep":
+	case "SetParentStep":
 		return &steps.SetParentStep{}
-	case "*SquashMergeStep":
+	case "SquashMergeStep":
 		return &steps.SquashMergeStep{}
-	case "*SkipCurrentBranchSteps":
+	case "SkipCurrentBranchSteps":
 		return &steps.SkipCurrentBranchSteps{}
-	case "*StashOpenChangesStep":
+	case "StashOpenChangesStep":
 		return &steps.StashOpenChangesStep{}
-	case "*UpdateProposalTargetStep":
+	case "UpdateProposalTargetStep":
 		return &steps.UpdateProposalTargetStep{}
 	}
 	return nil
@@ -124,7 +124,7 @@ func DetermineStep(stepType string) steps.Step {
 func typeName(myvar interface{}) string {
 	t := reflect.TypeOf(myvar)
 	if t.Kind() == reflect.Ptr {
-		return "*" + t.Elem().Name()
+		return t.Elem().Name()
 	}
 	return t.Name()
 }

--- a/src/runstate/jsonstep_test.go
+++ b/src/runstate/jsonstep_test.go
@@ -1,0 +1,7 @@
+package runstate_test
+
+import "testing"
+
+func TestTypeName(t *testing.T) {
+
+}

--- a/src/runstate/jsonstep_test.go
+++ b/src/runstate/jsonstep_test.go
@@ -1,7 +1,0 @@
-package runstate_test
-
-import "testing"
-
-func TestTypeName(t *testing.T) {
-
-}

--- a/src/runstate/persistence_test.go
+++ b/src/runstate/persistence_test.go
@@ -149,27 +149,27 @@ func TestSanitizePath(t *testing.T) {
   "RunStepList": [
     {
       "data": {},
-      "type": "*AbortMergeStep"
+      "type": "AbortMergeStep"
     },
     {
       "data": {},
-      "type": "*AbortRebaseStep"
+      "type": "AbortRebaseStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*AddToPerennialBranchesStep"
+      "type": "AddToPerennialBranchesStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*CheckoutStep"
+      "type": "CheckoutStep"
     },
     {
       "data": {},
-      "type": "*CommitOpenChangesStep"
+      "type": "CommitOpenChangesStep"
     },
     {
       "data": {
@@ -178,28 +178,28 @@ func TestSanitizePath(t *testing.T) {
         "ProposalMessage": "proposal message",
         "ProposalNumber": 123
       },
-      "type": "*ConnectorMergeProposalStep"
+      "type": "ConnectorMergeProposalStep"
     },
     {
       "data": {},
-      "type": "*ContinueMergeStep"
+      "type": "ContinueMergeStep"
     },
     {
       "data": {},
-      "type": "*ContinueRebaseStep"
+      "type": "ContinueRebaseStep"
     },
     {
       "data": {
         "Branch": "branch",
         "StartingPoint": "123456"
       },
-      "type": "*CreateBranchStep"
+      "type": "CreateBranchStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*CreateProposalStep"
+      "type": "CreateProposalStep"
     },
     {
       "data": {
@@ -207,14 +207,14 @@ func TestSanitizePath(t *testing.T) {
         "NoPushHook": true,
         "SHA": "123456"
       },
-      "type": "*CreateRemoteBranchStep"
+      "type": "CreateRemoteBranchStep"
     },
     {
       "data": {
         "Branch": "branch",
         "NoPushHook": true
       },
-      "type": "*CreateTrackingBranchStep"
+      "type": "CreateTrackingBranchStep"
     },
     {
       "data": {
@@ -222,58 +222,58 @@ func TestSanitizePath(t *testing.T) {
         "Parent": "parent",
         "Force": false
       },
-      "type": "*DeleteLocalBranchStep"
+      "type": "DeleteLocalBranchStep"
     },
     {
       "data": {
         "Branch": "branch",
         "NoPushHook": true
       },
-      "type": "*DeleteRemoteBranchStep"
+      "type": "DeleteRemoteBranchStep"
     },
     {
       "data": {
         "Branch": "branch",
         "Parent": "parent"
       },
-      "type": "*DeleteParentBranchStep"
+      "type": "DeleteParentBranchStep"
     },
     {
       "data": {
         "Branch": "branch",
         "NoPushHook": true
       },
-      "type": "*DeleteTrackingBranchStep"
+      "type": "DeleteTrackingBranchStep"
     },
     {
       "data": {},
-      "type": "*DiscardOpenChangesStep"
+      "type": "DiscardOpenChangesStep"
     },
     {
       "data": {
         "Branch": "branch",
         "Parent": "parent"
       },
-      "type": "*EnsureHasShippableChangesStep"
+      "type": "EnsureHasShippableChangesStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*FetchUpstreamStep"
+      "type": "FetchUpstreamStep"
     },
     {
       "data": {
         "Branch": "branch",
         "NoPushHook": true
       },
-      "type": "*ForcePushBranchStep"
+      "type": "ForcePushBranchStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*MergeStep"
+      "type": "MergeStep"
     },
     {
       "data": {
@@ -281,17 +281,17 @@ func TestSanitizePath(t *testing.T) {
         "InitialPreviouslyCheckedOutBranch": "initial-previous-branch",
         "MainBranch": "main"
       },
-      "type": "*PreserveCheckoutHistoryStep"
+      "type": "PreserveCheckoutHistoryStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*PullBranchStep"
+      "type": "PullBranchStep"
     },
     {
       "data": {},
-      "type": "*PushBranchAfterCurrentBranchSteps"
+      "type": "PushBranchAfterCurrentBranchSteps"
     },
     {
       "data": {
@@ -299,51 +299,51 @@ func TestSanitizePath(t *testing.T) {
         "NoPushHook": true,
         "Undoable": true
       },
-      "type": "*PushCurrentBranchStep"
+      "type": "PushCurrentBranchStep"
     },
     {
       "data": {},
-      "type": "*PushTagsStep"
+      "type": "PushTagsStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*RebaseBranchStep"
+      "type": "RebaseBranchStep"
     },
     {
       "data": {
         "Branch": "branch"
       },
-      "type": "*RemoveFromPerennialBranchesStep"
+      "type": "RemoveFromPerennialBranchesStep"
     },
     {
       "data": {
         "Hard": true,
         "SHA": "123456"
       },
-      "type": "*ResetCurrentBranchToSHAStep"
+      "type": "ResetCurrentBranchToSHAStep"
     },
     {
       "data": {},
-      "type": "*RestoreOpenChangesStep"
+      "type": "RestoreOpenChangesStep"
     },
     {
       "data": {
         "SHA": "123456"
       },
-      "type": "*RevertCommitStep"
+      "type": "RevertCommitStep"
     },
     {
       "data": {
         "Branch": "branch",
         "ParentBranch": "parent"
       },
-      "type": "*SetParentStep"
+      "type": "SetParentStep"
     },
     {
       "data": {},
-      "type": "*SkipCurrentBranchSteps"
+      "type": "SkipCurrentBranchSteps"
     },
     {
       "data": {
@@ -351,11 +351,11 @@ func TestSanitizePath(t *testing.T) {
         "CommitMessage": "commit message",
         "Parent": "parent"
       },
-      "type": "*SquashMergeStep"
+      "type": "SquashMergeStep"
     },
     {
       "data": {},
-      "type": "*StashOpenChangesStep"
+      "type": "StashOpenChangesStep"
     },
     {
       "data": {
@@ -363,7 +363,7 @@ func TestSanitizePath(t *testing.T) {
         "NewTarget": "new-target",
         "ExistingTarget": "existing-target"
       },
-      "type": "*UpdateProposalTargetStep"
+      "type": "UpdateProposalTargetStep"
     }
   ],
   "UndoStepList": [],


### PR DESCRIPTION
The persistence format contains unnecessary Go-specific implementation details, in particular whether a data element is a pointer or not. This isn't really necessary and unnecessarily binds this to Go as the implementation language.