### PR TITLE
Improvements to the logic for setting the previous branch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,9 @@ issues:
     - path: src/gohacks/cache/cache.go
       linters:
         - ireturn
+    - path: src/gohacks/cache/with_previous.go
+      linters:
+        - ireturn
     - path: src/gohacks/slice/first_element_or.go
       linters:
         - ireturn

--- a/features/append/features/tracking_branch_deleted.feature
+++ b/features/append/features/tracking_branch_deleted.feature
@@ -10,7 +10,6 @@ Feature: append a branch to a branch whose tracking branch was deleted
     And an uncommitted file
     When I run "git-town append new"
 
-  @debug @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                  |

--- a/features/append/features/tracking_branch_deleted.feature
+++ b/features/append/features/tracking_branch_deleted.feature
@@ -10,6 +10,7 @@ Feature: append a branch to a branch whose tracking branch was deleted
     And an uncommitted file
     When I run "git-town append new"
 
+  @debug @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                  |

--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -33,15 +33,13 @@ Feature: display all executed Git commands
       |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       |          | backend  | git config git-town-branch.new.parent existing       |
       | existing | frontend | git checkout new                                     |
-      |          | backend  | git show-ref --quiet refs/heads/existing             |
-      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}            |
       |          | backend  | git config -lz --global                              |
       |          | backend  | git config -lz --local                               |
       |          | backend  | git branch -vva                                      |
       |          | backend  | git stash list                                       |
     And it prints:
       """
-      Ran 29 shell commands.
+      Ran 27 shell commands.
       """
     And the current branch is now "new"
 

--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -33,13 +33,14 @@ Feature: display all executed Git commands
       |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       |          | backend  | git config git-town-branch.new.parent existing       |
       | existing | frontend | git checkout new                                     |
+      |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       |          | backend  | git config -lz --global                              |
       |          | backend  | git config -lz --local                               |
       |          | backend  | git branch -vva                                      |
       |          | backend  | git stash list                                       |
     And it prints:
       """
-      Ran 27 shell commands.
+      Ran 28 shell commands.
       """
     And the current branch is now "new"
 

--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -50,6 +50,6 @@ Feature: display all executed Git commands
     When I run "git-town undo --verbose"
     Then it prints:
       """
-      Ran 19 shell commands.
+      Ran 17 shell commands.
       """
     And the current branch is now "existing"

--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -33,6 +33,7 @@ Feature: display all executed Git commands
       |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       |          | backend  | git config git-town-branch.new.parent existing       |
       | existing | frontend | git checkout new                                     |
+      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}            |
       |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       |          | backend  | git config -lz --global                              |
       |          | backend  | git config -lz --local                               |
@@ -40,7 +41,7 @@ Feature: display all executed Git commands
       |          | backend  | git stash list                                       |
     And it prints:
       """
-      Ran 28 shell commands.
+      Ran 29 shell commands.
       """
     And the current branch is now "new"
 

--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -49,6 +49,6 @@ Feature: display all executed Git commands
     When I run "git-town undo --verbose"
     Then it prints:
       """
-      Ran 21 shell commands.
+      Ran 19 shell commands.
       """
     And the current branch is now "existing"

--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -33,7 +33,6 @@ Feature: display all executed Git commands
       |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       |          | backend  | git config git-town-branch.new.parent existing       |
       | existing | frontend | git checkout new                                     |
-      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}            |
       |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       |          | backend  | git config -lz --global                              |
       |          | backend  | git config -lz --local                               |
@@ -41,7 +40,7 @@ Feature: display all executed Git commands
       |          | backend  | git stash list                                       |
     And it prints:
       """
-      Ran 29 shell commands.
+      Ran 28 shell commands.
       """
     And the current branch is now "new"
 
@@ -50,6 +49,6 @@ Feature: display all executed Git commands
     When I run "git-town undo --verbose"
     Then it prints:
       """
-      Ran 17 shell commands.
+      Ran 16 shell commands.
       """
     And the current branch is now "existing"

--- a/features/hack/features/verbose.feature
+++ b/features/hack/features/verbose.feature
@@ -28,15 +28,13 @@ Feature: display all executed Git commands
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git config git-town-branch.new.parent main    |
       | main   | frontend | git checkout new                              |
-      |        | backend  | git show-ref --quiet refs/heads/main          |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
       |        | backend  | git branch -vva                               |
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 24 shell commands.
+      Ran 22 shell commands.
       """
     And the current branch is now "new"
 

--- a/features/hack/features/verbose.feature
+++ b/features/hack/features/verbose.feature
@@ -28,13 +28,14 @@ Feature: display all executed Git commands
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git config git-town-branch.new.parent main    |
       | main   | frontend | git checkout new                              |
+      |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
       |        | backend  | git branch -vva                               |
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 22 shell commands.
+      Ran 23 shell commands.
       """
     And the current branch is now "new"
 

--- a/features/hack/features/verbose.feature
+++ b/features/hack/features/verbose.feature
@@ -28,6 +28,7 @@ Feature: display all executed Git commands
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git config git-town-branch.new.parent main    |
       | main   | frontend | git checkout new                              |
+      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
@@ -35,7 +36,7 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 23 shell commands.
+      Ran 24 shell commands.
       """
     And the current branch is now "new"
 
@@ -58,15 +59,13 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --short HEAD                    |
       | main   | frontend | git reset --hard {{ sha 'initial commit' }}   |
       |        | frontend | git branch -D new                             |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main |
-      |        | backend  | git checkout main                             |
-      |        | backend  | git checkout main                             |
+      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
       |        | backend  | git branch -vva                               |
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 21 shell commands.
+      Ran 19 shell commands.
       """
     And the current branch is now "main"

--- a/features/hack/features/verbose.feature
+++ b/features/hack/features/verbose.feature
@@ -58,9 +58,7 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --short HEAD                    |
       | main   | frontend | git reset --hard {{ sha 'initial commit' }}   |
       |        | frontend | git branch -D new                             |
-      |        | backend  | git show-ref --quiet refs/heads/main          |
-      |        | backend  | git show-ref --quiet refs/heads/new           |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
+      |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git checkout main                             |
       |        | backend  | git checkout main                             |
       |        | backend  | git config -lz --global                       |
@@ -69,6 +67,6 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 23 shell commands.
+      Ran 21 shell commands.
       """
     And the current branch is now "main"

--- a/features/hack/features/verbose.feature
+++ b/features/hack/features/verbose.feature
@@ -28,7 +28,6 @@ Feature: display all executed Git commands
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git config git-town-branch.new.parent main    |
       | main   | frontend | git checkout new                              |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
@@ -36,7 +35,7 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 24 shell commands.
+      Ran 23 shell commands.
       """
     And the current branch is now "new"
 
