### PR TITLE
Simplify config naming

### DIFF
--- a/src/cmd/aliases.go
+++ b/src/cmd/aliases.go
@@ -72,7 +72,7 @@ func addAliases(run *git.ProdRunner) error {
 
 func removeAliases(run *git.ProdRunner) error {
 	for _, alias := range configdomain.Aliases() {
-		existingAlias := run.Config.GitAlias(alias)
+		existingAlias := run.GitTown.GitAlias(alias)
 		if existingAlias == "town "+alias.String() {
 			err := run.Frontend.RemoveGitAlias(alias)
 			if err != nil {

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -99,9 +99,9 @@ type appendConfig struct {
 }
 
 func determineAppendConfig(targetBranch domain.LocalBranchName, repo *execute.OpenRepoResult, verbose bool) (*appendConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
 	fc := gohacks.FailureCollector{}
-	pushHook := fc.PushHook(repo.Runner.Config.PushHook())
+	pushHook := fc.PushHook(repo.Runner.GitTown.PushHook())
 	branches, branchesSnapshot, stashSnapshot, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
 		Repo:                  repo,
 		Verbose:               verbose,
@@ -117,10 +117,10 @@ func determineAppendConfig(targetBranch domain.LocalBranchName, repo *execute.Op
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
 	remotes := fc.Remotes(repo.Runner.Backend.Remotes())
-	mainBranch := repo.Runner.Config.MainBranch()
-	syncPerennialStrategy := fc.SyncPerennialStrategy(repo.Runner.Config.SyncPerennialStrategy())
+	mainBranch := repo.Runner.GitTown.MainBranch()
+	syncPerennialStrategy := fc.SyncPerennialStrategy(repo.Runner.GitTown.SyncPerennialStrategy())
 	repoStatus := fc.RepoStatus(repo.Runner.Backend.RepoStatus())
-	shouldNewBranchPush := fc.NewBranchPush(repo.Runner.Config.ShouldNewBranchPush())
+	shouldNewBranchPush := fc.NewBranchPush(repo.Runner.GitTown.ShouldNewBranchPush())
 	if fc.Err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, fc.Err
 	}
@@ -143,8 +143,8 @@ func determineAppendConfig(targetBranch domain.LocalBranchName, repo *execute.Op
 	}
 	branchNamesToSync := lineage.BranchAndAncestors(branches.Initial)
 	branchesToSync := fc.BranchesSyncStatus(branches.All.Select(branchNamesToSync))
-	syncFeatureStrategy := fc.SyncFeatureStrategy(repo.Runner.Config.SyncFeatureStrategy())
-	syncUpstream := fc.SyncUpstream(repo.Runner.Config.ShouldSyncUpstream())
+	syncFeatureStrategy := fc.SyncFeatureStrategy(repo.Runner.GitTown.SyncFeatureStrategy())
+	syncUpstream := fc.SyncUpstream(repo.Runner.GitTown.ShouldSyncUpstream())
 	initialAndAncestors := lineage.BranchAndAncestors(branches.Initial)
 	slices.Reverse(initialAndAncestors)
 	return &appendConfig{

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -63,20 +63,20 @@ func executeConfig(verbose bool) error {
 
 func determineConfigConfig(run *git.ProdRunner) (ConfigConfig, error) {
 	fc := gohacks.FailureCollector{}
-	branchTypes := run.Config.BranchTypes()
-	deleteOrigin := fc.ShipDeleteRemoteBranch(run.Config.ShouldShipDeleteOriginBranch())
-	giteaToken := run.Config.GiteaToken()
-	githubToken := run.Config.GitHubToken()
-	gitlabToken := run.Config.GitLabToken()
-	hosting := fc.Hosting(run.Config.HostingService())
-	isOffline := fc.Offline(run.Config.IsOffline())
-	lineage := run.Config.Lineage(run.Backend.GitTown.RemoveLocalConfigValue)
-	syncPerennialStrategy := fc.SyncPerennialStrategy(run.Config.SyncPerennialStrategy())
-	pushHook := fc.PushHook(run.Config.PushHook())
-	pushNewBranches := fc.NewBranchPush(run.Config.ShouldNewBranchPush())
-	syncUpstream := fc.SyncUpstream(run.Config.ShouldSyncUpstream())
-	syncFeatureStrategy := fc.SyncFeatureStrategy(run.Config.SyncFeatureStrategy())
-	syncBeforeShip := fc.SyncBeforeShip(run.Config.SyncBeforeShip())
+	branchTypes := run.GitTown.BranchTypes()
+	deleteOrigin := fc.ShipDeleteRemoteBranch(run.GitTown.ShouldShipDeleteOriginBranch())
+	giteaToken := run.GitTown.GiteaToken()
+	githubToken := run.GitTown.GitHubToken()
+	gitlabToken := run.GitTown.GitLabToken()
+	hosting := fc.Hosting(run.GitTown.HostingService())
+	isOffline := fc.Offline(run.GitTown.IsOffline())
+	lineage := run.GitTown.Lineage(run.Backend.GitTown.RemoveLocalConfigValue)
+	syncPerennialStrategy := fc.SyncPerennialStrategy(run.GitTown.SyncPerennialStrategy())
+	pushHook := fc.PushHook(run.GitTown.PushHook())
+	pushNewBranches := fc.NewBranchPush(run.GitTown.ShouldNewBranchPush())
+	syncUpstream := fc.SyncUpstream(run.GitTown.ShouldSyncUpstream())
+	syncFeatureStrategy := fc.SyncFeatureStrategy(run.GitTown.SyncFeatureStrategy())
+	syncBeforeShip := fc.SyncBeforeShip(run.GitTown.SyncBeforeShip())
 	return ConfigConfig{
 		branchTypes:           branchTypes,
 		deleteTrackingBranch:  deleteOrigin,

--- a/src/cmd/config_mainbranch.go
+++ b/src/cmd/config_mainbranch.go
@@ -54,12 +54,12 @@ func executeConfigMainBranch(args []string, verbose bool) error {
 }
 
 func printMainBranch(run *git.ProdRunner) {
-	io.Println(format.StringSetting(run.Config.MainBranch().String()))
+	io.Println(format.StringSetting(run.GitTown.MainBranch().String()))
 }
 
 func setMainBranch(branch domain.LocalBranchName, run *git.ProdRunner) error {
 	if !run.Backend.HasLocalBranch(branch) {
 		return fmt.Errorf(messages.BranchDoesntExist, branch)
 	}
-	return run.Config.SetMainBranch(branch)
+	return run.GitTown.SetMainBranch(branch)
 }

--- a/src/cmd/config_offline.go
+++ b/src/cmd/config_offline.go
@@ -53,7 +53,7 @@ func executeOffline(args []string, verbose bool) error {
 }
 
 func displayOfflineStatus(run *git.ProdRunner) error {
-	isOffline, err := run.Config.IsOffline()
+	isOffline, err := run.GitTown.IsOffline()
 	if err != nil {
 		return err
 	}
@@ -66,5 +66,5 @@ func setOfflineStatus(text string, run *git.ProdRunner) error {
 	if err != nil {
 		return fmt.Errorf(messages.ValueInvalid, configdomain.KeyOffline, text)
 	}
-	return run.Config.SetOffline(configdomain.Offline(value))
+	return run.GitTown.SetOffline(configdomain.Offline(value))
 }

--- a/src/cmd/config_perennial_branches.go
+++ b/src/cmd/config_perennial_branches.go
@@ -57,7 +57,7 @@ func executeConfigPerennialBranches(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	io.Println(format.StringSetting(repo.Runner.Config.PerennialBranches().Join("\n")))
+	io.Println(format.StringSetting(repo.Runner.GitTown.PerennialBranches().Join("\n")))
 	return nil
 }
 
@@ -73,8 +73,8 @@ func updatePerennialBranches(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return err
 	}

--- a/src/cmd/config_push_hook.go
+++ b/src/cmd/config_push_hook.go
@@ -58,9 +58,9 @@ func printPushHook(globalFlag bool, run *git.ProdRunner) error {
 	var setting configdomain.PushHook
 	var err error
 	if globalFlag {
-		setting, err = run.Config.PushHookGlobal()
+		setting, err = run.GitTown.PushHookGlobal()
 	} else {
-		setting, err = run.Config.PushHook()
+		setting, err = run.GitTown.PushHook()
 	}
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func setPushHook(text string, global bool, run *git.ProdRunner) error {
 	}
 	value := configdomain.PushHook(valueBool)
 	if global {
-		return run.Config.SetPushHookGlobally(value)
+		return run.GitTown.SetPushHookGlobally(value)
 	}
-	return run.Config.SetPushHookLocally(value)
+	return run.GitTown.SetPushHookLocally(value)
 }

--- a/src/cmd/config_push_new_branches.go
+++ b/src/cmd/config_push_new_branches.go
@@ -59,9 +59,9 @@ func printPushNewBranches(globalFlag bool, run *git.ProdRunner) error {
 	var setting configdomain.NewBranchPush
 	var err error
 	if globalFlag {
-		setting, err = run.Config.ShouldNewBranchPushGlobal()
+		setting, err = run.GitTown.ShouldNewBranchPushGlobal()
 	} else {
-		setting, err = run.Config.ShouldNewBranchPush()
+		setting, err = run.GitTown.ShouldNewBranchPush()
 	}
 	if err != nil {
 		return err
@@ -75,5 +75,5 @@ func setPushNewBranches(text string, globalFlag bool, run *git.ProdRunner) error
 	if err != nil {
 		return fmt.Errorf(messages.InputYesOrNo, text)
 	}
-	return run.Config.SetNewBranchPush(configdomain.NewBranchPush(boolValue), globalFlag)
+	return run.GitTown.SetNewBranchPush(configdomain.NewBranchPush(boolValue), globalFlag)
 }

--- a/src/cmd/config_reset.go
+++ b/src/cmd/config_reset.go
@@ -35,5 +35,5 @@ func executeConfigResetStatus(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	return repo.Runner.Config.RemoveLocalGitConfiguration()
+	return repo.Runner.GitTown.RemoveLocalGitConfiguration()
 }

--- a/src/cmd/config_setup.go
+++ b/src/cmd/config_setup.go
@@ -37,8 +37,8 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return err
 	}

--- a/src/cmd/config_sync_feature_strategy.go
+++ b/src/cmd/config_sync_feature_strategy.go
@@ -54,9 +54,9 @@ func printSyncFeatureStrategy(globalFlag bool, run *git.ProdRunner) error {
 	var strategy configdomain.SyncFeatureStrategy
 	var err error
 	if globalFlag {
-		strategy, err = run.Config.SyncFeatureStrategyGlobal()
+		strategy, err = run.GitTown.SyncFeatureStrategyGlobal()
 	} else {
-		strategy, err = run.Config.SyncFeatureStrategy()
+		strategy, err = run.GitTown.SyncFeatureStrategy()
 	}
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func setSyncFeatureStrategy(globalFlag bool, run *git.ProdRunner, value string) 
 		return err
 	}
 	if globalFlag {
-		return run.Config.SetSyncFeatureStrategyGlobal(syncFeatureStrategy)
+		return run.GitTown.SetSyncFeatureStrategyGlobal(syncFeatureStrategy)
 	}
-	return run.Config.SetSyncFeatureStrategy(syncFeatureStrategy)
+	return run.GitTown.SetSyncFeatureStrategy(syncFeatureStrategy)
 }

--- a/src/cmd/config_sync_perennial_strategy.go
+++ b/src/cmd/config_sync_perennial_strategy.go
@@ -50,7 +50,7 @@ func executeConfigPullBranch(args []string, verbose bool) error {
 }
 
 func displaySyncPerennialStrategy(run *git.ProdRunner) error {
-	syncPerennialStrategy, err := run.Config.SyncPerennialStrategy()
+	syncPerennialStrategy, err := run.GitTown.SyncPerennialStrategy()
 	if err != nil {
 		return err
 	}
@@ -63,5 +63,5 @@ func setSyncPerennialStrategy(value string, run *git.ProdRunner) error {
 	if err != nil {
 		return err
 	}
-	return run.Config.SetSyncPerennialStrategy(syncPerennialStrategy)
+	return run.GitTown.SetSyncPerennialStrategy(syncPerennialStrategy)
 }

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -70,8 +70,8 @@ func executeContinue(verbose bool) error {
 }
 
 func determineContinueConfig(repo *execute.OpenRepoResult, verbose bool) (*continueConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, domain.EmptyBranchesSnapshot(), domain.EmptyStashSnapshot(), false, err
 	}
@@ -98,19 +98,19 @@ func determineContinueConfig(repo *execute.OpenRepoResult, verbose bool) (*conti
 	if repoStatus.UntrackedChanges {
 		return nil, initialBranchesSnapshot, initialStashSnapshot, false, fmt.Errorf(messages.ContinueUntrackedChanges)
 	}
-	originURL := repo.Runner.Config.OriginURL()
-	hostingService, err := repo.Runner.Config.HostingService()
+	originURL := repo.Runner.GitTown.OriginURL()
+	hostingService, err := repo.Runner.GitTown.HostingService()
 	if err != nil {
 		return nil, initialBranchesSnapshot, initialStashSnapshot, false, err
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	connector, err := hosting.NewConnector(hosting.NewConnectorArgs{
 		HostingService:  hostingService,
 		GetSHAForBranch: repo.Runner.Backend.SHAForBranch,
 		OriginURL:       originURL,
-		GiteaAPIToken:   repo.Runner.Config.GiteaToken(),
-		GithubAPIToken:  github.GetAPIToken(repo.Runner.Config.GitHubToken()),
-		GitlabAPIToken:  repo.Runner.Config.GitLabToken(),
+		GiteaAPIToken:   repo.Runner.GitTown.GiteaToken(),
+		GithubAPIToken:  github.GetAPIToken(repo.Runner.GitTown.GitHubToken()),
+		GitlabAPIToken:  repo.Runner.GitTown.GitLabToken(),
 		MainBranch:      mainBranch,
 		Log:             log.Printing{},
 	})

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -66,8 +66,8 @@ type diffParentConfig struct {
 
 // Does not return error because "Ensure" functions will call exit directly.
 func determineDiffParentConfig(args []string, repo *execute.OpenRepoResult, verbose bool) (*diffParentConfig, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, false, err
 	}
@@ -90,11 +90,11 @@ func determineDiffParentConfig(args []string, repo *execute.OpenRepoResult, verb
 			return nil, false, fmt.Errorf(messages.BranchDoesntExist, branch)
 		}
 	}
-	branchTypes := repo.Runner.Config.BranchTypes()
+	branchTypes := repo.Runner.GitTown.BranchTypes()
 	if !branchTypes.IsFeatureBranch(branch) {
 		return nil, false, fmt.Errorf(messages.DiffParentNoFeatureBranch)
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	branches.Types, lineage, err = execute.EnsureKnownBranchAncestry(branch, execute.EnsureKnownBranchAncestryArgs{
 		AllBranches:   branches.All,
 		BranchTypes:   branchTypes,

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -76,9 +76,9 @@ func executeHack(args []string, verbose bool) error {
 }
 
 func determineHackConfig(args []string, repo *execute.OpenRepoResult, verbose bool) (*appendConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
 	fc := gohacks.FailureCollector{}
-	pushHook := fc.PushHook(repo.Runner.Config.PushHook())
+	pushHook := fc.PushHook(repo.Runner.GitTown.PushHook())
 	branches, branchesSnapshot, stashSnapshot, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
 		Repo:                  repo,
 		Verbose:               verbose,
@@ -95,10 +95,10 @@ func determineHackConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
 	repoStatus := fc.RepoStatus(repo.Runner.Backend.RepoStatus())
 	targetBranch := domain.NewLocalBranchName(args[0])
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	remotes := fc.Remotes(repo.Runner.Backend.Remotes())
-	shouldNewBranchPush := fc.NewBranchPush(repo.Runner.Config.ShouldNewBranchPush())
-	isOffline := fc.Offline(repo.Runner.Config.IsOffline())
+	shouldNewBranchPush := fc.NewBranchPush(repo.Runner.GitTown.ShouldNewBranchPush())
+	isOffline := fc.Offline(repo.Runner.GitTown.IsOffline())
 	if branches.All.HasLocalBranch(targetBranch) {
 		return nil, branchesSnapshot, stashSnapshot, false, fmt.Errorf(messages.BranchAlreadyExistsLocally, targetBranch)
 	}
@@ -107,9 +107,9 @@ func determineHackConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 	}
 	branchNamesToSync := domain.LocalBranchNames{mainBranch}
 	branchesToSync := fc.BranchesSyncStatus(branches.All.Select(branchNamesToSync))
-	syncUpstream := fc.SyncUpstream(repo.Runner.Config.ShouldSyncUpstream())
-	syncPerennialStrategy := fc.SyncPerennialStrategy(repo.Runner.Config.SyncPerennialStrategy())
-	syncFeatureStrategy := fc.SyncFeatureStrategy(repo.Runner.Config.SyncFeatureStrategy())
+	syncUpstream := fc.SyncUpstream(repo.Runner.GitTown.ShouldSyncUpstream())
+	syncPerennialStrategy := fc.SyncPerennialStrategy(repo.Runner.GitTown.SyncPerennialStrategy())
+	syncFeatureStrategy := fc.SyncFeatureStrategy(repo.Runner.GitTown.SyncFeatureStrategy())
 	return &appendConfig{
 		branches:                  branches,
 		branchesToSync:            branchesToSync,

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -90,8 +90,8 @@ type killConfig struct {
 }
 
 func determineKillConfig(args []string, repo *execute.OpenRepoResult, verbose bool) (*killConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, domain.EmptyBranchesSnapshot(), domain.EmptyStashSnapshot(), false, err
 	}
@@ -108,7 +108,7 @@ func determineKillConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 	if err != nil || exit {
 		return nil, branchesSnapshot, stashSnapshot, exit, err
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	branchNameToKill := domain.NewLocalBranchName(slice.FirstElementOr(args, branches.Initial.String()))
 	branchToKill := branches.All.FindByLocalName(branchNameToKill)
 	if branchToKill == nil {

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -101,9 +101,9 @@ type prependConfig struct {
 }
 
 func determinePrependConfig(args []string, repo *execute.OpenRepoResult, verbose bool) (*prependConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
 	fc := gohacks.FailureCollector{}
-	pushHook := fc.PushHook(repo.Runner.Config.PushHook())
+	pushHook := fc.PushHook(repo.Runner.GitTown.PushHook())
 	branches, branchesSnapshot, stashSnapshot, exit, err := execute.LoadBranches(execute.LoadBranchesArgs{
 		Repo:                  repo,
 		Verbose:               verbose,
@@ -120,11 +120,11 @@ func determinePrependConfig(args []string, repo *execute.OpenRepoResult, verbose
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
 	repoStatus := fc.RepoStatus(repo.Runner.Backend.RepoStatus())
 	remotes := fc.Remotes(repo.Runner.Backend.Remotes())
-	shouldNewBranchPush := fc.NewBranchPush(repo.Runner.Config.ShouldNewBranchPush())
-	mainBranch := repo.Runner.Config.MainBranch()
-	syncFeatureStrategy := fc.SyncFeatureStrategy(repo.Runner.Config.SyncFeatureStrategy())
-	syncPerennialStrategy := fc.SyncPerennialStrategy(repo.Runner.Config.SyncPerennialStrategy())
-	syncUpstream := fc.SyncUpstream(repo.Runner.Config.ShouldSyncUpstream())
+	shouldNewBranchPush := fc.NewBranchPush(repo.Runner.GitTown.ShouldNewBranchPush())
+	mainBranch := repo.Runner.GitTown.MainBranch()
+	syncFeatureStrategy := fc.SyncFeatureStrategy(repo.Runner.GitTown.SyncFeatureStrategy())
+	syncPerennialStrategy := fc.SyncPerennialStrategy(repo.Runner.GitTown.SyncPerennialStrategy())
+	syncUpstream := fc.SyncUpstream(repo.Runner.GitTown.ShouldSyncUpstream())
 	targetBranch := domain.NewLocalBranchName(args[0])
 	if branches.All.HasLocalBranch(targetBranch) {
 		return nil, branchesSnapshot, stashSnapshot, false, fmt.Errorf(messages.BranchAlreadyExistsLocally, targetBranch)

--- a/src/cmd/propose.go
+++ b/src/cmd/propose.go
@@ -106,8 +106,8 @@ type proposeConfig struct {
 }
 
 func determineProposeConfig(repo *execute.OpenRepoResult, verbose bool) (*proposeConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, domain.EmptyBranchesSnapshot(), domain.EmptyStashSnapshot(), false, err
 	}
@@ -133,7 +133,7 @@ func determineProposeConfig(repo *execute.OpenRepoResult, verbose bool) (*propos
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	branches.Types, lineage, err = execute.EnsureKnownBranchAncestry(branches.Initial, execute.EnsureKnownBranchAncestryArgs{
 		AllBranches:   branches.All,
 		BranchTypes:   branches.Types,
@@ -145,20 +145,20 @@ func determineProposeConfig(repo *execute.OpenRepoResult, verbose bool) (*propos
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncFeatureStrategy, err := repo.Runner.Config.SyncFeatureStrategy()
+	syncFeatureStrategy, err := repo.Runner.GitTown.SyncFeatureStrategy()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncPerennialStrategy, err := repo.Runner.Config.SyncPerennialStrategy()
+	syncPerennialStrategy, err := repo.Runner.GitTown.SyncPerennialStrategy()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncUpstream, err := repo.Runner.Config.ShouldSyncUpstream()
+	syncUpstream, err := repo.Runner.GitTown.ShouldSyncUpstream()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	originURL := repo.Runner.Config.OriginURL()
-	hostingService, err := repo.Runner.Config.HostingService()
+	originURL := repo.Runner.GitTown.OriginURL()
+	hostingService, err := repo.Runner.GitTown.HostingService()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
@@ -166,9 +166,9 @@ func determineProposeConfig(repo *execute.OpenRepoResult, verbose bool) (*propos
 		HostingService:  hostingService,
 		GetSHAForBranch: repo.Runner.Backend.SHAForBranch,
 		OriginURL:       originURL,
-		GiteaAPIToken:   repo.Runner.Config.GiteaToken(),
-		GithubAPIToken:  github.GetAPIToken(repo.Runner.Config.GitHubToken()),
-		GitlabAPIToken:  repo.Runner.Config.GitLabToken(),
+		GiteaAPIToken:   repo.Runner.GitTown.GiteaToken(),
+		GithubAPIToken:  github.GetAPIToken(repo.Runner.GitTown.GitHubToken()),
+		GitlabAPIToken:  repo.Runner.GitTown.GitLabToken(),
 		MainBranch:      mainBranch,
 		Log:             log.Printing{},
 	})

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -99,8 +99,8 @@ type renameBranchConfig struct {
 }
 
 func determineRenameBranchConfig(args []string, forceFlag bool, repo *execute.OpenRepoResult, verbose bool) (*renameBranchConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, domain.EmptyBranchesSnapshot(), domain.EmptyStashSnapshot(), false, err
 	}
@@ -118,7 +118,7 @@ func determineRenameBranchConfig(args []string, forceFlag bool, repo *execute.Op
 		return nil, branchesSnapshot, stashSnapshot, exit, err
 	}
 	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	var oldBranchName domain.LocalBranchName
 	var newBranchName domain.LocalBranchName
 	if len(args) == 1 {
@@ -128,7 +128,7 @@ func determineRenameBranchConfig(args []string, forceFlag bool, repo *execute.Op
 		oldBranchName = domain.NewLocalBranchName(args[0])
 		newBranchName = domain.NewLocalBranchName(args[1])
 	}
-	if repo.Runner.Config.IsMainBranch(oldBranchName) {
+	if repo.Runner.GitTown.IsMainBranch(oldBranchName) {
 		return nil, branchesSnapshot, stashSnapshot, false, fmt.Errorf(messages.RenameMainBranch)
 	}
 	if !forceFlag {

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -70,7 +70,7 @@ func determineRepoConfig(repo *execute.OpenRepoResult) (*repoConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	branchTypes := repo.Runner.Config.BranchTypes()
+	branchTypes := repo.Runner.GitTown.BranchTypes()
 	branches := domain.Branches{
 		All:     branchesSnapshot.Branches,
 		Types:   branchTypes,
@@ -80,19 +80,19 @@ func determineRepoConfig(repo *execute.OpenRepoResult) (*repoConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	originURL := repo.Runner.Config.OriginURL()
-	hostingService, err := repo.Runner.Config.HostingService()
+	originURL := repo.Runner.GitTown.OriginURL()
+	hostingService, err := repo.Runner.GitTown.HostingService()
 	if err != nil {
 		return nil, err
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	connector, err := hosting.NewConnector(hosting.NewConnectorArgs{
 		HostingService:  hostingService,
 		GetSHAForBranch: repo.Runner.Backend.SHAForBranch,
 		OriginURL:       originURL,
-		GiteaAPIToken:   repo.Runner.Config.GiteaToken(),
-		GithubAPIToken:  github.GetAPIToken(repo.Runner.Config.GitHubToken()),
-		GitlabAPIToken:  repo.Runner.Config.GitLabToken(),
+		GiteaAPIToken:   repo.Runner.GitTown.GiteaToken(),
+		GithubAPIToken:  github.GetAPIToken(repo.Runner.GitTown.GitHubToken()),
+		GitlabAPIToken:  repo.Runner.GitTown.GitLabToken(),
 		MainBranch:      mainBranch,
 		Log:             log.Printing{},
 	})

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -40,8 +40,8 @@ func executeSetParent(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return err
 	}
@@ -64,11 +64,11 @@ func executeSetParent(verbose bool) error {
 	existingParent := lineage.Parent(branches.Initial)
 	if !existingParent.IsEmpty() {
 		// TODO: delete the old parent only when the user has entered a new parent
-		repo.Runner.Config.RemoveParent(branches.Initial)
+		repo.Runner.GitTown.RemoveParent(branches.Initial)
 	} else {
-		existingParent = repo.Runner.Config.MainBranch()
+		existingParent = repo.Runner.GitTown.MainBranch()
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	branches.Types, _, err = execute.EnsureKnownBranchAncestry(branches.Initial, execute.EnsureKnownBranchAncestryArgs{
 		AllBranches:   branches.All,
 		BranchTypes:   branches.Types,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -138,8 +138,8 @@ type shipConfig struct {
 }
 
 func determineShipConfig(args []string, repo *execute.OpenRepoResult, verbose bool) (*shipConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, domain.EmptyBranchesSnapshot(), domain.EmptyStashSnapshot(), false, err
 	}
@@ -165,30 +165,30 @@ func determineShipConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	deleteTrackingBranch, err := repo.Runner.Config.ShouldShipDeleteOriginBranch()
+	deleteTrackingBranch, err := repo.Runner.GitTown.ShouldShipDeleteOriginBranch()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	branchNameToShip := domain.NewLocalBranchName(slice.FirstElementOr(args, branches.Initial.String()))
 	branchToShip := branches.All.FindByLocalName(branchNameToShip)
 	if branchToShip != nil && branchToShip.SyncStatus == domain.SyncStatusOtherWorktree {
 		return nil, branchesSnapshot, stashSnapshot, false, fmt.Errorf(messages.ShipBranchOtherWorktree, branchNameToShip)
 	}
 	isShippingInitialBranch := branchNameToShip == branches.Initial
-	syncFeatureStrategy, err := repo.Runner.Config.SyncFeatureStrategy()
+	syncFeatureStrategy, err := repo.Runner.GitTown.SyncFeatureStrategy()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncPerennialStrategy, err := repo.Runner.Config.SyncPerennialStrategy()
+	syncPerennialStrategy, err := repo.Runner.GitTown.SyncPerennialStrategy()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncUpstream, err := repo.Runner.Config.ShouldSyncUpstream()
+	syncUpstream, err := repo.Runner.GitTown.ShouldSyncUpstream()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncBeforeShip, err := repo.Runner.Config.SyncBeforeShip()
+	syncBeforeShip, err := repo.Runner.GitTown.SyncBeforeShip()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
@@ -225,12 +225,12 @@ func determineShipConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 	var proposal *domain.Proposal
 	childBranches := lineage.Children(branchNameToShip)
 	proposalsOfChildBranches := []domain.Proposal{}
-	pushHook, err = repo.Runner.Config.PushHook()
+	pushHook, err = repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	originURL := repo.Runner.Config.OriginURL()
-	hostingService, err := repo.Runner.Config.HostingService()
+	originURL := repo.Runner.GitTown.OriginURL()
+	hostingService, err := repo.Runner.GitTown.HostingService()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
@@ -238,9 +238,9 @@ func determineShipConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 		HostingService:  hostingService,
 		GetSHAForBranch: repo.Runner.Backend.SHAForBranch,
 		OriginURL:       originURL,
-		GiteaAPIToken:   repo.Runner.Config.GiteaToken(),
-		GithubAPIToken:  github.GetAPIToken(repo.Runner.Config.GitHubToken()),
-		GitlabAPIToken:  repo.Runner.Config.GitLabToken(),
+		GiteaAPIToken:   repo.Runner.GitTown.GiteaToken(),
+		GithubAPIToken:  github.GetAPIToken(repo.Runner.GitTown.GitHubToken()),
+		GitlabAPIToken:  repo.Runner.GitTown.GitLabToken(),
 		MainBranch:      mainBranch,
 		Log:             log.Printing{},
 	})

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -41,8 +41,8 @@ func executeSkip(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return err
 	}

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -73,8 +73,8 @@ type switchConfig struct {
 }
 
 func determineSwitchConfig(repo *execute.OpenRepoResult, verbose bool) (*switchConfig, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, false, err
 	}

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -128,8 +128,8 @@ type syncConfig struct {
 }
 
 func determineSyncConfig(allFlag bool, repo *execute.OpenRepoResult, verbose bool) (*syncConfig, domain.BranchesSnapshot, domain.StashSnapshot, bool, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, domain.EmptyBranchesSnapshot(), domain.EmptyStashSnapshot(), false, err
 	}
@@ -155,7 +155,7 @@ func determineSyncConfig(allFlag bool, repo *execute.OpenRepoResult, verbose boo
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	mainBranch := repo.Runner.Config.MainBranch()
+	mainBranch := repo.Runner.GitTown.MainBranch()
 	var branchNamesToSync domain.LocalBranchNames
 	var shouldPushTags bool
 	if allFlag {
@@ -190,15 +190,15 @@ func determineSyncConfig(allFlag bool, repo *execute.OpenRepoResult, verbose boo
 		shouldPushTags = !branches.Types.IsFeatureBranch(branches.Initial)
 	}
 	allBranchNamesToSync := lineage.BranchesAndAncestors(branchNamesToSync)
-	syncFeatureStrategy, err := repo.Runner.Config.SyncFeatureStrategy()
+	syncFeatureStrategy, err := repo.Runner.GitTown.SyncFeatureStrategy()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncPerennialStrategy, err := repo.Runner.Config.SyncPerennialStrategy()
+	syncPerennialStrategy, err := repo.Runner.GitTown.SyncPerennialStrategy()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}
-	syncUpstream, err := repo.Runner.Config.ShouldSyncUpstream()
+	syncUpstream, err := repo.Runner.GitTown.ShouldSyncUpstream()
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err
 	}

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -81,8 +81,8 @@ type undoConfig struct {
 }
 
 func determineUndoConfig(repo *execute.OpenRepoResult, verbose bool) (*undoConfig, domain.StashSnapshot, configdomain.Lineage, error) {
-	lineage := repo.Runner.Config.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
-	pushHook, err := repo.Runner.Config.PushHook()
+	lineage := repo.Runner.GitTown.Lineage(repo.Runner.Backend.GitTown.RemoveLocalConfigValue)
+	pushHook, err := repo.Runner.GitTown.PushHook()
 	if err != nil {
 		return nil, domain.EmptyStashSnapshot(), lineage, err
 	}
@@ -105,18 +105,18 @@ func determineUndoConfig(repo *execute.OpenRepoResult, verbose bool) (*undoConfi
 	if err != nil {
 		return nil, initialStashSnapshot, lineage, err
 	}
-	hostingService, err := repo.Runner.Config.HostingService()
+	hostingService, err := repo.Runner.GitTown.HostingService()
 	if err != nil {
 		return nil, initialStashSnapshot, lineage, err
 	}
-	originURL := repo.Runner.Config.OriginURL()
+	originURL := repo.Runner.GitTown.OriginURL()
 	connector, err := hosting.NewConnector(hosting.NewConnectorArgs{
 		HostingService:  hostingService,
 		GetSHAForBranch: repo.Runner.Backend.SHAForBranch,
 		OriginURL:       originURL,
-		GiteaAPIToken:   repo.Runner.Config.GiteaToken(),
-		GithubAPIToken:  github.GetAPIToken(repo.Runner.Config.GitHubToken()),
-		GitlabAPIToken:  repo.Runner.Config.GitLabToken(),
+		GiteaAPIToken:   repo.Runner.GitTown.GiteaToken(),
+		GithubAPIToken:  github.GetAPIToken(repo.Runner.GitTown.GitHubToken()),
+		GitlabAPIToken:  repo.Runner.GitTown.GitLabToken(),
 		MainBranch:      mainBranch,
 		Log:             log.Printing{},
 	})

--- a/src/execute/ensure_known_branch_ancestry.go
+++ b/src/execute/ensure_known_branch_ancestry.go
@@ -25,9 +25,9 @@ func EnsureKnownBranchAncestry(branch domain.LocalBranchName, args EnsureKnownBr
 		return args.BranchTypes, args.Lineage, err
 	}
 	if updated {
-		args.Runner.Config.Reload()
-		args.Lineage = args.Runner.Config.Lineage(args.Runner.Backend.GitTown.RemoveLocalConfigValue) // reload after ancestry change
-		args.BranchTypes = args.Runner.Config.BranchTypes()
+		args.Runner.GitTown.Reload()
+		args.Lineage = args.Runner.GitTown.Lineage(args.Runner.Backend.GitTown.RemoveLocalConfigValue) // reload after ancestry change
+		args.BranchTypes = args.Runner.GitTown.BranchTypes()
 	}
 	return args.BranchTypes, args.Lineage, nil
 }

--- a/src/execute/ensure_known_branches_ancestry.go
+++ b/src/execute/ensure_known_branches_ancestry.go
@@ -24,9 +24,9 @@ func EnsureKnownBranchesAncestry(args EnsureKnownBranchesAncestryArgs) (domain.B
 		return args.BranchTypes, args.Lineage, err
 	}
 	if updated {
-		args.Runner.Config.Reload()
-		args.Lineage = args.Runner.Config.Lineage(args.Runner.Backend.GitTown.RemoveLocalConfigValue) // reload after ancestry change
-		args.BranchTypes = args.Runner.Config.BranchTypes()
+		args.Runner.GitTown.Reload()
+		args.Lineage = args.Runner.GitTown.Lineage(args.Runner.Backend.GitTown.RemoveLocalConfigValue) // reload after ancestry change
+		args.BranchTypes = args.Runner.GitTown.BranchTypes()
 	}
 	return args.BranchTypes, args.Lineage, nil
 }

--- a/src/execute/load_branches.go
+++ b/src/execute/load_branches.go
@@ -67,7 +67,7 @@ func LoadBranches(args LoadBranchesArgs) (domain.Branches, domain.BranchesSnapsh
 			return domain.EmptyBranches(), branchesSnapshot, stashSnapshot, false, err
 		}
 	}
-	branchTypes := args.Repo.Runner.Config.BranchTypes()
+	branchTypes := args.Repo.Runner.GitTown.BranchTypes()
 	branches := domain.Branches{
 		All:     branchesSnapshot.Branches,
 		Types:   branchTypes,

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -51,7 +51,7 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 	gitTown := config.NewGitTown(configSnapshot.GitConfig.Clone(), backendRunner)
 	backendCommands.GitTown = gitTown
 	prodRunner := git.ProdRunner{
-		Config:  *gitTown,
+		GitTown: *gitTown,
 		Backend: backendCommands,
 		Frontend: git.FrontendCommands{
 			FrontendRunner: newFrontendRunner(newFrontendRunnerArgs{
@@ -67,7 +67,7 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 		FinalMessages:   &stringslice.Collector{},
 	}
 	if args.DryRun {
-		prodRunner.Config.DryRun = true
+		prodRunner.GitTown.DryRun = true
 	}
 	rootDir := backendCommands.RootDirectory()
 	if args.ValidateGitRepo {

--- a/src/git/prod_runner.go
+++ b/src/git/prod_runner.go
@@ -8,7 +8,7 @@ import (
 
 // ProdRunner provides Git functionality for production code.
 type ProdRunner struct {
-	GitTown         config.GitTown
+	config.GitTown
 	Backend         BackendCommands
 	Frontend        FrontendCommands
 	CommandsCounter *gohacks.Counter

--- a/src/git/prod_runner.go
+++ b/src/git/prod_runner.go
@@ -8,7 +8,7 @@ import (
 
 // ProdRunner provides Git functionality for production code.
 type ProdRunner struct {
-	Config          config.GitTown
+	GitTown         config.GitTown
 	Backend         BackendCommands
 	Frontend        FrontendCommands
 	CommandsCounter *gohacks.Counter

--- a/src/undo/create_undo_list.go
+++ b/src/undo/create_undo_list.go
@@ -47,8 +47,8 @@ func determineUndoBranchesProgram(initialBranchesSnapshot domain.BranchesSnapsho
 	branchSpans := NewBranchSpans(initialBranchesSnapshot, finalBranchesSnapshot)
 	branchChanges := branchSpans.Changes()
 	return branchChanges.UndoProgram(BranchChangesUndoProgramArgs{
-		Lineage:                  runner.Config.Lineage(runner.Config.RemoveLocalConfigValue),
-		BranchTypes:              runner.Config.BranchTypes(),
+		Lineage:                  runner.GitTown.Lineage(runner.GitTown.RemoveLocalConfigValue),
+		BranchTypes:              runner.GitTown.BranchTypes(),
 		InitialBranch:            initialBranchesSnapshot.Active,
 		FinalBranch:              finalBranchesSnapshot.Active,
 		UndoablePerennialCommits: undoablePerennialCommits,

--- a/src/vm/interpreter/errored.go
+++ b/src/vm/interpreter/errored.go
@@ -41,7 +41,7 @@ func errored(failedOpcode shared.Opcode, runErr error, args ExecuteArgs) error {
 	if err != nil {
 		return err
 	}
-	if args.RunState.Command == "sync" && !(repoStatus.RebaseInProgress && args.Run.Config.IsMainBranch(currentBranch)) {
+	if args.RunState.Command == "sync" && !(repoStatus.RebaseInProgress && args.Run.GitTown.IsMainBranch(currentBranch)) {
 		args.RunState.UnfinishedDetails.CanSkip = true
 	}
 	err = statefile.Save(args.RunState, args.RootDir)

--- a/src/vm/opcode/add_to_perennial_branches.go
+++ b/src/vm/opcode/add_to_perennial_branches.go
@@ -12,5 +12,5 @@ type AddToPerennialBranches struct {
 }
 
 func (self *AddToPerennialBranches) Run(args shared.RunArgs) error {
-	return args.Runner.Config.AddToPerennialBranches(self.Branch)
+	return args.Runner.GitTown.AddToPerennialBranches(self.Branch)
 }

--- a/src/vm/opcode/change_parent.go
+++ b/src/vm/opcode/change_parent.go
@@ -17,7 +17,7 @@ type ChangeParent struct {
 }
 
 func (self *ChangeParent) Run(args shared.RunArgs) error {
-	err := args.Runner.Config.SetParent(self.Branch, self.Parent)
+	err := args.Runner.GitTown.SetParent(self.Branch, self.Parent)
 	if err != nil {
 		return err
 	}

--- a/src/vm/opcode/create_proposal.go
+++ b/src/vm/opcode/create_proposal.go
@@ -19,7 +19,7 @@ func (self *CreateProposal) CreateContinueProgram() []shared.Opcode {
 }
 
 func (self *CreateProposal) Run(args shared.RunArgs) error {
-	parentBranch := args.Runner.Config.Lineage(args.Runner.Config.RemoveLocalConfigValue)[self.Branch]
+	parentBranch := args.Runner.GitTown.Lineage(args.Runner.GitTown.RemoveLocalConfigValue)[self.Branch]
 	prURL, err := args.Connector.NewProposalURL(self.Branch, parentBranch)
 	if err != nil {
 		return err

--- a/src/vm/opcode/delete_parent_branch.go
+++ b/src/vm/opcode/delete_parent_branch.go
@@ -12,6 +12,6 @@ type DeleteParentBranch struct {
 }
 
 func (self *DeleteParentBranch) Run(args shared.RunArgs) error {
-	args.Runner.Config.RemoveParent(self.Branch)
+	args.Runner.GitTown.RemoveParent(self.Branch)
 	return nil
 }

--- a/src/vm/opcode/force_push_current_branch.go
+++ b/src/vm/opcode/force_push_current_branch.go
@@ -20,7 +20,7 @@ func (self *ForcePushCurrentBranch) Run(args shared.RunArgs) error {
 	if err != nil {
 		return err
 	}
-	if !shouldPush && !args.Runner.Config.DryRun {
+	if !shouldPush && !args.Runner.GitTown.DryRun {
 		return nil
 	}
 	return args.Runner.Frontend.ForcePushBranch(self.NoPushHook)

--- a/src/vm/opcode/push_current_branch.go
+++ b/src/vm/opcode/push_current_branch.go
@@ -24,7 +24,7 @@ func (self *PushCurrentBranch) Run(args shared.RunArgs) error {
 	if err != nil {
 		return err
 	}
-	if !shouldPush && !args.Runner.Config.DryRun {
+	if !shouldPush && !args.Runner.GitTown.DryRun {
 		return nil
 	}
 	return args.Runner.Frontend.PushCurrentBranch(self.NoPushHook)

--- a/src/vm/opcode/remove_from_perennial_branches.go
+++ b/src/vm/opcode/remove_from_perennial_branches.go
@@ -12,5 +12,5 @@ type RemoveFromPerennialBranches struct {
 }
 
 func (self *RemoveFromPerennialBranches) Run(args shared.RunArgs) error {
-	return args.Runner.Config.RemoveFromPerennialBranches(self.Branch)
+	return args.Runner.GitTown.RemoveFromPerennialBranches(self.Branch)
 }

--- a/src/vm/opcode/remove_global_config.go
+++ b/src/vm/opcode/remove_global_config.go
@@ -11,5 +11,5 @@ type RemoveGlobalConfig struct {
 }
 
 func (self *RemoveGlobalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.RemoveGlobalConfigValue(self.Key)
+	return args.Runner.GitTown.RemoveGlobalConfigValue(self.Key)
 }

--- a/src/vm/opcode/remove_local_config.go
+++ b/src/vm/opcode/remove_local_config.go
@@ -11,5 +11,5 @@ type RemoveLocalConfig struct {
 }
 
 func (self *RemoveLocalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.RemoveLocalConfigValue(self.Key)
+	return args.Runner.GitTown.RemoveLocalConfigValue(self.Key)
 }

--- a/src/vm/opcode/set_existing_parent.go
+++ b/src/vm/opcode/set_existing_parent.go
@@ -15,5 +15,5 @@ type SetExistingParent struct {
 
 func (self *SetExistingParent) Run(args shared.RunArgs) error {
 	nearestAncestor := args.Runner.Backend.FirstExistingBranch(self.Ancestors, self.MainBranch)
-	return args.Runner.Config.SetParent(self.Branch, nearestAncestor)
+	return args.Runner.GitTown.SetParent(self.Branch, nearestAncestor)
 }

--- a/src/vm/opcode/set_global_config.go
+++ b/src/vm/opcode/set_global_config.go
@@ -12,5 +12,5 @@ type SetGlobalConfig struct {
 }
 
 func (self *SetGlobalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.SetGlobalConfigValue(self.Key, self.Value)
+	return args.Runner.GitTown.SetGlobalConfigValue(self.Key, self.Value)
 }

--- a/src/vm/opcode/set_local_config.go
+++ b/src/vm/opcode/set_local_config.go
@@ -12,5 +12,5 @@ type SetLocalConfig struct {
 }
 
 func (self *SetLocalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.SetLocalConfigValue(self.Key, self.Value)
+	return args.Runner.GitTown.SetLocalConfigValue(self.Key, self.Value)
 }

--- a/src/vm/opcode/set_parent.go
+++ b/src/vm/opcode/set_parent.go
@@ -14,5 +14,5 @@ type SetParent struct {
 }
 
 func (self *SetParent) Run(args shared.RunArgs) error {
-	return args.Runner.Config.SetParent(self.Branch, self.Parent)
+	return args.Runner.GitTown.SetParent(self.Branch, self.Parent)
 }

--- a/src/vm/opcode/set_parent_if_branch_exists.go
+++ b/src/vm/opcode/set_parent_if_branch_exists.go
@@ -17,5 +17,5 @@ func (self *SetParentIfBranchExists) Run(args shared.RunArgs) error {
 	if !args.Runner.Backend.BranchExists(self.Branch) {
 		return nil
 	}
-	return args.Runner.Config.SetParent(self.Branch, self.Parent)
+	return args.Runner.GitTown.SetParent(self.Branch, self.Parent)
 }


### PR DESCRIPTION
Avoid `.Config.Config`