### PR TITLE
Indicate config file optionality

### DIFF
--- a/src/config/configfile/load.go
+++ b/src/config/configfile/load.go
@@ -13,21 +13,22 @@ import (
 
 const FileName = ".git-branches.toml"
 
-func Load() (configdomain.PartialConfig, error) {
+func Load() (*configdomain.PartialConfig, error) {
 	file, err := os.Open(FileName)
 	if err != nil {
-		return configdomain.EmptyPartialConfig(), nil //nolint:nilerr
+		return nil, nil //nolint:nilerr,nilnil
 	}
 	defer file.Close()
 	bytes, err := io.ReadAll(file)
 	if err != nil {
-		return configdomain.EmptyPartialConfig(), fmt.Errorf(messages.ConfigFileCannotRead, ".git-branches.yml", err)
+		return nil, fmt.Errorf(messages.ConfigFileCannotRead, ".git-branches.yml", err)
 	}
 	configFileData, err := Parse(string(bytes))
 	if err != nil {
-		return configdomain.EmptyPartialConfig(), fmt.Errorf(messages.ConfigFileInvalidData, ".git-branches.yml", err)
+		return nil, fmt.Errorf(messages.ConfigFileInvalidData, ".git-branches.yml", err)
 	}
-	return Validate(*configFileData)
+	result, err := Validate(*configFileData)
+	return &result, err
 }
 
 // Parse converts the given config file TOML source into Go data.


### PR DESCRIPTION
Indicate whether the config file is there by making its Go counterpart optional.