### PR TITLE
More precise syncstatus check

### DIFF
--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -253,7 +253,7 @@ func IsInSync(branchName, remoteText string) (bool, domain.RemoteBranchName) {
 	return false, domain.EmptyRemoteBranchName()
 }
 
-// IsRemoteGone indicates whether the given remoteText indicates a deleted tracking branch
+// IsRemoteGone indicates whether the given remoteText indicates a deleted tracking branch.
 func IsRemoteGone(branchName, remoteText string) (bool, domain.RemoteBranchName) {
 	reText := fmt.Sprintf(`^\[(\w+\/%s): gone\] `, branchName)
 	re := regexp.MustCompile(reText)

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -214,7 +214,7 @@ func determineSyncStatus(branchName, remoteText string) (syncStatus domain.SyncS
 }
 
 func IsAhead(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+\] `, branchName)
+	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+\] `, regexp.QuoteMeta(branchName))
 	re := regexp.MustCompile(reText)
 	matches := re.FindStringSubmatch(remoteText)
 	if len(matches) == 2 {
@@ -224,7 +224,7 @@ func IsAhead(branchName, remoteText string) (bool, domain.RemoteBranchName) {
 }
 
 func IsAheadAndBehind(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+, behind \d+\] `, branchName)
+	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+, behind \d+\] `, regexp.QuoteMeta(branchName))
 	re := regexp.MustCompile(reText)
 	matches := re.FindStringSubmatch(remoteText)
 	if len(matches) == 2 {
@@ -234,7 +234,7 @@ func IsAheadAndBehind(branchName, remoteText string) (bool, domain.RemoteBranchN
 }
 
 func IsBehind(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s): behind \d+\] `, branchName)
+	reText := fmt.Sprintf(`\[(\w+\/%s): behind \d+\] `, regexp.QuoteMeta(branchName))
 	re := regexp.MustCompile(reText)
 	matches := re.FindStringSubmatch(remoteText)
 	if len(matches) == 2 {
@@ -244,7 +244,7 @@ func IsBehind(branchName, remoteText string) (bool, domain.RemoteBranchName) {
 }
 
 func IsInSync(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s)\] `, branchName)
