### PR TITLE
Make gitconfig access explicit

### DIFF
--- a/src/cmd/config/reset.go
+++ b/src/cmd/config/reset.go
@@ -36,5 +36,5 @@ func executeConfigResetStatus(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	return repo.Runner.RemoveLocalGitConfiguration(repo.Runner.Lineage)
+	return repo.Runner.Access.RemoveLocalGitConfiguration(repo.Runner.Lineage)
 }

--- a/src/cmd/config/reset.go
+++ b/src/cmd/config/reset.go
@@ -36,5 +36,5 @@ func executeConfigResetStatus(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	return repo.Runner.Access.RemoveLocalGitConfiguration(repo.Runner.Lineage)
+	return repo.Runner.GitConfig.RemoveLocalGitConfiguration(repo.Runner.Lineage)
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -19,7 +19,7 @@ import (
 // Config provides type-safe access to Git Town configuration settings
 // stored in the local and global Git configuration.
 type Config struct {
-	Access                  gitconfig.Access           // access to the Git configuration settings
+	GitConfig               gitconfig.Access           // access to the Git configuration settings
 	configdomain.FullConfig                            // the merged configuration data
 	configFile              configdomain.PartialConfig // content of git-town.toml
 	GlobalGitConfig         configdomain.PartialConfig // content of the global Git configuration
@@ -52,12 +52,12 @@ func (self *Config) OriginURLString() string {
 	if remote != "" {
 		return remote
 	}
-	return self.Access.OriginRemote()
+	return self.GitConfig.OriginRemote()
 }
 
 func (self *Config) Reload() {
-	_, self.GlobalGitConfig, _ = self.Access.Load(true) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	_, self.LocalGitConfig, _ = self.Access.Load(false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	_, self.GlobalGitConfig, _ = self.GitConfig.Load(true) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	_, self.LocalGitConfig, _ = self.GitConfig.Load(false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	self.FullConfig = configdomain.DefaultConfig()
 	// TODO: merge this code with the similar code in NewGitTown.
 	self.FullConfig.Merge(self.configFile)
@@ -74,7 +74,7 @@ func (self *Config) RemoveFromPerennialBranches(branch gitdomain.LocalBranchName
 // RemoveParent removes the parent branch entry for the given branch from the Git configuration.
 func (self *Config) RemoveParent(branch gitdomain.LocalBranchName) {
 	self.LocalGitConfig.Lineage.RemoveBranch(branch)
-	_ = self.Access.RemoveLocalConfigValue(gitconfig.NewParentKey(branch))
+	_ = self.GitConfig.RemoveLocalConfigValue(gitconfig.NewParentKey(branch))
 }
 
 // SetMainBranch marks the given branch as the main branch
@@ -82,7 +82,7 @@ func (self *Config) RemoveParent(branch gitdomain.LocalBranchName) {
 func (self *Config) SetMainBranch(branch gitdomain.LocalBranchName) error {
 	self.MainBranch = branch
 	self.LocalGitConfig.MainBranch = &branch
-	return self.Access.SetLocalConfigValue(gitconfig.KeyMainBranch, branch.String())
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeyMainBranch, branch.String())
 }
 
 // SetNewBranchPush updates whether the current repository is configured to push
@@ -92,16 +92,16 @@ func (self *Config) SetNewBranchPush(value configdomain.NewBranchPush, global bo
 	self.NewBranchPush = value
 	if global {
 		self.GlobalGitConfig.NewBranchPush = &value
-		return self.Access.SetGlobalConfigValue(gitconfig.KeyPushNewBranches, setting)
+		return self.GitConfig.SetGlobalConfigValue(gitconfig.KeyPushNewBranches, setting)
 	}
 	self.LocalGitConfig.NewBranchPush = &value
-	return self.Access.SetLocalConfigValue(gitconfig.KeyPushNewBranches, setting)
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeyPushNewBranches, setting)
 }
 
 // SetOffline updates whether Git Town is in offline mode.
 func (self *Config) SetOffline(value configdomain.Offline) error {
 	self.FullConfig.Offline = value
-	return self.Access.SetGlobalConfigValue(gitconfig.KeyOffline, value.String())
+	return self.GitConfig.SetGlobalConfigValue(gitconfig.KeyOffline, value.String())
 }
 
 // SetParent marks the given branch as the direct parent of the other given branch
@@ -111,56 +111,56 @@ func (self *Config) SetParent(branch, parentBranch gitdomain.LocalBranchName) er
 		return nil
 	}
 	self.Lineage[branch] = parentBranch
-	return self.Access.SetLocalConfigValue(gitconfig.NewParentKey(branch), parentBranch.String())
+	return self.GitConfig.SetLocalConfigValue(gitconfig.NewParentKey(branch), parentBranch.String())
 }
 
 // SetPerennialBranches marks the given branches as perennial branches.
 func (self *Config) SetPerennialBranches(branches gitdomain.LocalBranchNames) error {
 	self.PerennialBranches = branches
-	return self.Access.SetLocalConfigValue(gitconfig.KeyPerennialBranches, branches.Join(" "))
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeyPerennialBranches, branches.Join(" "))
 }
 
 // SetPushHook updates the configured push-hook strategy.
 func (self *Config) SetPushHookGlobally(value configdomain.PushHook) error {
 	self.GlobalGitConfig.PushHook = &value
 	self.PushHook = value
-	return self.Access.SetGlobalConfigValue(gitconfig.KeyPushHook, strconv.FormatBool(value.Bool()))
+	return self.GitConfig.SetGlobalConfigValue(gitconfig.KeyPushHook, strconv.FormatBool(value.Bool()))
 }
 
 // SetPushHookLocally updates the locally configured push-hook strategy.
 func (self *Config) SetPushHookLocally(value configdomain.PushHook) error {
 	self.LocalGitConfig.PushHook = &value
 	self.PushHook = value
-	return self.Access.SetLocalConfigValue(gitconfig.KeyPushHook, strconv.FormatBool(bool(value)))
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeyPushHook, strconv.FormatBool(bool(value)))
 }
 
 // SetShipDeleteTrackingBranch updates the configured delete-remote-branch strategy.
 func (self *Config) SetShipDeleteTrackingBranch(value configdomain.ShipDeleteTrackingBranch) error {
-	return self.Access.SetLocalConfigValue(gitconfig.KeyShipDeleteTrackingBranch, strconv.FormatBool(value.Bool()))
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeyShipDeleteTrackingBranch, strconv.FormatBool(value.Bool()))
 }
 
 func (self *Config) SetSyncFeatureStrategy(value configdomain.SyncFeatureStrategy) error {
 	self.LocalGitConfig.SyncFeatureStrategy = &value
 	self.FullConfig.SyncFeatureStrategy = value
-	return self.Access.SetLocalConfigValue(gitconfig.KeySyncFeatureStrategy, value.String())
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeySyncFeatureStrategy, value.String())
 }
 
 func (self *Config) SetSyncFeatureStrategyGlobal(value configdomain.SyncFeatureStrategy) error {
 	self.GlobalGitConfig.SyncFeatureStrategy = &value
 	self.FullConfig.SyncFeatureStrategy = value
-	return self.Access.SetGlobalConfigValue(gitconfig.KeySyncFeatureStrategy, value.String())
+	return self.GitConfig.SetGlobalConfigValue(gitconfig.KeySyncFeatureStrategy, value.String())
 }
 
 // SetSyncPerennialStrategy updates the configured sync-perennial strategy.
 func (self *Config) SetSyncPerennialStrategy(strategy configdomain.SyncPerennialStrategy) error {
 	self.LocalGitConfig.SyncPerennialStrategy = &strategy
 	self.FullConfig.SyncPerennialStrategy = strategy
-	return self.Access.SetLocalConfigValue(gitconfig.KeySyncPerennialStrategy, strategy.String())
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeySyncPerennialStrategy, strategy.String())
 }
 
 // SetSyncUpstream updates the configured sync-upstream strategy.
 func (self *Config) SetSyncUpstream(value configdomain.SyncUpstream) error {
-	return self.Access.SetLocalConfigValue(gitconfig.KeySyncUpstream, strconv.FormatBool(value.Bool()))
+	return self.GitConfig.SetLocalConfigValue(gitconfig.KeySyncUpstream, strconv.FormatBool(value.Bool()))
 }
 
 func NewConfig(globalConfig, localConfig configdomain.PartialConfig, dryRun bool, runner gitconfig.Runner) (*Config, error) {
@@ -173,7 +173,7 @@ func NewConfig(globalConfig, localConfig configdomain.PartialConfig, dryRun bool
 	config.Merge(globalConfig)
 	config.Merge(localConfig)
 	return &Config{
-		Access:          gitconfig.Access{Runner: runner},
+		GitConfig:       gitconfig.Access{Runner: runner},
 		FullConfig:      config,
 		configFile:      configFile,
 		GlobalGitConfig: globalConfig,

--- a/src/undo/create_undo_program.go
+++ b/src/undo/create_undo_program.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CreateUndoProgram(args CreateUndoProgramArgs) (program.Program, error) {
-	undoConfigProgram, err := undoconfig.DetermineUndoConfigProgram(args.InitialConfigSnapshot, &args.Run.Config.Access)
+	undoConfigProgram, err := undoconfig.DetermineUndoConfigProgram(args.InitialConfigSnapshot, &args.Run.Config.GitConfig)
 	if err != nil {
 		return program.Program{}, err
 	}

--- a/src/vm/opcode/remove_global_config.go
+++ b/src/vm/opcode/remove_global_config.go
@@ -11,5 +11,5 @@ type RemoveGlobalConfig struct {
 }
 
 func (self *RemoveGlobalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.Access.RemoveGlobalConfigValue(self.Key)
+	return args.Runner.Config.GitConfig.RemoveGlobalConfigValue(self.Key)
 }

--- a/src/vm/opcode/remove_global_config.go
+++ b/src/vm/opcode/remove_global_config.go
@@ -11,5 +11,5 @@ type RemoveGlobalConfig struct {
 }
 
 func (self *RemoveGlobalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.RemoveGlobalConfigValue(self.Key)
+	return args.Runner.Config.Access.RemoveGlobalConfigValue(self.Key)
 }

--- a/src/vm/opcode/remove_local_config.go
+++ b/src/vm/opcode/remove_local_config.go
@@ -11,5 +11,5 @@ type RemoveLocalConfig struct {
 }
 
 func (self *RemoveLocalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.RemoveLocalConfigValue(self.Key)
+	return args.Runner.Config.Access.RemoveLocalConfigValue(self.Key)
 }

--- a/src/vm/opcode/remove_local_config.go
+++ b/src/vm/opcode/remove_local_config.go
@@ -11,5 +11,5 @@ type RemoveLocalConfig struct {
 }
 
 func (self *RemoveLocalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.Access.RemoveLocalConfigValue(self.Key)
+	return args.Runner.Config.GitConfig.RemoveLocalConfigValue(self.Key)
 }

--- a/src/vm/opcode/set_global_config.go
+++ b/src/vm/opcode/set_global_config.go
@@ -12,5 +12,5 @@ type SetGlobalConfig struct {
 }
 
 func (self *SetGlobalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.SetGlobalConfigValue(self.Key, self.Value)
+	return args.Runner.Config.Access.SetGlobalConfigValue(self.Key, self.Value)
 }

--- a/src/vm/opcode/set_global_config.go
+++ b/src/vm/opcode/set_global_config.go
@@ -12,5 +12,5 @@ type SetGlobalConfig struct {
 }
 
 func (self *SetGlobalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.Access.SetGlobalConfigValue(self.Key, self.Value)
+	return args.Runner.Config.GitConfig.SetGlobalConfigValue(self.Key, self.Value)
 }

--- a/src/vm/opcode/set_local_config.go
+++ b/src/vm/opcode/set_local_config.go
@@ -12,5 +12,5 @@ type SetLocalConfig struct {
 }
 
 func (self *SetLocalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.Access.SetLocalConfigValue(self.Key, self.Value)
+	return args.Runner.Config.GitConfig.SetLocalConfigValue(self.Key, self.Value)
 }

--- a/src/vm/opcode/set_local_config.go
+++ b/src/vm/opcode/set_local_config.go
@@ -12,5 +12,5 @@ type SetLocalConfig struct {
 }
 
 func (self *SetLocalConfig) Run(args shared.RunArgs) error {
-	return args.Runner.Config.SetLocalConfigValue(self.Key, self.Value)
+	return args.Runner.Config.Access.SetLocalConfigValue(self.Key, self.Value)
 }

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -341,7 +341,7 @@ func (self *TestCommands) RemoveMainBranchConfiguration() {
 
 // RemovePerennialBranchConfiguration removes the configuration entry for the perennial branches.
 func (self *TestCommands) RemovePerennialBranchConfiguration() error {
-	return self.RemoveLocalConfigValue(gitconfig.KeyPerennialBranches)
+	return self.Access.RemoveLocalConfigValue(gitconfig.KeyPerennialBranches)
 }
 
 // RemoveRemote deletes the Git remote with the given name.

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -341,7 +341,7 @@ func (self *TestCommands) RemoveMainBranchConfiguration() {
 
 // RemovePerennialBranchConfiguration removes the configuration entry for the perennial branches.
 func (self *TestCommands) RemovePerennialBranchConfiguration() error {
-	return self.Access.RemoveLocalConfigValue(gitconfig.KeyPerennialBranches)
+	return self.GitConfig.RemoveLocalConfigValue(gitconfig.KeyPerennialBranches)
 }
 
 // RemoveRemote deletes the Git remote with the given name.

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -249,7 +249,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	suite.Step(`^Git Town parent setting for branch "([^"]*)" is "([^"]*)"$`, func(branch, value string) error {
 		branchName := gitdomain.NewLocalBranchName(branch)
 		configKey := gitconfig.NewParentKey(branchName)
-		return state.fixture.DevRepo.Config.Access.SetLocalConfigValue(configKey, value)
+		return state.fixture.DevRepo.Config.GitConfig.SetLocalConfigValue(configKey, value)
 	})
 
 	suite.Step(`^global Git setting "alias\.(.*?)" is (?:now|still) "([^"]*)"$`, func(name, want string) error {
@@ -270,7 +270,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^global Git Town setting "([^"]*)" is "([^"]*)"$`, func(name, value string) error {
 		configKey := gitconfig.ParseKey("git-town." + name)
-		return state.fixture.DevRepo.Config.Access.SetGlobalConfigValue(*configKey, value)
+		return state.fixture.DevRepo.Config.GitConfig.SetGlobalConfigValue(*configKey, value)
 	})
 
 	suite.Step(`^global Git Town setting "([^"]*)" no longer exists$`, func(name string) error {
@@ -576,7 +576,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^(?:local )?Git Town setting "([^"]*)" is "([^"]*)"$`, func(name, value string) error {
 		configKey := gitconfig.ParseKey("git-town." + name)
-		return state.fixture.DevRepo.Config.Access.SetLocalConfigValue(*configKey, value)
+		return state.fixture.DevRepo.Config.GitConfig.SetLocalConfigValue(*configKey, value)
 	})
 
 	suite.Step(`^local Git Town setting "code-hosting-platform" is now "([^"]*)"$`, func(want string) error {

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -249,7 +249,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	suite.Step(`^Git Town parent setting for branch "([^"]*)" is "([^"]*)"$`, func(branch, value string) error {
 		branchName := gitdomain.NewLocalBranchName(branch)
 		configKey := gitconfig.NewParentKey(branchName)
-		return state.fixture.DevRepo.Config.SetLocalConfigValue(configKey, value)
+		return state.fixture.DevRepo.Config.Access.SetLocalConfigValue(configKey, value)
 	})
 
 	suite.Step(`^global Git setting "alias\.(.*?)" is (?:now|still) "([^"]*)"$`, func(name, want string) error {
@@ -270,7 +270,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^global Git Town setting "([^"]*)" is "([^"]*)"$`, func(name, value string) error {
 		configKey := gitconfig.ParseKey("git-town." + name)
-		return state.fixture.DevRepo.Config.SetGlobalConfigValue(*configKey, value)
+		return state.fixture.DevRepo.Config.Access.SetGlobalConfigValue(*configKey, value)
 	})
 
 	suite.Step(`^global Git Town setting "([^"]*)" no longer exists$`, func(name string) error {
@@ -576,7 +576,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^(?:local )?Git Town setting "([^"]*)" is "([^"]*)"$`, func(name, value string) error {
 		configKey := gitconfig.ParseKey("git-town." + name)
-		return state.fixture.DevRepo.Config.SetLocalConfigValue(*configKey, value)
+		return state.fixture.DevRepo.Config.Access.SetLocalConfigValue(*configKey, value)
 	})
 
 	suite.Step(`^local Git Town setting "code-hosting-platform" is now "([^"]*)"$`, func(want string) error {


### PR DESCRIPTION
Gitconfig is no longer the only way to persist configuration information. It should therefore no longer be used implicitly. This PR makes usage of gitconfig explicit.