### PR TITLE
Remove tracking branch when undoing creating one

### DIFF
--- a/features/rename_branch/features/debug.feature
+++ b/features/rename_branch/features/debug.feature
@@ -53,8 +53,7 @@ Feature: display debug statistics
       |        | backend  | git branch -vva                               |
       | new    | frontend | git branch old {{ sha 'old commit' }}         |
       |        | frontend | git push -u origin old                        |
-      |        | backend  | git rev-parse origin/new                      |
-      | new    | frontend | git push origin :new                          |
+      |        | frontend | git push origin :new                          |
       |        | backend  | git config --unset git-town-branch.new.parent |
       |        | backend  | git config git-town-branch.old.parent main    |
       | new    | frontend | git checkout old                              |
@@ -63,6 +62,6 @@ Feature: display debug statistics
       | old    | frontend | git branch -D new                             |
     And it prints:
       """
-      Ran 15 shell commands.
+      Ran 14 shell commands.
       """
     And the current branch is now "old"

--- a/src/steps/create_tracking_branch_step.go
+++ b/src/steps/create_tracking_branch_step.go
@@ -15,7 +15,7 @@ type CreateTrackingBranchStep struct {
 }
 
 func (step *CreateTrackingBranchStep) CreateUndoSteps(_ *git.BackendCommands) ([]Step, error) {
-	return []Step{&DeleteRemoteBranchStep{Branch: step.Branch, NoPushHook: false}}, nil
+	return []Step{&DeleteTrackingBranchStep{Branch: step.Branch, NoPushHook: false}}, nil
 }
 
 func (step *CreateTrackingBranchStep) Run(run *git.ProdRunner, _ hosting.Connector) error {


### PR DESCRIPTION
The step to undo creating a tracking branch should remove the tracking branch, not just simply remove the remote branch.