### PR TITLE
Remove snapshot for current directory

### DIFF
--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -39,18 +39,12 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	currentDirectory, err := os.Getwd()
-	if err != nil {
-		err = errors.New(messages.DirCurrentProblem)
-		return nil, err
-	}
 	configGitAccess := gitconfig.Access{Runner: backendRunner}
 	fullCache, err := gitconfig.LoadFullCache(&configGitAccess)
 	if err != nil {
 		return nil, err
 	}
 	configSnapshot := undo.ConfigSnapshot{
-		Cwd:       currentDirectory,
 		GitConfig: fullCache,
 	}
 	gitTown, err := config.NewGitTown(configSnapshot.GitConfig.Clone(), backendRunner, false)

--- a/src/undo/config_snapshot.go
+++ b/src/undo/config_snapshot.go
@@ -4,6 +4,5 @@ import "github.com/git-town/git-town/v11/src/config/gitconfig"
 
 // ConfigSnapshot is a snapshot of the Git configuration at a particular point in time.
 type ConfigSnapshot struct {
-	Cwd       string // the current working directory
 	GitConfig gitconfig.FullCache
 }

--- a/src/undo/config_test.go
+++ b/src/undo/config_test.go
@@ -18,7 +18,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("adding a value to the global cache", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline: "0",
@@ -29,7 +28,6 @@ func TestConfigUndo(t *testing.T) {
 			},
 		}
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline:               "0",
@@ -64,7 +62,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("adding a value to the global config", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache:  gitconfig.SingleCache{},
 				GlobalConfig: configdomain.PartialConfig{}, //nolint:exhaustruct
@@ -74,7 +71,6 @@ func TestConfigUndo(t *testing.T) {
 		}
 		perennialsAfter := domain.NewLocalBranchNames("one", "two")
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{},
 				GlobalConfig: configdomain.PartialConfig{ //nolint:exhaustruct
@@ -108,7 +104,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("removing a value from the global cache", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline:               "0",
@@ -120,7 +115,6 @@ func TestConfigUndo(t *testing.T) {
 			},
 		}
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline: "0",
@@ -159,7 +153,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("changing a value in the global cache", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline: "0",
@@ -170,7 +163,6 @@ func TestConfigUndo(t *testing.T) {
 			},
 		}
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline: "1",
@@ -212,7 +204,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("adding a value to the local cache", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache:  gitconfig.SingleCache{},
 				GlobalConfig: configdomain.EmptyPartialConfig(),
@@ -223,7 +214,6 @@ func TestConfigUndo(t *testing.T) {
 			},
 		}
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache:  gitconfig.SingleCache{},
 				GlobalConfig: configdomain.EmptyPartialConfig(),
@@ -258,7 +248,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("removing a value from the local cache", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache:  gitconfig.SingleCache{},
 				GlobalConfig: configdomain.EmptyPartialConfig(),
@@ -270,7 +259,6 @@ func TestConfigUndo(t *testing.T) {
 			},
 		}
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache:  gitconfig.SingleCache{},
 				GlobalConfig: configdomain.EmptyPartialConfig(),
@@ -309,7 +297,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("changing a value in the local cache", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache:  gitconfig.SingleCache{},
 				GlobalConfig: configdomain.EmptyPartialConfig(),
@@ -320,7 +307,6 @@ func TestConfigUndo(t *testing.T) {
 			},
 		}
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache:  gitconfig.SingleCache{},
 				GlobalConfig: configdomain.EmptyPartialConfig(),
@@ -362,7 +348,6 @@ func TestConfigUndo(t *testing.T) {
 	t.Run("complex example", func(t *testing.T) {
 		t.Parallel()
 		before := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline:  "0",
@@ -377,7 +362,6 @@ func TestConfigUndo(t *testing.T) {
 			},
 		}
 		after := undo.ConfigSnapshot{
-			Cwd: "/foo",
 			GitConfig: gitconfig.FullCache{
 				GlobalCache: gitconfig.SingleCache{
 					configdomain.KeyOffline:               "1",

--- a/src/undo/create_undo_list.go
+++ b/src/undo/create_undo_list.go
@@ -1,14 +1,10 @@
 package undo
 
 import (
-	"errors"
-	"os"
-
 	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/config/gitconfig"
 	"github.com/git-town/git-town/v11/src/domain"
 	"github.com/git-town/git-town/v11/src/git"
-	"github.com/git-town/git-town/v11/src/messages"
 	"github.com/git-town/git-town/v11/src/vm/program"
 )
 
@@ -57,16 +53,11 @@ func determineUndoBranchesProgram(initialBranchesSnapshot domain.BranchesSnapsho
 }
 
 func determineUndoConfigProgram(initialConfigSnapshot ConfigSnapshot, configGit *gitconfig.Access) (program.Program, error) {
-	currentDirectory, err := os.Getwd()
-	if err != nil {
-		return program.Program{}, errors.New(messages.DirCurrentProblem)
-	}
 	fullCache, err := gitconfig.LoadFullCache(configGit)
 	if err != nil {
-		return program.Program{}, errors.New(messages.DirCurrentProblem)
+		return program.Program{}, err
 	}
 	finalConfigSnapshot := ConfigSnapshot{
-		Cwd:       currentDirectory,
 		GitConfig: fullCache,
 	}
 	configDiff := NewConfigDiffs(initialConfigSnapshot, finalConfigSnapshot)


### PR DESCRIPTION
The cwd snapshot isn't used since Git Town cannot return the calling shell to a particular directory. Git Town still cd's to the repo root folder.