### PR TITLE
Manual comparison for IfElse opcode

### DIFF
--- a/src/vm/opcode/if_else.go
+++ b/src/vm/opcode/if_else.go
@@ -1,6 +1,8 @@
 package opcode
 
 import (
+	"reflect"
+
 	"github.com/git-town/git-town/v9/src/config"
 	"github.com/git-town/git-town/v9/src/git"
 	"github.com/git-town/git-town/v9/src/vm/shared"
@@ -25,4 +27,10 @@ func (self *IfElse) Run(args shared.RunArgs) error {
 		args.PrependOpcodes(self.WhenFalse...)
 	}
 	return nil
+}
+
+// Equal implements the XXX interface. This is needed for comparison.
+func (self IfElse) Equal(other IfElse) bool {
+	return reflect.DeepEqual(self.WhenFalse, other.WhenFalse) &&
+		reflect.DeepEqual(self.WhenTrue, other.WhenTrue)
 }

--- a/src/vm/opcode/if_else.go
+++ b/src/vm/opcode/if_else.go
@@ -16,6 +16,12 @@ type IfElse struct {
 	undeclaredOpcodeMethods
 }
 
+// Equal implements the XXX interface. This is needed for comparison.
+func (self IfElse) Equal(other IfElse) bool {
+	return reflect.DeepEqual(self.WhenFalse, other.WhenFalse) &&
+		reflect.DeepEqual(self.WhenTrue, other.WhenTrue)
+}
+
 func (self *IfElse) Run(args shared.RunArgs) error {
 	condition, err := self.Condition(&args.Runner.Backend, args.Lineage)
 	if err != nil {
@@ -27,10 +33,4 @@ func (self *IfElse) Run(args shared.RunArgs) error {
 		args.PrependOpcodes(self.WhenFalse...)
 	}
 	return nil
-}
-
-// Equal implements the XXX interface. This is needed for comparison.
-func (self IfElse) Equal(other IfElse) bool {
-	return reflect.DeepEqual(self.WhenFalse, other.WhenFalse) &&
-		reflect.DeepEqual(self.WhenTrue, other.WhenTrue)
 }

--- a/src/vm/opcode/if_else.go
+++ b/src/vm/opcode/if_else.go
@@ -16,7 +16,7 @@ type IfElse struct {
 	undeclaredOpcodeMethods
 }
 
-// Equal implements the XXX interface. This is needed for comparison.
+// This method makes comparison work in unit tests.
 func (self IfElse) Equal(other IfElse) bool {
 	return reflect.DeepEqual(self.WhenFalse, other.WhenFalse) &&
 		reflect.DeepEqual(self.WhenTrue, other.WhenTrue)

--- a/src/vm/opcode/if_else_test.go
+++ b/src/vm/opcode/if_else_test.go
@@ -87,19 +87,19 @@ func TestIfElse(t *testing.T) {
 		one := opcode.IfElse{
 			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
-				&opcode.AbortRebase{},
+				&opcode.AbortMerge{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.AbortMerge{},
+				&opcode.AbortRebase{},
 			},
 		}
 		two := opcode.IfElse{
 			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
 			WhenTrue: []shared.Opcode{
-				&opcode.AbortRebase{},
+				&opcode.AbortMerge{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.AbortMerge{},
+				&opcode.AbortRebase{},
 			},
 		}
 		must.Eq(t, one, two)

--- a/src/vm/opcode/if_else_test.go
+++ b/src/vm/opcode/if_else_test.go
@@ -12,20 +12,6 @@ import (
 
 func TestIfElse(t *testing.T) {
 	t.Parallel()
-	t.Run("empty values", func(t *testing.T) {
-		t.Parallel()
-		one := opcode.IfElse{
-			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
-			WhenTrue:  []shared.Opcode{},
-			WhenFalse: []shared.Opcode{},
-		}
-		two := opcode.IfElse{
-			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
-			WhenTrue:  []shared.Opcode{},
-			WhenFalse: []shared.Opcode{},
-		}
-		must.Eq(t, one, two)
-	})
 
 	t.Run("equal values", func(t *testing.T) {
 		t.Parallel()

--- a/src/vm/opcode/if_else_test.go
+++ b/src/vm/opcode/if_else_test.go
@@ -1,0 +1,26 @@
+package opcode_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v9/src/config"
+	"github.com/git-town/git-town/v9/src/git"
+	"github.com/git-town/git-town/v9/src/vm/opcode"
+	"github.com/git-town/git-town/v9/src/vm/shared"
+	"github.com/shoenig/test/must"
+)
+
+func TestIfElse(t *testing.T) {
+	t.Parallel()
+	one := opcode.IfElse{
+		Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+		WhenFalse: []shared.Opcode{},
+		WhenTrue:  []shared.Opcode{},
+	}
+	two := opcode.IfElse{
+		Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+		WhenFalse: []shared.Opcode{},
+		WhenTrue:  []shared.Opcode{},
+	}
+	must.Eq(t, one, two)
+}

--- a/src/vm/opcode/if_else_test.go
+++ b/src/vm/opcode/if_else_test.go
@@ -39,7 +39,7 @@ func TestIfElse(t *testing.T) {
 			},
 		}
 		two := opcode.IfElse{
-			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
 				&opcode.AbortRebase{},
 			},
@@ -62,7 +62,7 @@ func TestIfElse(t *testing.T) {
 			},
 		}
 		two := opcode.IfElse{
-			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
 				&opcode.ContinueMerge{},
 			},
@@ -85,7 +85,7 @@ func TestIfElse(t *testing.T) {
 			},
 		}
 		two := opcode.IfElse{
-			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
 				&opcode.AbortRebase{},
 			},
@@ -94,5 +94,28 @@ func TestIfElse(t *testing.T) {
 			},
 		}
 		must.NotEq(t, one, two)
+	})
+
+	t.Run("different condition function", func(t *testing.T) {
+		t.Parallel()
+		one := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.AbortRebase{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.AbortMerge{},
+			},
+		}
+		two := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.AbortRebase{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.AbortMerge{},
+			},
+		}
+		must.Eq(t, one, two)
 	})
 }

