### PR TITLE
Eliminate redundant ShellCheck run on CI

### DIFF
--- a/.github/workflows/lint_unit.yml
+++ b/.github/workflows/lint_unit.yml
@@ -14,10 +14,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.21
-      - name: ShellCheck
-        uses: ludeeus/action-shellcheck@1.1.0
-        with:
-          ignore: vendor
       - run: make fix
       - name: Indicate formatting issues
         run: git diff HEAD --exit-code --color


### PR DESCRIPTION
`make fix` is already running ShellCheck