### PR TITLE
Change the default of sync-before-ship to off

### DIFF
--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -18,7 +18,7 @@ Feature: show the configuration
         sync-feature strategy: merge
         sync-perennial strategy: rebase
         sync with upstream: yes
-        sync before shipping: yes
+        sync before shipping: no
 
       Hosting:
         hosting service override: (not set)
@@ -47,7 +47,7 @@ Feature: show the configuration
         sync-feature strategy: merge
         sync-perennial strategy: rebase
         sync with upstream: yes
-        sync before shipping: yes
+        sync before shipping: no
 
       Hosting:
         hosting service override: (not set)
@@ -82,7 +82,7 @@ Feature: show the configuration
         sync-feature strategy: merge
         sync-perennial strategy: rebase
         sync with upstream: yes
-        sync before shipping: yes
+        sync before shipping: no
 
       Hosting:
         hosting service override: (not set)

--- a/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
+++ b/features/ship/current_branch/edge_cases/commit_message_containing_double_quotes.feature
@@ -12,11 +12,6 @@ Feature: commit message with double-quotes
       | BRANCH  | COMMAND                              |
       | feature | git fetch --prune --tags             |
       |         | git checkout main                    |
-      | main    | git rebase origin/main               |
-      |         | git checkout feature                 |
-      | feature | git merge --no-edit origin/feature   |
-      |         | git merge --no-edit main             |
-      |         | git checkout main                    |
       | main    | git merge --squash feature           |
       |         | git commit -m "with "double quotes"" |
       |         | git push                             |

--- a/features/ship/current_branch/edge_cases/default_commit_message.feature
+++ b/features/ship/current_branch/edge_cases/default_commit_message.feature
@@ -9,18 +9,13 @@ Feature: must provide a commit message
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit                         |
-      |         | git reset --hard                   |
-      |         | git checkout feature               |
+      | BRANCH  | COMMAND                    |
+      | feature | git fetch --prune --tags   |
+      |         | git checkout main          |
+      | main    | git merge --squash feature |
+      |         | git commit                 |
+      |         | git reset --hard           |
+      |         | git checkout feature       |
     And it prints the error:
       """
       aborted because commit exited with error

--- a/features/ship/current_branch/edge_cases/empty_branch.feature
+++ b/features/ship/current_branch/edge_cases/empty_branch.feature
@@ -8,7 +8,6 @@ Feature: does not ship an empty branch
       | empty  | local    | empty commit | common_file | common content |
     When I run "git-town ship"
 
-  @debug @this
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/ship/current_branch/edge_cases/empty_branch.feature
+++ b/features/ship/current_branch/edge_cases/empty_branch.feature
@@ -4,23 +4,15 @@ Feature: does not ship an empty branch
     Given the current branch is a feature branch "empty"
     And the commits
       | BRANCH | LOCATION | MESSAGE      | FILE NAME   | FILE CONTENT   |
-      | main   | origin   | main commit  | common_file | common content |
+      | main   | local    | main commit  | common_file | common content |
       | empty  | local    | empty commit | common_file | common content |
     When I run "git-town ship"
 
+  @debug @this
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                                     |
-      | empty  | git fetch --prune --tags                    |
-      |        | git checkout main                           |
-      | main   | git rebase origin/main                      |
-      |        | git checkout empty                          |
-      | empty  | git merge --no-edit origin/empty            |
-      |        | git merge --no-edit main                    |
-      |        | git reset --hard {{ sha 'empty commit' }}   |
-      |        | git checkout main                           |
-      | main   | git reset --hard {{ sha 'Initial commit' }} |
-      |        | git checkout empty                          |
+      | BRANCH | COMMAND                  |
+      | empty  | git fetch --prune --tags |
     And it prints the error:
       """
       the branch "empty" has no shippable changes

