### PR TITLE
Iterable list of opcode types

### DIFF
--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -22,6 +22,7 @@ Feature: delete a local branch
       | local, origin | main     |
     And no branch hierarchy exists now
 
+  @debug @this
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands

--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -22,7 +22,6 @@ Feature: delete a local branch
       | local, origin | main     |
     And no branch hierarchy exists now
 
-  @debug @this
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands

--- a/src/vm/opcode/core.go
+++ b/src/vm/opcode/core.go
@@ -78,6 +78,7 @@ func Types() []shared.Opcode {
 		&ResetRemoteBranchToSHA{},
 		&RestoreOpenChanges{},
 		&RevertCommit{},
+		&SetExistingParent{},
 		&SetGlobalConfig{},
 		&SetLocalConfig{},
 		&SetParent{},

--- a/src/vm/opcode/core.go
+++ b/src/vm/opcode/core.go
@@ -90,7 +90,7 @@ func Types() []shared.Opcode {
 
 func Lookup(opcodeType string) shared.Opcode { //nolint:ireturn
 	for _, opcode := range Types() {
-		if opcodeType == gohacks.TypeName(opcode) {
+		if gohacks.TypeName(opcode) == opcodeType {
 			return opcode
 		}
 	}

--- a/src/vm/opcode/core.go
+++ b/src/vm/opcode/core.go
@@ -32,6 +32,15 @@ func (self *undeclaredOpcodeMethods) ShouldAutomaticallyAbortOnError() bool {
 	return false
 }
 
+func Lookup(opcodeType string) shared.Opcode { //nolint:ireturn
+	for _, opcode := range Types() {
+		if gohacks.TypeName(opcode) == opcodeType {
+			return opcode
+		}
+	}
+	return nil
+}
+
 // Types provides all existing opcodes.
 // This is used to iterate all opcode types.
 func Types() []shared.Opcode {
@@ -87,13 +96,4 @@ func Types() []shared.Opcode {
 		&SquashMerge{},
 		&UpdateProposalTarget{},
 	}
-}
-
-func Lookup(opcodeType string) shared.Opcode { //nolint:ireturn
-	for _, opcode := range Types() {
-		if gohacks.TypeName(opcode) == opcodeType {
-			return opcode
-		}
-	}
-	return nil
 }

--- a/src/vm/opcode/core.go
+++ b/src/vm/opcode/core.go
@@ -94,6 +94,7 @@ func Types() []shared.Opcode {
 		&SkipCurrentBranch{},
 		&StashOpenChanges{},
 		&SquashMerge{},
+		&UndoLastCommit{},
 		&UpdateProposalTarget{},
 	}
 }

--- a/src/vm/opcode/core.go
+++ b/src/vm/opcode/core.go
@@ -5,6 +5,7 @@ package opcode
 import (
 	"errors"
 
+	"github.com/git-town/git-town/v9/src/gohacks"
 	"github.com/git-town/git-town/v9/src/vm/shared"
 )
 
@@ -31,104 +32,67 @@ func (self *undeclaredOpcodeMethods) ShouldAutomaticallyAbortOnError() bool {
 	return false
 }
 
+// Types provides all existing opcodes.
+// This is used to iterate all opcode types.
+func Types() []shared.Opcode {
+	return []shared.Opcode{
+		&AbortMerge{},
+		&AbortRebase{},
+		&AddToPerennialBranches{},
+		&ChangeParent{},
+		&Checkout{},
+		&CheckoutIfExists{},
+		&CheckoutParent{},
+		&ChangeParent{},
+		&CommitOpenChanges{},
+		&ConnectorMergeProposal{},
+		&ContinueMerge{},
+		&ContinueRebase{},
+		&CreateBranch{},
+		&CreateBranchExistingParent{},
+		&CreateProposal{},
+		&CreateRemoteBranch{},
+		&CreateTrackingBranch{},
+		&DeleteLocalBranch{},
+		&DeleteParentBranch{},
+		&DeleteRemoteBranch{},
+		&DeleteTrackingBranch{},
+		&DiscardOpenChanges{},
+		&EnsureHasShippableChanges{},
+		&FetchUpstream{},
+		&ForcePushCurrentBranch{},
+		&IfElse{},
+		&Merge{},
+		&MergeParent{},
+		&PreserveCheckoutHistory{},
+		&PullCurrentBranch{},
+		&PushCurrentBranch{},
+		&PushTags{},
+		&RebaseBranch{},
+		&RebaseParent{},
+		&RemoveBranchFromLineage{},
+		&RemoveFromPerennialBranches{},
+		&RemoveGlobalConfig{},
+		&RemoveLocalConfig{},
+		&ResetCurrentBranchToSHA{},
+		&ResetRemoteBranchToSHA{},
+		&RestoreOpenChanges{},
+		&RevertCommit{},
+		&SetGlobalConfig{},
+		&SetLocalConfig{},
+		&SetParent{},
+		&SkipCurrentBranch{},
+		&StashOpenChanges{},
+		&SquashMerge{},
+		&UpdateProposalTarget{},
+	}
+}
+
 func Lookup(opcodeType string) shared.Opcode { //nolint:ireturn
-	switch opcodeType {
-	case "AbortMerge":
-		return &AbortMerge{}
-	case "AbortRebase":
-		return &AbortRebase{}
-	case "AddToPerennialBranches":
-		return &AddToPerennialBranches{}
-	case "ChangeParent":
-		return &ChangeParent{}
-	case "Checkout":
-		return &Checkout{}
-	case "CheckoutIfExists":
-		return &CheckoutIfExists{}
-	case "CommitOpenChanges":
-		return &CommitOpenChanges{}
-	case "ConnectorMergeProposal":
-		return &ConnectorMergeProposal{}
-	case "ContinueMerge":
-		return &ContinueMerge{}
-	case "ContinueRebase":
-		return &ContinueRebase{}
-	case "CreateBranch":
-		return &CreateBranch{}
-	case "CreateBranchExistingParent":
-		return &CreateBranchExistingParent{}
-	case "CreateProposal":
-		return &CreateProposal{}
-	case "CreateRemoteBranch":
-		return &CreateRemoteBranch{}
-	case "CreateTrackingBranch":
-		return &CreateTrackingBranch{}
-	case "DeleteLocalBranch":
-		return &DeleteLocalBranch{}
-	case "DeleteParentBranch":
-		return &DeleteParentBranch{}
-	case "DeleteRemoteBranch":
-		return &DeleteRemoteBranch{}
-	case "DeleteTrackingBranch":
-		return &DeleteTrackingBranch{}
-	case "DiscardOpenChanges":
-		return &DiscardOpenChanges{}
-	case "EnsureHasShippableChanges":
-		return &EnsureHasShippableChanges{}
-	case "FetchUpstream":
-		return &FetchUpstream{}
-	case "ForcePushCurrentBranch":
-		return &ForcePushCurrentBranch{}
-	case "Merge":
-		return &Merge{}
-	case "MergeParent":
-		return &MergeParent{}
-	case "PreserveCheckoutHistory":
-		return &PreserveCheckoutHistory{}
-	case "PullCurrentBranch":
-		return &PullCurrentBranch{}
-	case "PushCurrentBranch":
-		return &PushCurrentBranch{}
-	case "PushTags":
-		return &PushTags{}
-	case "RebaseBranch":
-		return &RebaseBranch{}
-	case "RebaseParent":
-		return &RebaseParent{}
-	case "RemoveFromPerennialBranches":
-		return &RemoveFromPerennialBranches{}
-	case "RemoveGlobalConfig":
-		return &RemoveGlobalConfig{}
-	case "RemoveLocalConfig":
-		return &RemoveLocalConfig{}
-	case "ResetCurrentBranchToSHA":
-		return &ResetCurrentBranchToSHA{}
-	case "ResetRemoteBranchToSHA":
-		return &ResetRemoteBranchToSHA{}
-	case "RestoreOpenChanges":
-		return &RestoreOpenChanges{}
-	case "RevertCommit":
-		return &RevertCommit{}
-	case "SetExistingParent":
-		return &SetExistingParent{}
-	case "SetGlobalConfig":
-		return &SetGlobalConfig{}
-	case "SetLocalConfig":
-		return &SetLocalConfig{}
-	case "SetParent":
-		return &SetParent{}
-	case "SetParentIfBranchExists":
-		return &SetParentIfBranchExists{}
-	case "SquashMerge":
-		return &SquashMerge{}
-	case "SkipCurrentBranch":
-		return &SkipCurrentBranch{}
-	case "StashOpenChanges":
-		return &StashOpenChanges{}
-	case "UndoLastCommit":
-		return &UndoLastCommit{}
-	case "UpdateProposalTarget":
-		return &UpdateProposalTarget{}
+	for _, opcode := range Types() {
+		if opcodeType == gohacks.TypeName(opcode) {
+			return opcode
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
We need an iterable list of opcode types in a number of places, so this PR introduces it. This also cleans up a repetitive and error-prone mapping of type names to types.