### PR TITLE
Allow cache to return interfaces

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,9 @@ issues:
     - linters:
         - ireturn
       text: (github.com/git-town/git-town/v9/src/hosting.Connector|github.com/git-town/git-town/v9/src/steps.Step)
+    - path: src/gohacks/cache/cache.go
+      linters:
+        - ireturn
     - text: is missing field Empty
       linters:
         - exhaustruct

--- a/src/gohacks/cache/cache.go
+++ b/src/gohacks/cache/cache.go
@@ -16,7 +16,7 @@ func (c *Cache[T]) Set(newValue T) {
 }
 
 // Value provides the current value.
-func (c *Cache[T]) Value() T { //nolint:ireturn
+func (c *Cache[T]) Value() T {
 	if !c.initialized {
 		panic(messages.CacheUnitialized)
 	}


### PR DESCRIPTION
The nolint directives in this file seem to confuse the linter, resulting in occasional false-positive linter warnings. This change fixes the issue once and for all.