--- a/features/ship/current_branch/edge_cases/empty_commit_message.feature
+++ b/features/ship/current_branch/edge_cases/empty_commit_message.feature
@@ -10,18 +10,13 @@ Feature: abort the ship by empty commit message
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit                         |
-      |         | git reset --hard                   |
-      |         | git checkout feature               |
+      | BRANCH  | COMMAND                    |
+      | feature | git fetch --prune --tags   |
+      |         | git checkout main          |
+      | main    | git merge --squash feature |
+      |         | git commit                 |
+      |         | git reset --hard           |
+      |         | git checkout feature       |
     And it prints the error:
       """
       aborted because commit exited with error

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -8,7 +8,6 @@ Feature: handle conflicts between the shipped branch and the main branch
       | feature | local    | conflicting feature commit | conflicting_file | feature content |
     And I run "git-town ship -m 'feature done'"
 
-  @debug @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                    |

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -29,49 +29,12 @@ Feature: handle conflicts between the shipped branch and the main branch
 
   Scenario: undo
     When I run "git-town undo"
-    Then it runs the commands
-      | BRANCH  | COMMAND           |
-      | feature | git merge --abort |
+    Then it prints the error:
+      """
+      nothing to undo
+      """
+    And it runs no commands
     And the current branch is still "feature"
     And no merge is in progress
-    And now these commits exist
-      | BRANCH  | LOCATION      | MESSAGE                    | FILE NAME        | FILE CONTENT    |
-      | main    | local, origin | conflicting main commit    | conflicting_file | main content    |
-      | feature | local         | conflicting feature commit | conflicting_file | feature content |
-    And the initial branch hierarchy exists
-
-  Scenario: resolve and continue
-    When I resolve the conflict in "conflicting_file"
-    And I run "git-town continue"
-    Then it runs the commands
-      | BRANCH  | COMMAND                      |
-      | feature | git commit --no-edit         |
-      |         | git checkout main            |
-      | main    | git merge --squash feature   |
-      |         | git commit -m "feature done" |
-      |         | git push                     |
-      |         | git push origin :feature     |
-      |         | git branch -D feature        |
-    And the current branch is now "main"
-    And the branches are now
-      | REPOSITORY    | BRANCHES |
-      | local, origin | main     |
-    And now these commits exist
-      | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT     |
-      | main   | local, origin | conflicting main commit | conflicting_file | main content     |
-      |        |               | feature done            | conflicting_file | resolved content |
-    And no branch hierarchy exists now
-
-  Scenario: resolve, commit, and continue
-    When I resolve the conflict in "conflicting_file"
-    And I run "git commit --no-edit"
-    And I run "git-town continue"
-    Then it runs the commands
-      | BRANCH  | COMMAND                      |
-      | feature | git checkout main            |
-      | main    | git merge --squash feature   |
-      |         | git commit -m "feature done" |
-      |         | git push                     |
-      |         | git push origin :feature     |
-      |         | git branch -D feature        |
-    And the current branch is now "main"
+    And now the initial commits exist
+    And the initial branches and hierarchy exist

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_main_branch_conflict.feature
@@ -8,27 +8,25 @@ Feature: handle conflicts between the shipped branch and the main branch
       | feature | local    | conflicting feature commit | conflicting_file | feature content |
     And I run "git-town ship -m 'feature done'"
 
+  @debug @this
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git push                           |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
+      | BRANCH  | COMMAND                    |
+      | feature | git fetch --prune --tags   |
+      |         | git checkout main          |
+      | main    | git merge --squash feature |
+      |         | git reset --hard           |
+      |         | git checkout feature       |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
-      To continue after having resolved conflicts, run "git-town continue".
+      aborted because commit exited with error
       """
     And the current branch is still "feature"
-    And a merge is now in progress
+    And no merge is in progress
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -6,6 +6,7 @@ Feature: handle conflicts between the shipped branch and its tracking branch
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
       | feature | local    | conflicting local commit  | conflicting_file | local content  |
       |         | origin   | conflicting origin commit | conflicting_file | origin content |
+    And Git Town setting "sync-before-ship" is "true"
     When I run "git-town ship -m 'feature done'"
 
   Scenario: result

--- a/features/ship/current_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/current_branch/edge_cases/in_subfolder.feature
@@ -9,19 +9,14 @@ Feature: ship the current feature branch from a subfolder on the shipped branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
+      | BRANCH  | COMMAND                      |
+      | feature | git fetch --prune --tags     |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git push origin :feature     |
+      |         | git branch -D feature        |
     And the current branch is now "main"
     And the branches are now
       | REPOSITORY    | BRANCHES |

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -7,6 +7,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | main    | local    | conflicting local commit  | conflicting_file | local content   |
       |         | origin   | conflicting origin commit | conflicting_file | origin content  |
       | feature | local    | feature commit            | feature_file     | feature content |
+    And Git Town setting "sync-before-ship" is "true"
     When I run "git-town ship -m 'feature done'"
 
   Scenario: result

--- a/features/ship/current_branch/features/commit_message_via_cli.feature
+++ b/features/ship/current_branch/features/commit_message_via_cli.feature
@@ -9,19 +9,14 @@ Feature: ship the current feature branch with a tracking branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
+      | BRANCH  | COMMAND                      |
+      | feature | git fetch --prune --tags     |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git push origin :feature     |
+      |         | git branch -D feature        |
     And the current branch is now "main"
     And the branches are now
       | REPOSITORY    | BRANCHES |

