### PR TITLE
Improve performance of the undo commands

### DIFF
--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -44,11 +44,12 @@ Feature: display all executed Git commands
       """
     And the current branch is now "new"
 
+  @this
   Scenario: undo
     Given I ran "git-town append new"
     When I run "git-town undo --verbose"
     Then it prints:
       """
-      Ran 16 shell commands.
+      Ran 12 shell commands.
       """
     And the current branch is now "existing"

--- a/features/append/features/verbose.feature
+++ b/features/append/features/verbose.feature
@@ -44,7 +44,6 @@ Feature: display all executed Git commands
       """
     And the current branch is now "new"
 
-  @this
   Scenario: undo
     Given I ran "git-town append new"
     When I run "git-town undo --verbose"
@@ -62,10 +61,6 @@ Feature: display all executed Git commands
       |          | backend  | git config --unset git-town-branch.new.parent |
       | new      | frontend | git checkout existing                         |
       | existing | frontend | git branch -D new                             |
-      |          | backend  | git config -lz --global                       |
-      |          | backend  | git config -lz --local                        |
-      |          | backend  | git branch -vva                               |
-      |          | backend  | git stash list                                |
     And it prints:
       """
       Ran 12 shell commands.

--- a/features/hack/features/verbose.feature
+++ b/features/hack/features/verbose.feature
@@ -58,12 +58,8 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --short HEAD                    |
       | main   | frontend | git reset --hard {{ sha 'initial commit' }}   |
       |        | frontend | git branch -D new                             |
-      |        | backend  | git config -lz --global                       |
-      |        | backend  | git config -lz --local                        |
-      |        | backend  | git branch -vva                               |
-      |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 18 shell commands.
+      Ran 14 shell commands.
       """
     And the current branch is now "main"

--- a/features/prepend/features/verbose.feature
+++ b/features/prepend/features/verbose.feature
@@ -65,12 +65,8 @@ Feature: display all executed Git commands
       |        | backend  | git config git-town-branch.old.parent main       |
       | parent | frontend | git checkout old                                 |
       | old    | frontend | git branch -D parent                             |
-      |        | backend  | git config -lz --global                          |
-      |        | backend  | git config -lz --local                           |
-      |        | backend  | git branch -vva                                  |
-      |        | backend  | git stash list                                   |
     And it prints:
       """
-      Ran 17 shell commands.
+      Ran 13 shell commands.
       """
     And the current branch is now "old"

--- a/features/rename_branch/features/verbose.feature
+++ b/features/rename_branch/features/verbose.feature
@@ -66,12 +66,8 @@ Feature: display all executed Git commands
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git checkout main                             |
       |        | backend  | git checkout old                              |
-      |        | backend  | git config -lz --global                       |
-      |        | backend  | git config -lz --local                        |
-      |        | backend  | git branch -vva                               |
-      |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 23 shell commands.
+      Ran 19 shell commands.
       """
     And the current branch is now "old"

--- a/features/ship/current_branch/features/verbose.feature
+++ b/features/ship/current_branch/features/verbose.feature
@@ -79,12 +79,8 @@ Feature: display all executed Git commands
       |        | frontend | git push -u origin feature                     |
       |        | frontend | git checkout feature                           |
       |        | backend  | git show-ref --verify --quiet refs/heads/      |
-      |        | backend  | git config -lz --global                        |
-      |        | backend  | git config -lz --local                         |
-      |        | backend  | git branch -vva                                |
-      |        | backend  | git stash list                                 |
     And it prints:
       """
-      Ran 22 shell commands.
+      Ran 18 shell commands.
       """
     And the current branch is now "feature"

--- a/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/verbose.feature
+++ b/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/verbose.feature
@@ -68,13 +68,9 @@ Feature: display all executed Git commands
       | main   | frontend | git branch old {{ sha 'initial commit' }}  |
       |        | frontend | git checkout old                           |
       |        | backend  | git show-ref --verify --quiet refs/heads/  |
-      |        | backend  | git config -lz --global                    |
-      |        | backend  | git config -lz --local                     |
-      |        | backend  | git branch -vva                            |
-      |        | backend  | git stash list                             |
     And it prints:
       """
-      Ran 17 shell commands.
+      Ran 13 shell commands.
       """
     And the current branch is now "old"
     And the initial branches and lineage exist

--- a/src/vm/interpreter/finished.go
+++ b/src/vm/interpreter/finished.go
@@ -12,12 +12,7 @@ import (
 // finished is called when executing all steps has successfully finished.
 func finished(args ExecuteArgs) error {
 	if args.RunState.IsUndo {
-		err := statefile.Delete(args.RootDir)
-		if err != nil {
-			return fmt.Errorf(messages.RunstateDeleteProblem, err)
-		}
-		print.Footer(args.Verbose, args.Run.CommandsCounter.Count(), args.Run.FinalMessages.Result())
-		return nil
+		return finishedUndoCommand(args)
 	}
 	args.RunState.MarkAsFinished()
 	undoProgram, err := undo.CreateUndoProgram(undo.CreateUndoProgramArgs{
@@ -36,6 +31,15 @@ func finished(args ExecuteArgs) error {
 	err = statefile.Save(args.RunState, args.RootDir)
 	if err != nil {
 		return fmt.Errorf(messages.RunstateSaveProblem, err)
+	}
+	print.Footer(args.Verbose, args.Run.CommandsCounter.Count(), args.Run.FinalMessages.Result())
+	return nil
+}
+
+func finishedUndoCommand(args ExecuteArgs) error {
+	err := statefile.Delete(args.RootDir)
+	if err != nil {
+		return fmt.Errorf(messages.RunstateDeleteProblem, err)
 	}
 	print.Footer(args.Verbose, args.Run.CommandsCounter.Count(), args.Run.FinalMessages.Result())
 	return nil

--- a/src/vm/interpreter/finished.go
+++ b/src/vm/interpreter/finished.go
@@ -11,6 +11,14 @@ import (
 
 // finished is called when executing all steps has successfully finished.
 func finished(args ExecuteArgs) error {
+	if args.RunState.IsUndo {
+		err := statefile.Delete(args.RootDir)
+		if err != nil {
+			return fmt.Errorf(messages.RunstateDeleteProblem, err)
+		}
+		print.Footer(args.Verbose, args.Run.CommandsCounter.Count(), args.Run.FinalMessages.Result())
+		return nil
+	}
 	args.RunState.MarkAsFinished()
 	undoProgram, err := undo.CreateUndoProgram(undo.CreateUndoProgramArgs{
 		Run:                      args.Run,
@@ -25,16 +33,9 @@ func finished(args ExecuteArgs) error {
 	}
 	args.RunState.UndoProgram.AddProgram(undoProgram)
 	args.RunState.UndoProgram.AddProgram(args.RunState.FinalUndoProgram)
-	if args.RunState.IsUndo {
-		err := statefile.Delete(args.RootDir)
-		if err != nil {
-			return fmt.Errorf(messages.RunstateDeleteProblem, err)
-		}
-	} else {
-		err := statefile.Save(args.RunState, args.RootDir)
-		if err != nil {
-			return fmt.Errorf(messages.RunstateSaveProblem, err)
-		}
+	err = statefile.Save(args.RunState, args.RootDir)
+	if err != nil {
+		return fmt.Errorf(messages.RunstateSaveProblem, err)
 	}
 	print.Footer(args.Verbose, args.Run.CommandsCounter.Count(), args.Run.FinalMessages.Result())
 	return nil


### PR DESCRIPTION
Not calculating the undo state after an undo command finishes - because we won't use it anyways - shaves off 4 expensive Git operations from the undo command stack.