### PR TITLE
Determine the parent branch dynamically

### DIFF
--- a/features/prune_branches/features/debug.feature
+++ b/features/prune_branches/features/debug.feature
@@ -8,6 +8,7 @@ Feature: display debug statistics
     And origin deletes the "old" branch
     And the current branch is "old"
 
+  # @debug @this
   Scenario: result
     When I run "git-town prune-branches --debug"
     Then it runs the commands

--- a/features/prune_branches/features/debug.feature
+++ b/features/prune_branches/features/debug.feature
@@ -8,7 +8,6 @@ Feature: display debug statistics
     And origin deletes the "old" branch
     And the current branch is "old"
 
-  # @debug @this
   Scenario: result
     When I run "git-town prune-branches --debug"
     Then it runs the commands
@@ -27,7 +26,6 @@ Feature: display debug statistics
       | old    | frontend | git checkout main                             |
       | main   | frontend | git rebase origin/main                        |
       |        | backend  | git rev-list --left-right main...origin/main  |
-      | main   | frontend | git merge --no-edit main                      |
       |        | backend  | git diff main..old                            |
       |        | backend  | git log main..old                             |
       | main   | frontend | git branch -d old                             |
@@ -45,7 +43,7 @@ Feature: display debug statistics
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 30 shell commands.
+      Ran 29 shell commands.
       """
     And the current branch is now "main"
     And the branches are now

--- a/features/prune_branches/features/perennial_branch.feature
+++ b/features/prune_branches/features/perennial_branch.feature
@@ -13,7 +13,6 @@ Feature: remove perennial branch configuration when pruning a perennial branch
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | old    | git fetch --prune --tags |
-      |        | git merge --no-edit main |
       |        | git checkout main        |
       | main   | git branch -d old        |
     And the current branch is now "main"

--- a/features/prune_branches/features/perennial_branch_with_children.feature
+++ b/features/prune_branches/features/perennial_branch_with_children.feature
@@ -13,7 +13,6 @@ Feature: remove parent info of children of deleted perennial branches
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | old    | git fetch --prune --tags |
-      |        | git merge --no-edit main |
       |        | git checkout main        |
       | main   | git branch -d old        |
     And the current branch is now "main"

--- a/features/prune_branches/features/shipped_parent.feature
+++ b/features/prune_branches/features/shipped_parent.feature
@@ -16,7 +16,6 @@ Feature: a parent branch of a local branch was shipped
       | child  | git fetch --prune --tags |
       |        | git checkout main        |
       | main   | git rebase origin/main   |
-      |        | git merge --no-edit main |
       |        | git branch -d parent     |
       |        | git checkout child       |
     And the current branch is still "child"

--- a/features/prune_branches/features/unmerged_commits.feature
+++ b/features/prune_branches/features/unmerged_commits.feature
@@ -19,7 +19,6 @@ Feature: prune a branch with unmerged commits whose tracking branch was deleted
       |          | git stash                |
       |          | git checkout main        |
       | main     | git rebase origin/main   |
-      |          | git merge --no-edit main |
       |          | git checkout dead-end    |
       | dead-end | git stash pop            |
     And it prints:

--- a/features/prune_branches/features/unshipped_local_changes.feature
+++ b/features/prune_branches/features/unshipped_local_changes.feature
@@ -19,7 +19,6 @@ Feature: sync a shipped branch with additional unshipped local changes
       |         | git stash                |
       |         | git checkout main        |
       | main    | git rebase origin/main   |
-      |         | git merge --no-edit main |
       |         | git checkout shipped     |
       | shipped | git stash pop            |
     And it prints:

--- a/features/prune_branches/prune_branches.feature
+++ b/features/prune_branches/prune_branches.feature
@@ -19,7 +19,6 @@ Feature: delete branches that were shipped or removed on another machine
       |        | git stash                |
       |        | git checkout main        |
       | main   | git rebase origin/main   |
-      |        | git merge --no-edit main |
       |        | git branch -d old        |
       |        | git stash pop            |
     And the current branch is now "main"

--- a/src/cmd/prune_branches.go
+++ b/src/cmd/prune_branches.go
@@ -151,7 +151,7 @@ func pruneBranchesSteps(config *pruneBranchesConfig, backend git.BackendCommands
 		if parent.IsEmpty() {
 			parent = config.mainBranch
 		}
-		pullParentBranchOfCurrentFeatureBranchStep(&list, parent, config.syncStrategy)
+		pullParentBranchOfCurrentFeatureBranchStep(&list, config.syncStrategy)
 		list.Add(&step.IfElse{
 			Condition: func() (bool, error) {
 				return backend.BranchHasUnmergedChanges(branchWithDeletedRemote, parent.Location())

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -245,7 +245,7 @@ func syncBranchSteps(list *steps.List, args syncBranchStepsArgs) {
 	}
 	list.Add(&step.Checkout{Branch: args.branch.LocalName})
 	if isFeatureBranch {
-		syncFeatureBranchSteps(list, args.branch, args.lineage, args.syncStrategy)
+		syncFeatureBranchSteps(list, args.branch, args.syncStrategy)
 	} else {
 		syncPerennialBranchSteps(list, args)
 	}
@@ -276,11 +276,11 @@ type syncBranchStepsArgs struct {
 }
 
 // syncFeatureBranchSteps adds all the steps to sync the feature branch with the given name.
-func syncFeatureBranchSteps(list *steps.List, branch domain.BranchInfo, lineage config.Lineage, syncStrategy config.SyncStrategy) {
+func syncFeatureBranchSteps(list *steps.List, branch domain.BranchInfo, syncStrategy config.SyncStrategy) {
 	if branch.HasTrackingBranch() {
 		pullTrackingBranchOfCurrentFeatureBranchStep(list, branch.RemoteName, syncStrategy)
 	}
-	pullParentBranchOfCurrentFeatureBranchStep(list, lineage.Parent(branch.LocalName), syncStrategy)
+	pullParentBranchOfCurrentFeatureBranchStep(list, syncStrategy)
 }
 
 // syncPerennialBranchSteps adds all the steps to sync the perennial branch with the given name.
@@ -305,12 +305,12 @@ func pullTrackingBranchOfCurrentFeatureBranchStep(list *steps.List, trackingBran
 }
 
 // pullParentBranchOfCurrentFeatureBranchStep adds the step to pull updates from the parent branch of the current feature branch into the current feature branch.
-func pullParentBranchOfCurrentFeatureBranchStep(list *steps.List, parentBranch domain.LocalBranchName, strategy config.SyncStrategy) {
+func pullParentBranchOfCurrentFeatureBranchStep(list *steps.List, strategy config.SyncStrategy) {
 	switch strategy {
 	case config.SyncStrategyMerge:
 		list.Add(&step.MergeParent{})
 	case config.SyncStrategyRebase:
-		list.Add(&step.RebaseBranch{Branch: parentBranch.BranchName()})
+		list.Add(&step.RebaseParent{})
 	}
 }
 

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -308,7 +308,7 @@ func pullTrackingBranchOfCurrentFeatureBranchStep(list *steps.List, trackingBran
 func pullParentBranchOfCurrentFeatureBranchStep(list *steps.List, parentBranch domain.LocalBranchName, strategy config.SyncStrategy) {
 	switch strategy {
 	case config.SyncStrategyMerge:
-		list.Add(&step.Merge{Branch: parentBranch.BranchName()})
+		list.Add(&step.MergeParent{})
 	case config.SyncStrategyRebase:
 		list.Add(&step.RebaseBranch{Branch: parentBranch.BranchName()})
 	}

--- a/src/persistence/save_load_test.go
+++ b/src/persistence/save_load_test.go
@@ -97,6 +97,7 @@ func TestLoadSave(t *testing.T) {
 						NoPushHook: true,
 					},
 					&step.Merge{Branch: domain.NewBranchName("branch")},
+					&step.MergeParent{},
 					&step.PreserveCheckoutHistory{
 						InitialBranch:                     domain.NewLocalBranchName("initial-branch"),
 						InitialPreviouslyCheckedOutBranch: domain.NewLocalBranchName("initial-previous-branch"),
@@ -109,6 +110,7 @@ func TestLoadSave(t *testing.T) {
 					},
 					&step.PushTags{},
 					&step.RebaseBranch{Branch: domain.NewBranchName("branch")},
+					&step.RebaseParent{},
 					&step.RemoveFromPerennialBranches{
 						Branch: domain.NewLocalBranchName("branch"),
 					},
@@ -301,6 +303,10 @@ func TestLoadSave(t *testing.T) {
       "type": "Merge"
     },
     {
+      "data": {},
+      "type": "MergeParent"
+    },
+    {
       "data": {
         "InitialBranch": "initial-branch",
         "InitialPreviouslyCheckedOutBranch": "initial-previous-branch",
@@ -328,6 +334,10 @@ func TestLoadSave(t *testing.T) {
         "Branch": "branch"
       },
       "type": "RebaseBranch"
+    },
+    {
+      "data": {},
+      "type": "RebaseParent"
     },
     {
       "data": {

--- a/src/step/checkout_parent.go
+++ b/src/step/checkout_parent.go
@@ -1,6 +1,6 @@
 package step
 
-// CheckoutParent checks out the parent of the current branch.
+// CheckoutParent checks out the parent branch of the current branch.
 type CheckoutParent struct {
 	Empty
 }

--- a/src/step/checkout_parent.go
+++ b/src/step/checkout_parent.go
@@ -1,0 +1,18 @@
+package step
+
+// CheckoutParent checks out the parent of the current branch.
+type CheckoutParent struct {
+	Empty
+}
+
+func (step *CheckoutParent) Run(args RunArgs) error {
+	currentBranch, err := args.Runner.Backend.CurrentBranch()
+	if err != nil {
+		return err
+	}
+	parent := args.Lineage.Parent(currentBranch)
+	if currentBranch == parent {
+		return nil
+	}
+	return args.Runner.Frontend.CheckoutBranch(parent)
+}

--- a/src/step/merge.go
+++ b/src/step/merge.go
@@ -11,7 +11,7 @@ type Merge struct {
 }
 
 func (step *Merge) CreateAbortSteps() []Step {
-	return []Step{&AbortMerge{}}
+	return []Step{&AbortMerge{}} // TODO: move the step on a new line for readability
 }
 
 func (step *Merge) CreateContinueSteps() []Step {

--- a/src/step/merge.go
+++ b/src/step/merge.go
@@ -11,7 +11,7 @@ type Merge struct {
 }
 
 func (step *Merge) CreateAbortSteps() []Step {
-	return []Step{&AbortMerge{}} // TODO: move the step on a new line for readability
+	return []Step{&AbortMerge{}}
 }
 
 func (step *Merge) CreateContinueSteps() []Step {

--- a/src/step/merge_parent.go
+++ b/src/step/merge_parent.go
@@ -1,0 +1,27 @@
+package step
+
+// MergeParent merges the current parent of the current branch into the current branch.
+type MergeParent struct {
+	Empty
+}
+
+func (step *MergeParent) CreateAbortSteps() []Step {
+	return []Step{
+		&AbortMerge{},
+	}
+}
+
+func (step *MergeParent) CreateContinueSteps() []Step {
+	return []Step{
+		&ContinueMerge{},
+	}
+}
+
+func (step *MergeParent) Run(args RunArgs) error {
+	currentBranch, err := args.Runner.Backend.CurrentBranch()
+	if err != nil {
+		return err
+	}
+	parent := args.Lineage.Parent(currentBranch)
+	return args.Runner.Frontend.MergeBranchNoEdit(parent.BranchName())
+}

--- a/src/step/merge_parent.go
+++ b/src/step/merge_parent.go
@@ -23,5 +23,8 @@ func (step *MergeParent) Run(args RunArgs) error {
 		return err
 	}
 	parent := args.Lineage.Parent(currentBranch)
+	if parent.IsEmpty() {
+		return nil
+	}
 	return args.Runner.Frontend.MergeBranchNoEdit(parent.BranchName())
 }

--- a/src/step/rebase_parent.go
+++ b/src/step/rebase_parent.go
@@ -1,0 +1,23 @@
+package step
+
+// RebaseParent rebases the current branch against its current parent branch.
+type RebaseParent struct {
+	Empty
+}
+
+func (step *RebaseParent) CreateAbortSteps() []Step {
+	return []Step{&AbortRebase{}}
+}
+
+func (step *RebaseParent) CreateContinueSteps() []Step {
+	return []Step{&ContinueRebase{}}
+}
+
+func (step *RebaseParent) Run(args RunArgs) error {
+	currentBranch, err := args.Runner.Backend.CurrentBranch()
+	if err != nil {
+		return err
+	}
+	parent := args.Lineage.Parent(currentBranch)
+	return args.Runner.Frontend.Rebase(parent.BranchName())
+}

--- a/src/steps/json.go
+++ b/src/steps/json.go
@@ -91,6 +91,8 @@ func DetermineStep(stepType string) step.Step { //nolint:ireturn
 		return &step.ForcePushCurrentBranch{}
 	case "Merge":
 		return &step.Merge{}
+	case "MergeParent":
+		return &step.MergeParent{}
 	case "PreserveCheckoutHistory":
 		return &step.PreserveCheckoutHistory{}
 	case "PullCurrentBranch":
@@ -101,6 +103,8 @@ func DetermineStep(stepType string) step.Step { //nolint:ireturn
 		return &step.PushTags{}
 	case "RebaseBranch":
 		return &step.RebaseBranch{}
+	case "RebaseParent":
+		return &step.RebaseParent{}
 	case "RemoveFromPerennialBranches":
 		return &step.RemoveFromPerennialBranches{}
 	case "RemoveGlobalConfig":


### PR DESCRIPTION
In #2026, the branch lineage will change at runtime when branches with a deleted remote are deleted rather than synced. This means that parent branches that were determined before the command runs might no longer be valid when it runs because the parent branch no longer exists and the grandparent should be used instead. 

We'll address this by keeping the lineage up to date as the program executes, and looking up the parent branch to use at runtime. This PR implements this change ahead of time to ensure this change doesn't break anything.