### PR TITLE
Remove json tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - lll # we aren't enforcing a line length at this point
     - maligned # deprecated
     - maintidx # we keep complexity under check with code reviews
+    - musttag # we document JSON serialization via unit tests
     - nakedret # not useful
     - nestif # we keep complexity under check with code reviews
     - nonamedreturns # they are useful in too many situations

--- a/src/vm/runstate/runstate.go
+++ b/src/vm/runstate/runstate.go
@@ -17,16 +17,16 @@ import (
 // including which operations are left to do,
 // and how to undo what has been done so far.
 type RunState struct {
-	Command                  string                     `json:"Command"`
-	IsAbort                  bool                       `exhaustruct:"optional"     json:"IsAbort"`
-	IsUndo                   bool                       `exhaustruct:"optional"     json:"IsUndo"`
-	AbortProgram             program.Program            `exhaustruct:"optional"     json:"AbortProgram"`
-	RunProgram               program.Program            `json:"RunProgram"`
-	UndoProgram              program.Program            `exhaustruct:"optional"     json:"UndoProgram"`
-	InitialActiveBranch      domain.LocalBranchName     `json:"InitialActiveBranch"`
-	FinalUndoProgram         program.Program            `exhaustruct:"optional"     json:"FinalUndoProgram"`
-	UnfinishedDetails        *UnfinishedRunStateDetails `exhaustruct:"optional"     json:"UnfinishedDetails"`
-	UndoablePerennialCommits []domain.SHA               `exhaustruct:"optional"     json:"UndoablePerennialCommits"`
+	Command                  string
+	IsAbort                  bool            `exhaustruct:"optional"`
+	IsUndo                   bool            `exhaustruct:"optional"`
+	AbortProgram             program.Program `exhaustruct:"optional"`
+	RunProgram               program.Program
+	UndoProgram              program.Program `exhaustruct:"optional"`
+	InitialActiveBranch      domain.LocalBranchName
+	FinalUndoProgram         program.Program            `exhaustruct:"optional"`
+	UnfinishedDetails        *UnfinishedRunStateDetails `exhaustruct:"optional"`
+	UndoablePerennialCommits []domain.SHA               `exhaustruct:"optional"`
 }
 
 // AddPushBranchAfterCurrentBranchProgram inserts a PushBranch opcode


### PR DESCRIPTION
Now that the `musttag` linter is disabled, we can remove all the redundant json tags.