### PR TITLE
Consistently use short SHAs everywhere

### DIFF
--- a/features/append/features/debug.feature
+++ b/features/append/features/debug.feature
@@ -22,13 +22,13 @@ Feature: display debug statistics
       |          | backend  | git rev-parse --verify --abbrev-ref @{-1}            |
       |          | backend  | git status --porcelain --ignore-submodules           |
       | existing | frontend | git checkout main                                    |
-      |          | backend  | git rev-parse HEAD                                   |
+      |          | backend  | git rev-parse --short HEAD                           |
       | main     | frontend | git rebase origin/main                               |
       |          | backend  | git rev-list --left-right main...origin/main         |
       | main     | frontend | git checkout existing                                |
-      |          | backend  | git rev-parse HEAD                                   |
+      |          | backend  | git rev-parse --short HEAD                           |
       | existing | frontend | git merge --no-edit origin/existing                  |
-      |          | backend  | git rev-parse HEAD                                   |
+      |          | backend  | git rev-parse --short HEAD                           |
       | existing | frontend | git merge --no-edit main                             |
       |          | backend  | git rev-list --left-right existing...origin/existing |
       | existing | frontend | git branch new existing                              |

--- a/features/hack/edge_cases/unconfigured.feature
+++ b/features/hack/edge_cases/unconfigured.feature
@@ -20,6 +20,7 @@ Feature: missing configuration
       | BRANCH  | PARENT |
       | feature | main   |
 
+  @debug @this
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands

--- a/features/hack/edge_cases/unconfigured.feature
+++ b/features/hack/edge_cases/unconfigured.feature
@@ -20,7 +20,6 @@ Feature: missing configuration
       | BRANCH  | PARENT |
       | feature | main   |
 
-  @debug @this
   Scenario: undo
     When I run "git town undo"
     Then it runs the commands

--- a/features/hack/features/debug.feature
+++ b/features/hack/features/debug.feature
@@ -21,7 +21,7 @@ Feature: display debug statistics
       |        | backend  | git branch -vva                              |
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}    |
       |        | backend  | git status --porcelain --ignore-submodules   |
-      |        | backend  | git rev-parse HEAD                           |
+      |        | backend  | git rev-parse --short HEAD                   |
       | main   | frontend | git rebase origin/main                       |
       |        | backend  | git rev-list --left-right main...origin/main |
       | main   | frontend | git branch new main                          |

--- a/features/kill/current_branch/features/debug.feature
+++ b/features/kill/current_branch/features/debug.feature
@@ -26,7 +26,7 @@ Feature: display debug statistics
       |         | backend  | git status --porcelain --ignore-submodules        |
       | current | frontend | git push origin :current                          |
       |         | frontend | git checkout main                                 |
-      |         | backend  | git rev-parse current                             |
+      |         | backend  | git rev-parse --short current                     |
       |         | backend  | git log main..current                             |
       | main    | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |

--- a/features/new_pull_request/features/debug.feature
+++ b/features/new_pull_request/features/debug.feature
@@ -20,13 +20,13 @@ Feature: display debug statistics
       |         | backend  | git rev-parse --verify --abbrev-ref @{-1}                          |
       |         | backend  | git status --porcelain --ignore-submodules                         |
       | feature | frontend | git checkout main                                                  |
-      |         | backend  | git rev-parse HEAD                                                 |
+      |         | backend  | git rev-parse --short HEAD                                         |
       | main    | frontend | git rebase origin/main                                             |
       |         | backend  | git rev-list --left-right main...origin/main                       |
       | main    | frontend | git checkout feature                                               |
-      |         | backend  | git rev-parse HEAD                                                 |
+      |         | backend  | git rev-parse --short HEAD                                         |
       | feature | frontend | git merge --no-edit origin/feature                                 |
-      |         | backend  | git rev-parse HEAD                                                 |
+      |         | backend  | git rev-parse --short HEAD                                         |
       | feature | frontend | git merge --no-edit main                                           |
       |         | backend  | git rev-list --left-right feature...origin/feature                 |
       |         | backend  | git show-ref --quiet refs/heads/main                               |

--- a/features/prepend/features/debug.feature
+++ b/features/prepend/features/debug.feature
@@ -57,7 +57,7 @@ Feature: display debug statistics
       | parent | frontend | git checkout old                                 |
       |        | backend  | git config git-town-branch.old.parent main       |
       |        | backend  | git config --unset git-town-branch.parent.parent |
-      |        | backend  | git rev-parse parent                             |
+      |        | backend  | git rev-parse --short parent                     |
       |        | backend  | git log main..parent                             |
       | old    | frontend | git branch -D parent                             |
       |        | frontend | git checkout main                                |

--- a/features/prepend/features/debug.feature
+++ b/features/prepend/features/debug.feature
@@ -6,7 +6,7 @@ Feature: display debug statistics
       | BRANCH | LOCATION      | MESSAGE    |
       | old    | local, origin | old commit |
 
