### PR TITLE
Move the wrap function to the cmd package

### DIFF
--- a/src/cmd/abort.go
+++ b/src/cmd/abort.go
@@ -12,7 +12,6 @@ import (
 	"github.com/git-town/git-town/v9/src/hosting/github"
 	"github.com/git-town/git-town/v9/src/messages"
 	"github.com/git-town/git-town/v9/src/vm/interpreter"
-	"github.com/git-town/git-town/v9/src/vm/program"
 	"github.com/git-town/git-town/v9/src/vm/runstate"
 	"github.com/git-town/git-town/v9/src/vm/statefile"
 	"github.com/spf13/cobra"
@@ -143,7 +142,7 @@ func determineAbortRunstate(config *abortConfig, repo *execute.OpenRepoResult) (
 		return runstate.RunState{}, fmt.Errorf(messages.AbortNothingToDo)
 	}
 	abortRunState := runState.CreateAbortRunState()
-	abortRunState.RunProgram.Wrap(program.WrapOptions{
+	wrap(&abortRunState.RunProgram, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
 		MainBranch:       config.mainBranch,

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -201,7 +201,7 @@ func appendProgram(config *appendConfig) program.Program {
 	if config.remotes.HasOrigin() && config.shouldNewBranchPush && !config.isOffline {
 		prog.Add(&opcode.CreateTrackingBranch{Branch: config.targetBranch, NoPushHook: !config.pushHook})
 	}
-	prog.Wrap(program.WrapOptions{
+	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
 		MainBranch:       config.mainBranch,

--- a/src/cmd/core.go
+++ b/src/cmd/core.go
@@ -1,6 +1,12 @@
 // Package cmd defines the Git Town commands.
 package cmd
 
+import (
+	"github.com/git-town/git-town/v9/src/domain"
+	"github.com/git-town/git-town/v9/src/vm/opcode"
+	"github.com/git-town/git-town/v9/src/vm/program"
+)
+
 // Execute runs the Cobra stack.
 func Execute() error {
 	rootCmd := rootCmd()
@@ -32,4 +38,29 @@ func long(summary string, desc ...string) string {
 		return summary + ".\n" + desc[0]
 	}
 	return summary + "."
+}
+
+// wrap wraps the given list with opcodes that change the Git root directory or stash away open changes.
+// TODO: only wrap if the list actually contains any opcodes.
+func wrap(program *program.Program, options wrapOptions) {
+	if !options.PreviousBranch.IsEmpty() {
+		program.Add(&opcode.PreserveCheckoutHistory{
+			InitialBranch:                     options.InitialBranch,
+			InitialPreviouslyCheckedOutBranch: options.PreviousBranch,
+			MainBranch:                        options.MainBranch,
+		})
+	}
+	if options.StashOpenChanges {
+		program.Prepend(&opcode.StashOpenChanges{})
+		program.Add(&opcode.RestoreOpenChanges{})
+	}
+}
+
+// wrapOptions represents the options given to Wrap.
+type wrapOptions struct {
+	RunInGitRoot     bool
+	StashOpenChanges bool
+	MainBranch       domain.LocalBranchName
+	InitialBranch    domain.LocalBranchName
+	PreviousBranch   domain.LocalBranchName
 }

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -161,7 +161,7 @@ func (self killConfig) targetBranchParent() domain.LocalBranchName {
 func killProgram(config *killConfig) (runProgram, finalUndoProgram program.Program) {
 	prog := program.Program{}
 	killFeatureBranch(&prog, &finalUndoProgram, *config)
-	prog.Wrap(program.WrapOptions{
+	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.initialBranch != config.targetBranch.LocalName && config.targetBranch.LocalName == config.previousBranch && config.hasOpenChanges,
 		MainBranch:       config.mainBranch,

--- a/src/cmd/new_pull_request.go
+++ b/src/cmd/new_pull_request.go
@@ -217,7 +217,7 @@ func newPullRequestProgram(config *newPullRequestConfig) program.Program {
 			syncStrategy:       config.syncStrategy,
 		})
 	}
-	prog.Wrap(program.WrapOptions{
+	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
 		MainBranch:       config.mainBranch,

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -208,7 +208,7 @@ func prependProgram(config *prependConfig) program.Program {
 	if config.remotes.HasOrigin() && config.shouldNewBranchPush && !config.isOffline {
 		prog.Add(&opcode.CreateTrackingBranch{Branch: config.targetBranch, NoPushHook: !config.pushHook})
 	}
-	prog.Wrap(program.WrapOptions{
+	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
 		MainBranch:       config.mainBranch,

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -186,7 +186,7 @@ func renameBranchProgram(config *renameBranchConfig) program.Program {
 		result.Add(&opcode.DeleteTrackingBranch{Branch: config.oldBranch.RemoteName})
 	}
 	result.Add(&opcode.DeleteLocalBranch{Branch: config.oldBranch.LocalName, Force: false})
-	result.Wrap(program.WrapOptions{
+	wrap(&result, wrapOptions{
 		RunInGitRoot:     false,
 		StashOpenChanges: false,
 		MainBranch:       config.mainBranch,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -371,7 +371,7 @@ func shipProgram(config *shipConfig, commitMessage string) program.Program {
 	if !config.isShippingInitialBranch {
 		prog.Add(&opcode.Checkout{Branch: config.branches.Initial})
 	}
-	prog.Wrap(program.WrapOptions{
+	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: !config.isShippingInitialBranch && config.hasOpenChanges,
 		MainBranch:       config.mainBranch,

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -238,7 +238,7 @@ func syncBranchesProgram(args syncBranchesProgramArgs) {
 	if args.remotes.HasOrigin() && args.shouldPushTags && !args.isOffline {
 		args.program.Add(&opcode.PushTags{})
 	}
-	args.program.Wrap(program.WrapOptions{
+	wrap(args.program, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: args.hasOpenChanges,
 		MainBranch:       args.mainBranch,

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -11,7 +11,6 @@ import (
 	"github.com/git-town/git-town/v9/src/messages"
 	"github.com/git-town/git-town/v9/src/vm/interpreter"
 	"github.com/git-town/git-town/v9/src/vm/opcode"
-	"github.com/git-town/git-town/v9/src/vm/program"
 	"github.com/git-town/git-town/v9/src/vm/runstate"
 	"github.com/git-town/git-town/v9/src/vm/shared"
 	"github.com/git-town/git-town/v9/src/vm/statefile"
@@ -121,7 +120,7 @@ func determineUndoRunState(config *undoConfig, repo *execute.OpenRepoResult) (ru
 		return runstate.RunState{}, fmt.Errorf(messages.UndoNothingToDo)
 	}
 	undoRunState := runState.CreateUndoRunState()
-	undoRunState.RunProgram.Wrap(program.WrapOptions{
+	wrap(&undoRunState.RunProgram, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
 		MainBranch:       config.mainBranch,

--- a/src/vm/program/program.go
+++ b/src/vm/program/program.go
@@ -6,9 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/git-town/git-town/v9/src/domain"
 	"github.com/git-town/git-town/v9/src/gohacks/slice"
-	"github.com/git-town/git-town/v9/src/vm/opcode"
 	"github.com/git-town/git-town/v9/src/vm/shared"
 )
 
@@ -147,30 +145,4 @@ func (self *Program) UnmarshalJSON(b []byte) error {
 		}
 	}
 	return nil
-}
-
-// WrapOptions represents the options given to Wrap.
-type WrapOptions struct {
-	RunInGitRoot     bool
-	StashOpenChanges bool
-	MainBranch       domain.LocalBranchName
-	InitialBranch    domain.LocalBranchName
-	PreviousBranch   domain.LocalBranchName
-}
-
-// Wrap wraps the list with opcodes that
-// change to the Git root directory or stash away open changes.
-// TODO: only wrap if the list actually contains any opcodes.
-func (self *Program) Wrap(options WrapOptions) {
-	if !options.PreviousBranch.IsEmpty() {
-		self.Add(&opcode.PreserveCheckoutHistory{
-			InitialBranch:                     options.InitialBranch,
-			InitialPreviouslyCheckedOutBranch: options.PreviousBranch,
-			MainBranch:                        options.MainBranch,
-		})
-	}
-	if options.StashOpenChanges {
-		self.Prepend(&opcode.StashOpenChanges{})
-		self.Add(&opcode.RestoreOpenChanges{})
-	}
 }


### PR DESCRIPTION
Wrapping in general might be a function of `Program`, but wrapping with specific opcodes isn't its function. This isn't a method, it should be a stand-alone function in `cmd` where the other business logic resides.