### PR TITLE
Remove SyncStatus.IsLocal

### DIFF
--- a/src/domain/branch_info.go
+++ b/src/domain/branch_info.go
@@ -70,7 +70,7 @@ func (self BranchInfo) IsEmpty() bool {
 
 // IsLocalBranch indicates whether this branch exists in the local repo that Git Town is running in.
 func (self BranchInfo) IsLocal() bool {
-	return self.SyncStatus.IsLocal()
+	return !self.LocalName.IsEmpty()
 }
 
 // IsOmniBranch indicates whether the local and remote branch are in sync.

--- a/src/domain/branch_infos_test.go
+++ b/src/domain/branch_infos_test.go
@@ -198,10 +198,10 @@ func TestBranchInfos(t *testing.T) {
 				RemoteSHA:  domain.EmptySHA(),
 			},
 			domain.BranchInfo{
-				LocalName:  domain.NewLocalBranchName("remote-only"),
+				LocalName:  domain.EmptyLocalBranchName(),
 				LocalSHA:   domain.EmptySHA(),
 				SyncStatus: domain.SyncStatusRemoteOnly,
-				RemoteName: domain.EmptyRemoteBranchName(),
+				RemoteName: domain.NewRemoteBranchName("origin/remote-only"),
 				RemoteSHA:  domain.EmptySHA(),
 			},
 			domain.BranchInfo{

--- a/src/domain/sync_status.go
+++ b/src/domain/sync_status.go
@@ -1,23 +1,8 @@
 package domain
 
-import (
-	"fmt"
-)
-
 // SyncStatus encodes the places a branch can exist at.
 // This is a type-safe enum, see https://npf.io/2022/05/safer-enums.
 type SyncStatus string
-
-// IsLocal indicates whether a branch with this SyncStatus exists in the local repo.
-func (self SyncStatus) IsLocal() bool {
-	switch self {
-	case SyncStatusLocalOnly, SyncStatusUpToDate, SyncStatusNotInSync, SyncStatusDeletedAtRemote:
-		return true
-	case SyncStatusRemoteOnly:
-		return false
-	}
-	panic(fmt.Sprintf("uncaptured sync status: %v", self))
-}
 
 func (self SyncStatus) String() string {
 	return string(self)


### PR DESCRIPTION
This functionality is redundant and can be queried more reliably by inspecting the local branch name.