### PR TITLE
Fix config command to view/set main-branch

### DIFF
--- a/website/src/preferences/main-branch-name.md
+++ b/website/src/preferences/main-branch-name.md
@@ -10,5 +10,5 @@ parent branch for new feature branches created with
 [ships](../commands/ship.md) finished feature branches.
 
 Git Town automatically asks for this setting if needed. You can run the
-[git town main-branch](../commands/config-main-branch.md) command to see or
+[git town config main-branch](../commands/config-main-branch.md) command to see or
 update the configured main branch.


### PR DESCRIPTION
A minor omission in `git town config` command 