### PR TITLE
Inject Git config data

### DIFF
--- a/src/config/git.go
+++ b/src/config/git.go
@@ -13,9 +13,9 @@ type runner interface {
 }
 
 // NewConfiguration provides a Configuration instance reflecting the configuration values in the given directory.
-func NewGit(runner runner) Git {
+func NewGit(gitConfig GitConfig, runner runner) Git {
 	return Git{
-		config: LoadGitConfig(runner),
+		config: gitConfig,
 		runner: runner,
 	}
 }

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -21,9 +21,9 @@ type GitTown struct {
 	originURLCache OriginURLCache
 }
 
-func NewGitTown(runner runner) *GitTown {
+func NewGitTown(gitConfig GitConfig, runner runner) *GitTown {
 	return &GitTown{
-		Git:            NewGit(runner),
+		Git:            NewGit(gitConfig, runner),
 		originURLCache: OriginURLCache{},
 	}
 }

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -40,8 +40,9 @@ func OpenRepo(args OpenRepoArgs) (result OpenRepoResult, err error) {
 	if err != nil {
 		return
 	}
+	gitConfig := config.LoadGitConfig(backendRunner)
 	repoConfig := git.RepoConfig{
-		GitTown: config.NewGitTown(backendRunner),
+		GitTown: config.NewGitTown(gitConfig, backendRunner),
 		DryRun:  false, // to bootstrap this, DryRun always gets initialized as false and later enabled if needed
 	}
 	backendCommands.Config = &repoConfig

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -56,8 +56,9 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 		HomeDir:    homeDir,
 		BinDir:     binDir,
 	}
+	gitConfig := config.LoadGitConfig(&runner)
 	config := git.RepoConfig{
-		GitTown: config.NewGitTown(&runner),
+		GitTown: config.NewGitTown(gitConfig, &runner),
 		DryRun:  false,
 	}
 	backendCommands := git.BackendCommands{


### PR DESCRIPTION
Removes the code smell that the constructor for Git was loading the config data from disk.