### PR TITLE
Reduce concurrency under Windows

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -25,10 +25,12 @@ func TestGodog(t *testing.T) {
 	if os.Getenv("cukethis") != "" {
 		tags = "@this"
 	}
-	concurrency := 4
+	var concurrency int
 	if runtime.GOOS == "windows" {
 		tags = "~@skipWindows"
 		concurrency = 1
+	} else {
+		concurrency = 4
 	}
 	status := godog.RunWithOptions("godog", func(s *godog.Suite) {
 		FeatureContext(s)

--- a/main_test.go
+++ b/main_test.go
@@ -25,14 +25,16 @@ func TestGodog(t *testing.T) {
 	if os.Getenv("cukethis") != "" {
 		tags = "@this"
 	}
+	concurrency := 4
 	if runtime.GOOS == "windows" {
 		tags = "~@skipWindows"
+		concurrency = 1
 	}
 	status := godog.RunWithOptions("godog", func(s *godog.Suite) {
 		FeatureContext(s)
 	}, godog.Options{
 		Format:      "progress",
-		Concurrency: runtime.NumCPU() * 4,
+		Concurrency: runtime.NumCPU() * concurrency,
 		Strict:      true,
 		Paths:       []string{"features/"},
 		Tags:        tags,


### PR DESCRIPTION
Windows suffers from pretty drastic slowness under concurrency that doesn't happen under Linux running on the exact same hardware. To account for this, let's reduce the concurrency under Windows. This yields a roughly 2x performance improvement under Windows on my hardware.