### PR TITLE
Move the giturl package under the git package

### DIFF
--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/gohacks/slice"
 	"github.com/git-town/git-town/v9/src/messages"
 )

--- a/src/config/git_town_test.go
+++ b/src/config/git_town_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/test/testruntime"
 	"github.com/shoenig/test/must"
 )

--- a/src/git/giturl/git_url.go
+++ b/src/git/giturl/git_url.go
@@ -1,5 +1,4 @@
 // Package giturl provides facilities to work with the special URL formats used in Git remotes.
-// TODO: rename this package to "git/url".
 package giturl
 
 import (

--- a/src/git/giturl/git_url_test.go
+++ b/src/git/giturl/git_url_test.go
@@ -3,7 +3,7 @@ package giturl_test
 import (
 	"testing"
 
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/shoenig/test/must"
 )
 

--- a/src/hosting/bitbucket/connector.go
+++ b/src/hosting/bitbucket/connector.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/messages"
 )

--- a/src/hosting/bitbucket/connector_test.go
+++ b/src/hosting/bitbucket/connector_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/bitbucket"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/shoenig/test/must"

--- a/src/hosting/gitea/connector.go
+++ b/src/hosting/gitea/connector.go
@@ -8,7 +8,7 @@ import (
 	"code.gitea.io/sdk/gitea"
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/messages"
 	"golang.org/x/oauth2"

--- a/src/hosting/gitea/connector_test.go
+++ b/src/hosting/gitea/connector_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/git-town/git-town/v9/src/cli/log"
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/hosting/gitea"
 	"github.com/shoenig/test/must"

--- a/src/hosting/github/connector.go
+++ b/src/hosting/github/connector.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/messages"
 	"github.com/google/go-github/v50/github"

--- a/src/hosting/github/connector_test.go
+++ b/src/hosting/github/connector_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/git-town/git-town/v9/src/cli/log"
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/hosting/github"
 	"github.com/shoenig/test/must"

--- a/src/hosting/gitlab/connector.go
+++ b/src/hosting/gitlab/connector.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/messages"
 	"github.com/xanzy/go-gitlab"

--- a/src/hosting/gitlab/connector_test.go
+++ b/src/hosting/gitlab/connector_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/git-town/git-town/v9/src/cli/log"
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/hosting/gitlab"
 	"github.com/shoenig/test/must"

--- a/src/hosting/new_connector.go
+++ b/src/hosting/new_connector.go
@@ -3,7 +3,7 @@ package hosting
 import (
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/domain"
-	"github.com/git-town/git-town/v9/src/giturl"
+	"github.com/git-town/git-town/v9/src/git/giturl"
 	"github.com/git-town/git-town/v9/src/hosting/bitbucket"
 	"github.com/git-town/git-town/v9/src/hosting/common"
 	"github.com/git-town/git-town/v9/src/hosting/gitea"


### PR DESCRIPTION
It semantically belongs to the git domain and is only used there. `git/url` would have been a better name but it collides with `net/url` and is ambiguous since this package only deals with Git-specific URLs.