### PR TITLE
Install ShellCheck via Homebrew on Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ fix: tools/golangci_lint_${GOLANGCILINT_VERSION} tools/gofumpt_${GOFUMPT_VERSION
 	${CURDIR}/tools/node_modules/.bin/dprint fmt
 	${CURDIR}/tools/node_modules/.bin/prettier --write '**/*.yml'
 	tools/shfmt_${SHFMT_VERSION} -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs tools/shfmt_${SHFMT_VERSION} --write
-	tools/run_shellcheck "${SHFMT_VERSION}" "${SHELLCHECK_VERSION}"
+	tools/run_shellcheck ${SHFMT_VERSION} ${SHELLCHECK_VERSION}
 	${CURDIR}/tools/node_modules/.bin/gherkin-lint
 	tools/golangci_lint_${GOLANGCILINT_VERSION} run
 	tools/ensure_no_files_with_dashes.sh

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ fix: tools/golangci_lint_${GOLANGCILINT_VERSION} tools/gofumpt_${GOFUMPT_VERSION
 	${CURDIR}/tools/node_modules/.bin/dprint fmt
 	${CURDIR}/tools/node_modules/.bin/prettier --write '**/*.yml'
 	tools/shfmt_${SHFMT_VERSION} -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs tools/shfmt_${SHFMT_VERSION} --write
-	tools/shfmt_${SHFMT_VERSION} -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs tools/shellcheck_${SHELLCHECK_VERSION}
+	tools/run_shellcheck "${SHFMT_VERSION}" "${SHELLCHECK_VERSION}"
 	${CURDIR}/tools/node_modules/.bin/gherkin-lint
 	tools/golangci_lint_${GOLANGCILINT_VERSION} run
 	tools/ensure_no_files_with_dashes.sh

--- a/tools/run_shellcheck
+++ b/tools/run_shellcheck
@@ -19,5 +19,5 @@ if [ "$os" = "Darwin" ] && [ "$machine" = "arm64" ]; then
 		exit 1
 	fi
 else
-	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs "shellcheck_${SHELLCHECK_VERSION}"
+	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs "tools/shellcheck_${SHELLCHECK_VERSION}"
 fi

--- a/tools/run_shellcheck
+++ b/tools/run_shellcheck
@@ -11,14 +11,13 @@ os=$(uname -s)
 machine=$(uname -m)
 if [ "$os" = "Darwin" ] && [ "$machine" = "arm64" ]; then
 	if command -v shellcheck >/dev/null 2>&1; then
-		echo "using homebrew ShellCheck"
+		"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs shellcheck
 	else
 		echo
 		echo "Please install ShellCheck via Homebrew since you use Apple Silicon."
 		echo
 		exit 1
 	fi
-	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs shellcheck
 else
 	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs "shellcheck_${SHELLCHECK_VERSION}"
 fi

--- a/tools/run_shellcheck
+++ b/tools/run_shellcheck
@@ -9,7 +9,6 @@ fi
 
 os=$(uname -s)
 machine=$(uname -m)
-
 if [ "$os" = "Darwin" ] && [ "$machine" = "arm64" ]; then
 	if command -v shellcheck >/dev/null 2>&1; then
 	else

--- a/tools/run_shellcheck
+++ b/tools/run_shellcheck
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+SHFMT_VERSION=$1
+SHELLCHECK_VERSION=$2
+if [ -z "$SHFMT_VERSION" ] || [ -z "$SHELLCHECK_VERSION" ]; then
+	echo "Usage: $0 <SHFMT_VERSION> <SHELLCHECK_VERSION>"
+	exit 1
+fi
+
+os=$(uname -s)
+machine=$(uname -m)
+
+if [ "$os" = "Darwin" ] && [ "$machine" = "arm64" ]; then
+	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs shellcheck
+else
+	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs "shellcheck_${SHELLCHECK_VERSION}"
+fi

--- a/tools/run_shellcheck
+++ b/tools/run_shellcheck
@@ -14,7 +14,7 @@ if [ "$os" = "Darwin" ] && [ "$machine" = "arm64" ]; then
 		"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs shellcheck
 	else
 		echo
-		echo "Please install ShellCheck via Homebrew since you use Apple Silicon."
+		echo "For the time being, please install ShellCheck via Homebrew on Apple Silicon."
 		echo
 		exit 1
 	fi

--- a/tools/run_shellcheck
+++ b/tools/run_shellcheck
@@ -11,6 +11,7 @@ os=$(uname -s)
 machine=$(uname -m)
 if [ "$os" = "Darwin" ] && [ "$machine" = "arm64" ]; then
 	if command -v shellcheck >/dev/null 2>&1; then
+		echo "using homebrew ShellCheck"
 	else
 		echo
 		echo "Please install ShellCheck via Homebrew since you use Apple Silicon."

--- a/tools/run_shellcheck
+++ b/tools/run_shellcheck
@@ -11,6 +11,13 @@ os=$(uname -s)
 machine=$(uname -m)
 
 if [ "$os" = "Darwin" ] && [ "$machine" = "arm64" ]; then
+	if command -v shellcheck >/dev/null 2>&1; then
+	else
+		echo
+		echo "Please install ShellCheck via Homebrew since you use Apple Silicon."
+		echo
+		exit 1
+	fi
 	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs shellcheck
 else
 	"tools/shfmt_${SHFMT_VERSION}" -f . | grep -v tools/node_modules | grep -v '^vendor/' | xargs "shellcheck_${SHELLCHECK_VERSION}"


### PR DESCRIPTION
ShellCheck still doesn't provide Apple Silicon binaries but it is installable via Homebrew.