### PR TITLE
Move RepoStatus to domain package

### DIFF
--- a/src/domain/repo_status.go
+++ b/src/domain/repo_status.go
@@ -1,0 +1,7 @@
+package domain
+
+type RepoStatus struct {
+	Conflicts        bool // the repo contains merge conflicts
+	OpenChanges      bool // there are uncommitted changes
+	RebaseInProgress bool // a rebase is in progress
+}

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -421,25 +421,19 @@ func (bcs *BackendCommands) RemoveOutdatedConfiguration(allBranches domain.Branc
 }
 
 // HasConflicts returns whether the local repository currently has unresolved merge conflicts.
-func (bcs *BackendCommands) RepoStatus() (RepoStatus, error) {
+func (bcs *BackendCommands) RepoStatus() (domain.RepoStatus, error) {
 	output, err := bcs.QueryTrim("git", "status", "--ignore-submodules")
 	if err != nil {
-		return RepoStatus{}, fmt.Errorf(messages.ConflictDetectionProblem, err)
+		return domain.RepoStatus{}, fmt.Errorf(messages.ConflictDetectionProblem, err)
 	}
 	hasConflicts := strings.Contains(output, "Unmerged paths")
 	hasOpenChanges := outputIndicatesOpenChanges(output)
 	rebaseInProgress := outputIndicatesRebaseInProgress(output)
-	return RepoStatus{
+	return domain.RepoStatus{
 		Conflicts:        hasConflicts,
 		OpenChanges:      hasOpenChanges,
 		RebaseInProgress: rebaseInProgress,
 	}, nil
-}
-
-type RepoStatus struct {
-	Conflicts        bool // the repo contains merge conflicts
-	OpenChanges      bool // there are uncommitted changes
-	RebaseInProgress bool // a rebase is in progress
 }
 
 // RootDirectory provides the path of the rood directory of the current repository,

--- a/src/gohacks/failure_collector.go
+++ b/src/gohacks/failure_collector.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/git"
 )
 
 // FailureCollector helps avoid excessive error checking
@@ -72,7 +71,7 @@ func (fc *FailureCollector) Remotes(value domain.Remotes, err error) domain.Remo
 	return value
 }
 
-func (fc *FailureCollector) RepoStatus(value git.RepoStatus, err error) git.RepoStatus {
+func (fc *FailureCollector) RepoStatus(value domain.RepoStatus, err error) domain.RepoStatus {
 	fc.Check(err)
 	return value
 }


### PR DESCRIPTION
Leaving it in the git package causes import loops because the gohacks package shouldn't have a dependency on the git package. If anything, it should be the other way around. RepoStatus is a part of Git Town's domain model.
