### PR TITLE
Avoid branch lookups when force-deleting branches

### DIFF
--- a/features/append/features/debug.feature
+++ b/features/append/features/debug.feature
@@ -48,6 +48,6 @@ Feature: display debug statistics
     When I run "git-town undo --debug"
     Then it prints:
       """
-      Ran 21 shell commands.
+      Ran 20 shell commands.
       """
     And the current branch is now "existing"

--- a/features/hack/features/debug.feature
+++ b/features/hack/features/debug.feature
@@ -67,6 +67,6 @@ Feature: display debug statistics
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 23 shell commands.
+      Ran 22 shell commands.
       """
     And the current branch is now "main"

--- a/features/hack/features/debug.feature
+++ b/features/hack/features/debug.feature
@@ -55,8 +55,7 @@ Feature: display debug statistics
       | new    | frontend | git checkout main                             |
       |        | backend  | git rev-parse --short HEAD                    |
       | main   | frontend | git reset --hard {{ sha 'Initial commit' }}   |
-      |        | backend  | git log main..new                             |
-      | main   | frontend | git branch -D new                             |
+      |        | frontend | git branch -D new                             |
       |        | backend  | git show-ref --quiet refs/heads/main          |
       |        | backend  | git show-ref --quiet refs/heads/new           |
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |

--- a/features/kill/current_branch/features/debug.feature
+++ b/features/kill/current_branch/features/debug.feature
@@ -39,6 +39,6 @@ Feature: display debug statistics
       |         | backend  | git stash list                                    |
     And it prints:
       """
-      Ran 26 shell commands.
+      Ran 25 shell commands.
       """
     And the current branch is now "main"

--- a/features/kill/current_branch/features/debug.feature
+++ b/features/kill/current_branch/features/debug.feature
@@ -26,7 +26,6 @@ Feature: display debug statistics
       |         | backend  | git status --ignore-submodules                    |
       | current | frontend | git push origin :current                          |
       |         | frontend | git checkout main                                 |
-      |         | backend  | git log main..current                             |
       | main    | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |
       |         | backend  | git show-ref --quiet refs/heads/other             |

--- a/features/prepend/features/debug.feature
+++ b/features/prepend/features/debug.feature
@@ -61,7 +61,6 @@ Feature: display debug statistics
       |        | backend  | git config --unset git-town-branch.parent.parent |
       |        | backend  | git config git-town-branch.old.parent main       |
       | parent | frontend | git checkout old                                 |
-      |        | backend  | git log main..parent                             |
       | old    | frontend | git branch -D parent                             |
       |        | backend  | git show-ref --quiet refs/heads/old              |
       |        | backend  | git show-ref --quiet refs/heads/parent           |

--- a/features/prepend/features/debug.feature
+++ b/features/prepend/features/debug.feature
@@ -73,6 +73,6 @@ Feature: display debug statistics
       |        | backend  | git stash list                                   |
     And it prints:
       """
-      Ran 22 shell commands.
+      Ran 21 shell commands.
       """
     And the current branch is now "old"

--- a/features/rename_branch/features/debug.feature
+++ b/features/rename_branch/features/debug.feature
@@ -63,7 +63,6 @@ Feature: display debug statistics
       |        | frontend | git push -u origin old                        |
       |        | frontend | git push origin :new                          |
       |        | frontend | git checkout old                              |
-      |        | backend  | git log main..new                             |
       | old    | frontend | git branch -D new                             |
       |        | backend  | git show-ref --quiet refs/heads/main          |
       |        | backend  | git show-ref --quiet refs/heads/new           |

--- a/features/rename_branch/features/debug.feature
+++ b/features/rename_branch/features/debug.feature
@@ -75,6 +75,6 @@ Feature: display debug statistics
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 25 shell commands.
+      Ran 24 shell commands.
       """
     And the current branch is now "old"

--- a/src/step/delete_local_branch.go
+++ b/src/step/delete_local_branch.go
@@ -13,9 +13,15 @@ type DeleteLocalBranch struct {
 }
 
 func (step *DeleteLocalBranch) Run(args RunArgs) error {
-	hasUnmergedCommits, err := args.Runner.Backend.BranchHasUnmergedCommits(step.Branch, step.Parent)
-	if err != nil {
-		return err
+	useForce := step.Force
+	if !useForce {
+		hasUnmergedCommits, err := args.Runner.Backend.BranchHasUnmergedCommits(step.Branch, step.Parent)
+		if err != nil {
+			return err
+		}
+		if hasUnmergedCommits {
+			useForce = true
+		}
 	}
-	return args.Runner.Frontend.DeleteLocalBranch(step.Branch, step.Force || hasUnmergedCommits)
+	return args.Runner.Frontend.DeleteLocalBranch(step.Branch, useForce)
 }


### PR DESCRIPTION
Since we already know that we want to force-delete, there is no point in checking whether the branch is fully merged or not.