--- a/features/ship/current_branch/features/coworker_branch.feature
+++ b/features/ship/current_branch/features/coworker_branch.feature
@@ -12,11 +12,6 @@ Feature: ship a coworker's feature branch
       | BRANCH  | COMMAND                                                                 |
       | feature | git fetch --prune --tags                                                |
       |         | git checkout main                                                       |
-      | main    | git rebase origin/main                                                  |
-      |         | git checkout feature                                                    |
-      | feature | git merge --no-edit origin/feature                                      |
-      |         | git merge --no-edit main                                                |
-      |         | git checkout main                                                       |
       | main    | git merge --squash feature                                              |
       |         | git commit -m "feature done" --author "coworker <coworker@example.com>" |
       |         | git push                                                                |
@@ -32,11 +27,6 @@ Feature: ship a coworker's feature branch
     Then it runs the commands
       | BRANCH  | COMMAND                                               |
       | feature | git fetch --prune --tags                              |
-      |         | git checkout main                                     |
-      | main    | git rebase origin/main                                |
-      |         | git checkout feature                                  |
-      | feature | git merge --no-edit origin/feature                    |
-      |         | git merge --no-edit main                              |
       |         | git checkout main                                     |
       | main    | git merge --squash feature                            |
       |         | git commit --author "coworker <coworker@example.com>" |

--- a/features/ship/current_branch/features/hotfix_branch.feature
+++ b/features/ship/current_branch/features/hotfix_branch.feature
@@ -11,19 +11,14 @@ Feature: ship hotfixes
 
   Scenario: result
     Then it runs the commands
-      | BRANCH     | COMMAND                           |
-      | hotfix     | git fetch --prune --tags          |
-      |            | git checkout production           |
-      | production | git rebase origin/production      |
-      |            | git checkout hotfix               |
-      | hotfix     | git merge --no-edit origin/hotfix |
-      |            | git merge --no-edit production    |
-      |            | git checkout production           |
-      | production | git merge --squash hotfix         |
-      |            | git commit -m "hotfix done"       |
-      |            | git push                          |
-      |            | git push origin :hotfix           |
-      |            | git branch -D hotfix              |
+      | BRANCH     | COMMAND                     |
+      | hotfix     | git fetch --prune --tags    |
+      |            | git checkout production     |
+      | production | git merge --squash hotfix   |
+      |            | git commit -m "hotfix done" |
+      |            | git push                    |
+      |            | git push origin :hotfix     |
+      |            | git branch -D hotfix        |
     And the current branch is now "production"
     And the branches are now
       | REPOSITORY    | BRANCHES         |

--- a/features/ship/current_branch/features/local_branch.feature
+++ b/features/ship/current_branch/features/local_branch.feature
@@ -12,10 +12,6 @@ Feature: ship a local feature branch
       | BRANCH  | COMMAND                      |
       | feature | git fetch --prune --tags     |
       |         | git checkout main            |
-      | main    | git rebase origin/main       |
-      |         | git checkout feature         |
-      | feature | git merge --no-edit main     |
-      |         | git checkout main            |
       | main    | git merge --squash feature   |
       |         | git commit -m "feature done" |
       |         | git push                     |

--- a/features/ship/current_branch/features/local_repo.feature
+++ b/features/ship/current_branch/features/local_repo.feature
@@ -11,8 +11,7 @@ Feature: ship a feature branch in a local repo
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                      |
-      | feature | git merge --no-edit main     |
-      |         | git checkout main            |
+      | feature | git checkout main            |
       | main    | git merge --squash feature   |
       |         | git commit -m "feature done" |
       |         | git branch -D feature        |

--- a/features/ship/current_branch/features/offline.feature
+++ b/features/ship/current_branch/features/offline.feature
@@ -10,16 +10,11 @@ Feature: offline mode
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git branch -D feature              |
+      | BRANCH  | COMMAND                      |
+      | feature | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git branch -D feature        |
     And the current branch is now "main"
     And now these commits exist
       | BRANCH  | LOCATION | MESSAGE        |