@@ -59,13 +58,12 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --short HEAD                    |
       | main   | frontend | git reset --hard {{ sha 'initial commit' }}   |
       |        | frontend | git branch -D new                             |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
       |        | backend  | git branch -vva                               |
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 19 shell commands.
+      Ran 18 shell commands.
       """
     And the current branch is now "main"

--- a/features/kill/current_branch/features/preserve_git_history.feature
+++ b/features/kill/current_branch/features/preserve_git_history.feature
@@ -9,7 +9,6 @@ Feature: preserve the previous Git branch
     Then the current branch is now "main"
     And the previous Git branch is still "previous"
 
-  @debug @this
   Scenario: previous branch gone
     When I run "git-town kill previous -v"
     Then the current branch is still "current"

--- a/features/kill/current_branch/features/preserve_git_history.feature
+++ b/features/kill/current_branch/features/preserve_git_history.feature
@@ -9,8 +9,9 @@ Feature: preserve the previous Git branch
     Then the current branch is now "main"
     And the previous Git branch is still "previous"
 
+  @debug @this
   Scenario: previous branch gone
-    When I run "git-town kill previous"
+    When I run "git-town kill previous -v"
     Then the current branch is still "current"
     And the previous Git branch is now "main"
 

--- a/features/kill/current_branch/features/preserve_git_history.feature
+++ b/features/kill/current_branch/features/preserve_git_history.feature
@@ -10,7 +10,7 @@ Feature: preserve the previous Git branch
     And the previous Git branch is still "previous"
 
   Scenario: previous branch gone
-    When I run "git-town kill previous -v"
+    When I run "git-town kill previous"
     Then the current branch is still "current"
     And the previous Git branch is now ""
 

--- a/features/kill/current_branch/features/preserve_git_history.feature
+++ b/features/kill/current_branch/features/preserve_git_history.feature
@@ -13,7 +13,7 @@ Feature: preserve the previous Git branch
   Scenario: previous branch gone
     When I run "git-town kill previous -v"
     Then the current branch is still "current"
-    And the previous Git branch is now "main"
+    And the previous Git branch is now ""
 
   Scenario: current and previous branch exist
     Given a feature branch "victim"

--- a/features/kill/current_branch/features/verbose.feature
+++ b/features/kill/current_branch/features/verbose.feature
@@ -29,7 +29,7 @@ Feature: display all executed Git commands
       |         | backend  | git log main..current                             |
       | main    | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |
-      |         | backend  | git show-ref --verify --quiet refs/heads/current  |
+      |         | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
       |         | backend  | git show-ref --verify --quiet refs/heads/other    |
       |         | backend  | git checkout other                                |
       |         | backend  | git checkout main                                 |

--- a/features/kill/current_branch/features/verbose.feature
+++ b/features/kill/current_branch/features/verbose.feature
@@ -29,7 +29,6 @@ Feature: display all executed Git commands
       |         | backend  | git log main..current                             |
       | main    | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |
-      |         | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
       |         | backend  | git show-ref --verify --quiet refs/heads/other    |
       |         | backend  | git checkout other                                |
       |         | backend  | git checkout main                                 |
@@ -39,6 +38,6 @@ Feature: display all executed Git commands
       |         | backend  | git stash list                                    |
     And it prints:
       """
-      Ran 25 shell commands.
+      Ran 24 shell commands.
       """
     And the current branch is now "main"

--- a/features/kill/current_branch/features/verbose.feature
+++ b/features/kill/current_branch/features/verbose.feature
@@ -29,6 +29,7 @@ Feature: display all executed Git commands
       |         | backend  | git log main..current                             |
       | main    | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |
+      |         | backend  | git show-ref --verify --quiet refs/heads/current  |
       |         | backend  | git show-ref --verify --quiet refs/heads/other    |
       |         | backend  | git checkout other                                |
       |         | backend  | git checkout main                                 |
@@ -38,6 +39,6 @@ Feature: display all executed Git commands
       |         | backend  | git stash list                                    |
     And it prints:
       """
-      Ran 24 shell commands.
+      Ran 25 shell commands.
       """
     And the current branch is now "main"

--- a/features/kill/current_branch/features/verbose.feature
+++ b/features/kill/current_branch/features/verbose.feature
@@ -29,9 +29,7 @@ Feature: display all executed Git commands
       |         | backend  | git log main..current                             |
       | main    | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |
-      |         | backend  | git show-ref --quiet refs/heads/other             |
-      |         | backend  | git show-ref --quiet refs/heads/current           |
-      |         | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
+      |         | backend  | git show-ref --verify --quiet refs/heads/other    |
       |         | backend  | git checkout other                                |
       |         | backend  | git checkout main                                 |
       |         | backend  | git config -lz --global                           |
@@ -40,6 +38,6 @@ Feature: display all executed Git commands
       |         | backend  | git stash list                                    |
     And it prints:
       """
-      Ran 26 shell commands.
+      Ran 24 shell commands.
       """
     And the current branch is now "main"

--- a/features/kill/supplied_branch/features/local_repo.feature
+++ b/features/kill/supplied_branch/features/local_repo.feature
@@ -15,7 +15,10 @@ Feature: local repository
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND             |
-      | good   | git branch -D other |
+      | good   | git add -A          |
+      |        | git stash           |
+      |        | git branch -D other |
+      |        | git stash pop       |
     And the current branch is still "good"
     And the uncommitted file still exists
     And the branches are now

--- a/features/kill/supplied_branch/features/parent_branch.feature
+++ b/features/kill/supplied_branch/features/parent_branch.feature
@@ -17,8 +17,11 @@ Feature: delete a parent branch
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | gamma  | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
       |        | git push origin :beta    |
       |        | git branch -D beta       |
+      |        | git stash pop            |
     And the current branch is now "gamma"
     And the uncommitted file still exists
     And the branches are now

--- a/features/kill/supplied_branch/kill.feature
+++ b/features/kill/supplied_branch/kill.feature
@@ -15,8 +15,11 @@ Feature: delete another than the current branch
     Then it runs the commands
       | BRANCH | COMMAND                  |
       | good   | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
       |        | git push origin :dead    |
       |        | git branch -D dead       |
+      |        | git stash pop            |
     And the current branch is still "good"
     And the uncommitted file still exists
     And the branches are now

--- a/features/prepend/features/verbose.feature
+++ b/features/prepend/features/verbose.feature
@@ -36,15 +36,14 @@ Feature: display all executed Git commands
       |        | backend  | git show-ref --verify --quiet refs/heads/old  |
       |        | backend  | git config git-town-branch.old.parent parent  |
       | old    | frontend | git checkout parent                           |
-      |        | backend  | git show-ref --quiet refs/heads/old           |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
+      |        | backend  | git show-ref --verify --quiet refs/heads/old  |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
       |        | backend  | git branch -vva                               |
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 31 shell commands.
+      Ran 30 shell commands.
       """
     And the current branch is now "parent"
 
@@ -66,9 +65,7 @@ Feature: display all executed Git commands
       |        | backend  | git config git-town-branch.old.parent main       |
       | parent | frontend | git checkout old                                 |
       | old    | frontend | git branch -D parent                             |
-      |        | backend  | git show-ref --quiet refs/heads/old              |
-      |        | backend  | git show-ref --quiet refs/heads/parent           |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}        |
+      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
       |        | backend  | git checkout old                                 |
       |        | backend  | git checkout old                                 |
       |        | backend  | git config -lz --global                          |
@@ -77,6 +74,6 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                   |
     And it prints:
       """
-      Ran 22 shell commands.
+      Ran 20 shell commands.
       """
     And the current branch is now "old"

--- a/features/prepend/features/verbose.feature
+++ b/features/prepend/features/verbose.feature
@@ -65,15 +65,12 @@ Feature: display all executed Git commands
       |        | backend  | git config git-town-branch.old.parent main       |
       | parent | frontend | git checkout old                                 |
       | old    | frontend | git branch -D parent                             |
-      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
-      |        | backend  | git checkout old                                 |
-      |        | backend  | git checkout old                                 |
       |        | backend  | git config -lz --global                          |
       |        | backend  | git config -lz --local                           |
       |        | backend  | git branch -vva                                  |
       |        | backend  | git stash list                                   |
     And it prints:
       """
-      Ran 20 shell commands.
+      Ran 17 shell commands.
       """
     And the current branch is now "old"

--- a/features/propose/features/verbose.feature
+++ b/features/propose/features/verbose.feature
@@ -26,8 +26,7 @@ Feature: display all executed Git commands
       | feature | frontend | git merge --no-edit origin/feature                                 |
       |         | frontend | git merge --no-edit main                                           |
       |         | backend  | git rev-list --left-right feature...origin/feature                 |
