### PR TITLE
Mention the continue option first

### DIFF
--- a/features/hack/edge_cases/main_branch_conflict.feature
+++ b/features/hack/edge_cases/main_branch_conflict.feature
@@ -23,8 +23,8 @@ Feature: conflicts between the main branch and its tracking branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And a rebase is now in progress
     And the uncommitted file is stashed

--- a/features/propose/edge_cases/conflict.feature
+++ b/features/propose/edge_cases/conflict.feature
@@ -24,8 +24,8 @@ Feature: merge conflict
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And a merge is now in progress

--- a/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/feature_branch_merge_tracking_branch_conflict.feature
@@ -23,8 +23,8 @@ Feature: handle conflicts between the shipped branch and its tracking branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And a merge is now in progress

--- a/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/ship/current_branch/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -22,8 +22,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And a rebase is now in progress
 

--- a/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_feature_tracking_branch.feature
@@ -27,8 +27,8 @@ Feature: handle conflicts between the supplied feature branch and its tracking b
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is now "feature"
     And the uncommitted file is stashed

--- a/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
+++ b/features/ship/supplied_branch/edge_cases/conflict_main_tracking_branch.feature
@@ -26,8 +26,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And a rebase is now in progress
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -33,8 +33,8 @@ Feature: handle merge conflicts between feature branch and main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -32,9 +32,9 @@ Feature: handle merge conflicts between feature branch and main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -28,9 +28,9 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -13,6 +13,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
     And an uncommitted file
     When I run "git-town sync --all"
 
+  @this
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |
@@ -29,8 +30,8 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/local_repo.feature
@@ -13,7 +13,6 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
     And an uncommitted file
     When I run "git-town sync --all"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH | COMMAND                  |

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
@@ -27,8 +27,8 @@ Feature: shipped changes conflict with multiple existing feature branches
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is now "alpha"
     And the uncommitted file is stashed
@@ -57,8 +57,8 @@ Feature: shipped changes conflict with multiple existing feature branches
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is now "gamma"
     When I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
@@ -26,9 +26,9 @@ Feature: shipped changes conflict with multiple existing feature branches
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is now "alpha"
     And the uncommitted file is stashed
@@ -56,9 +56,9 @@ Feature: shipped changes conflict with multiple existing feature branches
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is now "gamma"
     When I resolve the conflict in "conflicting_file"

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -33,9 +33,9 @@ Feature: handle merge conflicts between feature branch and main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -34,8 +34,8 @@ Feature: handle merge conflicts between feature branch and main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -32,9 +32,9 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_tracking_branch_conflict.feature
@@ -33,8 +33,8 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is now "beta"
     And the uncommitted file is stashed

--- a/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/main_branch_rebase_tracking_branch_conflict.feature
@@ -24,8 +24,8 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And the uncommitted file is stashed
     And a rebase is now in progress

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -31,8 +31,8 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the uncommitted file is stashed
     And a rebase is now in progress

--- a/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/edge_cases/perennial_branch_tracking_branch_conflict.feature
@@ -30,9 +30,9 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the uncommitted file is stashed
     And a rebase is now in progress

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -28,8 +28,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -27,9 +27,9 @@ Feature: handle conflicts between the current feature branch and the main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -23,8 +23,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -22,9 +22,9 @@ Feature: handle conflicts between the current feature branch and the main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -29,8 +29,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -28,9 +28,9 @@ Feature: handle conflicts between the current feature branch and the main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -25,9 +25,9 @@ Feature: handle conflicts between the current feature branch and its tracking br
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -26,8 +26,8 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -23,8 +23,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And a rebase is now in progress
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -29,8 +29,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_branch.feature
@@ -28,9 +28,9 @@ Feature: handle conflicts between the current feature branch and the main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -24,8 +24,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_local_repo.feature
@@ -23,9 +23,9 @@ Feature: handle conflicts between the current feature branch and the main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -30,8 +30,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_main_branch_with_tracking.feature
@@ -29,9 +29,9 @@ Feature: handle conflicts between the current feature branch and the main branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -26,9 +26,9 @@ Feature: handle conflicts between the current feature branch and its tracking br
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_feature_branch_tracking_branch.feature
@@ -27,8 +27,8 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And the current branch is still "feature"
     And the uncommitted file is stashed

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_main_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/edge_cases/conflict_main_branch_tracking_branch.feature
@@ -24,8 +24,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And a rebase is now in progress
     And the uncommitted file is stashed

