### PR TITLE
Fix flaky unit tests

### DIFF
--- a/src/domain/local_branches_shas.go
+++ b/src/domain/local_branches_shas.go
@@ -5,5 +5,7 @@ import "golang.org/x/exp/maps"
 type LocalBranchesSHAs map[LocalBranchName]SHA
 
 func (lbs LocalBranchesSHAs) BranchNames() LocalBranchNames {
-	return maps.Keys(lbs)
+	result := LocalBranchNames(maps.Keys(lbs))
+	result.Sort()
+	return result
 }

--- a/src/domain/remote_branch_change.go
+++ b/src/domain/remote_branch_change.go
@@ -18,5 +18,7 @@ func (rbc RemoteBranchChange) Categorize(branchTypes BranchTypes) (perennialChan
 }
 
 func (rbc RemoteBranchChange) BranchNames() RemoteBranchNames {
-	return maps.Keys(rbc)
+	result := RemoteBranchNames(maps.Keys(rbc))
+	result.Sort()
+	return result
 }

--- a/src/domain/remote_branch_names.go
+++ b/src/domain/remote_branch_names.go
@@ -4,18 +4,18 @@ import "sort"
 
 type RemoteBranchNames []RemoteBranchName
 
+// Sort orders the branches in this collection alphabetically.
+func (rbns RemoteBranchNames) Sort() {
+	sort.Slice(rbns, func(a, b int) bool {
+		return rbns[a].id < rbns[b].id
+	})
+}
+
 // Strings provides these remote branch names as strings.
-func (r RemoteBranchNames) Strings() []string {
-	result := make([]string, len(r))
-	for b, branch := range r {
+func (rbns RemoteBranchNames) Strings() []string {
+	result := make([]string, len(rbns))
+	for b, branch := range rbns {
 		result[b] = branch.String()
 	}
 	return result
-}
-
-// Sort orders the branches in this collection alphabetically.
-func (l RemoteBranchNames) Sort() {
-	sort.Slice(l, func(a, b int) bool {
-		return l[a].id < l[b].id
-	})
 }

--- a/src/domain/remote_branch_names.go
+++ b/src/domain/remote_branch_names.go
@@ -1,5 +1,7 @@
 package domain
 
+import "sort"
+
 type RemoteBranchNames []RemoteBranchName
 
 // Strings provides these remote branch names as strings.
@@ -9,4 +11,11 @@ func (r RemoteBranchNames) Strings() []string {
 		result[b] = branch.String()
 	}
 	return result
+}
+
+// Sort orders the branches in this collection alphabetically.
+func (l RemoteBranchNames) Sort() {
+	sort.Slice(l, func(a, b int) bool {
+		return l[a].id < l[b].id
+	})
 }

--- a/src/domain/remote_branch_names_test.go
+++ b/src/domain/remote_branch_names_test.go
@@ -1,0 +1,11 @@
+package domain_test
+
+import "testing"
+
+func TestRemoteBranchNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Sort", func(t *testing.T) {
+		t.Parallel()
+	})
+}

--- a/src/domain/remote_branch_names_test.go
+++ b/src/domain/remote_branch_names_test.go
@@ -1,11 +1,40 @@
 package domain_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v9/src/domain"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestRemoteBranchNames(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Sort", func(t *testing.T) {
 		t.Parallel()
+		have := domain.RemoteBranchNames{
+			domain.NewRemoteBranchName("origin/branch-3"),
+			domain.NewRemoteBranchName("origin/branch-2"),
+			domain.NewRemoteBranchName("origin/branch-1"),
+		}
+		have.Sort()
+		want := domain.RemoteBranchNames{
+			domain.NewRemoteBranchName("origin/branch-1"),
+			domain.NewRemoteBranchName("origin/branch-2"),
+			domain.NewRemoteBranchName("origin/branch-3"),
+		}
+		assert.Equal(t, want, have)
+	})
+
+	t.Run("Strings", func(t *testing.T) {
+		t.Parallel()
+		give := domain.RemoteBranchNames{
+			domain.NewRemoteBranchName("origin/branch-1"),
+			domain.NewRemoteBranchName("origin/branch-2"),
+			domain.NewRemoteBranchName("origin/branch-3"),
+		}
+		have := give.Strings()
+		want := []string{"origin/branch-1", "origin/branch-2", "origin/branch-3"}
+		assert.Equal(t, want, have)
 	})
 }

--- a/src/domain/remote_branch_names_test.go
+++ b/src/domain/remote_branch_names_test.go
@@ -34,7 +34,11 @@ func TestRemoteBranchNames(t *testing.T) {
 			domain.NewRemoteBranchName("origin/branch-3"),
 		}
 		have := give.Strings()
-		want := []string{"origin/branch-1", "origin/branch-2", "origin/branch-3"}
+		want := []string{
+			"origin/branch-1",
+			"origin/branch-2",
+			"origin/branch-3",
+		}
 		assert.Equal(t, want, have)
 	})
 }

--- a/src/domain/remote_branch_sha.go
+++ b/src/domain/remote_branch_sha.go
@@ -19,5 +19,7 @@ func (rbs RemoteBranchesSHAs) Categorize(branchTypes BranchTypes) (perennials, f
 
 // BranchNames provides the names of the involved branches as strings.
 func (rbs RemoteBranchesSHAs) BranchNames() RemoteBranchNames {
-	return maps.Keys(rbs)
+	result := RemoteBranchNames(maps.Keys(rbs))
+	result.Sort()
+	return result
 }

--- a/src/undo/branch_changes_test.go
+++ b/src/undo/branch_changes_test.go
@@ -1309,12 +1309,12 @@ func TestChanges(t *testing.T) {
 			wantSteps := runstate.StepList{
 				List: []steps.Step{
 					&steps.CreateBranchStep{
-						Branch:        domain.NewLocalBranchName("perennial-branch"),
-						StartingPoint: domain.NewSHA("111111").Location(),
-					},
-					&steps.CreateBranchStep{
 						Branch:        domain.NewLocalBranchName("feature-branch"),
 						StartingPoint: domain.NewSHA("222222").Location(),
+					},
+					&steps.CreateBranchStep{
+						Branch:        domain.NewLocalBranchName("perennial-branch"),
+						StartingPoint: domain.NewSHA("111111").Location(),
 					},
 					&steps.CheckoutIfExistsStep{Branch: domain.NewLocalBranchName("feature-branch")},
 				},


### PR DESCRIPTION
The Go test runner has a tendency to hide flaky tests because it keeps executing them until they randomly pass, then it keeps using that cached result.