--- a/features/ship/current_branch/features/parent_branch.feature
+++ b/features/ship/current_branch/features/parent_branch.feature
@@ -11,18 +11,13 @@ Feature: ship a parent branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                           |
-      | parent | git fetch --prune --tags          |
-      |        | git checkout main                 |
-      | main   | git rebase origin/main            |
-      |        | git checkout parent               |
-      | parent | git merge --no-edit origin/parent |
-      |        | git merge --no-edit main          |
-      |        | git checkout main                 |
-      | main   | git merge --squash parent         |
-      |        | git commit -m "parent done"       |
-      |        | git push                          |
-      |        | git branch -D parent              |
+      | BRANCH | COMMAND                     |
+      | parent | git fetch --prune --tags    |
+      |        | git checkout main           |
+      | main   | git merge --squash parent   |
+      |        | git commit -m "parent done" |
+      |        | git push                    |
+      |        | git branch -D parent        |
     And it prints:
       """
       branch "child" is now a child of "main"

--- a/features/ship/current_branch/features/preserve_git_history.feature
+++ b/features/ship/current_branch/features/preserve_git_history.feature
@@ -25,7 +25,7 @@ Feature: preserve the previous Git branch
     Given a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION |
-      | feature | origin   |
+      | feature | local    |
     And the current branch is "current" and the previous branch is "previous"
     When I run "git-town ship feature -m "feature done""
     Then the current branch is still "current"

--- a/features/ship/current_branch/features/rebase_sync_feature_strategy.feature
+++ b/features/ship/current_branch/features/rebase_sync_feature_strategy.feature
@@ -13,11 +13,6 @@ Feature: "rebase" sync-feature strategy
       | BRANCH  | COMMAND                    |
       | feature | git fetch --prune --tags   |
       |         | git checkout main          |
-      | main    | git rebase origin/main     |
-      |         | git checkout feature       |
-      | feature | git rebase origin/feature  |
-      |         | git rebase main            |
-      |         | git checkout main          |
       | main    | git merge --squash feature |
       |         | git commit                 |
       |         | git push                   |

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -11,18 +11,13 @@ Feature: ship-delete-remote-branch disabled
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git branch -D feature              |
+      | BRANCH  | COMMAND                      |
+      | feature | git fetch --prune --tags     |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git branch -D feature        |
     And the current branch is now "main"
     And the branches are now
       | REPOSITORY    | BRANCHES |

--- a/features/ship/current_branch/features/sync_before_ship.feature
+++ b/features/ship/current_branch/features/sync_before_ship.feature
@@ -5,19 +5,24 @@ Feature: sync-before-ship disabled
     And the commits
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, origin | feature commit |
-    And Git Town setting "sync-before-ship" is "false"
+    And Git Town setting "sync-before-ship" is "true"
     When I run "git-town ship -m 'feature done'"
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                      |
-      | feature | git fetch --prune --tags     |
-      |         | git checkout main            |
-      | main    | git merge --squash feature   |
-      |         | git commit -m "feature done" |
-      |         | git push                     |
-      |         | git push origin :feature     |
-      |         | git branch -D feature        |
+      | BRANCH  | COMMAND                            |
+      | feature | git fetch --prune --tags           |
+      |         | git checkout main                  |
+      | main    | git rebase origin/main             |
+      |         | git checkout feature               |
+      | feature | git merge --no-edit origin/feature |
+      |         | git merge --no-edit main           |
+      |         | git checkout main                  |
+      | main    | git merge --squash feature         |
+      |         | git commit -m "feature done"       |
+      |         | git push                           |
+      |         | git push origin :feature           |
+      |         | git branch -D feature              |
     And the current branch is now "main"
     And the branches are now
       | REPOSITORY    | BRANCHES |

--- a/features/ship/current_branch/features/verbose.feature
+++ b/features/ship/current_branch/features/verbose.feature
@@ -5,6 +5,7 @@ Feature: display all executed Git commands
     And the commits
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, origin | feature commit |
+    And Git Town setting "sync-before-ship" is "true"
 
   Scenario: result
     When I run "git-town ship -m done --verbose"

--- a/features/ship/current_branch/ship_current_branch.feature
+++ b/features/ship/current_branch/ship_current_branch.feature
@@ -9,19 +9,14 @@ Feature: enter the commit message interactively via the editor
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit                         |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
+      | BRANCH  | COMMAND                    |
+      | feature | git fetch --prune --tags   |
+      |         | git checkout main          |
+      | main    | git merge --squash feature |
+      |         | git commit                 |
+      |         | git push                   |
+      |         | git push origin :feature   |
+      |         | git branch -D feature      |
     And the current branch is now "main"
     And the branches are now
       | REPOSITORY    | BRANCHES |

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -12,109 +12,36 @@ Feature: handle conflicts between the supplied feature branch and the main branc
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | other   | git fetch --prune --tags           |
-      |         | git add -A                         |
-      |         | git stash                          |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git push                           |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
+      | BRANCH | COMMAND                    |
+      | other  | git fetch --prune --tags   |
+      |        | git add -A                 |
+      |        | git stash                  |
+      |        | git checkout main          |
+      | main   | git merge --squash feature |
+      |        | git reset --hard           |
+      |        | git checkout other         |
+      | other  | git stash pop              |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
-      To continue after having resolved conflicts, run "git-town continue".
+      aborted because commit exited with error
       """