-      |         | backend  | git show-ref --quiet refs/heads/main                               |
-      |         | backend  | git rev-parse --verify --abbrev-ref @{-1}                          |
+      |         | backend  | git show-ref --verify --quiet refs/heads/main                      |
       |         | backend  | which wsl-open                                                     |
       |         | backend  | which garcon-url-handler                                           |
       |         | backend  | which xdg-open                                                     |
@@ -39,7 +38,7 @@ Feature: display all executed Git commands
       |         | backend  | git stash list                                                     |
     And it prints:
       """
-      Ran 29 shell commands.
+      Ran 28 shell commands.
       """
     And "open" launches a new proposal with this url in my browser:
       """

--- a/features/rename_branch/features/preserve_git_history.feature
+++ b/features/rename_branch/features/preserve_git_history.feature
@@ -12,4 +12,4 @@ Feature: preserve the previous Git branch
   Scenario: previous branch renamed
     When I run "git-town rename-branch previous new"
     Then the current branch is now "current"
-    And the previous Git branch is now "main"
+    And the previous Git branch is now "new"

--- a/features/rename_branch/features/verbose.feature
+++ b/features/rename_branch/features/verbose.feature
@@ -29,9 +29,7 @@ Feature: display all executed Git commands
       |        | frontend | git push origin :old                          |
       |        | backend  | git log main..old                             |
       | new    | frontend | git branch -D old                             |
-      |        | backend  | git show-ref --quiet refs/heads/main          |
-      |        | backend  | git show-ref --quiet refs/heads/old           |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
+      |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git checkout main                             |
       |        | backend  | git checkout new                              |
       |        | backend  | git config -lz --global                       |
@@ -40,7 +38,7 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 27 shell commands.
+      Ran 25 shell commands.
       """
     And the current branch is now "new"
 
@@ -65,9 +63,7 @@ Feature: display all executed Git commands
       |        | frontend | git push origin :new                          |
       |        | frontend | git checkout old                              |
       | old    | frontend | git branch -D new                             |
-      |        | backend  | git show-ref --quiet refs/heads/main          |
-      |        | backend  | git show-ref --quiet refs/heads/new           |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
+      |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git checkout main                             |
       |        | backend  | git checkout old                              |
       |        | backend  | git config -lz --global                       |
@@ -76,6 +72,6 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 25 shell commands.
+      Ran 23 shell commands.
       """
     And the current branch is now "old"

--- a/features/ship/current_branch/features/verbose.feature
+++ b/features/ship/current_branch/features/verbose.feature
@@ -45,17 +45,14 @@ Feature: display all executed Git commands
       |         | backend  | git log main..feature                             |
       | main    | frontend | git branch -D feature                             |
       |         | backend  | git config --unset git-town-branch.feature.parent |
-      |         | backend  | git show-ref --quiet refs/heads/feature           |
-      |         | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
-      |         | backend  | git checkout main                                 |
-      |         | backend  | git checkout main                                 |
+      |         | backend  | git show-ref --verify --quiet refs/heads/feature  |
       |         | backend  | git config -lz --global                           |
       |         | backend  | git config -lz --local                            |
       |         | backend  | git branch -vva                                   |
       |         | backend  | git stash list                                    |
     And it prints:
       """
-      Ran 42 shell commands.
+      Ran 39 shell commands.
       """
     And the current branch is now "main"
 
@@ -81,14 +78,13 @@ Feature: display all executed Git commands
       |        | frontend | git branch feature {{ sha 'feature commit' }}  |
       |        | frontend | git push -u origin feature                     |
       |        | frontend | git checkout feature                           |
-      |        | backend  | git show-ref --quiet refs/heads/main           |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}      |
+      |        | backend  | git show-ref --verify --quiet refs/heads/      |
       |        | backend  | git config -lz --global                        |
       |        | backend  | git config -lz --local                         |
       |        | backend  | git branch -vva                                |
       |        | backend  | git stash list                                 |
     And it prints:
       """
-      Ran 23 shell commands.
+      Ran 22 shell commands.
       """
     And the current branch is now "feature"

--- a/features/sync/all_branches/features/preserve_git_history.feature
+++ b/features/sync/all_branches/features/preserve_git_history.feature
@@ -1,3 +1,4 @@
+@this
 Feature: preserve the previous Git branch
 
   Background:
@@ -8,7 +9,7 @@ Feature: preserve the previous Git branch
     Given origin deletes the "current" branch
     When I run "git-town sync --all"
     Then the current branch is now "previous"
-    And the previous Git branch is still "previous"
+    And the previous Git branch is now "main"
 
   Scenario: current branch exists, previous branch gone
     Given origin deletes the "previous" branch
@@ -21,7 +22,7 @@ Feature: preserve the previous Git branch
     And origin deletes the "current" branch
     When I run "git-town sync --all"
     Then the current branch is now "main"
-    And the previous Git branch is now "main"
+    And the previous Git branch is now ""
 
   Scenario: both branches exist
     When I run "git-town sync --all"

--- a/features/sync/all_branches/features/preserve_git_history.feature
+++ b/features/sync/all_branches/features/preserve_git_history.feature
@@ -1,4 +1,3 @@
-@this
 Feature: preserve the previous Git branch
 
   Background:

--- a/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/verbose.feature
+++ b/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/verbose.feature
@@ -34,18 +34,13 @@ Feature: display all executed Git commands
       | main   | frontend | git branch -d old                             |
       |        | backend  | git config --unset git-town-branch.old.parent |
       |        | backend  | git show-ref --quiet refs/heads/old           |
-      |        | backend  | git show-ref --quiet refs/heads/main          |
-      |        | backend  | git show-ref --quiet refs/heads/old           |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
-      |        | backend  | git checkout main                             |
-      |        | backend  | git checkout main                             |
       |        | backend  | git config -lz --global                       |
       |        | backend  | git config -lz --local                        |
       |        | backend  | git branch -vva                               |
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 31 shell commands.
+      Ran 26 shell commands.
       """
     And the current branch is now "main"
     And the branches are now
@@ -72,15 +67,14 @@ Feature: display all executed Git commands
       |        | backend  | git config git-town-branch.old.parent main |
       | main   | frontend | git branch old {{ sha 'initial commit' }}  |
       |        | frontend | git checkout old                           |
-      |        | backend  | git show-ref --quiet refs/heads/main       |
-      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}  |
+      |        | backend  | git show-ref --verify --quiet refs/heads/  |
       |        | backend  | git config -lz --global                    |
       |        | backend  | git config -lz --local                     |
       |        | backend  | git branch -vva                            |
       |        | backend  | git stash list                             |
     And it prints:
       """
-      Ran 18 shell commands.
+      Ran 17 shell commands.
       """
     And the current branch is now "old"
     And the initial branches and hierarchy exist

--- a/features/sync/features/verbose.feature
+++ b/features/sync/features/verbose.feature
@@ -34,14 +34,13 @@ Feature: display all executed Git commands
       |         | backend  | git rev-list --left-right feature...origin/feature |
       | feature | frontend | git push                                           |
       |         | backend  | git show-ref --quiet refs/heads/feature            |
