### PR TITLE
Remove Scoop deployment

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,16 +51,5 @@ release:
   ids:
     - nothing
 
-scoop:
-  bucket:
-    owner: git-town
-    name: scoop
-  commit_author:
-    name: kevgo
-    email: kevin.goslar@gmail.com
-  description: "High-level CLI for Git"
-  homepage: https://www.git-town.com
-  license: MIT
-
 snapshot:
   name_template: "{{ .Tag }}"


### PR DESCRIPTION
Git Town is now in the main Scoop bucket (https://github.com/ScoopInstaller/Main/blob/master/bucket/git-town.json) and we therefore don't need our custom Scoop bucket anymore.