### PR TITLE
Fix file permission syntax

### DIFF
--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -97,7 +97,7 @@ func (tc *TestCommands) CreateFile(name, content string) {
 	folderPath := filepath.Dir(filePath)
 	asserts.NoError(os.MkdirAll(folderPath, os.ModePerm))
 	//nolint:gosec // need permission 700 here in order for tests to work
-	asserts.NoError(os.WriteFile(filePath, []byte(content), 0x700))
+	asserts.NoError(os.WriteFile(filePath, []byte(content), 0o700))
 }
 
 // CreatePerennialBranches creates perennial branches with the given names in this repository.

--- a/test/filesystem/create_file.go
+++ b/test/filesystem/create_file.go
@@ -15,6 +15,6 @@ func CreateFile(t *testing.T, dir, filename string) {
 	err := os.MkdirAll(filepath.Dir(filePath), 0o744)
 	assert.NoError(t, err)
 	//nolint:gosec // need permission 700 here for the tests to work
-	err = os.WriteFile(filePath, []byte(filename+" content"), 0x700)
+	err = os.WriteFile(filePath, []byte(filename+" content"), 0o700)
 	assert.NoError(t, err)
 }

--- a/test/ostools/unix.go
+++ b/test/ostools/unix.go
@@ -23,13 +23,13 @@ func CreateInputTool(toolPath string) {
 read i1
 read i2
 echo You entered $i1 and $i2
-`), 0x744))
+`), 0o744))
 }
 
 // CreateLsTool creates a tool in the given folder that lists all files in its current folder.
 func CreateLsTool(toolPath string) {
 	//nolint:gosec // intentionally creating an executable here
-	asserts.NoError(os.WriteFile(toolPath, []byte("#!/usr/bin/env bash\n\nls\n"), 0x744))
+	asserts.NoError(os.WriteFile(toolPath, []byte("#!/usr/bin/env bash\n\nls\n"), 0o744))
 }
 
 // ScriptName provides the name of the given script file on the Windows.

--- a/test/subshell/test_runner.go
+++ b/test/subshell/test_runner.go
@@ -61,7 +61,7 @@ func (tr *TestRunner) createBinDir() {
 func (tr *TestRunner) createMockBinary(name string, content string) {
 	tr.createBinDir()
 	//nolint:gosec // intentionally creating an executable here
-	asserts.NoError(os.WriteFile(filepath.Join(tr.BinDir, name), []byte(content), 0x744))
+	asserts.NoError(os.WriteFile(filepath.Join(tr.BinDir, name), []byte(content), 0o744))
 }
 
 // MockBrokenCommand adds a mock for the given command that returns an error.

--- a/test/testruntime/testruntime_test.go
+++ b/test/testruntime/testruntime_test.go
@@ -17,7 +17,7 @@ func TestRunner(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		workingDir := filepath.Join(dir, "working")
-		err := os.Mkdir(workingDir, 0x744)
+		err := os.Mkdir(workingDir, 0o744)
 		assert.NoError(t, err)
 		homeDir := filepath.Join(dir, "home")
 		binDir := filepath.Join(dir, "bin")


### PR DESCRIPTION
The filesystem seems to expect octal notation, hexadecimal notation is not the same value.