### PR TITLE
Make the repo runner a pointer

### DIFF
--- a/src/cmd/aliases.go
+++ b/src/cmd/aliases.go
@@ -52,9 +52,9 @@ func executeAliases(arg string, verbose bool) error {
 	}
 	switch strings.ToLower(arg) {
 	case "add":
-		return addAliases(&repo.Runner)
+		return addAliases(repo.Runner)
 	case "remove":
-		return removeAliases(&repo.Runner)
+		return removeAliases(repo.Runner)
 	}
 	return fmt.Errorf(messages.InputAddOrRemove, arg)
 }

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -67,7 +67,7 @@ func executeAppend(arg string, verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               nil,
 		Verbose:                 verbose,
 		RootDir:                 repo.RootDir,
@@ -136,7 +136,7 @@ func determineAppendConfig(targetBranch domain.LocalBranchName, repo *execute.Op
 		DefaultBranch: mainBranch,
 		Lineage:       lineage,
 		MainBranch:    mainBranch,
-		Runner:        &repo.Runner,
+		Runner:        repo.Runner,
 	})
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -53,7 +53,7 @@ func executeConfig(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	config, err := determineConfigConfig(&repo.Runner)
+	config, err := determineConfigConfig(repo.Runner)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/config_mainbranch.go
+++ b/src/cmd/config_mainbranch.go
@@ -47,9 +47,9 @@ func executeConfigMainBranch(args []string, verbose bool) error {
 	}
 	if len(args) > 0 {
 		newMainBranch := domain.NewLocalBranchName(args[0])
-		return setMainBranch(newMainBranch, &repo.Runner)
+		return setMainBranch(newMainBranch, repo.Runner)
 	}
-	printMainBranch(&repo.Runner)
+	printMainBranch(repo.Runner)
 	return nil
 }
 

--- a/src/cmd/config_offline.go
+++ b/src/cmd/config_offline.go
@@ -47,9 +47,9 @@ func executeOffline(args []string, verbose bool) error {
 		return err
 	}
 	if len(args) > 0 {
-		return setOfflineStatus(args[0], &repo.Runner)
+		return setOfflineStatus(args[0], repo.Runner)
 	}
-	return displayOfflineStatus(&repo.Runner)
+	return displayOfflineStatus(repo.Runner)
 }
 
 func displayOfflineStatus(run *git.ProdRunner) error {

--- a/src/cmd/config_push_hook.go
+++ b/src/cmd/config_push_hook.go
@@ -49,9 +49,9 @@ func executeConfigPushHook(args []string, global, verbose bool) error {
 		return err
 	}
 	if len(args) > 0 {
-		return setPushHook(args[0], global, &repo.Runner)
+		return setPushHook(args[0], global, repo.Runner)
 	}
-	return printPushHook(global, &repo.Runner)
+	return printPushHook(global, repo.Runner)
 }
 
 func printPushHook(globalFlag bool, run *git.ProdRunner) error {

--- a/src/cmd/config_push_new_branches.go
+++ b/src/cmd/config_push_new_branches.go
@@ -50,9 +50,9 @@ func executeConfigPushNewBranches(args []string, global, verbose bool) error {
 		return err
 	}
 	if len(args) > 0 {
-		return setPushNewBranches(args[0], global, &repo.Runner)
+		return setPushNewBranches(args[0], global, repo.Runner)
 	}
-	return printPushNewBranches(global, &repo.Runner)
+	return printPushNewBranches(global, repo.Runner)
 }
 
 func printPushNewBranches(globalFlag bool, run *git.ProdRunner) error {

--- a/src/cmd/config_sync_feature_strategy.go
+++ b/src/cmd/config_sync_feature_strategy.go
@@ -45,9 +45,9 @@ func executeConfigSyncFeatureStrategy(args []string, global, verbose bool) error
 		return err
 	}
 	if len(args) > 0 {
-		return setSyncFeatureStrategy(global, &repo.Runner, args[0])
+		return setSyncFeatureStrategy(global, repo.Runner, args[0])
 	}