-      |         | backend  | git show-ref --quiet refs/heads/main               |
-      |         | backend  | git rev-parse --verify --abbrev-ref @{-1}          |
+      |         | backend  | git show-ref --verify --quiet refs/heads/main      |
       |         | backend  | git config -lz --global                            |
       |         | backend  | git config -lz --local                             |
       |         | backend  | git branch -vva                                    |
       |         | backend  | git stash list                                     |
     And it prints:
       """
-      Ran 27 shell commands.
+      Ran 26 shell commands.
       """
     And all branches are now synchronized

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -201,7 +201,7 @@ func appendProgram(config *appendConfig) program.Program {
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
-		PreviousBranch:   config.previousBranch,
+		PreviousBranch:   config.branches.Initial,
 	})
 	return prog
 }

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -198,11 +198,10 @@ func appendProgram(config *appendConfig) program.Program {
 	if config.remotes.HasOrigin() && config.shouldNewBranchPush && !config.isOffline {
 		prog.Add(&opcode.CreateTrackingBranch{Branch: config.targetBranch, NoPushHook: !config.pushHook})
 	}
-	previousBranchCandidates := domain.LocalBranchNames{config.branches.Initial, config.previousBranch}
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:             true,
 		StashOpenChanges:         config.hasOpenChanges,
-		PreviousBranchCandidates: previousBranchCandidates,
+		PreviousBranchCandidates: domain.LocalBranchNames{config.branches.Initial, config.previousBranch},
 	})
 	return prog
 }

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -201,8 +201,6 @@ func appendProgram(config *appendConfig) program.Program {
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
-		MainBranch:       config.mainBranch,
-		InitialBranch:    config.branches.Initial,
 		PreviousBranch:   config.previousBranch,
 	})
 	return prog

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -199,7 +199,6 @@ func appendProgram(config *appendConfig) program.Program {
 		prog.Add(&opcode.CreateTrackingBranch{Branch: config.targetBranch, NoPushHook: !config.pushHook})
 	}
 	previousBranchCandidates := domain.LocalBranchNames{config.branches.Initial, config.previousBranch}
-	previousBranchCandidates = append(previousBranchCandidates, config.lineage.Ancestors(config.branches.Initial)...)
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:             true,
 		StashOpenChanges:         config.hasOpenChanges,

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -198,7 +198,7 @@ func appendProgram(config *appendConfig) program.Program {
 	if config.remotes.HasOrigin() && config.shouldNewBranchPush && !config.isOffline {
 		prog.Add(&opcode.CreateTrackingBranch{Branch: config.targetBranch, NoPushHook: !config.pushHook})
 	}
-	previousBranchCandidates := domain.FromLocalBranchNames(config.branches.Initial, config.previousBranch)
+	previousBranchCandidates := domain.LocalBranchNames{config.branches.Initial, config.previousBranch}
 	previousBranchCandidates = append(previousBranchCandidates, config.lineage.Ancestors(config.branches.Initial)...)
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:             true,

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -198,10 +198,12 @@ func appendProgram(config *appendConfig) program.Program {
 	if config.remotes.HasOrigin() && config.shouldNewBranchPush && !config.isOffline {
 		prog.Add(&opcode.CreateTrackingBranch{Branch: config.targetBranch, NoPushHook: !config.pushHook})
 	}
+	previousBranchCandidates := domain.FromLocalBranchNames(config.branches.Initial, config.previousBranch)
+	previousBranchCandidates = append(previousBranchCandidates, config.lineage.Ancestors(config.branches.Initial)...)
 	wrap(&prog, wrapOptions{
-		RunInGitRoot:     true,
-		StashOpenChanges: config.hasOpenChanges,
-		PreviousBranch:   config.branches.Initial,
+		RunInGitRoot:             true,
+		StashOpenChanges:         config.hasOpenChanges,
+		PreviousBranchCandidates: previousBranchCandidates,
 	})
 	return prog
 }

--- a/src/cmd/core.go
+++ b/src/cmd/core.go
@@ -43,11 +43,9 @@ func long(summary string, desc ...string) string {
 // wrap wraps the given list with opcodes that change the Git root directory or stash away open changes.
 // TODO: only wrap if the list actually contains any opcodes.
 func wrap(program *program.Program, options wrapOptions) {
-	if !options.PreviousBranchCandidates.IsEmpty() {
-		program.Add(&opcode.PreserveCheckoutHistory{
-			PreviousBranchCandidates: options.PreviousBranchCandidates,
-		})
-	}
+	program.Add(&opcode.PreserveCheckoutHistory{
+		PreviousBranchCandidates: options.PreviousBranchCandidates,
+	})
 	if options.StashOpenChanges {
 		program.Prepend(&opcode.StashOpenChanges{})
 		program.Add(&opcode.RestoreOpenChanges{})

--- a/src/cmd/core.go
+++ b/src/cmd/core.go
@@ -43,9 +43,9 @@ func long(summary string, desc ...string) string {
 // wrap wraps the given list with opcodes that change the Git root directory or stash away open changes.
 // TODO: only wrap if the list actually contains any opcodes.
 func wrap(program *program.Program, options wrapOptions) {
-	if !options.PreviousBranch.IsEmpty() {
+	if !options.PreviousBranchCandidates.IsEmpty() {
 		program.Add(&opcode.PreserveCheckoutHistory{
-			PreviousBranch: options.PreviousBranch,
+			PreviousBranchCandidates: options.PreviousBranchCandidates,
 		})
 	}
 	if options.StashOpenChanges {
@@ -56,7 +56,7 @@ func wrap(program *program.Program, options wrapOptions) {
 
 // wrapOptions represents the options given to Wrap.
 type wrapOptions struct {
-	RunInGitRoot     bool
-	StashOpenChanges bool
-	PreviousBranch   domain.LocalBranchName
+	RunInGitRoot             bool
+	StashOpenChanges         bool
+	PreviousBranchCandidates domain.LocalBranchNames
 }

--- a/src/cmd/core.go
+++ b/src/cmd/core.go
@@ -45,9 +45,7 @@ func long(summary string, desc ...string) string {
 func wrap(program *program.Program, options wrapOptions) {
 	if !options.PreviousBranch.IsEmpty() {
 		program.Add(&opcode.PreserveCheckoutHistory{
-			InitialBranch:                     options.InitialBranch,
-			InitialPreviouslyCheckedOutBranch: options.PreviousBranch,
-			MainBranch:                        options.MainBranch,
+			PreviousBranch: options.PreviousBranch,
 		})
 	}
 	if options.StashOpenChanges {
@@ -60,7 +58,5 @@ func wrap(program *program.Program, options wrapOptions) {
 type wrapOptions struct {
 	RunInGitRoot     bool
 	StashOpenChanges bool
-	MainBranch       domain.LocalBranchName
-	InitialBranch    domain.LocalBranchName
 	PreviousBranch   domain.LocalBranchName
 }

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -163,8 +163,6 @@ func killProgram(config *killConfig) (runProgram, finalUndoProgram program.Progr
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.initialBranch != config.branchToKill.LocalName && config.branchToKill.LocalName == config.previousBranch && config.hasOpenChanges,
-		MainBranch:       config.mainBranch,
-		InitialBranch:    config.initialBranch,
 		PreviousBranch:   config.previousBranch,
 	})
 	return prog, finalUndoProgram

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -163,7 +163,7 @@ func killProgram(config *killConfig) (runProgram, finalUndoProgram program.Progr
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:             true,
 		StashOpenChanges:         config.initialBranch != config.branchToKill.LocalName && config.branchToKill.LocalName == config.previousBranch && config.hasOpenChanges,
-		PreviousBranchCandidates: domain.LocalBranchNames{config.initialBranch, config.previousBranch, config.mainBranch},
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch, config.initialBranch},
 	})
 	return prog, finalUndoProgram
 }

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -163,7 +163,7 @@ func killProgram(config *killConfig) (runProgram, finalUndoProgram program.Progr
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:             true,
 		StashOpenChanges:         config.initialBranch != config.branchToKill.LocalName && config.branchToKill.LocalName == config.previousBranch && config.hasOpenChanges,
-		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch, config.initialBranch},
+		PreviousBranchCandidates: domain.LocalBranchNames{config.initialBranch, config.previousBranch},
 	})
 	return prog, finalUndoProgram
 }

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -163,7 +163,7 @@ func killProgram(config *killConfig) (runProgram, finalUndoProgram program.Progr
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:             true,
 		StashOpenChanges:         config.initialBranch != config.branchToKill.LocalName && config.branchToKill.LocalName == config.previousBranch && config.hasOpenChanges,
-		PreviousBranchCandidates: domain.LocalBranchNames{config.initialBranch, config.previousBranch},
+		PreviousBranchCandidates: domain.LocalBranchNames{config.initialBranch, config.previousBranch, config.mainBranch},
 	})
 	return prog, finalUndoProgram
 }

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -161,9 +161,9 @@ func killProgram(config *killConfig) (runProgram, finalUndoProgram program.Progr
 	prog := program.Program{}
 	killFeatureBranch(&prog, &finalUndoProgram, *config)
 	wrap(&prog, wrapOptions{
-		RunInGitRoot:     true,
-		StashOpenChanges: config.initialBranch != config.branchToKill.LocalName && config.branchToKill.LocalName == config.previousBranch && config.hasOpenChanges,
-		PreviousBranch:   config.previousBranch,
+		RunInGitRoot:             true,
+		StashOpenChanges:         config.initialBranch != config.branchToKill.LocalName && config.branchToKill.LocalName == config.previousBranch && config.hasOpenChanges,
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch, config.initialBranch},
 	})
 	return prog, finalUndoProgram
 }

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -162,7 +162,7 @@ func killProgram(config *killConfig) (runProgram, finalUndoProgram program.Progr
 	killFeatureBranch(&prog, &finalUndoProgram, *config)
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:             true,
-		StashOpenChanges:         config.initialBranch != config.branchToKill.LocalName && config.branchToKill.LocalName == config.previousBranch && config.hasOpenChanges,
+		StashOpenChanges:         config.initialBranch != config.branchToKill.LocalName && config.hasOpenChanges,
 		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch, config.initialBranch},
 	})
 	return prog, finalUndoProgram

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -211,8 +211,6 @@ func prependProgram(config *prependConfig) program.Program {
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
-		MainBranch:       config.mainBranch,
-		InitialBranch:    config.branches.Initial,
 		PreviousBranch:   config.previousBranch,
 	})
 	return prog

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -209,9 +209,9 @@ func prependProgram(config *prependConfig) program.Program {
 		prog.Add(&opcode.CreateTrackingBranch{Branch: config.targetBranch, NoPushHook: !config.pushHook})
 	}
 	wrap(&prog, wrapOptions{
-		RunInGitRoot:     true,
-		StashOpenChanges: config.hasOpenChanges,
-		PreviousBranch:   config.previousBranch,
+		RunInGitRoot:             true,
+		StashOpenChanges:         config.hasOpenChanges,
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch},
 	})
 	return prog
 }