-  # TODO: eliminate redundant "git rev-parse HEAD"
+  # TODO: eliminate redundant "git rev-parse --short HEAD"
   Scenario: result
     When I run "git-town prepend parent --debug"
     Then it runs the commands
@@ -23,13 +23,13 @@ Feature: display debug statistics
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git status --porcelain --ignore-submodules    |
       | old    | frontend | git checkout main                             |
-      |        | backend  | git rev-parse HEAD                            |
+      |        | backend  | git rev-parse --short HEAD                    |
       | main   | frontend | git rebase origin/main                        |
       |        | backend  | git rev-list --left-right main...origin/main  |
       | main   | frontend | git checkout old                              |
-      |        | backend  | git rev-parse HEAD                            |
+      |        | backend  | git rev-parse --short HEAD                    |
       | old    | frontend | git merge --no-edit origin/old                |
-      |        | backend  | git rev-parse HEAD                            |
+      |        | backend  | git rev-parse --short HEAD                    |
       | old    | frontend | git merge --no-edit main                      |
       |        | backend  | git rev-list --left-right old...origin/old    |
       | old    | frontend | git branch parent main                        |

--- a/features/prune_branches/features/debug.feature
+++ b/features/prune_branches/features/debug.feature
@@ -25,7 +25,7 @@ Feature: display debug statistics
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       | old    | frontend | git checkout main                             |
       |        | backend  | git config --unset git-town-branch.old.parent |
-      |        | backend  | git rev-parse old                             |
+      |        | backend  | git rev-parse --short old                     |
       |        | backend  | git log main..old                             |
       | main   | frontend | git branch -D old                             |
       |        | backend  | git show-ref --quiet refs/heads/main          |

--- a/features/rename_branch/features/debug.feature
+++ b/features/rename_branch/features/debug.feature
@@ -27,7 +27,7 @@ Feature: display debug statistics
       |        | backend  | git config git-town-branch.new.parent main    |
       | new    | frontend | git push -u origin new                        |
       |        | frontend | git push origin :old                          |
-      |        | backend  | git rev-parse old                             |
+      |        | backend  | git rev-parse --short old                     |
       |        | backend  | git log main..old                             |
       | new    | frontend | git branch -D old                             |
       |        | backend  | git show-ref --quiet refs/heads/main          |
@@ -57,7 +57,7 @@ Feature: display debug statistics
       |        | backend  | git config --unset git-town-branch.new.parent |
       |        | backend  | git config git-town-branch.old.parent main    |
       | new    | frontend | git checkout old                              |
-      |        | backend  | git rev-parse new                             |
+      |        | backend  | git rev-parse --short new                     |
       |        | backend  | git log old..new                              |
       | old    | frontend | git branch -D new                             |
     And it prints:

--- a/features/ship/current_branch/features/debug.feature
+++ b/features/ship/current_branch/features/debug.feature
@@ -45,7 +45,7 @@ Feature: display debug statistics
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git push                                          |
       |         | frontend | git push origin :feature                          |
-      |         | backend  | git rev-parse feature                             |
+      |         | backend  | git rev-parse --short feature                     |
       |         | backend  | git log main..feature                             |
       | main    | frontend | git branch -D feature                             |
       |         | backend  | git config --unset git-town-branch.feature.parent |

--- a/features/ship/current_branch/features/debug.feature
+++ b/features/ship/current_branch/features/debug.feature
@@ -26,13 +26,13 @@ Feature: display debug statistics
       |         | backend  | git remote get-url origin                         |
       |         | backend  | git status --porcelain --ignore-submodules        |
       | feature | frontend | git checkout main                                 |
-      |         | backend  | git rev-parse HEAD                                |
+      |         | backend  | git rev-parse --short HEAD                        |
       | main    | frontend | git rebase origin/main                            |
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git checkout feature                              |
-      |         | backend  | git rev-parse HEAD                                |
+      |         | backend  | git rev-parse --short HEAD                        |
       | feature | frontend | git merge --no-edit origin/feature                |
-      |         | backend  | git rev-parse HEAD                                |
+      |         | backend  | git rev-parse --short HEAD                        |
       | feature | frontend | git merge --no-edit main                          |
       |         | backend  | git diff main..feature                            |
       | feature | frontend | git checkout main                                 |
@@ -41,7 +41,7 @@ Feature: display debug statistics
       |         | backend  | git config user.name                              |
       |         | backend  | git config user.email                             |
       | main    | frontend | git commit -m done                                |
-      |         | backend  | git rev-parse HEAD                                |
+      |         | backend  | git rev-parse --short HEAD                        |
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git push                                          |
       |         | frontend | git push origin :feature                          |
@@ -77,8 +77,8 @@ Feature: display debug statistics
       |         | backend  | git rev-list --left-right main...origin/main   |
       | main    | frontend | git push                                       |
       |         | frontend | git checkout feature                           |
