### PR TITLE
Build before running unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,15 +66,15 @@ test-go: tools/run-that-app@${RUN_THAT_APP_VERSION}  # smoke tests for Go refact
 todo:  # displays all TODO items
 	git grep --line-number TODO ':!vendor'
 
-unit:  # runs only the unit tests for changed code
+unit: build  # runs only the unit tests for changed code
 	@env GOGC=off go test -timeout 30s ./src/... ./test/...
 	@go run tools/format_unittests/format.go test
 	@go run tools/format_self/format.go test
 
-unit-all:  # runs all the unit tests
+unit-all: build  # runs all the unit tests
 	env GOGC=off go test -count=1 -timeout 60s ./src/... ./test/...
 
-unit-race:  # runs all the unit tests with race detector
+unit-race: build  # runs all the unit tests with race detector
 	env GOGC=off go test -count=1 -timeout 60s -race ./src/... ./test/...
 
 update: tools/run-that-app@${RUN_THAT_APP_VERSION}  # updates all dependencies


### PR DESCRIPTION
The unit tests execute the git-town binary, so it needs to be built before they run.