### PR TITLE
Move dryrun out of GitTown

### DIFF
--- a/features/sync/features/dry_run.feature
+++ b/features/sync/features/dry_run.feature
@@ -10,7 +10,6 @@ Feature: dry run
       |         | origin   | origin feature commit |
     When I run "git-town sync --dry-run"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                            |

--- a/features/sync/features/dry_run.feature
+++ b/features/sync/features/dry_run.feature
@@ -10,6 +10,7 @@ Feature: dry run
       |         | origin   | origin feature commit |
     When I run "git-town sync --dry-run"
 
+  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                            |
@@ -23,6 +24,7 @@ Feature: dry run
       |         | git push                           |
     And the current branch is still "feature"
     And the initial commits exist
+    And the initial branches and lineage exist
 
   Scenario: undo
     When I run "git-town undo"

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -63,6 +63,7 @@ func executeAppend(arg string, verbose bool) error {
 	}
 	runState := runstate.RunState{
 		Command:             "append",
+		DryRun:              false,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		RunProgram:          appendProgram(config),
 	}

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -58,6 +58,7 @@ func executeHack(args []string, verbose bool) error {
 	}
 	runState := runstate.RunState{
 		Command:             "hack",
+		DryRun:              false,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		RunProgram:          appendProgram(config),
 	}

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -61,6 +61,7 @@ func executeKill(args []string, verbose bool) error {
 	}
 	runState := runstate.RunState{
 		Command:             "kill",
+		DryRun:              false,
 		RunProgram:          steps,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		FinalUndoProgram:    finalUndoProgram,

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -65,6 +65,7 @@ func executePrepend(args []string, verbose bool) error {
 	}
 	runState := runstate.RunState{
 		Command:             "prepend",
+		DryRun:              false,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		RunProgram:          prependProgram(config),
 	}

--- a/src/cmd/propose.go
+++ b/src/cmd/propose.go
@@ -75,6 +75,7 @@ func executePropose(verbose bool) error {
 	}
 	runState := runstate.RunState{
 		Command:             "propose",
+		DryRun:              false,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		RunProgram:          proposeProgram(config),
 	}

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -71,6 +71,7 @@ func executeRenameBranch(args []string, force, verbose bool) error {
 	}
 	runState := runstate.RunState{
 		Command:             "rename-branch",
+		DryRun:              false,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		RunProgram:          renameBranchProgram(config),
 	}

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -98,6 +98,7 @@ func executeShip(args []string, message string, verbose bool) error {
 	}
 	runState := runstate.RunState{
 		Command:             "ship",
+		DryRun:              false,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		RunProgram:          shipProgram(config, message),
 	}

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -94,6 +94,7 @@ func executeSync(all, dryRun, verbose bool) error {
 	})
 	runState := runstate.RunState{
 		Command:             "sync",
+		DryRun:              dryRun,
 		InitialActiveBranch: initialBranchesSnapshot.Active,
 		RunProgram:          runProgram,
 	}

--- a/src/config/git_town.go
+++ b/src/config/git_town.go
@@ -18,7 +18,6 @@ type GitTown struct {
 	configdomain.CachedAccess // access to the Git configuration settings
 	configdomain.Config       // the merged configuration data
 	configFile                configdomain.PartialConfig
-	DryRun                    bool // single source of truth for whether to dry-run Git commands in this repo
 	originURLCache            configdomain.OriginURLCache
 }
 
@@ -183,7 +182,7 @@ func (self *GitTown) SetTestOrigin(value string) error {
 	return self.SetLocalConfigValue(configdomain.KeyTestingRemoteURL, value)
 }
 