-      |         | backend  | git rev-parse HEAD                             |
-      |         | backend  | git rev-parse HEAD                             |
+      |         | backend  | git rev-parse --short HEAD                     |
+      |         | backend  | git rev-parse --short HEAD                     |
       | feature | frontend | git checkout main                              |
       | main    | frontend | git checkout feature                           |
     And it prints:

--- a/features/ship/current_branch/features/debug.feature
+++ b/features/ship/current_branch/features/debug.feature
@@ -72,7 +72,7 @@ Feature: display debug statistics
       |         | backend  | git config git-town-branch.feature.parent main |
       | main    | frontend | git branch feature {{ sha 'feature commit' }}  |
       |         | frontend | git push -u origin feature                     |
-      |         | backend  | git log --pretty=format:%H -10                 |
+      |         | backend  | git log --pretty=format:%h -10                 |
       | main    | frontend | git revert {{ sha 'done' }}                    |
       |         | backend  | git rev-list --left-right main...origin/main   |
       | main    | frontend | git push                                       |

--- a/features/sync/features/debug.feature
+++ b/features/sync/features/debug.feature
@@ -25,14 +25,14 @@ Feature: display debug statistics
       |         | backend  | git rev-parse --verify --abbrev-ref @{-1}          |
       |         | backend  | git status --porcelain --ignore-submodules         |
       | feature | frontend | git checkout main                                  |
-      |         | backend  | git rev-parse HEAD                                 |
+      |         | backend  | git rev-parse --short HEAD                         |
       | main    | frontend | git rebase origin/main                             |
       |         | backend  | git rev-list --left-right main...origin/main       |
       | main    | frontend | git push                                           |
       |         | frontend | git checkout feature                               |
-      |         | backend  | git rev-parse HEAD                                 |
+      |         | backend  | git rev-parse --short HEAD                         |
       | feature | frontend | git merge --no-edit origin/feature                 |
-      |         | backend  | git rev-parse HEAD                                 |
+      |         | backend  | git rev-parse --short HEAD                         |
       | feature | frontend | git merge --no-edit main                           |
       |         | backend  | git rev-list --left-right feature...origin/feature |
       | feature | frontend | git push                                           |

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -462,7 +462,7 @@ func (bc *BackendCommands) RootDirectory() domain.RepoRootDir {
 
 // SHAForBranch provides the SHA for the local branch with the given name.
 func (bc *BackendCommands) SHAForBranch(name domain.BranchName) (domain.SHA, error) {
-	output, err := bc.QueryTrim("git", "rev-parse", name.String())
+	output, err := bc.QueryTrim("git", "rev-parse", "--short", name.String())
 	if err != nil {
 		return domain.SHA{}, fmt.Errorf(messages.BranchLocalSHAProblem, name, err)
 	}

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -230,14 +230,14 @@ func (bc *BackendCommands) CommitsInFeatureBranch(branch, parent domain.LocalBra
 	result := make([]domain.SHA, 0, len(lines))
 	for _, line := range lines {
 		if len(line) > 0 {
-			result = append(result, domain.NewSHA(line[2:]))
+			result = append(result, domain.NewSHA(line[2:9]))
 		}
 	}
 	return result, nil
 }
 
 func (bc *BackendCommands) CommitsInPerennialBranch() (domain.SHAs, error) {
-	output, err := bc.QueryTrim("git", "log", "--pretty=format:%H", "-10")
+	output, err := bc.QueryTrim("git", "log", "--pretty=format:%h", "-10")
 	if err != nil {
 		return domain.SHAs{}, err
 	}

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -309,7 +309,7 @@ func (r *TestCommands) RemoveUnnecessaryFiles() {
 
 // SHAForCommit provides the SHA for the commit with the given name.
 func (r *TestCommands) SHAForCommit(name string) string {
-	output := r.MustQuery("git", "log", "--reflog", "--format=%H", "--grep=^"+name+"$")
+	output := r.MustQuery("git", "log", "--reflog", "--format=%h", "--grep=^"+name+"$")
 	if output == "" {
 		log.Fatalf("cannot find the SHA of commit %q", name)
 	}

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -360,7 +360,7 @@ func TestTestCommands(t *testing.T) {
 		repo := testruntime.Create(t)
 		repo.CreateCommit(git.Commit{Branch: domain.NewLocalBranchName("initial"), FileName: "foo", FileContent: "bar", Message: "commit"})
 		sha := repo.SHAForCommit("commit")
-		assert.Len(t, sha, 40)
+		assert.Len(t, sha, 7)
 	})
 
 	t.Run("UncommittedFiles", func(t *testing.T) {


### PR DESCRIPTION
Git Town used a mix of short (7 digits) and long (40 digits) SHAs. This leads to problems when comparing SHAs. This PR makes Git Town use short SHAs everywhere.