### PR TITLE
Move IsCheckoutOpcode to shared package

### DIFF
--- a/src/vm/program/program.go
+++ b/src/vm/program/program.go
@@ -97,7 +97,7 @@ func (self *Program) RemoveDuplicateCheckout() Program {
 	// this one is populated only if the last opcode is a checkout
 	var lastOpcode shared.Opcode
 	for _, opcode := range self.Opcodes {
-		if IsCheckoutOpcode(opcode) {
+		if shared.IsCheckoutOpcode(opcode) {
 			lastOpcode = opcode
 			continue
 		}

--- a/src/vm/runstate/runstate.go
+++ b/src/vm/runstate/runstate.go
@@ -35,7 +35,7 @@ func (self *RunState) AddPushBranchAfterCurrentBranchProgram(backend *git.Backen
 	popped := program.Program{}
 	for {
 		nextOpcode := self.RunProgram.Peek()
-		if !program.IsCheckoutOpcode(nextOpcode) {
+		if !shared.IsCheckoutOpcode(nextOpcode) {
 			popped.Add(self.RunProgram.Pop())
 		} else {
 			currentBranch, err := backend.CurrentBranch()
@@ -73,14 +73,14 @@ func (self *RunState) CreateSkipRunState() RunState {
 		RunProgram:          self.AbortProgram,
 	}
 	for _, opcode := range self.UndoProgram.Opcodes {
-		if program.IsCheckoutOpcode(opcode) {
+		if shared.IsCheckoutOpcode(opcode) {
 			break
 		}
 		result.RunProgram.Add(opcode)
 	}
 	skipping := true
 	for _, opcode := range self.RunProgram.Opcodes {
-		if program.IsCheckoutOpcode(opcode) {
+		if shared.IsCheckoutOpcode(opcode) {
 			skipping = false
 		}
 		if !skipping {
@@ -154,7 +154,7 @@ func (self *RunState) RegisterUndoablePerennialCommit(commit domain.SHA) {
 func (self *RunState) SkipCurrentBranchProgram() {
 	for {
 		opcode := self.RunProgram.Peek()
-		if program.IsCheckoutOpcode(opcode) {
+		if shared.IsCheckoutOpcode(opcode) {
 			break
 		}
 		self.RunProgram.Pop()

--- a/src/vm/shared/is_checkout_opcode.go
+++ b/src/vm/shared/is_checkout_opcode.go
@@ -1,11 +1,10 @@
-package program
+package shared
 
 import (
 	"github.com/git-town/git-town/v9/src/gohacks"
-	"github.com/git-town/git-town/v9/src/vm/shared"
 )
 
-func IsCheckoutOpcode(opcode shared.Opcode) bool {
+func IsCheckoutOpcode(opcode Opcode) bool {
 	typeName := gohacks.TypeName(opcode)
 	return typeName == "Checkout" || typeName == "CheckoutIfExists"
 }

--- a/src/vm/shared/is_checkout_opcode_test.go
+++ b/src/vm/shared/is_checkout_opcode_test.go
@@ -1,11 +1,11 @@
-package program_test
+package shared_test
 
 import (
 	"testing"
 
 	"github.com/git-town/git-town/v9/src/domain"
 	"github.com/git-town/git-town/v9/src/vm/opcode"
-	"github.com/git-town/git-town/v9/src/vm/program"
+	"github.com/git-town/git-town/v9/src/vm/shared"
 	"github.com/shoenig/test/must"
 )
 
@@ -15,18 +15,18 @@ func TestIsCheckout(t *testing.T) {
 	t.Run("given an opcode.Checkout", func(t *testing.T) {
 		t.Parallel()
 		give := &opcode.Checkout{Branch: domain.NewLocalBranchName("branch")}
-		must.True(t, program.IsCheckoutOpcode(give))
+		must.True(t, shared.IsCheckoutOpcode(give))
 	})
 
 	t.Run("given an opcode.CheckoutIfExists", func(t *testing.T) {
 		t.Parallel()
 		give := &opcode.CheckoutIfExists{Branch: domain.NewLocalBranchName("branch")}
-		must.True(t, program.IsCheckoutOpcode(give))
+		must.True(t, shared.IsCheckoutOpcode(give))
 	})
 
 	t.Run("given another opcode", func(t *testing.T) {
 		t.Parallel()
 		give := &opcode.AbortMerge{}
-		must.False(t, program.IsCheckoutOpcode(give))
+		must.False(t, shared.IsCheckoutOpcode(give))
 	})
 }


### PR DESCRIPTION
Verifying whether an opcode is a checkout operation is not a responsibility of the `program` package. Moving it to shared since this is used in several places.