--- a/src/vm/opcode/if_else_test.go
+++ b/src/vm/opcode/if_else_test.go
@@ -73,7 +73,7 @@ func TestIfElse(t *testing.T) {
 		two := opcode.IfElse{
 			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
-				&opcode.AbortRebase{},
+				&opcode.AbortMerge{},
 			},
 			WhenFalse: []shared.Opcode{
 				&opcode.ContinueRebase{},

--- a/src/vm/opcode/if_else_test.go
+++ b/src/vm/opcode/if_else_test.go
@@ -12,15 +12,87 @@ import (
 
 func TestIfElse(t *testing.T) {
 	t.Parallel()
-	one := opcode.IfElse{
-		Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
-		WhenFalse: []shared.Opcode{},
-		WhenTrue:  []shared.Opcode{},
-	}
-	two := opcode.IfElse{
-		Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
-		WhenFalse: []shared.Opcode{},
-		WhenTrue:  []shared.Opcode{},
-	}
-	must.Eq(t, one, two)
+	t.Run("empty values", func(t *testing.T) {
+		t.Parallel()
+		one := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+			WhenTrue:  []shared.Opcode{},
+			WhenFalse: []shared.Opcode{},
+		}
+		two := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+			WhenTrue:  []shared.Opcode{},
+			WhenFalse: []shared.Opcode{},
+		}
+		must.Eq(t, one, two)
+	})
+
+	t.Run("equal values", func(t *testing.T) {
+		t.Parallel()
+		one := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.AbortRebase{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.AbortMerge{},
+			},
+		}
+		two := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.AbortRebase{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.AbortMerge{},
+			},
+		}
+		must.Eq(t, one, two)
+	})
+
+	t.Run("different WhenTrue values", func(t *testing.T) {
+		t.Parallel()
+		one := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.AbortRebase{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.AbortMerge{},
+			},
+		}
+		two := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.ContinueMerge{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.AbortMerge{},
+			},
+		}
+		must.NotEq(t, one, two)
+	})
+
+	t.Run("different WhenFalse values", func(t *testing.T) {
+		t.Parallel()
+		one := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.AbortRebase{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.AbortMerge{},
+			},
+		}
+		two := opcode.IfElse{
+			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return false, nil },
+			WhenTrue: []shared.Opcode{
+				&opcode.AbortRebase{},
+			},
+			WhenFalse: []shared.Opcode{
+				&opcode.ContinueMerge{},
+			},
+		}
+		must.NotEq(t, one, two)
+	})
 }

--- a/src/vm/opcode/if_else_test.go
+++ b/src/vm/opcode/if_else_test.go
@@ -18,19 +18,19 @@ func TestIfElse(t *testing.T) {
 		one := opcode.IfElse{
 			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
-				&opcode.AbortRebase{},
+				&opcode.AbortMerge{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.AbortMerge{},
+				&opcode.AbortRebase{},
 			},
 		}
 		two := opcode.IfElse{
 			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
-				&opcode.AbortRebase{},
+				&opcode.AbortMerge{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.AbortMerge{},
+				&opcode.AbortRebase{},
 			},
 		}
 		must.Eq(t, one, two)
@@ -41,10 +41,10 @@ func TestIfElse(t *testing.T) {
 		one := opcode.IfElse{
 			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
-				&opcode.AbortRebase{},
+				&opcode.AbortMerge{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.AbortMerge{},
+				&opcode.AbortRebase{},
 			},
 		}
 		two := opcode.IfElse{
@@ -53,7 +53,7 @@ func TestIfElse(t *testing.T) {
 				&opcode.ContinueMerge{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.AbortMerge{},
+				&opcode.AbortRebase{},
 			},
 		}
 		must.NotEq(t, one, two)
@@ -64,10 +64,10 @@ func TestIfElse(t *testing.T) {
 		one := opcode.IfElse{
 			Condition: func(bc *git.BackendCommands, l config.Lineage) (bool, error) { return true, nil },
 			WhenTrue: []shared.Opcode{
-				&opcode.AbortRebase{},
+				&opcode.AbortMerge{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.AbortMerge{},
+				&opcode.AbortRebase{},
 			},
 		}
 		two := opcode.IfElse{
@@ -76,7 +76,7 @@ func TestIfElse(t *testing.T) {
 				&opcode.AbortRebase{},
 			},
 			WhenFalse: []shared.Opcode{
-				&opcode.ContinueMerge{},
+				&opcode.ContinueRebase{},
 			},
 		}
 		must.NotEq(t, one, two)


### PR DESCRIPTION
The `IfElse` opcode has a field containing a function. This throws off the generic comparison algorithm.