### PR TITLE
DRY up Go version

### DIFF
--- a/.github/workflows/cuke.yml
+++ b/.github/workflows/cuke.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.21
+          go-version-file: go.mod
       - run: make cuke

--- a/.github/workflows/lint_unit.yml
+++ b/.github/workflows/lint_unit.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.21
+          go-version-file: go.mod
       - run: make fix
       - name: Indicate formatting issues
         run: git diff HEAD --exit-code --color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.4'
+          go-version-file: go.mod
       - run: ./tools/release.ps1 -ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CI now uses the Go version that the Go module in the code defines.