-    And the current branch is now "feature"
-    And the uncommitted file is stashed
-    And a merge is now in progress
+    And the current branch is still "other"
+    And the uncommitted file still exists
+    And no merge is in progress
 
   Scenario: undo
     When I run "git-town undo"
-    Then it runs the commands
-      | BRANCH  | COMMAND            |
-      | feature | git merge --abort  |
-      |         | git checkout other |
-      | other   | git stash pop      |
+    And it prints the error:
+      """
+      nothing to undo
+      """
+    Then it runs no commands
     And the current branch is now "other"
     And the uncommitted file still exists
     And no merge is in progress
-    And now these commits exist
-      | BRANCH  | LOCATION      | MESSAGE                    |
-      | main    | local, origin | conflicting main commit    |
-      | feature | local         | conflicting feature commit |
-    And the initial branch hierarchy exists
-
-  Scenario: resolve and continue
-    When I resolve the conflict in "conflicting_file"
-    And I run "git-town continue"
-    Then it runs the commands
-      | BRANCH  | COMMAND                      |
-      | feature | git commit --no-edit         |
-      |         | git checkout main            |
-      | main    | git merge --squash feature   |
-      |         | git commit -m "feature done" |
-      |         | git push                     |
-      |         | git push origin :feature     |
-      |         | git branch -D feature        |
-      |         | git checkout other           |
-      | other   | git stash pop                |
-    And the current branch is now "other"
-    And the uncommitted file still exists
-    And the branches are now
-      | REPOSITORY    | BRANCHES    |
-      | local, origin | main, other |
-    And now these commits exist
-      | BRANCH | LOCATION      | MESSAGE                 | FILE NAME        | FILE CONTENT     |
-      | main   | local, origin | conflicting main commit | conflicting_file | main content     |
-      |        |               | feature done            | conflicting_file | resolved content |
-    And this branch lineage exists now
-      | BRANCH | PARENT |
-      | other  | main   |
-
-  Scenario: resolve, commit, and continue
-    When I resolve the conflict in "conflicting_file"
-    And I run "git commit --no-edit"
-    And I run "git-town continue"
-    Then it runs the commands
-      | BRANCH  | COMMAND                      |
-      | feature | git checkout main            |
-      | main    | git merge --squash feature   |
-      |         | git commit -m "feature done" |
-      |         | git push                     |
-      |         | git push origin :feature     |
-      |         | git branch -D feature        |
-      |         | git checkout other           |
-      | other   | git stash pop                |
-    And the current branch is now "other"
-    And the uncommitted file still exists
-
-  Scenario: resolve, continue, and undo
-    When I resolve the conflict in "conflicting_file"
-    And I run "git-town continue"
-    And I run "git-town undo"
-    Then it runs the commands
-      | BRANCH | COMMAND                                                       |
-      | other  | git add -A                                                    |
-      |        | git stash                                                     |
-      |        | git checkout main                                             |
-      | main   | git revert {{ sha 'feature done' }}                           |
-      |        | git push                                                      |
-      |        | git push origin {{ sha 'Initial commit' }}:refs/heads/feature |
-      |        | git branch feature {{ sha 'conflicting feature commit' }}     |
-      |        | git checkout other                                            |
-      | other  | git stash pop                                                 |
-    And the current branch is now "other"
-    And now these commits exist
-      | BRANCH  | LOCATION      | MESSAGE                    |
-      | main    | local, origin | conflicting main commit    |
-      |         |               | feature done               |
-      |         |               | Revert "feature done"      |
-      | feature | local         | conflicting feature commit |
+    And now the initial commits exist
     And the initial branches and hierarchy exist

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_and_main_branch.feature
@@ -35,11 +35,11 @@ Feature: handle conflicts between the supplied feature branch and the main branc
 
   Scenario: undo
     When I run "git-town undo"
+    Then it runs no commands
     And it prints the error:
       """
       nothing to undo
       """
