### PR TITLE
Visualize empty CLI args

### DIFF
--- a/src/subshell/frontend_runner.go
+++ b/src/subshell/frontend_runner.go
@@ -78,7 +78,9 @@ func FormatCommand(currentBranch domain.LocalBranchName, omitBranch bool, execut
 		result = executable + " "
 	}
 	for index, part := range args {
-		if strings.Contains(part, " ") {
+		if part == "" {
+			part = `""`
+		} else if strings.Contains(part, " ") {
 			part = `"` + part + `"`
 		}
 		if index != 0 {

--- a/src/subshell/frontend_runner_test.go
+++ b/src/subshell/frontend_runner_test.go
@@ -16,9 +16,9 @@ func TestFormat(t *testing.T) {
 		executable string
 		args       []string
 	}{
-		"[branch] git checkout foo":          {omitBranch: false, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
-		"git checkout foo":                   {omitBranch: true, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
-		"git config perennial-branches \"\"": {omitBranch: true, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"config", "perennial-branches", ""}},
+		"[branch] git checkout foo":        {omitBranch: false, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
+		"git checkout foo":                 {omitBranch: true, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
+		`git config perennial-branches ""`: {omitBranch: true, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"config", "perennial-branches", ""}},
 	}
 	for want, give := range tests {
 		have := subshell.FormatCommand(give.branch, give.omitBranch, give.executable, give.args...)

--- a/src/subshell/frontend_runner_test.go
+++ b/src/subshell/frontend_runner_test.go
@@ -16,8 +16,9 @@ func TestFormat(t *testing.T) {
 		executable string
 		args       []string
 	}{
-		"[branch] git checkout foo": {omitBranch: false, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
-		"git checkout foo":          {omitBranch: true, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
+		"[branch] git checkout foo":          {omitBranch: false, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
+		"git checkout foo":                   {omitBranch: true, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"checkout", "foo"}},
+		"git config perennial-branches \"\"": {omitBranch: true, branch: domain.NewLocalBranchName("branch"), executable: "git", args: []string{"config", "perennial-branches", ""}},
 	}
 	for want, give := range tests {
 		have := subshell.FormatCommand(give.branch, give.omitBranch, give.executable, give.args...)


### PR DESCRIPTION
Sometimes Git Town executes CLI commands using empty strings as arguments. This breaks our string-based output verification. This PR visualizes empty CLI arguments using quotes.