--- a/src/cmd/propose.go
+++ b/src/cmd/propose.go
@@ -215,9 +215,9 @@ func proposeProgram(config *proposeConfig) program.Program {
 		})
 	}
 	wrap(&prog, wrapOptions{
-		RunInGitRoot:     true,
-		StashOpenChanges: config.hasOpenChanges,
-		PreviousBranch:   config.previousBranch,
+		RunInGitRoot:             true,
+		StashOpenChanges:         config.hasOpenChanges,
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch},
 	})
 	prog.Add(&opcode.CreateProposal{Branch: config.branches.Initial})
 	return prog

--- a/src/cmd/propose.go
+++ b/src/cmd/propose.go
@@ -217,8 +217,6 @@ func proposeProgram(config *proposeConfig) program.Program {
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
-		MainBranch:       config.mainBranch,
-		InitialBranch:    config.branches.Initial,
 		PreviousBranch:   config.previousBranch,
 	})
 	prog.Add(&opcode.CreateProposal{Branch: config.branches.Initial})

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -187,9 +187,9 @@ func renameBranchProgram(config *renameBranchConfig) program.Program {
 	}
 	result.Add(&opcode.DeleteLocalBranch{Branch: config.oldBranch.LocalName, Force: false})
 	wrap(&result, wrapOptions{
-		RunInGitRoot:     false,
-		StashOpenChanges: false,
-		PreviousBranch:   config.previousBranch,
+		RunInGitRoot:             false,
+		StashOpenChanges:         false,
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch},
 	})
 	return result
 }

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -189,8 +189,6 @@ func renameBranchProgram(config *renameBranchConfig) program.Program {
 	wrap(&result, wrapOptions{
 		RunInGitRoot:     false,
 		StashOpenChanges: false,
-		MainBranch:       config.mainBranch,
-		InitialBranch:    config.branches.Initial,
 		PreviousBranch:   config.previousBranch,
 	})
 	return result

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -189,7 +189,7 @@ func renameBranchProgram(config *renameBranchConfig) program.Program {
 	wrap(&result, wrapOptions{
 		RunInGitRoot:             false,
 		StashOpenChanges:         false,
-		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch},
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch, config.newBranch},
 	})
 	return result
 }

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -380,8 +380,6 @@ func shipProgram(config *shipConfig, commitMessage string) program.Program {
 	wrap(&prog, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: !config.isShippingInitialBranch && config.hasOpenChanges,
-		MainBranch:       config.mainBranch,
-		InitialBranch:    config.branches.Initial,
 		PreviousBranch:   config.previousBranch,
 	})
 	return prog

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -378,9 +378,9 @@ func shipProgram(config *shipConfig, commitMessage string) program.Program {
 		prog.Add(&opcode.Checkout{Branch: config.branches.Initial})
 	}
 	wrap(&prog, wrapOptions{
-		RunInGitRoot:     true,
-		StashOpenChanges: !config.isShippingInitialBranch && config.hasOpenChanges,
-		PreviousBranch:   config.previousBranch,
+		RunInGitRoot:             true,
+		StashOpenChanges:         !config.isShippingInitialBranch && config.hasOpenChanges,
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch},
 	})
 	return prog
 }

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -229,9 +229,9 @@ func syncBranchesProgram(args syncBranchesProgramArgs) {
 		args.program.Add(&opcode.PushTags{})
 	}
 	wrap(args.program, wrapOptions{
-		RunInGitRoot:     true,
-		StashOpenChanges: args.hasOpenChanges,
-		PreviousBranch:   args.previousBranch,
+		RunInGitRoot:             true,
+		StashOpenChanges:         args.hasOpenChanges,
+		PreviousBranchCandidates: domain.LocalBranchNames{args.previousBranch},
 	})
 }
 

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -231,8 +231,6 @@ func syncBranchesProgram(args syncBranchesProgramArgs) {
 	wrap(args.program, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: args.hasOpenChanges,
-		MainBranch:       args.mainBranch,
-		InitialBranch:    args.initialBranch,
 		PreviousBranch:   args.previousBranch,
 	})
 }

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -151,8 +151,6 @@ func determineUndoRunState(config *undoConfig, repo *execute.OpenRepoResult) (ru
 	wrap(&undoRunState.RunProgram, wrapOptions{
 		RunInGitRoot:     true,
 		StashOpenChanges: config.hasOpenChanges,
-		MainBranch:       config.mainBranch,
-		InitialBranch:    config.initialBranchesSnapshot.Active,
 		PreviousBranch:   config.previousBranch,
 	})
 	// If the command to undo failed and was continued,

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -149,9 +149,9 @@ func determineUndoRunState(config *undoConfig, repo *execute.OpenRepoResult) (ru
 		undoRunState = runState.CreateUndoRunState()
 	}
 	wrap(&undoRunState.RunProgram, wrapOptions{
-		RunInGitRoot:     true,
-		StashOpenChanges: config.hasOpenChanges,
-		PreviousBranch:   config.previousBranch,
+		RunInGitRoot:             true,
+		StashOpenChanges:         config.hasOpenChanges,
+		PreviousBranchCandidates: domain.LocalBranchNames{config.previousBranch},
 	})
 	// If the command to undo failed and was continued,
 	// there might be opcodes in the undo stack that became obsolete

--- a/src/domain/local_branch_names.go
+++ b/src/domain/local_branch_names.go
@@ -15,14 +15,6 @@ func NewLocalBranchNames(names ...string) LocalBranchNames {
 	return result
 }
 
-func FromLocalBranchNames(names ...LocalBranchName) LocalBranchNames {
-	result := make(LocalBranchNames, len(names))
-	for n, name := range names {
-		result[n] = name
-	}
-	return result
-}
-
 func (self LocalBranchNames) Categorize(branchTypes BranchTypes) (perennials, features LocalBranchNames) {
 	for _, branch := range self {
 		if branchTypes.IsFeatureBranch(branch) {

--- a/src/domain/local_branch_names.go
+++ b/src/domain/local_branch_names.go
@@ -15,6 +15,14 @@ func NewLocalBranchNames(names ...string) LocalBranchNames {
 	return result
 }
 
+func FromLocalBranchNames(names ...LocalBranchName) LocalBranchNames {
+	result := make(LocalBranchNames, len(names))
+	for n, name := range names {
+		result[n] = name
+	}
+	return result
+}
+
 func (self LocalBranchNames) Categorize(branchTypes BranchTypes) (perennials, features LocalBranchNames) {
 	for _, branch := range self {
 		if branchTypes.IsFeatureBranch(branch) {
@@ -24,6 +32,10 @@ func (self LocalBranchNames) Categorize(branchTypes BranchTypes) (perennials, fe
 		}
 	}
 	return
+}
+
+func (self LocalBranchNames) IsEmpty() bool {
+	return len(self) == 0
 }
 
 // Join provides the names of all branches in this collection connected by the given separator.

--- a/src/domain/local_branch_names.go
+++ b/src/domain/local_branch_names.go
@@ -26,10 +26,6 @@ func (self LocalBranchNames) Categorize(branchTypes BranchTypes) (perennials, fe
 	return
 }
 
-func (self LocalBranchNames) IsEmpty() bool {
-	return len(self) == 0
-}
-
 // Join provides the names of all branches in this collection connected by the given separator.
 func (self LocalBranchNames) Join(sep string) string {
 	return strings.Join(self.Strings(), sep)

--- a/src/domain/local_branch_names.go
+++ b/src/domain/local_branch_names.go
@@ -43,6 +43,17 @@ func (self LocalBranchNames) Join(sep string) string {
 	return strings.Join(self.Strings(), sep)
 }
 
+// Remove removes the given branch name from this collection.
+func (self LocalBranchNames) Remove(toRemove LocalBranchName) LocalBranchNames {
+	result := make(LocalBranchNames, 0, len(self)-1)
+	for _, branch := range self {
+		if branch != toRemove {
+			result = append(result, branch)
+		}
+	}
+	return result
+}
+
 // Sort orders the branches in this collection alphabetically.
 func (self LocalBranchNames) Sort() {
 	sort.Slice(self, func(a, b int) bool {

--- a/src/domain/local_branch_names_test.go
+++ b/src/domain/local_branch_names_test.go
@@ -25,6 +25,22 @@ func TestLocalBranchNames(t *testing.T) {
 		must.Eq(t, want, branches.Strings())
 	})
 
+	t.Run("Remove", func(t *testing.T) {
+		t.Parallel()
+		t.Run("the element to remove exist in the list", func(t *testing.T) {
+			branches := domain.NewLocalBranchNames("one", "two", "three")
+			have := branches.Remove("two")
+			want := domain.NewLocalBranchNames("one", "three")
+			must.Eq(t, want, have)
+		})
+		t.Run("the element to remove does not exist in the list", func(t *testing.T) {
+			branches := domain.NewLocalBranchNames("one", "two")
+			have := branches.Remove("zonk")
+			want := domain.NewLocalBranchNames("one", "two")
+			must.Eq(t, want, have)
+		})
+	})
+
 	t.Run("TrackingBranch", func(t *testing.T) {
 		t.Parallel()
 		branch := domain.NewLocalBranchName("branch")

--- a/src/domain/local_branch_names_test.go
+++ b/src/domain/local_branch_names_test.go
@@ -28,12 +28,14 @@ func TestLocalBranchNames(t *testing.T) {
 	t.Run("Remove", func(t *testing.T) {
 		t.Parallel()
 		t.Run("the element to remove exist in the list", func(t *testing.T) {
+			t.Parallel()
 			branches := domain.NewLocalBranchNames("one", "two", "three")
 			have := branches.Remove("two")
 			want := domain.NewLocalBranchNames("one", "three")
 			must.Eq(t, want, have)
 		})
 		t.Run("the element to remove does not exist in the list", func(t *testing.T) {
+			t.Parallel()
 			branches := domain.NewLocalBranchNames("one", "two")
 			have := branches.Remove("zonk")
 			want := domain.NewLocalBranchNames("one", "two")

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -26,7 +26,7 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 	backendCommands := git.BackendCommands{
 		BackendRunner:      backendRunner,
 		Config:             nil, // initializing to nil here to validate the Git version before running any Git commands, setting to the correct value after that is done
-		CurrentBranchCache: &cache.LocalBranch{},
+		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
 		RemotesCache:       &cache.Remotes{},
 	}
 	majorVersion, minorVersion, err := backendCommands.Version()

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -25,10 +25,10 @@ type BackendRunner interface {
 // They don't change the user's repo, execute instantaneously, and Git Town needs to know their output.
 // They are invisible to the end user unless the "verbose" option is set.
 type BackendCommands struct {
-	BackendRunner                         // executes shell commands in the directory of the Git repo
-	Config             *RepoConfig        // the known state of the Git repository
-	CurrentBranchCache *cache.LocalBranch // caches the currently checked out Git branch
-	RemotesCache       *cache.Remotes     // caches Git remotes
+	BackendRunner                                     // executes shell commands in the directory of the Git repo
+	Config             *RepoConfig                    // the known state of the Git repository
+	CurrentBranchCache *cache.LocalBranchWithPrevious // caches the currently checked out Git branch
+	RemotesCache       *cache.Remotes                 // caches Git remotes
 }
 
 // Author provides the locally Git configured user.

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -381,29 +381,6 @@ func (self *BackendCommands) CurrentSHA() (domain.SHA, error) {
 	return self.SHAForBranch(domain.NewBranchName("HEAD"))
 }
 
-// ExpectedPreviouslyCheckedOutBranch returns what is the expected previously checked out branch
-// given the inputs.
-func (self *BackendCommands) ExpectedPreviouslyCheckedOutBranch(initialPreviouslyCheckedOutBranch, initialBranch, mainBranch domain.LocalBranchName) (domain.LocalBranchName, error) {
-	// TODO: try to avoid repeated lookups to self.HasLocalBranch
-	if self.HasLocalBranch(initialPreviouslyCheckedOutBranch) {
-		currentBranch, err := self.CurrentBranch()
-		if err != nil {
-			return domain.EmptyLocalBranchName(), err
-		}
-		if currentBranch == initialBranch {
-			return initialPreviouslyCheckedOutBranch, nil
-		}
-		if initialBranch == initialPreviouslyCheckedOutBranch {
-			return initialBranch, nil
-		}
-		if self.HasLocalBranch(initialBranch) {
-			return initialBranch, nil
-		}
-		return initialPreviouslyCheckedOutBranch, nil
-	}
-	return mainBranch, nil
-}
-
 func (self *BackendCommands) FirstExistingBranch(branches domain.LocalBranchNames, mainBranch domain.LocalBranchName) domain.LocalBranchName {
 	for _, branch := range branches {
 		if self.BranchExists(branch) {

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -751,7 +751,7 @@ func TestBackendCommands(t *testing.T) {
 			cmds := git.BackendCommands{
 				BackendRunner:      runner,
 				Config:             nil,
-				CurrentBranchCache: &cache.LocalBranch{},
+				CurrentBranchCache: &cache.LocalBranchWithPrevious{},
 				RemotesCache:       &cache.Remotes{},
 			}
 			have := cmds.RootDirectory()

--- a/src/gohacks/cache/cache.go
+++ b/src/gohacks/cache/cache.go
@@ -21,8 +21,8 @@ func (c *Cache[T]) Invalidate() {
 
 // Set allows collaborators to signal when the current branch has changed.
 func (c *Cache[T]) Set(newValue T) {
-	c.initialized = true
 	c.value = newValue
+	c.initialized = true
 }
 
 // Value provides the current value.

--- a/src/gohacks/cache/core.go
+++ b/src/gohacks/cache/core.go
@@ -7,7 +7,7 @@ import "github.com/git-town/git-town/v11/src/domain"
 type Bool = Cache[bool]
 
 // LocalBranch is a cache for domain.LocalBranchName variables.
-type LocalBranch = Cache[domain.LocalBranchName]
+type LocalBranchWithPrevious = WithPrevious[domain.LocalBranchName]
 
 // RemoteBranch is a cache for domain.RemoteBranchName variables.
 type RemoteBranch = Cache[domain.RemoteBranchName]

--- a/src/gohacks/cache/with_previous.go
+++ b/src/gohacks/cache/with_previous.go
@@ -2,7 +2,7 @@ package cache
 
 import "github.com/git-town/git-town/v11/src/messages"
 
-// Cache is a cache implementation for arbitrary data structures that ensures it is initialized.
+// WithPrevious is a cache implementation for arbitrary data structures that keeps track of the current and previous values.
 // The zero value is an empty cache.
 type WithPrevious[T any] struct {
 	initialized bool

--- a/src/gohacks/cache/with_previous.go
+++ b/src/gohacks/cache/with_previous.go
@@ -30,9 +30,9 @@ func (c *WithPrevious[T]) Previous() T {
 
 // Set allows collaborators to signal when the current branch has changed.
 func (c *WithPrevious[T]) Set(newValue T) {
-	c.initialized = true
 	c.previous = c.value
 	c.value = newValue
+	c.initialized = true
 }
 
 // Value provides the current value.

--- a/src/gohacks/cache/with_previous.go
+++ b/src/gohacks/cache/with_previous.go
@@ -1,0 +1,44 @@
+package cache
+
+import "github.com/git-town/git-town/v11/src/messages"
+
+// Cache is a cache implementation for arbitrary data structures that ensures it is initialized.
+// The zero value is an empty cache.
+type WithPrevious[T any] struct {
+	initialized bool
+	previous    T // the previous value
+	value       T // the current value
+}
+
+// Initialized indicates if we have a current branch.
+func (c *WithPrevious[T]) Initialized() bool {
+	return c.initialized
+}
+
+// Invalidate removes the cached value.
+func (c *WithPrevious[T]) Invalidate() {
+	c.initialized = false
+}
+
+// Previous provides the previous value.
+func (c *WithPrevious[T]) Previous() T {
+	if !c.initialized {
+		panic(messages.CacheUnitialized)
+	}
+	return c.previous
+}
+
+// Set allows collaborators to signal when the current branch has changed.
+func (c *WithPrevious[T]) Set(newValue T) {
+	c.initialized = true
+	c.previous = c.value
+	c.value = newValue
+}
+
+// Value provides the current value.
+func (c *WithPrevious[T]) Value() T {
+	if !c.initialized {
+		panic(messages.CacheUnitialized)
+	}
+	return c.value
+}

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -17,9 +17,10 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 		return nil
 	}
 	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
-	previousBranchCandidates := self.PreviousBranchCandidates.Remove(currentBranch)
 	actualPreviousBranch := args.Runner.Backend.CurrentBranchCache.Previous()
-	expectedPreviousBranch := args.Runner.Backend.FirstExistingBranch(previousBranchCandidates, domain.EmptyLocalBranchName())
+	// remove the current branch from the list of previous branch candidates because the current branch should never also be the previous branch
+	candidatesWithoutCurrent := self.PreviousBranchCandidates.Remove(currentBranch)
+	expectedPreviousBranch := args.Runner.Backend.FirstExistingBranch(candidatesWithoutCurrent, domain.EmptyLocalBranchName())
 	if expectedPreviousBranch.IsEmpty() || actualPreviousBranch == expectedPreviousBranch {
 		return nil
 	}

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -31,7 +31,7 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 	return args.Runner.Backend.CheckoutBranchUncached(currentBranch)
 }
 
-// firstExistingBranch provides the first branch in the given list that actually exists
+// firstExistingBranch provides the first branch in the given list that actually exists.
 func firstExistingBranch(candidates domain.LocalBranchNames, cmd git.BackendCommands) domain.LocalBranchName {
 	for _, candidate := range candidates {
 		if cmd.BranchExists(candidate) {

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -20,6 +20,9 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
 	actualPreviousBranch := args.Runner.Backend.CurrentBranchCache.Previous()
 	expectedPreviousBranch := firstExistingBranch(self.PreviousBranchCandidates, args.Runner.Backend)
+	if expectedPreviousBranch.IsEmpty() {
+		return nil
+	}
 	if actualPreviousBranch == expectedPreviousBranch {
 		return nil
 	}

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -18,8 +18,8 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 		return nil
 	}
 	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
-	previousBranchCandidates := self.PreviousBranchCandidates.Remove(currentBranch)
 	actualPreviousBranch := args.Runner.Backend.PreviouslyCheckedOutBranch()
+	previousBranchCandidates := self.PreviousBranchCandidates.Remove(currentBranch)
 	expectedPreviousBranch := firstExistingBranch(previousBranchCandidates, args.Runner.Backend)
 	if expectedPreviousBranch.IsEmpty() {
 		return nil

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -2,12 +2,13 @@ package opcode
 
 import (
 	"github.com/git-town/git-town/v11/src/domain"
+	"github.com/git-town/git-town/v11/src/git"
 	"github.com/git-town/git-town/v11/src/vm/shared"
 )
 
 // PreserveCheckoutHistory does stuff.
 type PreserveCheckoutHistory struct {
-	PreviousBranch domain.LocalBranchName
+	PreviousBranchCandidates domain.LocalBranchNames
 	undeclaredOpcodeMethods
 }
 
@@ -16,18 +17,25 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 		// the branch cache is not initialized --> there were no branch changes --> no need to restore the branch history
 		return nil
 	}
+	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
 	actualPreviousBranch := args.Runner.Backend.CurrentBranchCache.Previous()
-	if actualPreviousBranch == self.PreviousBranch {
-		// the actually set previous branch is already the expected value --> nothing to do here
+	expectedPreviousBranch := firstExistingBranch(self.PreviousBranchCandidates, args.Runner.Backend)
+	if actualPreviousBranch == expectedPreviousBranch {
 		return nil
 	}
-	currentBranch, err := args.Runner.Backend.CurrentBranch()
-	if err != nil {
-		return err
-	}
-	err = args.Runner.Backend.CheckoutBranchUncached(self.PreviousBranch)
+	err := args.Runner.Backend.CheckoutBranchUncached(expectedPreviousBranch)
 	if err != nil {
 		return err
 	}
 	return args.Runner.Backend.CheckoutBranchUncached(currentBranch)
+}
+
+// firstExistingBranch provides the first branch in the given list that actually exists
+func firstExistingBranch(candidates domain.LocalBranchNames, cmd git.BackendCommands) domain.LocalBranchName {
+	for _, candidate := range candidates {
+		if cmd.BranchExists(candidate) {
+			return candidate
+		}
+	}
+	return domain.EmptyLocalBranchName()
 }

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -1,6 +1,8 @@
 package opcode
 
 import (
+	"fmt"
+
 	"github.com/git-town/git-town/v11/src/domain"
 	"github.com/git-town/git-town/v11/src/git"
 	"github.com/git-town/git-town/v11/src/vm/shared"
@@ -18,8 +20,13 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 		return nil
 	}
 	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
-	actualPreviousBranch := args.Runner.Backend.CurrentBranchCache.Previous()
+	fmt.Println("0000000000000000000", currentBranch)
+	self.PreviousBranchCandidates.Remove(currentBranch)
+
+	actualPreviousBranch := args.Runner.Backend.PreviouslyCheckedOutBranch()
 	expectedPreviousBranch := firstExistingBranch(self.PreviousBranchCandidates, args.Runner.Backend)
+	fmt.Println("1111111111111111111", actualPreviousBranch)
+	fmt.Println("2222222222222222222", expectedPreviousBranch)
 	if expectedPreviousBranch.IsEmpty() {
 		return nil
 	}

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -2,7 +2,6 @@ package opcode
 
 import (
 	"github.com/git-town/git-town/v11/src/domain"
-	"github.com/git-town/git-town/v11/src/git"
 	"github.com/git-town/git-town/v11/src/vm/shared"
 )
 
@@ -20,7 +19,7 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
 	previousBranchCandidates := self.PreviousBranchCandidates.Remove(currentBranch)
 	actualPreviousBranch := args.Runner.Backend.CurrentBranchCache.Previous()
-	expectedPreviousBranch := firstExistingBranch(previousBranchCandidates, args.Runner.Backend)
+	expectedPreviousBranch := args.Runner.Backend.FirstExistingBranch(previousBranchCandidates, domain.EmptyLocalBranchName())
 	if expectedPreviousBranch.IsEmpty() || actualPreviousBranch == expectedPreviousBranch {
 		return nil
 	}
@@ -29,14 +28,4 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 		return err
 	}
 	return args.Runner.Backend.CheckoutBranchUncached(currentBranch)
-}
-
-// firstExistingBranch provides the first branch in the given list that actually exists.
-func firstExistingBranch(candidates domain.LocalBranchNames, cmd git.BackendCommands) domain.LocalBranchName {
-	for _, candidate := range candidates {
-		if cmd.BranchExists(candidate) {
-			return candidate
-		}
-	}
-	return domain.EmptyLocalBranchName()
 }

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -1,8 +1,6 @@
 package opcode
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v11/src/domain"
 	"github.com/git-town/git-town/v11/src/git"
 	"github.com/git-town/git-town/v11/src/vm/shared"
@@ -20,13 +18,9 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 		return nil
 	}
 	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
-	fmt.Println("0000000000000000000", currentBranch)
-	self.PreviousBranchCandidates.Remove(currentBranch)
-
+	previousBranchCandidates := self.PreviousBranchCandidates.Remove(currentBranch)
 	actualPreviousBranch := args.Runner.Backend.PreviouslyCheckedOutBranch()
-	expectedPreviousBranch := firstExistingBranch(self.PreviousBranchCandidates, args.Runner.Backend)
-	fmt.Println("1111111111111111111", actualPreviousBranch)
-	fmt.Println("2222222222222222222", expectedPreviousBranch)
+	expectedPreviousBranch := firstExistingBranch(previousBranchCandidates, args.Runner.Backend)
 	if expectedPreviousBranch.IsEmpty() {
 		return nil
 	}

--- a/src/vm/opcode/preserve_checkout_history.go
+++ b/src/vm/opcode/preserve_checkout_history.go
@@ -18,13 +18,10 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 		return nil
 	}
 	currentBranch := args.Runner.Backend.CurrentBranchCache.Value()
-	actualPreviousBranch := args.Runner.Backend.PreviouslyCheckedOutBranch()
 	previousBranchCandidates := self.PreviousBranchCandidates.Remove(currentBranch)
+	actualPreviousBranch := args.Runner.Backend.CurrentBranchCache.Previous()
 	expectedPreviousBranch := firstExistingBranch(previousBranchCandidates, args.Runner.Backend)
-	if expectedPreviousBranch.IsEmpty() {
-		return nil
-	}
-	if actualPreviousBranch == expectedPreviousBranch {
+	if expectedPreviousBranch.IsEmpty() || actualPreviousBranch == expectedPreviousBranch {
 		return nil
 	}
 	err := args.Runner.Backend.CheckoutBranchUncached(expectedPreviousBranch)

--- a/src/vm/statefile/save_load_test.go
+++ b/src/vm/statefile/save_load_test.go
@@ -97,7 +97,7 @@ func TestLoadSave(t *testing.T) {
 				&opcode.Merge{Branch: domain.NewBranchName("branch")},
 				&opcode.MergeParent{CurrentBranch: domain.NewLocalBranchName("branch")},
 				&opcode.PreserveCheckoutHistory{
-					PreviousBranch: domain.NewLocalBranchName("previous"),
+					PreviousBranchCandidates: domain.NewLocalBranchNames("previous"),
 				},
 				&opcode.PullCurrentBranch{},
 				&opcode.PushCurrentBranch{
@@ -303,7 +303,9 @@ func TestLoadSave(t *testing.T) {
     },
     {
       "data": {
-        "PreviousBranch": "previous"
+        "PreviousBranchCandidates": [
+          "previous"
+        ]
       },
       "type": "PreserveCheckoutHistory"
     },

--- a/src/vm/statefile/save_load_test.go
+++ b/src/vm/statefile/save_load_test.go
@@ -97,9 +97,7 @@ func TestLoadSave(t *testing.T) {
 				&opcode.Merge{Branch: domain.NewBranchName("branch")},
 				&opcode.MergeParent{CurrentBranch: domain.NewLocalBranchName("branch")},
 				&opcode.PreserveCheckoutHistory{
-					InitialBranch:                     domain.NewLocalBranchName("initial-branch"),
-					InitialPreviouslyCheckedOutBranch: domain.NewLocalBranchName("initial-previous-branch"),
-					MainBranch:                        domain.NewLocalBranchName("main"),
+					PreviousBranch: domain.NewLocalBranchName("previous"),
 				},
 				&opcode.PullCurrentBranch{},
 				&opcode.PushCurrentBranch{
@@ -305,9 +303,7 @@ func TestLoadSave(t *testing.T) {
     },
     {
       "data": {
-        "InitialBranch": "initial-branch",
-        "InitialPreviouslyCheckedOutBranch": "initial-previous-branch",
-        "MainBranch": "main"
+        "PreviousBranch": "previous"
       },
       "type": "PreserveCheckoutHistory"
     },

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -84,7 +84,7 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 	backendCommands := git.BackendCommands{
 		BackendRunner:      &runner,
 		Config:             &config,
-		CurrentBranchCache: &cache.LocalBranch{},
+		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
 		RemotesCache:       &cache.Remotes{},
 	}
 	testCommands := commands.TestCommands{


### PR DESCRIPTION
- uses the existing CurrentBranchCache to cache the previous Git branch, so no more lookups for that
- each Git Town command can now provide multiple candidates for the previous branch after the command has finished
- only changes the previous branch if that's actually needed
- stashes open changes away to avoid conflicts when setting the previous branch
- the previous branches in edge cases make more sense now