-    Then it runs no commands
     And the current branch is now "other"
     And the uncommitted file still exists
     And no merge is in progress

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -6,6 +6,7 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
       | feature | local    | conflicting local commit  | conflicting_file | local content  |
       |         | origin   | conflicting origin commit | conflicting_file | origin content |
+    And Git Town setting "sync-before-ship" is "true"
     And the current branch is "other"
     And an uncommitted file
     And I run "git-town ship feature -m 'feature done'"

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -7,6 +7,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | main    | local    | conflicting local commit  | conflicting_file | local content   |
       |         | origin   | conflicting origin commit | conflicting_file | origin content  |
       | feature | local    | feature commit            | feature_file     | feature content |
+    And Git Town setting "sync-before-ship" is "true"
     And the current branch is "other"
     And an uncommitted file
     And I run "git-town ship feature -m 'feature done'"

--- a/features/ship/supplied_branch/edge_cases/empty_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_branch.feature
@@ -4,28 +4,20 @@ Feature: does not ship empty feature branches
     Given the feature branches "empty" and "other"
     And the commits
       | BRANCH | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
-      | main   | origin   | main commit    | common_file | common content |
+      | main   | local    | main commit    | common_file | common content |
       | empty  | local    | feature commit | common_file | common content |
     And the current branch is "other"
     And an uncommitted file
     When I run "git-town ship empty"
 
+  @this
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                                     |
-      | other  | git fetch --prune --tags                    |
-      |        | git add -A                                  |
-      |        | git stash                                   |
-      |        | git checkout main                           |
-      | main   | git rebase origin/main                      |
-      |        | git checkout empty                          |
-      | empty  | git merge --no-edit origin/empty            |
-      |        | git merge --no-edit main                    |
-      |        | git reset --hard {{ sha 'feature commit' }} |
-      |        | git checkout main                           |
-      | main   | git reset --hard {{ sha 'Initial commit' }} |
-      |        | git checkout other                          |
-      | other  | git stash pop                               |
+      | BRANCH | COMMAND                  |
+      | other  | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git stash pop            |
     And it prints the error:
       """
       the branch "empty" has no shippable changes

--- a/features/ship/supplied_branch/edge_cases/empty_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_branch.feature
@@ -10,7 +10,6 @@ Feature: does not ship empty feature branches
     And an uncommitted file
     When I run "git-town ship empty"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
+++ b/features/ship/supplied_branch/edge_cases/empty_commit_message.feature
@@ -13,23 +13,16 @@ Feature: abort the ship via empty commit message
   @skipWindows
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                                     |
-      | other   | git fetch --prune --tags                    |
-      |         | git add -A                                  |
-      |         | git stash                                   |
-      |         | git checkout main                           |
-      | main    | git rebase origin/main                      |
-      |         | git checkout feature                        |
-      | feature | git merge --no-edit origin/feature          |
-      |         | git merge --no-edit main                    |
-      |         | git checkout main                           |
-      | main    | git merge --squash feature                  |
-      |         | git commit                                  |
-      |         | git reset --hard                            |
-      |         | git checkout feature                        |
-      | feature | git reset --hard {{ sha 'feature commit' }} |
-      |         | git checkout other                          |
-      | other   | git stash pop                               |
+      | BRANCH | COMMAND                    |
+      | other  | git fetch --prune --tags   |
+      |        | git add -A                 |
+      |        | git stash                  |
+      |        | git checkout main          |
+      | main   | git merge --squash feature |
+      |        | git commit                 |
+      |        | git reset --hard           |
+      |        | git checkout other         |
+      | other  | git stash pop              |
     And it prints the error:
       """
       aborted because commit exited with error

--- a/features/ship/supplied_branch/edge_cases/in_subfolder.feature
+++ b/features/ship/supplied_branch/edge_cases/in_subfolder.feature
@@ -4,30 +4,25 @@ Feature: ship the supplied feature branch from a subfolder
     Given the feature branches "feature" and "other"
     And the commits
       | BRANCH  | LOCATION | MESSAGE        |
-      | feature | origin   | feature commit |
+      | feature | local    | feature commit |
     And the current branch is "other"
     And an uncommitted file with name "new_folder/other_feature_file" and content "other feature content"
     When I run "git-town ship feature -m 'feature done'" in the "new_folder" folder
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | other   | git fetch --prune --tags           |
-      |         | git add -A                         |
-      |         | git stash                          |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
-      |         | git checkout other                 |
-      | other   | git stash pop                      |
+      | BRANCH | COMMAND                      |
+      | other  | git fetch --prune --tags     |
+      |        | git add -A                   |
+      |        | git stash                    |
+      |        | git checkout main            |
+      | main   | git merge --squash feature   |
+      |        | git commit -m "feature done" |
+      |        | git push                     |
+      |        | git push origin :feature     |
+      |        | git branch -D feature        |
+      |        | git checkout other           |
+      | other  | git stash pop                |
     And the current branch is now "other"
     And the uncommitted file still exists
     And the branches are now
