### PR TITLE
Return OpenRepoResult as a pointer

### DIFF
--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -46,11 +46,11 @@ func executeAbort(debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialStashSnapshot, err := determineAbortConfig(&repo)
+	config, initialStashSnapshot, err := determineAbortConfig(repo)
 	if err != nil {
 		return err
 	}
-	abortRunState, err := determineAbortRunstate(config, &repo)
+	abortRunState, err := determineAbortRunstate(config, repo)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -54,7 +54,7 @@ func executeAppend(arg string, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineAppendConfig(domain.NewLocalBranchName(arg), &repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineAppendConfig(domain.NewLocalBranchName(arg), repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/config_perennial_branches.go
+++ b/src/cmd/config_perennial_branches.go
@@ -76,7 +76,7 @@ func updatePerennialBranches(debug bool) error {
 		return err
 	}
 	branches, _, _, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
-		Repo:                  &repo,
+		Repo:                  repo,
 		Fetch:                 false,
 		HandleUnfinishedState: false,
 		Lineage:               lineage,

--- a/src/cmd/config_setup.go
+++ b/src/cmd/config_setup.go
@@ -41,7 +41,7 @@ func executeConfigSetup(debug bool) error {
 		return err
 	}
 	branches, _, _, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
-		Repo:                  &repo,
+		Repo:                  repo,
 		Fetch:                 false,
 		HandleUnfinishedState: false,
 		Lineage:               lineage,

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -45,11 +45,11 @@ func executeContinue(debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineContinueConfig(&repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineContinueConfig(repo)
 	if err != nil || exit {
 		return err
 	}
-	runState, err := determineContinueRunstate(&repo)
+	runState, err := determineContinueRunstate(repo)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -46,7 +46,7 @@ func executeDiffParent(args []string, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, exit, err := determineDiffParentConfig(args, &repo)
+	config, exit, err := determineDiffParentConfig(args, repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -57,7 +57,7 @@ func executeHack(args []string, promptForParent, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineHackConfig(args, promptForParent, &repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineHackConfig(args, promptForParent, repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -49,7 +49,7 @@ func executeKill(args []string, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineKillConfig(args, &repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineKillConfig(args, repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -62,7 +62,7 @@ func executeNewPullRequest(debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineNewPullRequestConfig(&repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineNewPullRequestConfig(repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -57,7 +57,7 @@ func executePrepend(args []string, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determinePrependConfig(args, &repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determinePrependConfig(args, repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -44,7 +44,7 @@ func executePruneBranches(debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determinePruneBranchesConfig(&repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determinePruneBranchesConfig(repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -63,7 +63,7 @@ func executeRenameBranch(args []string, force, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineRenameBranchConfig(args, force, &repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineRenameBranchConfig(args, force, repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -53,7 +53,7 @@ func executeRepo(debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, err := determineRepoConfig(&repo)
+	config, err := determineRepoConfig(repo)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -45,7 +45,7 @@ func executeSetParent(debug bool) error {
 		return err
 	}
 	branches, _, _, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
-		Repo:                  &repo,
+		Repo:                  repo,
 		Fetch:                 false,
 		HandleUnfinishedState: true,
 		Lineage:               lineage,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -77,7 +77,7 @@ func executeShip(args []string, message string, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineShipConfig(args, &repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineShipConfig(args, repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -46,7 +46,7 @@ func executeSkip(debug bool) error {
 		return err
 	}
 	_, initialBranchesSnapshot, initialStashSnapshot, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
-		Repo:                  &repo,
+		Repo:                  repo,
 		Fetch:                 false,
 		HandleUnfinishedState: false,
 		Lineage:               lineage,

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -46,7 +46,7 @@ func executeSwitch(debug bool) error {
 		return err
 	}
 	branches, _, _, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
-		Repo:                  &repo,
+		Repo:                  repo,
 		Fetch:                 false,
 		HandleUnfinishedState: true,
 		Lineage:               lineage,

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -65,7 +65,7 @@ func executeSync(all, dryRun, debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineSyncConfig(all, &repo)
+	config, initialBranchesSnapshot, initialStashSnapshot, exit, err := determineSyncConfig(all, repo)
 	if err != nil || exit {
 		return err
 	}

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -46,11 +46,11 @@ func executeUndo(debug bool) error {
 	if err != nil {
 		return err
 	}
-	config, initialStashSnaphot, lineage, err := determineUndoConfig(&repo)
+	config, initialStashSnaphot, lineage, err := determineUndoConfig(repo)
 	if err != nil {
 		return err
 	}
-	undoRunState, err := determineUndoRunState(config, &repo)
+	undoRunState, err := determineUndoRunState(config, repo)
 	if err != nil {
 		return fmt.Errorf(messages.RunstateLoadProblem, err)
 	}

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -15,7 +15,7 @@ import (
 	"github.com/git-town/git-town/v9/src/validate"
 )
 
-func OpenRepo(args OpenRepoArgs) (result OpenRepoResult, err error) {
+func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 	var stats Statistics
 	if args.Debug {
 		stats = &statistics.CommandsRun{CommandsCount: 0}
@@ -35,16 +35,16 @@ func OpenRepo(args OpenRepoArgs) (result OpenRepoResult, err error) {
 	}
 	majorVersion, minorVersion, err := backendCommands.Version()
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	err = validate.HasGitVersion(majorVersion, minorVersion)
 	if err != nil {
-		return
+		return nil, err
 	}
 	currentDirectory, err := os.Getwd()
 	if err != nil {
 		err = errors.New(messages.DirCurrentProblem)
-		return
+		return nil, err
 	}
 	configSnapshot := undo.ConfigSnapshot{
 		Cwd:       currentDirectory,
@@ -71,29 +71,29 @@ func OpenRepo(args OpenRepoArgs) (result OpenRepoResult, err error) {
 	if args.ValidateGitRepo {
 		if rootDir.IsEmpty() {
 			err = errors.New(messages.RepoOutside)
-			return
+			return nil, err
 		}
 	}
 	isOffline, err := repoConfig.IsOffline()
 	if err != nil {
-		return
+		return nil, err
 	}
 	if args.ValidateIsOnline && isOffline {
 		err = errors.New(messages.OfflineNotAllowed)
-		return
+		return nil, err
 	}
 	if args.ValidateGitRepo {
 		var currentDirectory string
 		currentDirectory, err = os.Getwd()
 		if err != nil {
 			err = errors.New(messages.DirCurrentProblem)
-			return
+			return nil, err
 		}
 		if currentDirectory != rootDir.String() {
 			err = prodRunner.Frontend.NavigateToDir(rootDir)
 		}
 	}
-	return OpenRepoResult{
+	return &OpenRepoResult{
 		Runner:         prodRunner,
 		RootDir:        rootDir,
 		IsOffline:      isOffline,


### PR DESCRIPTION
It is only used as a pointer anyways, and this simplifies the code.