+	reText := fmt.Sprintf(`\[(\w+\/%s)\] `, regexp.QuoteMeta(branchName))
 	re := regexp.MustCompile(reText)
 	matches := re.FindStringSubmatch(remoteText)
 	if len(matches) == 2 {
@@ -255,7 +255,7 @@ func IsInSync(branchName, remoteText string) (bool, domain.RemoteBranchName) {
 
 // IsRemoteGone indicates whether the given remoteText indicates a deleted tracking branch.
 func IsRemoteGone(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`^\[(\w+\/%s): gone\] `, branchName)
+	reText := fmt.Sprintf(`^\[(\w+\/%s): gone\] `, regexp.QuoteMeta(branchName))
 	re := regexp.MustCompile(reText)
 	matches := re.FindStringSubmatch(remoteText)
 	if len(matches) == 2 {

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -211,12 +211,6 @@ func determineSyncStatus(branchName, remoteText string) (syncStatus domain.SyncS
 		return domain.SyncStatusRemoteOnly, domain.EmptyRemoteBranchName()
 	}
 	return domain.SyncStatusLocalOnly, domain.EmptyRemoteBranchName()
-	// 	closingBracketPos := strings.IndexRune(remoteText, ']')
-	// 	textInBrackets := remoteText[1:closingBracketPos]
-	// 	trackingBranchContent, remoteStatus, _ := strings.Cut(textInBrackets, ": ")
-	// 	trackingBranchName := domain.NewRemoteBranchName(trackingBranchContent)
-	// } else {
-	// }
 }
 
 func IsAhead(branchName, remoteText string) (bool, domain.RemoteBranchName) {

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -207,30 +207,16 @@ func determineSyncStatus(branchName, remoteText string) (syncStatus domain.SyncS
 	if IsAheadAndBehind {
 		return domain.SyncStatusNotInSync, trackingBranchName
 	}
+	if strings.HasPrefix(branchName, "remotes/") {
+		return domain.SyncStatusRemoteOnly, domain.EmptyRemoteBranchName()
+	}
+	return domain.SyncStatusLocalOnly, domain.EmptyRemoteBranchName()
 	// 	closingBracketPos := strings.IndexRune(remoteText, ']')
 	// 	textInBrackets := remoteText[1:closingBracketPos]
 	// 	trackingBranchContent, remoteStatus, _ := strings.Cut(textInBrackets, ": ")
 	// 	trackingBranchName := domain.NewRemoteBranchName(trackingBranchContent)
-	// 	if remoteStatus == "" {
-	// 		return domain.SyncStatusUpToDate, trackingBranchName
-	// 	}
-	// 	if strings.Contains(remoteStatus, ", behind ") {
-	// 		return domain.SyncStatusNotInSync, trackingBranchName
-	// 	}
-	// 	if strings.HasPrefix(remoteStatus, "ahead ") {
-	// 		return domain.SyncStatusNotInSync, trackingBranchName
-	// 	}
-	// 	if strings.HasPrefix(remoteStatus, "behind ") {
-	// 		return domain.SyncStatusNotInSync, trackingBranchName
-	// 	}
-	// 	panic(fmt.Sprintf(messages.SyncStatusNotRecognized, remoteText, branchName))
 	// } else {
-	// 	if strings.HasPrefix(branchName, "remotes/origin/") {
-	// 		return domain.SyncStatusRemoteOnly, domain.EmptyRemoteBranchName()
-	// 	}
-	// 	return domain.SyncStatusLocalOnly, domain.EmptyRemoteBranchName()
 	// }
-	return domain.SyncStatusNotInSync, domain.EmptyRemoteBranchName()
 }
 
 func IsAhead(branchName, remoteText string) (bool, domain.RemoteBranchName) {

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -119,6 +119,57 @@ func (self *BackendCommands) CheckoutBranch(name domain.LocalBranchName) error {
 	return nil
 }
 
+func IsAhead(branchName, remoteText string) (bool, domain.RemoteBranchName) {
+	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+\] `, regexp.QuoteMeta(branchName))
+	re := regexp.MustCompile(reText)
+	matches := re.FindStringSubmatch(remoteText)
+	if len(matches) == 2 {
+		return true, domain.NewRemoteBranchName(matches[1])
+	}
+	return false, domain.EmptyRemoteBranchName()
+}
+
+func IsAheadAndBehind(branchName, remoteText string) (bool, domain.RemoteBranchName) {
+	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+, behind \d+\] `, regexp.QuoteMeta(branchName))
+	re := regexp.MustCompile(reText)
+	matches := re.FindStringSubmatch(remoteText)
+	if len(matches) == 2 {
+		return true, domain.NewRemoteBranchName(matches[1])
+	}
+	return false, domain.EmptyRemoteBranchName()
+}
+
+func IsBehind(branchName, remoteText string) (bool, domain.RemoteBranchName) {
+	reText := fmt.Sprintf(`\[(\w+\/%s): behind \d+\] `, regexp.QuoteMeta(branchName))
+	re := regexp.MustCompile(reText)
+	matches := re.FindStringSubmatch(remoteText)
+	if len(matches) == 2 {
+		return true, domain.NewRemoteBranchName(matches[1])
+	}
+	return false, domain.EmptyRemoteBranchName()
+}
+
+func IsInSync(branchName, remoteText string) (bool, domain.RemoteBranchName) {
+	reText := fmt.Sprintf(`\[(\w+\/%s)\] `, regexp.QuoteMeta(branchName))
+	re := regexp.MustCompile(reText)
+	matches := re.FindStringSubmatch(remoteText)
+	if len(matches) == 2 {
+		return true, domain.NewRemoteBranchName(matches[1])
+	}
+	return false, domain.EmptyRemoteBranchName()
+}
+
+// IsRemoteGone indicates whether the given remoteText indicates a deleted tracking branch.
+func IsRemoteGone(branchName, remoteText string) (bool, domain.RemoteBranchName) {
+	reText := fmt.Sprintf(`^\[(\w+\/%s): gone\] `, regexp.QuoteMeta(branchName))
+	re := regexp.MustCompile(reText)
+	matches := re.FindStringSubmatch(remoteText)
+	if len(matches) == 2 {
+		return true, domain.NewRemoteBranchName(matches[1])
+	}
+	return false, domain.EmptyRemoteBranchName()
+}
+
 // ParseVerboseBranchesOutput provides the branches in the given Git output as well as the name of the currently checked out branch.
 func ParseVerboseBranchesOutput(output string) (domain.BranchInfos, domain.LocalBranchName) {
 	result := domain.BranchInfos{}
@@ -211,57 +262,6 @@ func determineSyncStatus(branchName, remoteText string) (syncStatus domain.SyncS
 		return domain.SyncStatusRemoteOnly, domain.EmptyRemoteBranchName()
 	}
 	return domain.SyncStatusLocalOnly, domain.EmptyRemoteBranchName()
-}
-
-func IsAhead(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+\] `, regexp.QuoteMeta(branchName))
-	re := regexp.MustCompile(reText)
-	matches := re.FindStringSubmatch(remoteText)
-	if len(matches) == 2 {
-		return true, domain.NewRemoteBranchName(matches[1])
-	}
-	return false, domain.EmptyRemoteBranchName()
-}
-
-func IsAheadAndBehind(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s): ahead \d+, behind \d+\] `, regexp.QuoteMeta(branchName))
-	re := regexp.MustCompile(reText)
-	matches := re.FindStringSubmatch(remoteText)
-	if len(matches) == 2 {
-		return true, domain.NewRemoteBranchName(matches[1])
-	}
-	return false, domain.EmptyRemoteBranchName()
-}
-
-func IsBehind(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s): behind \d+\] `, regexp.QuoteMeta(branchName))
-	re := regexp.MustCompile(reText)
-	matches := re.FindStringSubmatch(remoteText)
-	if len(matches) == 2 {
-		return true, domain.NewRemoteBranchName(matches[1])
-	}
-	return false, domain.EmptyRemoteBranchName()
-}
-
-func IsInSync(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`\[(\w+\/%s)\] `, regexp.QuoteMeta(branchName))
-	re := regexp.MustCompile(reText)
-	matches := re.FindStringSubmatch(remoteText)
-	if len(matches) == 2 {
-		return true, domain.NewRemoteBranchName(matches[1])
-	}
-	return false, domain.EmptyRemoteBranchName()
-}
-
-// IsRemoteGone indicates whether the given remoteText indicates a deleted tracking branch.
-func IsRemoteGone(branchName, remoteText string) (bool, domain.RemoteBranchName) {
-	reText := fmt.Sprintf(`^\[(\w+\/%s): gone\] `, regexp.QuoteMeta(branchName))
-	re := regexp.MustCompile(reText)
-	matches := re.FindStringSubmatch(remoteText)
-	if len(matches) == 2 {
-		return true, domain.NewRemoteBranchName(matches[1])
-	}
-	return false, domain.EmptyRemoteBranchName()
 }
 
 // isLocalBranchName indicates whether the branch with the given Git ref is local or remote.

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -406,13 +406,13 @@ func TestBackendCommands(t *testing.T) {
 					t.Parallel()
 					t.Run("is actually ahead", func(t *testing.T) {
 						t.Parallel()
-						isAhead, remoteBranchName := git.IsAhead("branch-1", "[origin/branch-1: ahead 10]")
+						isAhead, remoteBranchName := git.IsAhead("branch-1", "[origin/branch-1: ahead 10] commit message")
 						must.True(t, isAhead)
 						must.EqOp(t, "origin/branch-1", remoteBranchName.String())
 					})
 					t.Run("is not ahead", func(t *testing.T) {
 						t.Parallel()
-						isAhead, remoteBranchName := git.IsAhead("branch-1", "[origin/branch-1: behind 10]")
+						isAhead, remoteBranchName := git.IsAhead("branch-1", "[origin/branch-1: behind 10] commit message")
 						must.False(t, isAhead)
 						must.EqOp(t, "", remoteBranchName.String())
 					})
@@ -572,33 +572,6 @@ func TestBackendCommands(t *testing.T) {
 					have, _ := git.ParseVerboseBranchesOutput(give)
 					must.Eq(t, want, have)
 				})
-			})
-		})
-
-		t.Run("branch with a different tracking branch name", func(t *testing.T) {
-			t.Run("a branch uses a differently named tracking branch", func(t *testing.T) {
-				give := `
-  branch-1                     111111 [origin/branch-2] Commit message 1
-  remotes/origin/branch-1      222222 Commit message 2
-  remotes/origin/branch-2      111111 Commit message 1`[1:]
-				want := domain.BranchInfos{
-					domain.BranchInfo{
-						LocalName:  domain.NewLocalBranchName("branch-1"),
-						LocalSHA:   domain.NewSHA("111111"),
-						SyncStatus: domain.SyncStatusUpToDate,
-						RemoteName: domain.NewRemoteBranchName("origin/branch-2"),
-						RemoteSHA:  domain.NewSHA("111111"),
-					},
-					domain.BranchInfo{
-						LocalName:  domain.EmptyLocalBranchName(),
-						LocalSHA:   domain.EmptySHA(),
-						SyncStatus: domain.SyncStatusRemoteOnly,
-						RemoteName: domain.NewRemoteBranchName("origin/branch-1"),
-						RemoteSHA:  domain.NewSHA("222222"),
-					},
-				}
-				have, _ := git.ParseVerboseBranchesOutput(give)
-				must.Eq(t, want, have)
 			})
 		})
 

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -402,20 +402,38 @@ func TestBackendCommands(t *testing.T) {
 			t.Parallel()
 			t.Run("branch is ahead of its remote branch", func(t *testing.T) {
 				t.Parallel()
-				give := `
+				t.Run("IsAhead", func(t *testing.T) {
+					t.Parallel()
+					t.Run("is actually ahead", func(t *testing.T) {
+						t.Parallel()
+						isAhead, remoteBranchName := git.IsAhead("branch-1", "[origin/branch-1: ahead 10]")
+						must.True(t, isAhead)
+						must.EqOp(t, "origin/branch-1", remoteBranchName.String())
+					})
+					t.Run("is not ahead", func(t *testing.T) {
+						t.Parallel()
+						isAhead, remoteBranchName := git.IsAhead("branch-1", "[origin/branch-1: behind 10]")
+						must.False(t, isAhead)
+						must.EqOp(t, "", remoteBranchName.String())
+					})
+				})
+				t.Run("determineSyncStatus", func(t *testing.T) {
+					t.Parallel()
+					give := `
   branch-1                     111111 [origin/branch-1: ahead 1] Commit message 1a
   remotes/origin/branch-1      222222 Commit message 1b`[1:]
-				want := domain.BranchInfos{
-					domain.BranchInfo{
-						LocalName:  domain.NewLocalBranchName("branch-1"),
-						LocalSHA:   domain.NewSHA("111111"),
-						SyncStatus: domain.SyncStatusNotInSync,
-						RemoteName: domain.NewRemoteBranchName("origin/branch-1"),
-						RemoteSHA:  domain.NewSHA("222222"),
-					},
-				}
-				have, _ := git.ParseVerboseBranchesOutput(give)
-				must.Eq(t, want, have)
+					want := domain.BranchInfos{
+						domain.BranchInfo{
+							LocalName:  domain.NewLocalBranchName("branch-1"),
+							LocalSHA:   domain.NewSHA("111111"),
+							SyncStatus: domain.SyncStatusNotInSync,
+							RemoteName: domain.NewRemoteBranchName("origin/branch-1"),
+							RemoteSHA:  domain.NewSHA("222222"),
+						},
+					}
+					have, _ := git.ParseVerboseBranchesOutput(give)
+					must.Eq(t, want, have)
+				})
 			})
 
 			t.Run("branch is behind its remote branch", func(t *testing.T) {
@@ -456,20 +474,31 @@ func TestBackendCommands(t *testing.T) {
 
 			t.Run("branch is in sync with its remote branch", func(t *testing.T) {
 				t.Parallel()
-				give := `
+				t.Run("IsInSync", func(t *testing.T) {
+					t.Parallel()
+					t.Run("is actually in sync", func(t *testing.T) {
+						t.Parallel()
+						isInSync, remoteBranchName := git.IsInSync("branch-1", "[origin/branch-1] commit message")
+						must.True(t, isInSync)
+						must.EqOp(t, "origin/branch-1", remoteBranchName.String())
+					})
+				})
+				t.Run("ParseVerboseBranchesOutput", func(t *testing.T) {
+					give := `
   branch-1                     111111 [origin/branch-1] Commit message 1
   remotes/origin/branch-1      111111 Commit message 1`[1:]
-				want := domain.BranchInfos{
-					domain.BranchInfo{
-						LocalName:  domain.NewLocalBranchName("branch-1"),
-						LocalSHA:   domain.NewSHA("111111"),
-						SyncStatus: domain.SyncStatusUpToDate,
-						RemoteName: domain.NewRemoteBranchName("origin/branch-1"),
-						RemoteSHA:  domain.NewSHA("111111"),
-					},
-				}
-				have, _ := git.ParseVerboseBranchesOutput(give)
-				must.Eq(t, want, have)
+					want := domain.BranchInfos{
+						domain.BranchInfo{
+							LocalName:  domain.NewLocalBranchName("branch-1"),
+							LocalSHA:   domain.NewSHA("111111"),
+							SyncStatus: domain.SyncStatusUpToDate,
+							RemoteName: domain.NewRemoteBranchName("origin/branch-1"),
+							RemoteSHA:  domain.NewSHA("111111"),
+						},
+					}
+					have, _ := git.ParseVerboseBranchesOutput(give)
+					must.Eq(t, want, have)
+				})
 			})
 
 			t.Run("remote-only branch", func(t *testing.T) {


### PR DESCRIPTION
The old sync-status check was vulnerable against commit messages containing "[". This PR introduces a more strict check against the actually expected strings.