@@ -49,8 +44,8 @@ Feature: ship the supplied feature branch from a subfolder
       |        | git checkout main                                             |
       | main   | git revert {{ sha 'feature done' }}                           |
       |        | git push                                                      |
-      |        | git push origin {{ sha 'feature commit' }}:refs/heads/feature |
-      |        | git branch feature {{ sha 'Initial commit' }}                 |
+      |        | git push origin {{ sha 'Initial commit' }}:refs/heads/feature |
+      |        | git branch feature {{ sha 'feature commit' }}                 |
       |        | git checkout other                                            |
       | other  | git stash pop                                                 |
     And the current branch is now "other"
@@ -58,5 +53,5 @@ Feature: ship the supplied feature branch from a subfolder
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, origin | feature done          |
       |         |               | Revert "feature done" |
-      | feature | origin        | feature commit        |
+      | feature | local         | feature commit        |
     And the initial branches and hierarchy exist

--- a/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -9,19 +9,14 @@ Feature: ship the current feature branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | feature | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
+      | BRANCH  | COMMAND                      |
+      | feature | git fetch --prune --tags     |
+      |         | git checkout main            |
+      | main    | git merge --squash feature   |
+      |         | git commit -m "feature done" |
+      |         | git push                     |
+      |         | git push origin :feature     |
+      |         | git branch -D feature        |
     And the current branch is now "main"
     And the branches are now
       | REPOSITORY    | BRANCHES |

--- a/features/ship/supplied_branch/features/commit_message_via_cli.feature
+++ b/features/ship/supplied_branch/features/commit_message_via_cli.feature
@@ -9,25 +9,21 @@ Feature: provide the commit message via a CLI argument
     And an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
 
+  @this
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | other   | git fetch --prune --tags           |
-      |         | git add -A                         |
-      |         | git stash                          |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
-      |         | git checkout other                 |
-      | other   | git stash pop                      |
+      | BRANCH | COMMAND                      |
+      | other  | git fetch --prune --tags     |
+      |        | git add -A                   |
+      |        | git stash                    |
+      |        | git checkout main            |
+      | main   | git merge --squash feature   |
+      |        | git commit -m "feature done" |
+      |        | git push                     |
+      |        | git push origin :feature     |
+      |        | git branch -D feature        |
+      |        | git checkout other           |
+      | other  | git stash pop                |
     And the current branch is now "other"
     And the uncommitted file still exists
     And the branches are now

--- a/features/ship/supplied_branch/features/commit_message_via_cli.feature
+++ b/features/ship/supplied_branch/features/commit_message_via_cli.feature
@@ -9,7 +9,6 @@ Feature: provide the commit message via a CLI argument
     And an uncommitted file with name "conflicting_file" and content "conflicting content"
     When I run "git-town ship feature -m 'feature done'"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                      |

--- a/features/ship/supplied_branch/features/local_branch.feature
+++ b/features/ship/supplied_branch/features/local_branch.feature
@@ -11,23 +11,18 @@ Feature: ship the supplied feature branch without a tracking branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | other   | git fetch --prune --tags           |
-      |         | git add -A                         |
-      |         | git stash                          |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
-      |         | git checkout other                 |
-      | other   | git stash pop                      |
+      | BRANCH | COMMAND                      |
+      | other  | git fetch --prune --tags     |
+      |        | git add -A                   |
+      |        | git stash                    |
+      |        | git checkout main            |
+      | main   | git merge --squash feature   |
+      |        | git commit -m "feature done" |
+      |        | git push                     |
+      |        | git push origin :feature     |
+      |        | git branch -D feature        |
+      |        | git checkout other           |
+      | other  | git stash pop                |
     And the current branch is now "other"
     And the uncommitted file still exists
     And the branches are now