--- a/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/main_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -22,8 +22,8 @@ Feature: handle conflicts between the main branch and its tracking branch when s
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
     And a rebase is now in progress
     And the uncommitted file is stashed

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -24,8 +24,8 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git-town continue".
-      To continue by skipping the current branch, run "git-town skip".
       To go back to where you started, run "git-town undo".
+      To continue by skipping the current branch, run "git-town skip".
       """
     And a rebase is now in progress
     And the uncommitted file is stashed

--- a/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
+++ b/features/sync/current_branch/perennial_branch/edge_cases/rebase_tracking_branch_conflict.feature
@@ -23,9 +23,9 @@ Feature: handle conflicts between the current perennial branch and its tracking 
       """
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
       To continue by skipping the current branch, run "git-town skip".
+      To go back to where you started, run "git-town undo".
       """
     And a rebase is now in progress
     And the uncommitted file is stashed

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -11,8 +11,8 @@ Feature: handle previously unfinished Git Town commands
     And I run "git-town sync"
     And it prints the error:
       """
-      To go back to where you started, run "git-town undo".
       To continue after having resolved conflicts, run "git-town continue".
+      To go back to where you started, run "git-town undo".
       """
 
   Scenario: quit a command that is blocked by a previously unfinished Git Town command
@@ -52,7 +52,7 @@ Feature: handle previously unfinished Git Town commands
       |         | git push                           |
       |         | git stash pop                      |
     And all branches are now synchronized
-# notice how it executes the steps for "git sync" and not the steps for "git diff-parent" here
+  # notice how it executes the steps for "git sync" and not the steps for "git diff-parent" here
 
   Scenario: run a command and undo the previously unfinished one
     When I run "git-town sync" and answer the prompts:
@@ -93,9 +93,9 @@ Feature: handle previously unfinished Git Town commands
       | prepend foo       |
       | rename-branch foo |
       # | set-parent foo    |  # TODO: uncomment once set-parent accepts the parent as an argument
-      | ship   |
-      | switch |
-      | sync   |
+      | ship              |
+      | switch            |
+      | sync              |
 
   Scenario Outline: commands that don't require the user to resolve a previously unfinished Git Town command
     When I run "git rebase --abort"

--- a/features/sync/features/unfinished_state.feature
+++ b/features/sync/features/unfinished_state.feature
@@ -52,7 +52,7 @@ Feature: handle previously unfinished Git Town commands
       |         | git push                           |
       |         | git stash pop                      |
     And all branches are now synchronized
-  # notice how it executes the steps for "git sync" and not the steps for "git diff-parent" here
+# notice how it executes the steps for "git sync" and not the steps for "git diff-parent" here
 
   Scenario: run a command and undo the previously unfinished one
     When I run "git-town sync" and answer the prompts:
@@ -93,9 +93,9 @@ Feature: handle previously unfinished Git Town commands
       | prepend foo       |
       | rename-branch foo |
       # | set-parent foo    |  # TODO: uncomment once set-parent accepts the parent as an argument
-      | ship              |
-      | switch            |
-      | sync              |
+      | ship   |
+      | switch |
+      | sync   |
 
   Scenario Outline: commands that don't require the user to resolve a previously unfinished Git Town command
     When I run "git rebase --abort"

--- a/src/messages/en.go
+++ b/src/messages/en.go
@@ -1,7 +1,7 @@
 package messages
 
 const (
-	UndoContinueGuidance               = "\n\nTo go back to where you started, run \"git-town undo\".\nTo continue after having resolved conflicts, run \"git-town continue\".\n"
+	UndoContinueGuidance               = "\n\nTo continue after having resolved conflicts, run \"git-town continue\".\nTo go back to where you started, run \"git-town undo\".\n"
 	ArgumentUnknown                    = "unknown argument: %q"
 	BranchAlreadyExistsLocally         = "there is already a branch %q"
 	BranchAlreadyExistsRemotely        = "there is already a branch %q at the \"origin\" remote"


### PR DESCRIPTION
Git Town should encourage its users to resolve conflicts and continue, not abort and undo.