-	return printSyncFeatureStrategy(global, &repo.Runner)
+	return printSyncFeatureStrategy(global, repo.Runner)
 }
 
 func printSyncFeatureStrategy(globalFlag bool, run *git.ProdRunner) error {

--- a/src/cmd/config_sync_perennial_strategy.go
+++ b/src/cmd/config_sync_perennial_strategy.go
@@ -44,9 +44,9 @@ func executeConfigPullBranch(args []string, verbose bool) error {
 		return err
 	}
 	if len(args) > 0 {
-		return setSyncPerennialStrategy(args[0], &repo.Runner)
+		return setSyncPerennialStrategy(args[0], repo.Runner)
 	}
-	return displaySyncPerennialStrategy(&repo.Runner)
+	return displaySyncPerennialStrategy(repo.Runner)
 }
 
 func displaySyncPerennialStrategy(run *git.ProdRunner) error {

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -57,7 +57,7 @@ func executeContinue(verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               config.connector,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -101,7 +101,7 @@ func determineDiffParentConfig(args []string, repo *execute.OpenRepoResult, verb
 		DefaultBranch: mainBranch,
 		Lineage:       lineage,
 		MainBranch:    mainBranch,
-		Runner:        &repo.Runner,
+		Runner:        repo.Runner,
 	})
 	if err != nil {
 		return nil, false, err

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -63,7 +63,7 @@ func executeHack(args []string, verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               nil,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -65,7 +65,7 @@ func executeKill(args []string, verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               nil,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,
@@ -124,7 +124,7 @@ func determineKillConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 			DefaultBranch: mainBranch,
 			Lineage:       lineage,
 			MainBranch:    mainBranch,
-			Runner:        &repo.Runner,
+			Runner:        repo.Runner,
 		})
 		if err != nil {
 			return nil, branchesSnapshot, stashSnapshot, false, err

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -69,7 +69,7 @@ func executePrepend(args []string, verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               nil,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,
@@ -141,7 +141,7 @@ func determinePrependConfig(args []string, repo *execute.OpenRepoResult, verbose
 		DefaultBranch: mainBranch,
 		Lineage:       lineage,
 		MainBranch:    mainBranch,
-		Runner:        &repo.Runner,
+		Runner:        repo.Runner,
 	})
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err

--- a/src/cmd/propose.go
+++ b/src/cmd/propose.go
@@ -77,7 +77,7 @@ func executePropose(verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               config.connector,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,
@@ -140,7 +140,7 @@ func determineProposeConfig(repo *execute.OpenRepoResult, verbose bool) (*propos
 		DefaultBranch: mainBranch,
 		Lineage:       lineage,
 		MainBranch:    mainBranch,
-		Runner:        &repo.Runner,
+		Runner:        repo.Runner,
 	})
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -75,7 +75,7 @@ func executeRenameBranch(args []string, force, verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               nil,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -75,7 +75,7 @@ func executeSetParent(verbose bool) error {
 		DefaultBranch: existingParent,
 		Lineage:       lineage,
 		MainBranch:    mainBranch,
-		Runner:        &repo.Runner,
+		Runner:        repo.Runner,
 	})
 	if err != nil {
 		return err

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -100,7 +100,7 @@ func executeShip(args []string, message string, verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               config.connector,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,
@@ -206,7 +206,7 @@ func determineShipConfig(args []string, repo *execute.OpenRepoResult, verbose bo
 		DefaultBranch: mainBranch,
 		Lineage:       lineage,
 		MainBranch:    mainBranch,
-		Runner:        &repo.Runner,
+		Runner:        repo.Runner,
 	})
 	if err != nil {
 		return nil, branchesSnapshot, stashSnapshot, false, err

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -72,7 +72,7 @@ func executeSkip(verbose bool) error {
 	skipRunState := runState.CreateSkipRunState()
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &skipRunState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               nil,
 		Verbose:                 verbose,
 		Lineage:                 lineage,

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -99,7 +99,7 @@ func executeSync(all, dryRun, verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &runState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               nil,
 		Verbose:                 verbose,
 		Lineage:                 config.lineage,
@@ -165,7 +165,7 @@ func determineSyncConfig(allFlag bool, repo *execute.OpenRepoResult, verbose boo
 			BranchTypes: branches.Types,
 			Lineage:     lineage,
 			MainBranch:  mainBranch,
-			Runner:      &repo.Runner,
+			Runner:      repo.Runner,
 		})
 		if err != nil {
 			return nil, branchesSnapshot, stashSnapshot, false, err
@@ -179,7 +179,7 @@ func determineSyncConfig(allFlag bool, repo *execute.OpenRepoResult, verbose boo
 			DefaultBranch: mainBranch,
 			Lineage:       lineage,
 			MainBranch:    mainBranch,
-			Runner:        &repo.Runner,
+			Runner:        repo.Runner,
 		})
 		if err != nil {
 			return nil, branchesSnapshot, stashSnapshot, false, err

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -58,7 +58,7 @@ func executeUndo(verbose bool) error {
 	}
 	return interpreter.Execute(interpreter.ExecuteArgs{
 		RunState:                &undoRunState,
-		Run:                     &repo.Runner,
+		Run:                     repo.Runner,
 		Connector:               config.connector,
 		Verbose:                 verbose,
 		Lineage:                 lineage,

--- a/src/execute/load_branches.go
+++ b/src/execute/load_branches.go
@@ -28,7 +28,7 @@ func LoadBranches(args LoadBranchesArgs) (domain.Branches, domain.BranchesSnapsh
 			Lineage:                 args.Lineage,
 			PushHook:                args.PushHook,
 			RootDir:                 args.Repo.RootDir,
-			Run:                     &args.Repo.Runner,
+			Run:                     args.Repo.Runner,
 		})
 		if err != nil || exit {
 			return domain.EmptyBranches(), branchesSnapshot, stashSnapshot, exit, err

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -97,7 +97,7 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 		}
 	}
 	return &OpenRepoResult{
-		Runner:         prodRunner,
+		Runner:         &prodRunner,
 		RootDir:        rootDir,
 		IsOffline:      isOffline,
 		ConfigSnapshot: configSnapshot,
@@ -114,7 +114,7 @@ type OpenRepoArgs struct {
 }
 
 type OpenRepoResult struct {
-	Runner         git.ProdRunner
+	Runner         *git.ProdRunner
 	RootDir        domain.RepoRootDir
 	IsOffline      configdomain.Offline
 	ConfigSnapshot undo.ConfigSnapshot


### PR DESCRIPTION
This eliminates a source of unexpected loss of changes, and in the future we need this to me mutable anyways. This is also exclusively used as a reference, which is an indicator that it should be a reference.