### PR TITLE
Merge the commands analyzing the status of the Git repo

### DIFF
--- a/features/kill/current_branch/features/debug.feature
+++ b/features/kill/current_branch/features/debug.feature
@@ -18,7 +18,7 @@ Feature: display debug statistics
       |         | backend  | git rev-parse --show-toplevel                     |
       |         | backend  | git stash list                                    |
       |         | backend  | git remote                                        |
-      |         | backend  | git status                                        |
+      |         | backend  | git status --ignore-submodules                    |
       |         | backend  | git rev-parse --abbrev-ref HEAD                   |
       | current | frontend | git fetch --prune --tags                          |
       |         | backend  | git branch -vva                                   |

--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -103,14 +103,14 @@ func determineAbortConfig(repo *execute.OpenRepoResult) (*abortConfig, domain.St
 	if err != nil || exit {
 		return nil, initialStashSnapshot, err
 	}
-	hasOpenChanges, err := repo.Runner.Backend.HasOpenChanges()
+	repoStatus, err := repo.Runner.Backend.RepoStatus()
 	if err != nil {
 		return nil, initialStashSnapshot, err
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
 	return &abortConfig{
 		connector:               connector,
-		hasOpenChanges:          hasOpenChanges,
+		hasOpenChanges:          repoStatus.OpenChanges,
 		initialBranchesSnapshot: initialBranchesSnapshot,
 		lineage:                 lineage,
 		mainBranch:              mainBranch,

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -117,7 +117,7 @@ func determineAppendConfig(targetBranch domain.LocalBranchName, repo *execute.Op
 	remotes := fc.Remotes(repo.Runner.Backend.Remotes())
 	mainBranch := repo.Runner.Config.MainBranch()
 	pullBranchStrategy := fc.PullBranchStrategy(repo.Runner.Config.PullBranchStrategy())
-	hasOpenChanges := fc.Bool(repo.Runner.Backend.HasOpenChanges())
+	repoStatus := fc.RepoStatus(repo.Runner.Backend.RepoStatus())
 	shouldNewBranchPush := fc.Bool(repo.Runner.Config.ShouldNewBranchPush())
 	if fc.Err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, fc.Err
@@ -149,7 +149,7 @@ func determineAppendConfig(targetBranch domain.LocalBranchName, repo *execute.Op
 	return &appendConfig{
 		branches:            branches,
 		branchesToSync:      branchesToSync,
-		hasOpenChanges:      hasOpenChanges,
+		hasOpenChanges:      repoStatus.OpenChanges,
 		remotes:             remotes,
 		isOffline:           repo.IsOffline,
 		lineage:             lineage,

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -84,11 +84,11 @@ func determineContinueConfig(repo *execute.OpenRepoResult) (*continueConfig, dom
 	if err != nil || exit {
 		return nil, initialBranchesSnapshot, initialStashSnapshot, exit, err
 	}
-	hasConflicts, err := repo.Runner.Backend.HasConflicts()
+	repoStatus, err := repo.Runner.Backend.RepoStatus()
 	if err != nil {
 		return nil, initialBranchesSnapshot, initialStashSnapshot, false, err
 	}
-	if hasConflicts {
+	if repoStatus.Conflicts {
 		return nil, initialBranchesSnapshot, initialStashSnapshot, false, fmt.Errorf(messages.ContinueUnresolvedConflicts)
 	}
 	originURL := repo.Runner.Config.OriginURL()

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -100,7 +100,7 @@ func determineHackConfig(args []string, promptForParent bool, repo *execute.Open
 		return nil, branchesSnapshot, stashSnapshot, exit, err
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	hasOpenChanges := fc.Bool(repo.Runner.Backend.HasOpenChanges())
+	repoStatus := fc.RepoStatus(repo.Runner.Backend.RepoStatus())
 	targetBranch := domain.NewLocalBranchName(args[0])
 	mainBranch := repo.Runner.Config.MainBranch()
 	parentBranch, updated, err := determineParentBranch(determineParentBranchArgs{
@@ -136,7 +136,7 @@ func determineHackConfig(args []string, promptForParent bool, repo *execute.Open
 		branchesToSync:      branchesToSync,
 		targetBranch:        targetBranch,
 		parentBranch:        parentBranch,
-		hasOpenChanges:      hasOpenChanges,
+		hasOpenChanges:      repoStatus.OpenChanges,
 		remotes:             remotes,
 		lineage:             lineage,
 		mainBranch:          mainBranch,

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -131,12 +131,12 @@ func determineKillConfig(args []string, repo *execute.OpenRepoResult) (*killConf
 		}
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	hasOpenChanges, err := repo.Runner.Backend.HasOpenChanges()
+	repoStatus, err := repo.Runner.Backend.RepoStatus()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
 	return &killConfig{
-		hasOpenChanges: hasOpenChanges,
+		hasOpenChanges: repoStatus.OpenChanges,
 		initialBranch:  branches.Initial,
 		isOffline:      repo.IsOffline,
 		lineage:        lineage,

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -125,7 +125,7 @@ func determineNewPullRequestConfig(repo *execute.OpenRepoResult) (*newPullReques
 		return nil, branchesSnapshot, stashSnapshot, exit, err
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	hasOpenChanges, err := repo.Runner.Backend.HasOpenChanges()
+	repoStatus, err := repo.Runner.Backend.RepoStatus()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
@@ -187,7 +187,7 @@ func determineNewPullRequestConfig(repo *execute.OpenRepoResult) (*newPullReques
 		branches:           branches,
 		branchesToSync:     branchesToSync,
 		connector:          connector,
-		hasOpenChanges:     hasOpenChanges,
+		hasOpenChanges:     repoStatus.OpenChanges,
 		remotes:            remotes,
 		isOffline:          repo.IsOffline,
 		lineage:            lineage,

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -117,7 +117,7 @@ func determinePrependConfig(args []string, repo *execute.OpenRepoResult) (*prepe
 		return nil, branchesSnapshot, stashSnapshot, exit, err
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	hasOpenChanges := fc.Bool(repo.Runner.Backend.HasOpenChanges())
+	repoStatus := fc.RepoStatus(repo.Runner.Backend.RepoStatus())
 	remotes := fc.Remotes(repo.Runner.Backend.Remotes())
 	shouldNewBranchPush := fc.Bool(repo.Runner.Config.ShouldNewBranchPush())
 	mainBranch := repo.Runner.Config.MainBranch()
@@ -150,7 +150,7 @@ func determinePrependConfig(args []string, repo *execute.OpenRepoResult) (*prepe
 	return &prependConfig{
 		branches:            branches,
 		branchesToSync:      branchesToSync,
-		hasOpenChanges:      hasOpenChanges,
+		hasOpenChanges:      repoStatus.OpenChanges,
 		remotes:             remotes,
 		isOffline:           repo.IsOffline,
 		lineage:             lineage,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -81,11 +81,11 @@ func executeShip(args []string, message string, debug bool) error {
 		return err
 	}
 	if config.branchToShip.LocalName == config.branches.Initial {
-		hasOpenChanges, err := repo.Runner.Backend.HasOpenChanges()
+		repoStatus, err := repo.Runner.Backend.RepoStatus()
 		if err != nil {
 			return err
 		}
-		err = validate.NoOpenChanges(hasOpenChanges)
+		err = validate.NoOpenChanges(repoStatus.OpenChanges)
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func determineShipConfig(args []string, repo *execute.OpenRepoResult) (*shipConf
 		return nil, branchesSnapshot, stashSnapshot, exit, err
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	hasOpenChanges, err := repo.Runner.Backend.HasOpenChanges()
+	repoStatus, err := repo.Runner.Backend.RepoStatus()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
@@ -271,7 +271,7 @@ func determineShipConfig(args []string, repo *execute.OpenRepoResult) (*shipConf
 		childBranches:            childBranches,
 		proposalMessage:          proposalMessage,
 		deleteOriginBranch:       deleteOrigin,
-		hasOpenChanges:           hasOpenChanges,
+		hasOpenChanges:           repoStatus.OpenChanges,
 		remotes:                  remotes,
 		isOffline:                repo.IsOffline,
 		isShippingInitialBranch:  isShippingInitialBranch,

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -125,7 +125,7 @@ func determineSyncConfig(allFlag bool, repo *execute.OpenRepoResult) (*syncConfi
 		return nil, branchesSnapshot, stashSnapshot, exit, err
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	hasOpenChanges, err := repo.Runner.Backend.HasOpenChanges()
+	repoStatus, err := repo.Runner.Backend.RepoStatus()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
@@ -193,7 +193,7 @@ func determineSyncConfig(allFlag bool, repo *execute.OpenRepoResult) (*syncConfi
 	return &syncConfig{
 		branches:           branches,
 		branchesToSync:     branchesToSync,
-		hasOpenChanges:     hasOpenChanges,
+		hasOpenChanges:     repoStatus.OpenChanges,
 		remotes:            remotes,
 		isOffline:          repo.IsOffline,
 		lineage:            lineage,

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -94,12 +94,12 @@ func determineUndoConfig(repo *execute.OpenRepoResult) (*undoConfig, domain.Stas
 	}
 	mainBranch := repo.Runner.Backend.Config.MainBranch()
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	hasOpenChanges, err := repo.Runner.Backend.HasOpenChanges()
+	repoStatus, err := repo.Runner.Backend.RepoStatus()
 	if err != nil {
 		return nil, initialStashSnapshot, lineage, err
 	}
 	return &undoConfig{
-		hasOpenChanges:          hasOpenChanges,
+		hasOpenChanges:          repoStatus.OpenChanges,
 		initialBranchesSnapshot: initialBranchesSnapshot,
 		mainBranch:              mainBranch,
 		previousBranch:          previousBranch,

--- a/src/execute/load_branches.go
+++ b/src/execute/load_branches.go
@@ -34,11 +34,11 @@ func LoadBranches(args LoadBranchesArgs) (domain.Branches, domain.BranchesSnapsh
 		}
 	}
 	if args.ValidateNoOpenChanges {
-		hasOpenChanges, err := args.Repo.Runner.Backend.HasOpenChanges()
+		repoStatus, err := args.Repo.Runner.Backend.RepoStatus()
 		if err != nil {
 			return domain.EmptyBranches(), branchesSnapshot, stashSnapshot, false, err
 		}
-		err = validate.NoOpenChanges(hasOpenChanges)
+		err = validate.NoOpenChanges(repoStatus.OpenChanges)
 		if err != nil {
 			return domain.EmptyBranches(), branchesSnapshot, stashSnapshot, false, err
 		}

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -267,11 +267,11 @@ func (bc *BackendCommands) CreateFeatureBranch(name domain.LocalBranchName) erro
 
 // CurrentBranch provides the currently checked out branch.
 func (bc *BackendCommands) CurrentBranchUncached() (domain.LocalBranchName, error) {
-	rebasing, err := bc.HasRebaseInProgress()
+	repoStatus, err := bc.RepoStatus()
 	if err != nil {
 		return domain.LocalBranchName{}, fmt.Errorf(messages.BranchCurrentProblem, err)
 	}
-	if rebasing {
+	if repoStatus.RebaseInProgress {
 		currentBranch, err := bc.currentBranchDuringRebase()
 		if err != nil {
 			return domain.LocalBranchName{}, err
@@ -342,15 +342,6 @@ func (bc *BackendCommands) ExpectedPreviouslyCheckedOutBranch(initialPreviouslyC
 	return mainBranch, nil
 }
 
-// HasConflicts returns whether the local repository currently has unresolved merge conflicts.
-func (bc *BackendCommands) HasConflicts() (bool, error) {
-	output, err := bc.QueryTrim("git", "status")
-	if err != nil {
-		return false, fmt.Errorf(messages.ConflictDetectionProblem, err)
-	}
-	return strings.Contains(output, "Unmerged paths"), nil
-}
-
 // HasLocalBranch indicates whether this repo has a local branch with the given name.
 func (bc *BackendCommands) HasLocalBranch(name domain.LocalBranchName) bool {
 	return bc.Run("git", "show-ref", "--quiet", "refs/heads/"+name.String()) == nil
@@ -360,44 +351,6 @@ func (bc *BackendCommands) HasLocalBranch(name domain.LocalBranchName) bool {
 func (bc *BackendCommands) HasMergeInProgress() bool {
 	err := bc.Run("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
 	return err == nil
-}
-
-// HasOpenChanges indicates whether this repo has open changes.
-// TODO: merge this with HasRebaseInProgress and return two bools.
-func (bc *BackendCommands) HasOpenChanges() (bool, error) {
-	output, err := bc.QueryTrim("git", "status", "--ignore-submodules")
-	if err != nil {
-		return false, fmt.Errorf(messages.OpenChangesProblem, err)
-	}
-	if strings.Contains(output, "working tree clean") || strings.Contains(output, "nothing to commit") {
-		return false, nil
-	}
-	if outputIndicatesRebaseInProgress(output) || outputIndicatesMergeInProgress(output) {
-		return false, nil
-	}
-	for _, line := range strings.Split(output, "\n") {
-		if strings.HasPrefix(line, "AA ") {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-func outputIndicatesMergeInProgress(output string) bool {
-	return strings.Contains(output, "You have unmerged paths")
-}
-
-// HasRebaseInProgress indicates whether this Git repository currently has a rebase in progress.
-func (bc *BackendCommands) HasRebaseInProgress() (bool, error) {
-	output, err := bc.QueryTrim("git", "status")
-	if err != nil {
-		return false, fmt.Errorf(messages.RebaseProblem, err)
-	}
-	return outputIndicatesRebaseInProgress(output), nil
-}
-
-func outputIndicatesRebaseInProgress(output string) bool {
-	return strings.Contains(output, "rebase in progress") || strings.Contains(output, "You are currently rebasing")
 }
 
 // HasShippableChanges indicates whether the given branch has changes
@@ -468,6 +421,28 @@ func (bc *BackendCommands) RemoveOutdatedConfiguration(allBranches domain.Branch
 	return nil
 }
 
+// HasConflicts returns whether the local repository currently has unresolved merge conflicts.
+func (bc *BackendCommands) RepoStatus() (RepoStatus, error) {
+	output, err := bc.QueryTrim("git", "status")
+	if err != nil {
+		return RepoStatus{}, fmt.Errorf(messages.ConflictDetectionProblem, err)
+	}
+	hasConflicts := strings.Contains(output, "Unmerged paths")
+	hasOpenChanges := outputIndicatesOpenChanges(output)
+	rebaseInProgress := outputIndicatesRebaseInProgress(output)
+	return RepoStatus{
+		Conflicts:        hasConflicts,
+		OpenChanges:      hasOpenChanges,
+		RebaseInProgress: rebaseInProgress,
+	}, nil
+}
+
+type RepoStatus struct {
+	Conflicts        bool // the repo contains merge conflicts
+	OpenChanges      bool // there are uncommitted changes
+	RebaseInProgress bool // a rebase is in progress
+}
+
 // RootDirectory provides the path of the rood directory of the current repository,
 // i.e. the directory that contains the ".git" folder.
 func (bc *BackendCommands) RootDirectory() domain.RepoRootDir {
@@ -525,4 +500,28 @@ func (bc *BackendCommands) Version() (major int, minor int, err error) {
 		return 0, 0, fmt.Errorf(messages.GitVersionMinorNotNumber, matches[2], err)
 	}
 	return majorVersion, minorVersion, nil
+}
+
+// HasOpenChanges indicates whether this repo has open changes.
+func outputIndicatesOpenChanges(output string) bool {
+	if strings.Contains(output, "working tree clean") || strings.Contains(output, "nothing to commit") {
+		return false
+	}
+	if outputIndicatesRebaseInProgress(output) || outputIndicatesMergeInProgress(output) {
+		return false
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "AA ") {
+			return false
+		}
+	}
+	return true
+}
+
+func outputIndicatesMergeInProgress(output string) bool {
+	return strings.Contains(output, "You have unmerged paths")
+}
+
+func outputIndicatesRebaseInProgress(output string) bool {
+	return strings.Contains(output, "rebase in progress") || strings.Contains(output, "You are currently rebasing")
 }

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -423,7 +423,7 @@ func (bc *BackendCommands) RemoveOutdatedConfiguration(allBranches domain.Branch
 
 // HasConflicts returns whether the local repository currently has unresolved merge conflicts.
 func (bc *BackendCommands) RepoStatus() (RepoStatus, error) {
-	output, err := bc.QueryTrim("git", "status")
+	output, err := bc.QueryTrim("git", "status", "--ignore-submodules")
 	if err != nil {
 		return RepoStatus{}, fmt.Errorf(messages.ConflictDetectionProblem, err)
 	}

--- a/src/gohacks/failure_collector.go
+++ b/src/gohacks/failure_collector.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
+	"github.com/git-town/git-town/v9/src/git"
 )
 
 // FailureCollector helps avoid excessive error checking
@@ -67,6 +68,11 @@ func (ec *FailureCollector) PullBranchStrategy(value config.PullBranchStrategy, 
 // Remotes provides the domain.Remotes part of the given fallible function result
 // while registering the given error.
 func (ec *FailureCollector) Remotes(value domain.Remotes, err error) domain.Remotes {
+	ec.Check(err)
+	return value
+}
+
+func (ec *FailureCollector) RepoStatus(value git.RepoStatus, err error) git.RepoStatus {
 	ec.Check(err)
 	return value
 }

--- a/src/runvm/errored.go
+++ b/src/runvm/errored.go
@@ -36,11 +36,11 @@ func errored(step steps.Step, runErr error, args ExecuteArgs) error {
 	if err != nil {
 		return err
 	}
-	rebasing, err := args.Run.Backend.HasRebaseInProgress()
+	repoStatus, err := args.Run.Backend.RepoStatus()
 	if err != nil {
 		return err
 	}
-	if args.RunState.Command == "sync" && !(rebasing && args.Run.Config.IsMainBranch(currentBranch)) {
+	if args.RunState.Command == "sync" && !(repoStatus.RebaseInProgress && args.Run.Config.IsMainBranch(currentBranch)) {
 		args.RunState.UnfinishedDetails.CanSkip = true
 	}
 	err = persistence.Save(args.RunState, args.RootDir)

--- a/src/steps/continue_rebase_step.go
+++ b/src/steps/continue_rebase_step.go
@@ -15,11 +15,11 @@ func (step *ContinueRebaseStep) CreateContinueSteps() []Step {
 }
 
 func (step *ContinueRebaseStep) Run(args RunArgs) error {
-	hasRebaseInProgress, err := args.Runner.Backend.HasRebaseInProgress()
+	repoStatus, err := args.Runner.Backend.RepoStatus()
 	if err != nil {
 		return err
 	}
-	if hasRebaseInProgress {
+	if repoStatus.RebaseInProgress {
 		return args.Runner.Frontend.ContinueRebase()
 	}
 	return nil

--- a/src/validate/handle_unfinished_state.go
+++ b/src/validate/handle_unfinished_state.go
@@ -76,11 +76,11 @@ func abortRunstate(runState *runstate.RunState, args UnfinishedStateArgs) (bool,
 }
 
 func continueRunstate(runState *runstate.RunState, args UnfinishedStateArgs) (bool, error) {
-	hasConflicts, err := args.Run.Backend.HasConflicts()
+	repoStatus, err := args.Run.Backend.RepoStatus()
 	if err != nil {
 		return false, err
 	}
-	if hasConflicts {
+	if repoStatus.Conflicts {
 		return false, fmt.Errorf(messages.ContinueUnresolvedConflicts)
 	}
 	return true, runvm.Execute(runvm.ExecuteArgs{

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -130,9 +130,9 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^a rebase is now in progress$`, func() error {
-		hasRebase, err := state.fixture.DevRepo.HasRebaseInProgress()
+		repoStatus, err := state.fixture.DevRepo.RepoStatus()
 		asserts.NoError(err)
-		if !hasRebase {
+		if !repoStatus.RebaseInProgress {
 			return fmt.Errorf("expected rebase in progress")
 		}
 		return nil
@@ -459,11 +459,11 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^no rebase is in progress$`, func() error {
-		hasRebase, err := state.fixture.DevRepo.HasRebaseInProgress()
+		repoStatus, err := state.fixture.DevRepo.RepoStatus()
 		if err != nil {
 			return err
 		}
-		if hasRebase {
+		if repoStatus.RebaseInProgress {
 			return fmt.Errorf("expected no rebase in progress")
 		}
 		return nil


### PR DESCRIPTION
All of them run `git status`, so we could as well run that once and derive all the needed information from it.