### PR TITLE
Disable enforcement of keywords in logical order

### DIFF
--- a/.gherkin-lintrc
+++ b/.gherkin-lintrc
@@ -19,7 +19,7 @@
       "scenario tag": 2
     }
   ],
-  "keywords-in-logical-order": "on",
+  "keywords-in-logical-order": "off",
   "new-line-at-eof": [ "on", "yes" ],
   "no-background-only-scenario": "off",
   "no-dupe-scenario-names": [ "on", "in-feature" ],


### PR DESCRIPTION
We verify this manually, and start having tests that use multiple sequences of When and Then steps.