--- a/features/ship/supplied_branch/features/local_repo.feature
+++ b/features/ship/supplied_branch/features/local_repo.feature
@@ -12,17 +12,15 @@ Feature: ship the supplied feature branch in a local repo
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                      |
-      | other   | git add -A                   |
-      |         | git stash                    |
-      |         | git checkout feature         |
-      | feature | git merge --no-edit main     |
-      |         | git checkout main            |
-      | main    | git merge --squash feature   |
-      |         | git commit -m "feature done" |
-      |         | git branch -D feature        |
-      |         | git checkout other           |
-      | other   | git stash pop                |
+      | BRANCH | COMMAND                      |
+      | other  | git add -A                   |
+      |        | git stash                    |
+      |        | git checkout main            |
+      | main   | git merge --squash feature   |
+      |        | git commit -m "feature done" |
+      |        | git branch -D feature        |
+      |        | git checkout other           |
+      | other  | git stash pop                |
     And the current branch is now "other"
     And the uncommitted file still exists
     And the branches are now

--- a/features/ship/supplied_branch/features/parent_branch.feature
+++ b/features/ship/supplied_branch/features/parent_branch.feature
@@ -12,19 +12,14 @@ Feature: ship a parent branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                           |
-      | child  | git fetch --prune --tags          |
-      |        | git checkout main                 |
-      | main   | git rebase origin/main            |
-      |        | git checkout parent               |
-      | parent | git merge --no-edit origin/parent |
-      |        | git merge --no-edit main          |
-      |        | git checkout main                 |
-      | main   | git merge --squash parent         |
-      |        | git commit -m "parent done"       |
-      |        | git push                          |
-      |        | git branch -D parent              |
-      |        | git checkout child                |
+      | BRANCH | COMMAND                     |
+      | child  | git fetch --prune --tags    |
+      |        | git checkout main           |
+      | main   | git merge --squash parent   |
+      |        | git commit -m "parent done" |
+      |        | git push                    |
+      |        | git branch -D parent        |
+      |        | git checkout child          |
     And the current branch is now "child"
     And now these commits exist
       | BRANCH | LOCATION      | MESSAGE       |

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -1,4 +1,3 @@
-@this
 Feature: skip deleting the remote branch when shipping another branch
 
   Background:

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -1,3 +1,4 @@
+@this
 Feature: skip deleting the remote branch when shipping another branch
 
   Background:
@@ -13,19 +14,14 @@ Feature: skip deleting the remote branch when shipping another branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | other   | git fetch --prune --tags           |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit -m "feature done"       |
-      |         | git push                           |
-      |         | git branch -D feature              |
-      |         | git checkout other                 |
+      | BRANCH | COMMAND                      |
+      | other  | git fetch --prune --tags     |
+      |        | git checkout main            |
+      | main   | git merge --squash feature   |
+      |        | git commit -m "feature done" |
+      |        | git push                     |
+      |        | git branch -D feature        |
+      |        | git checkout other           |
     And the current branch is now "other"
     And the branches are now
       | REPOSITORY    | BRANCHES    |

--- a/features/ship/supplied_branch/ship_supplied_branch.feature
+++ b/features/ship/supplied_branch/ship_supplied_branch.feature
@@ -11,23 +11,18 @@ Feature: ship the supplied feature branch
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                            |
-      | other   | git fetch --prune --tags           |
-      |         | git add -A                         |
-      |         | git stash                          |
-      |         | git checkout main                  |
-      | main    | git rebase origin/main             |
-      |         | git checkout feature               |
-      | feature | git merge --no-edit origin/feature |
-      |         | git merge --no-edit main           |
-      |         | git checkout main                  |
-      | main    | git merge --squash feature         |
-      |         | git commit                         |
-      |         | git push                           |
-      |         | git push origin :feature           |
-      |         | git branch -D feature              |
-      |         | git checkout other                 |
-      | other   | git stash pop                      |
+      | BRANCH | COMMAND                    |
+      | other  | git fetch --prune --tags   |
+      |        | git add -A                 |
+      |        | git stash                  |
+      |        | git checkout main          |
+      | main   | git merge --squash feature |
+      |        | git commit                 |
+      |        | git push                   |
+      |        | git push origin :feature   |
+      |        | git branch -D feature      |
+      |        | git checkout other         |
+      | other  | git stash pop              |
     And the current branch is now "other"
     And the uncommitted file still exists
     And the branches are now

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -428,7 +428,7 @@ func (self *GitTown) ShouldSyncUpstream() (bool, error) {
 func (self *GitTown) SyncBeforeShip() (bool, error) {
 	text := self.LocalOrGlobalConfigValue(KeySyncBeforeShip)
 	if text == "" {
-		return true, nil
+		return false, nil
 	}
 	return ParseBool(text)
 }


### PR DESCRIPTION
Most people ship feature branches via the web hosting UI. Disabling this option makes more sense in this scenario.