### PR TITLE
Remove code triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
   <a href="https://goreportcard.com/report/github.com/git-town/git-town">
     <img src="https://goreportcard.com/badge/github.com/git-town/git-town" alt="Go report card status">
   </a>
-  <a href="https://www.codetriage.com/originate/git-town">
-    <img src="https://www.codetriage.com/originate/git-town/badges/users.svg" alt="Help Contribute to Open Source">
-  </a>
   <img src="https://api.netlify.com/api/v1/badges/c2ea5505-be48-42e5-bb8a-b807d18d99ed/deploy-status" alt="Netlify deploy status">
 </p>
 


### PR DESCRIPTION
It seems they removed Git Town on their end without reaching out to us, so this removes their broken badge.