### PR TITLE
Simplify data aliases

### DIFF
--- a/src/domain/branch_info.go
+++ b/src/domain/branch_info.go
@@ -24,7 +24,7 @@ type BranchInfo struct {
 
 func EmptyBranchInfo() BranchInfo {
 	return BranchInfo{
-		LocalName:  LocalBranchName{},
+		LocalName:  EmptyLocalBranchName(),
 		LocalSHA:   EmptySHA(),
 		SyncStatus: SyncStatusUpToDate,
 		RemoteName: EmptyRemoteBranchName(),

--- a/src/domain/branch_name.go
+++ b/src/domain/branch_name.go
@@ -1,52 +1,41 @@
 package domain
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
 
 // BranchName is the name of a local or remote Git branch.
-type BranchName struct {
-	id string
-}
+type BranchName string
 
 func NewBranchName(id string) BranchName {
 	if !isValidBranchName(id) {
 		panic(fmt.Sprintf("%q is not a valid Git branch name", id))
 	}
-	return BranchName{id}
+	return BranchName(id)
 }
 
 // IsLocal indicates whether the branch with this BranchName exists locally.
 func (self BranchName) IsLocal() bool {
-	return !strings.HasPrefix(self.id, "origin/")
+	return !strings.HasPrefix(string(self), "origin/")
 }
 
 // LocalName provides the local version of this branch name.
 func (self BranchName) LocalName() LocalBranchName {
-	return NewLocalBranchName(strings.TrimPrefix(self.id, "origin/"))
-}
-
-// MarshalJSON is used when serializing this LocalBranchName to JSON.
-func (self BranchName) MarshalJSON() ([]byte, error) {
-	return json.Marshal(self.id)
+	return NewLocalBranchName(strings.TrimPrefix(string(self), "origin/"))
 }
 
 // RemoteName provides the remote version of this branch name.
 func (self BranchName) RemoteName() RemoteBranchName {
-	if strings.HasPrefix(self.id, "origin/") {
-		return NewRemoteBranchName(self.id)
+	if strings.HasPrefix(string(self), "origin/") {
+		return NewRemoteBranchName(string(self))
 	}
-	return NewRemoteBranchName("origin/" + self.id)
+	return NewRemoteBranchName("origin/" + string(self))
 }
 
 // Implementation of the fmt.Stringer interface.
-func (self BranchName) String() string { return self.id }
-
-// UnmarshalJSON is used when de-serializing JSON into a LocalBranchName.
-func (self *BranchName) UnmarshalJSON(ba []byte) error {
-	return json.Unmarshal(ba, &self.id)
+func (self BranchName) String() string {
+	return string(self)
 }
 
 // isValidBranchName indicates whether the given text is a valid branch name.

--- a/src/domain/branch_name_test.go
+++ b/src/domain/branch_name_test.go
@@ -80,7 +80,7 @@ func TestBranchName(t *testing.T) {
 	t.Run("UnmarshalJSON", func(t *testing.T) {
 		t.Parallel()
 		give := `"branch-1"`
-		have := domain.BranchName{}
+		have := domain.NewBranchName("placeholder")
 		err := json.Unmarshal([]byte(give), &have)
 		must.NoError(t, err)
 		want := domain.NewBranchName("branch-1")

--- a/src/domain/branch_types.go
+++ b/src/domain/branch_types.go
@@ -22,7 +22,7 @@ func (self BranchTypes) IsPerennialBranch(branch LocalBranchName) bool {
 
 func EmptyBranchTypes() BranchTypes {
 	return BranchTypes{
-		MainBranch:        LocalBranchName{},
+		MainBranch:        EmptyLocalBranchName(),
 		PerennialBranches: LocalBranchNames{},
 	}
 }

--- a/src/domain/branches.go
+++ b/src/domain/branches.go
@@ -11,6 +11,6 @@ func EmptyBranches() Branches {
 	return Branches{
 		All:     BranchInfos{},
 		Types:   EmptyBranchTypes(),
-		Initial: LocalBranchName{},
+		Initial: EmptyLocalBranchName(),
 	}
 }

--- a/src/domain/branches_snapshot.go
+++ b/src/domain/branches_snapshot.go
@@ -14,7 +14,7 @@ type BranchesSnapshot struct {
 func EmptyBranchesSnapshot() BranchesSnapshot {
 	return BranchesSnapshot{
 		Branches: BranchInfos{},
-		Active:   LocalBranchName{},
+		Active:   EmptyLocalBranchName(),
 	}
 }
 

--- a/src/domain/local_branch_name.go
+++ b/src/domain/local_branch_name.go
@@ -1,25 +1,19 @@
 package domain
 
-import (
-	"encoding/json"
-)
-
 // LocalBranchName is the name of a local Git branch.
 // The zero value is an empty local branch name,
 // i.e. a local branch name that is unknown or not configured.
-type LocalBranchName struct {
-	id string
-}
+type LocalBranchName string
 
 func EmptyLocalBranchName() LocalBranchName {
-	return LocalBranchName{id: ""}
+	return ""
 }
 
 func NewLocalBranchName(id string) LocalBranchName {
 	if !isValidLocalBranchName(id) {
 		panic("local branch names cannot be empty")
 	}
-	return LocalBranchName{id}
+	return LocalBranchName(id)
 }
 
 func isValidLocalBranchName(value string) bool {
@@ -28,38 +22,28 @@ func isValidLocalBranchName(value string) bool {
 
 // AtRemote provides the RemoteBranchName of this branch at the given remote.
 func (self LocalBranchName) AtRemote(remote Remote) RemoteBranchName {
-	return NewRemoteBranchName(remote.String() + "/" + self.id)
+	return NewRemoteBranchName(remote.String() + "/" + (string(self)))
 }
 
 // BranchName widens the type of this LocalBranchName to a more generic BranchName.
 func (self LocalBranchName) BranchName() BranchName {
-	return NewBranchName(self.id)
+	return NewBranchName(string(self))
 }
 
 // IsEmpty indicates whether this branch name is not set.
 func (self LocalBranchName) IsEmpty() bool {
-	return self.id == ""
+	return self == ""
 }
 
 // Location widens the type of this LocalBranchName to a more generic Location.
 func (self LocalBranchName) Location() Location {
-	return Location(self)
-}
-
-// MarshalJSON is used when serializing this LocalBranchName to JSON.
-func (self LocalBranchName) MarshalJSON() ([]byte, error) {
-	return json.Marshal(self.id)
+	return NewLocation(string(self))
 }
 
 // Implementation of the fmt.Stringer interface.
-func (self LocalBranchName) String() string { return self.id }
+func (self LocalBranchName) String() string { return string(self) }
 
 // TrackingBranch provides the name of the tracking branch for this local branch.
 func (self LocalBranchName) TrackingBranch() RemoteBranchName {
 	return self.AtRemote(OriginRemote)
-}
-
-// UnmarshalJSON is used when de-serializing JSON into a LocalBranchName.
-func (self *LocalBranchName) UnmarshalJSON(b []byte) error {
-	return json.Unmarshal(b, &self.id)
 }

--- a/src/domain/local_branch_names.go
+++ b/src/domain/local_branch_names.go
@@ -34,7 +34,7 @@ func (self LocalBranchNames) Join(sep string) string {
 // Sort orders the branches in this collection alphabetically.
 func (self LocalBranchNames) Sort() {
 	sort.Slice(self, func(a, b int) bool {
-		return self[a].id < self[b].id
+		return self[a] < self[b]
 	})
 }
 

--- a/src/domain/location.go
+++ b/src/domain/location.go
@@ -1,30 +1,18 @@
 package domain
 
-import "encoding/json"
-
 // Location is a location within a Git repo.
 // Examples for locations are SHA addresses of commits or branch names.
-type Location struct {
-	id string // the textual description of the location
-}
+type Location string
 
 func EmptyLocation() Location {
-	return Location{id: ""}
+	return ""
 }
 
 func NewLocation(id string) Location {
-	return Location{id}
-}
-
-// MarshalJSON is used when serializing this Location to JSON.
-func (self Location) MarshalJSON() ([]byte, error) {
-	return json.Marshal(self.id)
+	return Location(id)
 }
 
 // Implementation of the fmt.Stringer interface.
-func (self Location) String() string { return self.id }
-
-// UnmarshalJSON is used when de-serializing JSON into a Location.
-func (self *Location) UnmarshalJSON(b []byte) error {
-	return json.Unmarshal(b, &self.id)
+func (self Location) String() string {
+	return string(self)
 }

--- a/src/domain/remote.go
+++ b/src/domain/remote.go
@@ -1,20 +1,20 @@
 package domain
 
 // Remote represents a Git remote.
-type Remote struct {
-	ID string
-}
+type Remote string
 
 func NewRemote(id string) Remote {
-	return Remote{id}
+	return Remote(id)
 }
 
 func (self Remote) IsEmpty() bool {
-	return self.ID == ""
+	return self == ""
 }
 
 // Implementation of the fmt.Stringer interface.
-func (self Remote) String() string { return self.ID }
+func (self Remote) String() string {
+	return string(self)
+}
 
 var (
 	NoRemote       = NewRemote("")         //nolint:gochecknoglobals

--- a/src/domain/remote_branch_name.go
+++ b/src/domain/remote_branch_name.go
@@ -1,25 +1,22 @@
 package domain
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
 
 // RemoteBranchName is the name of a remote branch, e.g. "origin/foo".
-type RemoteBranchName struct {
-	id string
-}
+type RemoteBranchName string
 
 func EmptyRemoteBranchName() RemoteBranchName {
-	return RemoteBranchName{id: ""}
+	return ""
 }
 
 func NewRemoteBranchName(id string) RemoteBranchName {
 	if !isValidRemoteBranchName(id) {
 		panic(fmt.Sprintf("%q is not a valid remote branch name", id))
 	}
-	return RemoteBranchName{id}
+	return RemoteBranchName(id)
 }
 
 func isValidRemoteBranchName(value string) bool {
@@ -34,11 +31,11 @@ func isValidRemoteBranchName(value string) bool {
 
 // BranchName widens the type of this RemoteBranchName to a more generic BranchName.
 func (self RemoteBranchName) BranchName() BranchName {
-	return NewBranchName(self.id)
+	return NewBranchName(string(self))
 }
 
 func (self RemoteBranchName) IsEmpty() bool {
-	return self.id == ""
+	return self == ""
 }
 
 // LocalBranchName provides the name of the local branch that this remote branch tracks.
@@ -47,12 +44,8 @@ func (self RemoteBranchName) LocalBranchName() LocalBranchName {
 	return localBranch
 }
 
-func (self RemoteBranchName) MarshalJSON() ([]byte, error) {
-	return json.Marshal(self.id)
-}
-
 func (self RemoteBranchName) Parts() (Remote, LocalBranchName) {
-	parts := strings.SplitN(self.id, "/", 2)
+	parts := strings.SplitN(string(self), "/", 2)
 	return NewRemote(parts[0]), NewLocalBranchName(parts[1])
 }
 
@@ -62,8 +55,6 @@ func (self RemoteBranchName) Remote() Remote {
 }
 
 // Implementation of the fmt.Stringer interface.
-func (self RemoteBranchName) String() string { return self.id }
-
-func (self *RemoteBranchName) UnmarshalJSON(b []byte) error {
-	return json.Unmarshal(b, &self.id)
+func (self RemoteBranchName) String() string {
+	return string(self)
 }

--- a/src/domain/remote_branch_names.go
+++ b/src/domain/remote_branch_names.go
@@ -7,7 +7,7 @@ type RemoteBranchNames []RemoteBranchName
 // Sort orders the branches in this collection alphabetically.
 func (self RemoteBranchNames) Sort() {
 	sort.Slice(self, func(a, b int) bool {
-		return self[a].id < self[b].id
+		return self[a] < self[b]
 	})
 }
 

--- a/src/domain/repo_root_dir.go
+++ b/src/domain/repo_root_dir.go
@@ -1,22 +1,20 @@
 package domain
 
 // RepoRootDir represents the root directory of a Git repository.
-type RepoRootDir struct {
-	value string
-}
+type RepoRootDir string
 
 func EmptyRepoRootDir() RepoRootDir {
-	return NewRepoRootDir("")
+	return ""
 }
 
 func NewRepoRootDir(dir string) RepoRootDir {
-	return RepoRootDir{value: dir}
+	return RepoRootDir(dir)
 }
 
 func (self RepoRootDir) IsEmpty() bool {
-	return self.value == ""
+	return self == ""
 }
 
 func (self RepoRootDir) String() string {
-	return self.value
+	return string(self)
 }

--- a/src/domain/sha.go
+++ b/src/domain/sha.go
@@ -1,20 +1,15 @@
 package domain
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
 // SHA represents a Git SHA as a dedicated data type.
 // This helps avoid stringly-typed code.
-type SHA struct {
-	id string
-}
+type SHA string
 
 func EmptySHA() SHA {
-	return SHA{
-		id: "",
-	}
+	return ""
 }
 
 // NewSHA creates a new SHA instance with the given value.
@@ -23,7 +18,7 @@ func NewSHA(id string) SHA {
 	if !validateSHA(id) {
 		panic(fmt.Sprintf("%q is not a valid Git SHA", id))
 	}
-	return SHA{id}
+	return SHA(id)
 }
 
 // validateSHA indicates whether the given SHA content is a valid Git SHA.
@@ -44,31 +39,23 @@ func validateSHA(content string) bool {
 }
 
 func (self SHA) IsEmpty() bool {
-	return self.id == ""
+	return self == ""
 }
 
 // Location widens the type of this SHA to a more generic Location.
 func (self SHA) Location() Location {
-	return Location(self)
-}
-
-// MarshalJSON is used when serializing this SHA to JSON.
-func (self SHA) MarshalJSON() ([]byte, error) {
-	return json.Marshal(self.id)
+	return Location(string(self))
 }
 
 // Implementation of the fmt.Stringer interface.
-func (self SHA) String() string { return self.id }
+func (self SHA) String() string {
+	return string(self)
+}
 
 // TruncateTo provides a new SHA instance that contains a shorter checksum.
 func (self SHA) TruncateTo(newLength int) SHA {
-	if len(self.id) < newLength {
+	if len(self) < newLength {
 		return self
 	}
-	return NewSHA(self.id[0:newLength])
-}
-
-// UnmarshalJSON is used when de-serializing JSON into a SHA.
-func (self *SHA) UnmarshalJSON(b []byte) error {
-	return json.Unmarshal(b, &self.id)
+	return NewSHA(string(self)[0:newLength])
 }

--- a/src/domain/stash_snapshot.go
+++ b/src/domain/stash_snapshot.go
@@ -1,10 +1,8 @@
 package domain
 
-// StashSnapshot is a snapshot of th state of Git stash at a given point in time.
-type StashSnapshot struct {
-	Amount int // the amount of Git stash entries
-}
+// StashSnapshot is a snapshot of the state of Git stash at a given point in time.
+type StashSnapshot int
 
 func EmptyStashSnapshot() StashSnapshot {
-	return StashSnapshot{Amount: 0}
+	return 0
 }

--- a/src/domain/sync_status.go
+++ b/src/domain/sync_status.go
@@ -23,12 +23,12 @@ func (self SyncStatus) String() string {
 	return string(self)
 }
 
-var (
-	SyncStatusUpToDate        SyncStatus = "up to date"        //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is up to date
-	SyncStatusBehind          SyncStatus = "behind"            //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is behind the remote tracking branch
-	SyncStatusAhead           SyncStatus = "ahead"             //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is ahead of its remote branch
-	SyncStatusAheadAndBehind  SyncStatus = "ahead and behind"  //nolint:gochecknoglobals // the branch exists locally and remotely, both ends have different commits
-	SyncStatusLocalOnly       SyncStatus = "local only"        //nolint:gochecknoglobals // the branch was created locally and hasn't been pushed to the remote yet
-	SyncStatusRemoteOnly      SyncStatus = "remote only"       //nolint:gochecknoglobals // the branch exists only at the remote
-	SyncStatusDeletedAtRemote SyncStatus = "deleted at remote" //nolint:gochecknoglobals // the branch was deleted on the remote
+const (
+	SyncStatusUpToDate        SyncStatus = "up to date"        // the branch exists locally and remotely, the local branch is up to date
+	SyncStatusBehind          SyncStatus = "behind"            // the branch exists locally and remotely, the local branch is behind the remote tracking branch
+	SyncStatusAhead           SyncStatus = "ahead"             // the branch exists locally and remotely, the local branch is ahead of its remote branch
+	SyncStatusAheadAndBehind  SyncStatus = "ahead and behind"  // the branch exists locally and remotely, both ends have different commits
+	SyncStatusLocalOnly       SyncStatus = "local only"        // the branch was created locally and hasn't been pushed to the remote yet
+	SyncStatusRemoteOnly      SyncStatus = "remote only"       // the branch exists only at the remote
+	SyncStatusDeletedAtRemote SyncStatus = "deleted at remote" // the branch was deleted on the remote
 )

--- a/src/domain/sync_status.go
+++ b/src/domain/sync_status.go
@@ -6,9 +6,7 @@ import (
 
 // SyncStatus encodes the places a branch can exist at.
 // This is a type-safe enum, see https://npf.io/2022/05/safer-enums.
-type SyncStatus struct {
-	name string
-}
+type SyncStatus string
 
 // IsLocal indicates whether a branch with this SyncStatus exists in the local repo.
 func (self SyncStatus) IsLocal() bool {
@@ -21,14 +19,16 @@ func (self SyncStatus) IsLocal() bool {
 	panic(fmt.Sprintf("uncaptured sync status: %v", self))
 }
 
-func (self SyncStatus) String() string { return self.name }
+func (self SyncStatus) String() string {
+	return string(self)
+}
 
 var (
-	SyncStatusUpToDate        = SyncStatus{"up to date"}        //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is up to date
-	SyncStatusBehind          = SyncStatus{"behind"}            //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is behind the remote tracking branch
-	SyncStatusAhead           = SyncStatus{"ahead"}             //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is ahead of its remote branch
-	SyncStatusAheadAndBehind  = SyncStatus{"ahead and behind"}  //nolint:gochecknoglobals // the branch exists locally and remotely, both ends have different commits
-	SyncStatusLocalOnly       = SyncStatus{"local only"}        //nolint:gochecknoglobals // the branch was created locally and hasn't been pushed to the remote yet
-	SyncStatusRemoteOnly      = SyncStatus{"remote only"}       //nolint:gochecknoglobals // the branch exists only at the remote
-	SyncStatusDeletedAtRemote = SyncStatus{"deleted at remote"} //nolint:gochecknoglobals // the branch was deleted on the remote
+	SyncStatusUpToDate        SyncStatus = "up to date"        //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is up to date
+	SyncStatusBehind          SyncStatus = "behind"            //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is behind the remote tracking branch
+	SyncStatusAhead           SyncStatus = "ahead"             //nolint:gochecknoglobals // the branch exists locally and remotely, the local branch is ahead of its remote branch
+	SyncStatusAheadAndBehind  SyncStatus = "ahead and behind"  //nolint:gochecknoglobals // the branch exists locally and remotely, both ends have different commits
+	SyncStatusLocalOnly       SyncStatus = "local only"        //nolint:gochecknoglobals // the branch was created locally and hasn't been pushed to the remote yet
+	SyncStatusRemoteOnly      SyncStatus = "remote only"       //nolint:gochecknoglobals // the branch exists only at the remote
+	SyncStatusDeletedAtRemote SyncStatus = "deleted at remote" //nolint:gochecknoglobals // the branch was deleted on the remote
 )

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -478,9 +478,7 @@ func (self *BackendCommands) ShouldPushBranch(branch domain.LocalBranchName, tra
 // StashSnapshot provides the number of stashes in this repository.
 func (self *BackendCommands) StashSnapshot() (domain.StashSnapshot, error) {
 	output, err := self.QueryTrim("git", "stash", "list")
-	return domain.StashSnapshot{
-		Amount: len(stringslice.Lines(output)),
-	}, err
+	return domain.StashSnapshot(len(stringslice.Lines(output))), err
 }
 
 // Version indicates whether the needed Git version is installed.

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -451,7 +451,7 @@ func (self *BackendCommands) RepoStatus() (domain.RepoStatus, error) {
 func (self *BackendCommands) RootDirectory() domain.RepoRootDir {
 	output, err := self.QueryTrim("git", "rev-parse", "--show-toplevel")
 	if err != nil {
-		return domain.RepoRootDir{}
+		return domain.EmptyRepoRootDir()
 	}
 	return domain.NewRepoRootDir(filepath.FromSlash(output))
 }

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -664,9 +664,7 @@ func TestBackendCommands(t *testing.T) {
 			runtime.CreateFile("file2", "content")
 			runtime.StashOpenFiles()
 			have, err := runtime.StashSnapshot()
-			want := domain.StashSnapshot{
-				Amount: 2,
-			}
+			want := domain.StashSnapshot(2)
 			must.NoError(t, err)
 			must.EqOp(t, want, have)
 		})
@@ -674,9 +672,7 @@ func TestBackendCommands(t *testing.T) {
 			t.Parallel()
 			runtime := testruntime.Create(t)
 			have, err := runtime.StashSnapshot()
-			want := domain.StashSnapshot{
-				Amount: 0,
-			}
+			want := domain.StashSnapshot(0)
 			must.NoError(t, err)
 			must.EqOp(t, want, have)
 		})

--- a/src/undo/stash_diff.go
+++ b/src/undo/stash_diff.go
@@ -14,7 +14,7 @@ type StashDiff struct {
 
 func NewStashDiff(before, after domain.StashSnapshot) StashDiff {
 	return StashDiff{
-		EntriesAdded: after.Amount - before.Amount,
+		EntriesAdded: int(after) - int(before),
 	}
 }
 

--- a/src/undo/stash_diff_test.go
+++ b/src/undo/stash_diff_test.go
@@ -15,12 +15,8 @@ func TestStashDiff(t *testing.T) {
 		t.Parallel()
 		t.Run("entries added", func(t *testing.T) {
 			t.Parallel()
-			before := domain.StashSnapshot{
-				Amount: 1,
-			}
-			after := domain.StashSnapshot{
-				Amount: 3,
-			}
+			before := domain.StashSnapshot(1)
+			after := domain.StashSnapshot(3)
 			have := undo.NewStashDiff(before, after)
 			want := undo.StashDiff{
 				EntriesAdded: 2,
@@ -29,12 +25,8 @@ func TestStashDiff(t *testing.T) {
 		})
 		t.Run("no entries added", func(t *testing.T) {
 			t.Parallel()
-			before := domain.StashSnapshot{
-				Amount: 1,
-			}
-			after := domain.StashSnapshot{
-				Amount: 1,
-			}
+			before := domain.StashSnapshot(1)
+			after := domain.StashSnapshot(1)
 			have := undo.NewStashDiff(before, after)
 			want := undo.StashDiff{
 				EntriesAdded: 0,

--- a/src/vm/program/json.go
+++ b/src/vm/program/json.go
@@ -12,7 +12,7 @@ import (
 
 // JSON is used to store an opcode in JSON.
 type JSON struct { //nolint:musttag // JSON uses a custom serialization algorithm
-	Opcode shared.Opcode
+	shared.Opcode
 }
 
 // MarshalJSON marshals the opcode to JSON.

--- a/src/vm/program/program_test.go
+++ b/src/vm/program/program_test.go
@@ -376,7 +376,7 @@ func TestProgram(t *testing.T) {
 		want := `
 Program:
 1: &opcode.AbortMerge{undeclaredOpcodeMethods:opcode.undeclaredOpcodeMethods{}}
-2: &opcode.AddToPerennialBranches{Branch:domain.LocalBranchName{id:"branch"}, undeclaredOpcodeMethods:opcode.undeclaredOpcodeMethods{}}
+2: &opcode.AddToPerennialBranches{Branch:"branch", undeclaredOpcodeMethods:opcode.undeclaredOpcodeMethods{}}
 `[1:]
 		must.EqOp(t, want, have)
 	})

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -907,8 +907,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		if err != nil {
 			return err
 		}
-		if stashSnapshot.Amount != 1 {
-			return fmt.Errorf("expected 1 stash but found %d", stashSnapshot.Amount)
+		if stashSnapshot != 1 {
+			return fmt.Errorf("expected 1 stash but found %d", stashSnapshot)
 		}
 		return nil
 	})


### PR DESCRIPTION
The extra strong separation using structs isn't necessary here. Removing it leads to an overall better readable codebase.