### PR TITLE
Add New Config Option `sync-before-ship`

### DIFF
--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -76,6 +76,7 @@ func determineConfigConfig(run *git.ProdRunner) (ConfigConfig, error) {
 	pushNewBranches := fc.Bool(run.Config.ShouldNewBranchPush())
 	shouldSyncUpstream := fc.Bool(run.Config.ShouldSyncUpstream())
 	syncFeatureStrategy := fc.SyncFeatureStrategy(run.Config.SyncFeatureStrategy())
+	syncBeforeShip := fc.Bool(run.Config.SyncBeforeShip())
 	return ConfigConfig{
 		branchTypes:           branchTypes,
 		deleteOrigin:          deleteOrigin,
@@ -90,6 +91,7 @@ func determineConfigConfig(run *git.ProdRunner) (ConfigConfig, error) {
 		pushNewBranches:       pushNewBranches,
 		shouldSyncUpstream:    shouldSyncUpstream,
 		syncFeatureStrategy:   syncFeatureStrategy,
+		syncBeforeShip:        syncBeforeShip,
 	}, fc.Err
 }
 
@@ -107,6 +109,7 @@ type ConfigConfig struct {
 	pushNewBranches       bool
 	shouldSyncUpstream    bool
 	syncFeatureStrategy   config.SyncFeatureStrategy
+	syncBeforeShip        bool
 }
 
 func printConfig(config ConfigConfig) {
@@ -123,6 +126,7 @@ func printConfig(config ConfigConfig) {
 	print.Entry("sync-feature strategy", config.syncFeatureStrategy.String())
 	print.Entry("sync-perennial strategy", config.syncPerennialStrategy.String())
 	print.Entry("sync with upstream", format.Bool(config.shouldSyncUpstream))
+	print.Entry("sync before shipping", format.Bool(config.syncBeforeShip))
 	fmt.Println()
 	print.Header("Hosting")
 	print.Entry("hosting service override", format.StringSetting(config.hosting.String()))

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -418,6 +418,15 @@ func (self *GitTown) ShouldSyncUpstream() (bool, error) {
 	return ParseBool(text)
 }
 
+// SyncBeforeShip indicates whether a sync should be performed before a ship
+func (self *GitTown) SyncBeforeShip() (bool, error) {
+	text := self.LocalOrGlobalConfigValue(KeySyncBeforeShip)
+	if text == "" {
+		return true, nil
+	}
+	return ParseBool(text)
+}
+
 func (self *GitTown) SyncFeatureStrategy() (SyncFeatureStrategy, error) {
 	err := self.updateDeprecatedSetting(KeyDeprecatedSyncStrategy, KeySyncFeatureStrategy)
 	if err != nil {

--- a/src/config/key.go
+++ b/src/config/key.go
@@ -59,6 +59,7 @@ var (
 	KeySyncUpstream                   = Key{"git-town.sync-upstream"}                //nolint:gochecknoglobals
 	KeySyncStrategy                   = Key{"git-town.sync-strategy"}                //nolint:gochecknoglobals
 	KeyTestingRemoteURL               = Key{"git-town.testing.remote-url"}           //nolint:gochecknoglobals
+	KeySyncBeforeShip                 = Key{"git-town.sync-before-ship"}             //nolint:gochecknoblavals
 )
 
 var keys = []Key{ //nolint:gochecknoglobals
@@ -85,6 +86,7 @@ var keys = []Key{ //nolint:gochecknoglobals
 	KeySyncUpstream,
 	KeySyncStrategy,
 	KeyTestingRemoteURL,
+	KeySyncBeforeShip,
 }
 
 func NewAliasKey(aliasType Alias) Key {

--- a/website/src/preferences/sync-before-ship.md
+++ b/website/src/preferences/sync-before-ship.md
@@ -1,0 +1,9 @@
+# sync-before-ship
+
+```
+git-town.sync-before-ship=<true|false>
+```
+
+Setting this to false disables syncing before a [ship](..commands/ship.md) command.
+This may be useful environments where syncing may cause CI to
+be re-run.


### PR DESCRIPTION
Adds a new configuration option `sync-before-ship`, which will enable/disable syncing when the ship command is run #2079 