### PR TITLE
Consistent naming for functions that implement command logic

### DIFF
--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -26,14 +26,14 @@ func abortCmd() *cobra.Command {
 		Short:   abortDesc,
 		Long:    long(abortDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return abort(readDebugFlag(cmd))
+			return runAbort(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func abort(debug bool) error {
+func runAbort(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/aliases.go
+++ b/src/cmd/aliases.go
@@ -31,14 +31,14 @@ func aliasesCommand() *cobra.Command {
 		Short:   aliasesDesc,
 		Long:    long(aliasesDesc, aliasesHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return aliases(args[0], readDebugFlag(cmd))
+			return runAliases(args[0], readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func aliases(arg string, debug bool) error {
+func runAliases(arg string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/completions.go
+++ b/src/cmd/completions.go
@@ -52,14 +52,14 @@ func completionsCmd(rootCmd *cobra.Command) *cobra.Command {
 		Short:                 completionsDesc,
 		Long:                  long(completionsDesc, completionsHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return completions(args, completionsNoDescFlag, rootCmd)
+			return runCompletions(args, completionsNoDescFlag, rootCmd)
 		},
 	}
 	completionsCmd.Flags().BoolVar(&completionsNoDescFlag, "no-descriptions", false, "disable completions description for shells that support it")
 	return &completionsCmd
 }
 
-func completions(args []string, completionsNoDescFlag bool, rootCmd *cobra.Command) error {
+func runCompletions(args []string, completionsNoDescFlag bool, rootCmd *cobra.Command) error {
 	completionType, err := NewCompletionType(args[0])
 	if err != nil {
 		return err

--- a/src/cmd/config_mainbranch.go
+++ b/src/cmd/config_mainbranch.go
@@ -25,14 +25,14 @@ func mainbranchConfigCmd() *cobra.Command {
 		Short: mainbranchDesc,
 		Long:  long(mainbranchDesc, mainbranchHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return configureMainBranch(args, readDebugFlag(cmd))
+			return runConfigMainBranch(args, readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func configureMainBranch(args []string, debug bool) error {
+func runConfigMainBranch(args []string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_offline.go
+++ b/src/cmd/config_offline.go
@@ -25,14 +25,14 @@ func offlineCmd() *cobra.Command {
 		Short: offlineDesc,
 		Long:  long(offlineDesc, offlineHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return offline(args, readDebugFlag(cmd))
+			return runOffline(args, readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func offline(args []string, debug bool) error {
+func runOffline(args []string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_perennial_branches.go
+++ b/src/cmd/config_perennial_branches.go
@@ -24,7 +24,7 @@ func perennialBranchesCmd() *cobra.Command {
 		Short: perennialDesc,
 		Long:  long(perennialDesc, perennialHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return displayPerennialBranches(readDisplayDebugFlag(cmd))
+			return runConfigPerennialBranches(readDisplayDebugFlag(cmd))
 		},
 	}
 	addDisplayDebugFlag(&displayCmd)
@@ -44,7 +44,7 @@ func perennialBranchesCmd() *cobra.Command {
 	return &displayCmd
 }
 
-func displayPerennialBranches(debug bool) error {
+func runConfigPerennialBranches(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_pull_branch_strategy.go
+++ b/src/cmd/config_pull_branch_strategy.go
@@ -24,14 +24,14 @@ func pullBranchStrategyCommand() *cobra.Command {
 		Short: pullBranchDesc,
 		Long:  long(pullBranchDesc, pullBranchHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return pullBranchStrategy(args, readDebugFlag(cmd))
+			return runConfigPullBranch(args, readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func pullBranchStrategy(args []string, debug bool) error {
+func runConfigPullBranch(args []string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_push_hook.go
+++ b/src/cmd/config_push_hook.go
@@ -26,7 +26,7 @@ func pushHookCommand() *cobra.Command {
 		Short: pushHookDesc,
 		Long:  long(pushHookDesc, pushHookHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return pushHook(args, readGlobalFlag(cmd), readDebugFlag(cmd))
+			return runConfigPushHook(args, readGlobalFlag(cmd), readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
@@ -34,7 +34,7 @@ func pushHookCommand() *cobra.Command {
 	return &cmd
 }
 
-func pushHook(args []string, global, debug bool) error {
+func runConfigPushHook(args []string, global, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_push_new_branches.go
+++ b/src/cmd/config_push_new_branches.go
@@ -27,7 +27,7 @@ func pushNewBranchesCommand() *cobra.Command {
 		Short: pushNewBranchesDesc,
 		Long:  long(pushNewBranchesDesc, pushNewBranchesHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return pushNewBranches(args, readGlobalFlag(cmd), readDebugFlag(cmd))
+			return runConfigPushNewBranches(args, readGlobalFlag(cmd), readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
@@ -35,7 +35,7 @@ func pushNewBranchesCommand() *cobra.Command {
 	return &cmd
 }
 
-func pushNewBranches(args []string, global, debug bool) error {
+func runConfigPushNewBranches(args []string, global, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_reset.go
+++ b/src/cmd/config_reset.go
@@ -16,14 +16,14 @@ func resetConfigCommand() *cobra.Command {
 		Short: resetConfigDesc,
 		Long:  long(resetConfigDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return resetStatus(readDebugFlag(cmd))
+			return runConfigResetStatus(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func resetStatus(debug bool) error {
+func runConfigResetStatus(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_setup.go
+++ b/src/cmd/config_setup.go
@@ -17,14 +17,14 @@ func setupConfigCommand() *cobra.Command {
 		Short: setupConfigDesc,
 		Long:  long(setupConfigDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return setup(readDebugFlag(cmd))
+			return runConfigSetup(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func setup(debug bool) error {
+func runConfigSetup(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/config_sync_strategy.go
+++ b/src/cmd/config_sync_strategy.go
@@ -24,7 +24,7 @@ func syncStrategyCommand() *cobra.Command {
 		Short: syncStrategyDesc,
 		Long:  long(syncStrategyDesc, syncStrategyHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return syncStrategy(args, readGlobalFlag(cmd), readDebugFlag(cmd))
+			return runConfigSyncStrategy(args, readGlobalFlag(cmd), readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
@@ -32,7 +32,7 @@ func syncStrategyCommand() *cobra.Command {
 	return &cmd
 }
 
-func syncStrategy(args []string, global, debug bool) error {
+func runConfigSyncStrategy(args []string, global, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -28,14 +28,14 @@ func diffParentCommand() *cobra.Command {
 		Short:   diffParentDesc,
 		Long:    long(diffParentDesc, diffParentHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return diffParent(args, readDebugFlag(cmd))
+			return runDiffParent(args, readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func diffParent(args []string, debug bool) error {
+func runDiffParent(args []string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -38,7 +38,7 @@ func hackCmd() *cobra.Command {
 		Short:   hackDesc,
 		Long:    long(hackDesc, hackHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return hack(args, readPromptFlag(cmd), readDebugFlag(cmd))
+			return runHack(args, readPromptFlag(cmd), readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
@@ -46,7 +46,7 @@ func hackCmd() *cobra.Command {
 	return &cmd
 }
 
-func hack(args []string, promptForParent, debug bool) error {
+func runHack(args []string, promptForParent, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -30,14 +30,14 @@ func killCommand() *cobra.Command {
 		Short: killDesc,
 		Long:  long(killDesc, killHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return kill(args, readDebugFlag(cmd))
+			return runKill(args, readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func kill(args []string, debug bool) error {
+func runKill(args []string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -43,14 +43,14 @@ func newPullRequestCommand() *cobra.Command {
 		Short:   newPullRequestDesc,
 		Long:    long(newPullRequestDesc, fmt.Sprintf(newPullRequestHelp, config.KeyCodeHostingDriver, config.KeyCodeHostingOriginHostname)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return newPullRequest(readDebugFlag(cmd))
+			return runNewPullRequest(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func newPullRequest(debug bool) error {
+func runNewPullRequest(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -38,14 +38,14 @@ func prependCommand() *cobra.Command {
 		Short:   prependDesc,
 		Long:    long(prependDesc, prependHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return prepend(args, readDebugFlag(cmd))
+			return runPrepend(args, readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func prepend(args []string, debug bool) error {
+func runPrepend(args []string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -25,14 +25,14 @@ func pruneBranchesCommand() *cobra.Command {
 		Short: pruneBranchesDesc,
 		Long:  long(pruneBranchesDesc, pruneBranchesHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return pruneBranches(readDebugFlag(cmd))
+			return runPruneBranches(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func pruneBranches(debug bool) error {
+func runPruneBranches(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -43,7 +43,7 @@ func renameBranchCommand() *cobra.Command {
 		Short: renameBranchDesc,
 		Long:  long(renameBranchDesc, renameBranchHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return renameBranch(args, readForceFlag(cmd), readDebugFlag(cmd))
+			return runRenameBranch(args, readForceFlag(cmd), readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
@@ -51,7 +51,7 @@ func renameBranchCommand() *cobra.Command {
 	return &cmd
 }
 
-func renameBranch(args []string, force, debug bool) error {
+func runRenameBranch(args []string, force, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -33,14 +33,14 @@ func repoCommand() *cobra.Command {
 		Short: repoDesc,
 		Long:  long(repoDesc, fmt.Sprintf(repoHelp, config.KeyCodeHostingDriver, config.KeyCodeHostingOriginHostname)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return repo(readDebugFlag(cmd))
+			return runRepo(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func repo(debug bool) error {
+func runRepo(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -21,14 +21,14 @@ func setParentCommand() *cobra.Command {
 		Short:   setParentDesc,
 		Long:    long(setParentDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return setParent(readDebugFlag(cmd))
+			return runSetParent(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func setParent(debug bool) error {
+func runSetParent(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -58,7 +58,7 @@ func shipCmd() *cobra.Command {
 		Short:   shipDesc,
 		Long:    long(shipDesc, fmt.Sprintf(shipHelp, config.KeyGithubToken, config.KeyShipDeleteRemoteBranch)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ship(args, readMessageFlag(cmd), readDebugFlag(cmd))
+			return runShip(args, readMessageFlag(cmd), readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
@@ -66,7 +66,7 @@ func shipCmd() *cobra.Command {
 	return &cmd
 }
 
-func ship(args []string, message string, debug bool) error {
+func runShip(args []string, message string, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -22,14 +22,14 @@ func skipCmd() *cobra.Command {
 		Short:   skipDesc,
 		Long:    long(skipDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return skip(readDebugFlag(cmd))
+			return runSkip(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func skip(debug bool) error {
+func runSkip(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/status.go
+++ b/src/cmd/status.go
@@ -23,7 +23,7 @@ func statusCommand() *cobra.Command {
 		Short:   statusDesc,
 		Long:    long(statusDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return status(readDebugFlag(cmd))
+			return runStatus(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
@@ -31,7 +31,7 @@ func statusCommand() *cobra.Command {
 	return &cmd
 }
 
-func status(debug bool) error {
+func runStatus(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/status_reset.go
+++ b/src/cmd/status_reset.go
@@ -19,14 +19,14 @@ func resetRunstateCommand() *cobra.Command {
 		Short: statusResetDesc,
 		Long:  long(statusResetDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return statusReset(readDebugFlag(cmd))
+			return runStatusReset(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func statusReset(debug bool) error {
+func runStatusReset(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -44,7 +44,7 @@ func syncCmd() *cobra.Command {
 		Short:   syncDesc,
 		Long:    long(syncDesc, fmt.Sprintf(syncHelp, config.KeySyncUpstream)),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return sync(readAllFlag(cmd), readDryRunFlag(cmd), readDebugFlag(cmd))
+			return runSync(readAllFlag(cmd), readDryRunFlag(cmd), readDebugFlag(cmd))
 		},
 	}
 	addAllFlag(&cmd)
@@ -53,7 +53,7 @@ func syncCmd() *cobra.Command {
 	return &cmd
 }
 
-func sync(all, dryRun, debug bool) error {
+func runSync(all, dryRun, debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           dryRun,

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -22,14 +22,14 @@ func undoCmd() *cobra.Command {
 		Short:   undoDesc,
 		Long:    long(undoDesc),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return undo(readDebugFlag(cmd))
+			return runUndo(readDebugFlag(cmd))
 		},
 	}
 	addDebugFlag(&cmd)
 	return &cmd
 }
 
-func undo(debug bool) error {
+func runUndo(debug bool) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		Debug:            debug,
 		DryRun:           false,


### PR DESCRIPTION
Some of these functions would use built-in names like `switch`, `continue`, etc. So the convention is to name them `run<Command>`.