-func NewGitTown(fullCache configdomain.FullCache, runner configdomain.Runner, dryrun bool) (*GitTown, error) {
+func NewGitTown(fullCache configdomain.FullCache, runner configdomain.Runner) (*GitTown, error) {
 	configFile, err := configdomain.LoadConfigFile()
 	if err != nil {
 		return nil, err
@@ -196,7 +195,6 @@ func NewGitTown(fullCache configdomain.FullCache, runner configdomain.Runner, dr
 		CachedAccess:   configdomain.NewCachedAccess(fullCache, runner),
 		Config:         config,
 		configFile:     configFile,
-		DryRun:         dryrun,
 		originURLCache: configdomain.OriginURLCache{},
 	}, nil
 }

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -26,6 +26,7 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 	}
 	backendCommands := git.BackendCommands{
 		BackendRunner:      backendRunner,
+		DryRun:             args.DryRun,
 		GitTown:            nil, // initializing to nil here to validate the Git version before running any Git commands, setting to the correct value after that is done
 		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
 		RemotesCache:       &cache.Remotes{},
@@ -47,7 +48,7 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 		Global: fullCache.GlobalCache.Clone(),
 		Local:  fullCache.LocalCache.Clone(),
 	}
-	gitTown, err := config.NewGitTown(fullCache, backendRunner, false)
+	gitTown, err := config.NewGitTown(fullCache, backendRunner)
 	if err != nil {
 		return nil, err
 	}
@@ -67,9 +68,6 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 		},
 		CommandsCounter: &commandsCounter,
 		FinalMessages:   &stringslice.Collector{},
-	}
-	if args.DryRun {
-		prodRunner.GitTown.DryRun = true
 	}
 	rootDir := backendCommands.RootDirectory()
 	if args.ValidateGitRepo {

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -28,7 +28,8 @@ type BackendRunner interface {
 // They don't change the user's repo, execute instantaneously, and Git Town needs to know their output.
 // They are invisible to the end user unless the "verbose" option is set.
 type BackendCommands struct {
-	BackendRunner                                     // executes shell commands in the directory of the Git repo
+	BackendRunner      // executes shell commands in the directory of the Git repo
+	DryRun             bool
 	*config.GitTown                                   // the known state of the Git repository
 	CurrentBranchCache *cache.LocalBranchWithPrevious // caches the currently checked out Git branch
 	RemotesCache       *cache.Remotes                 // caches Git remotes
@@ -108,7 +109,7 @@ func (self *BackendCommands) BranchesSnapshot() (gitdomain.BranchesStatus, error
 
 // CheckoutBranch checks out the Git branch with the given name.
 func (self *BackendCommands) CheckoutBranch(name gitdomain.LocalBranchName) error {
-	if !self.GitTown.DryRun {
+	if !self.DryRun {
 		err := self.CheckoutBranchUncached(name)
 		if err != nil {
 			return err
@@ -355,7 +356,7 @@ func (self *BackendCommands) CreateFeatureBranch(name gitdomain.LocalBranchName)
 
 // CurrentBranch provides the name of the currently checked out branch.
 func (self *BackendCommands) CurrentBranch() (gitdomain.LocalBranchName, error) {
-	if self.GitTown.DryRun {
+	if self.DryRun {
 		return self.CurrentBranchCache.Value(), nil
 	}
 	if !self.CurrentBranchCache.Initialized() {

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -776,6 +776,7 @@ func TestBackendCommands(t *testing.T) {
 			}
 			cmds := git.BackendCommands{
 				BackendRunner:      runner,
+				DryRun:             false,
 				GitTown:            nil,
 				CurrentBranchCache: &cache.LocalBranchWithPrevious{},
 				RemotesCache:       &cache.Remotes{},

--- a/src/vm/opcode/force_push_current_branch.go
+++ b/src/vm/opcode/force_push_current_branch.go
@@ -20,7 +20,7 @@ func (self *ForcePushCurrentBranch) Run(args shared.RunArgs) error {
 	if err != nil {
 		return err
 	}
-	if !shouldPush && !args.Runner.GitTown.DryRun {
+	if !shouldPush {
 		return nil
 	}
 	return args.Runner.Frontend.ForcePushBranch(self.NoPushHook)

--- a/src/vm/opcode/push_current_branch.go
+++ b/src/vm/opcode/push_current_branch.go
@@ -24,7 +24,7 @@ func (self *PushCurrentBranch) Run(args shared.RunArgs) error {
 	if err != nil {
 		return err
 	}
-	if !shouldPush && !args.Runner.GitTown.DryRun {
+	if !shouldPush {
 		return nil
 	}
 	return args.Runner.Frontend.PushCurrentBranch(self.NoPushHook)

--- a/src/vm/runstate/runstate.go
+++ b/src/vm/runstate/runstate.go
@@ -17,6 +17,7 @@ import (
 // and how to undo what has been done so far.
 type RunState struct {
 	Command                  string
+	DryRun                   bool
 	IsUndo                   bool            `exhaustruct:"optional"`
 	AbortProgram             program.Program `exhaustruct:"optional"`
 	RunProgram               program.Program
@@ -60,6 +61,7 @@ func (self *RunState) CreateAbortRunState() RunState {
 	abortProgram.AddProgram(self.UndoProgram)
 	return RunState{
 		Command:             self.Command,
+		DryRun:              self.DryRun,
 		IsUndo:              true,
 		InitialActiveBranch: self.InitialActiveBranch,
 		RunProgram:          abortProgram,
@@ -71,6 +73,7 @@ func (self *RunState) CreateAbortRunState() RunState {
 func (self *RunState) CreateSkipRunState() RunState {
 	result := RunState{
 		Command:             self.Command,
+		DryRun:              self.DryRun,
 		InitialActiveBranch: self.InitialActiveBranch,
 		RunProgram:          self.AbortProgram,
 	}
@@ -99,6 +102,7 @@ func (self *RunState) CreateSkipRunState() RunState {
 func (self *RunState) CreateUndoRunState() RunState {
 	result := RunState{
 		Command:                  self.Command,
+		DryRun:                   self.DryRun,
 		InitialActiveBranch:      self.InitialActiveBranch,
 		IsUndo:                   true,
 		RunProgram:               self.UndoProgram,

--- a/src/vm/runstate/runstate_test.go
+++ b/src/vm/runstate/runstate_test.go
@@ -18,6 +18,7 @@ func TestRunState(t *testing.T) {
 		t.Parallel()
 		runState := &runstate.RunState{
 			Command: "sync",
+			DryRun:  true,
 			AbortProgram: program.Program{
 				&opcode.ResetCurrentBranchToSHA{
 					MustHaveSHA: gitdomain.NewSHA("222222"),
@@ -47,6 +48,7 @@ func TestRunState(t *testing.T) {
 		want := `
 {
   "Command": "sync",
+  "DryRun": true,
   "IsUndo": false,
   "AbortProgram": [
     {

--- a/src/vm/statefile/save_load_test.go
+++ b/src/vm/statefile/save_load_test.go
@@ -38,6 +38,7 @@ func TestLoadSave(t *testing.T) {
 			Command:      "command",
 			IsUndo:       true,
 			AbortProgram: program.Program{},
+			DryRun:       true,
 			RunProgram: program.Program{
 				&opcode.AbortMerge{},
 				&opcode.AbortRebase{},
@@ -172,6 +173,7 @@ func TestLoadSave(t *testing.T) {
 		wantJSON := `
 {
   "Command": "command",
+  "DryRun": true,
   "IsUndo": true,
   "AbortProgram": [],
   "RunProgram": [

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -126,6 +126,7 @@ func (self *Fixture) AddSecondWorktree(branch gitdomain.LocalBranchName) {
 	}
 	backendCommands := git.BackendCommands{
 		BackendRunner:      &runner,
+		DryRun:             false,
 		GitTown:            self.DevRepo.GitTown,
 		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
 		RemotesCache:       &cache.Remotes{},

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -82,12 +82,13 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 	if err != nil {
 		panic(err)
 	}
-	gitTown, err := config.NewGitTown(gitConfig, &runner, false)
+	gitTown, err := config.NewGitTown(gitConfig, &runner)
 	if err != nil {
 		panic(err)
 	}
 	backendCommands := git.BackendCommands{
 		BackendRunner:      &runner,
+		DryRun:             false,
 		GitTown:            gitTown,
 		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
 		RemotesCache:       &cache.Remotes{},


### PR DESCRIPTION
It was put there as a single source of truth, but accessing it there from all the different places leads to unnecessarily tight coupling of the different packages.