### PR TITLE
Rename ship-delete-remote-branch to ship-delete-tracking-branch

### DIFF
--- a/features/config/ship_delete_remote_branch/upgrade.feature
+++ b/features/config/ship_delete_remote_branch/upgrade.feature
@@ -2,15 +2,15 @@ Feature: automatically upgrade outdated configuration
 
   @this
   Scenario Outline:
-    Given <LOCATION> Git Town setting "sync-delete-remote-branch" is "true"
+    Given <LOCATION> Git Town setting "ship-delete-remote-branch" is "true"
     When I run "git-town <COMMAND>"
     Then it prints:
       """
-      I found the deprecated <LOCATION> setting "git-town.sync-delete-remote-branch".
-      I am upgrading this setting to the new format "git-town.sync-delete-tracking-branch".
+      I found the deprecated <LOCATION> setting "git-town.ship-delete-remote-branch".
+      I am upgrading this setting to the new format "git-town.ship-delete-tracking-branch".
       """
-    And <LOCATION> Git Town setting "sync-delete-tracking-branch" is now "true"
-    And <LOCATION> Git Town setting "sync-delete-remote-branch" no longer exists
+    And <LOCATION> Git Town setting "ship-delete-tracking-branch" is now "true"
+    And <LOCATION> Git Town setting "ship-delete-remote-branch" no longer exists
 
     Examples:
       | COMMAND | LOCATION |

--- a/features/config/ship_delete_remote_branch/upgrade.feature
+++ b/features/config/ship_delete_remote_branch/upgrade.feature
@@ -1,0 +1,18 @@
+Feature: automatically upgrade outdated configuration
+
+  @this
+  Scenario Outline:
+    Given <LOCATION> Git Town setting "sync-delete-remote-branch" is "true"
+    When I run "git-town <COMMAND>"
+    Then it prints:
+      """
+      I found the deprecated <LOCATION> setting "git-town.sync-delete-remote-branch".
+      I am upgrading this setting to the new format "git-town.sync-delete-tracking-branch".
+      """
+    And <LOCATION> Git Town setting "sync-delete-tracking-branch" is now "true"
+    And <LOCATION> Git Town setting "sync-delete-remote-branch" no longer exists
+
+    Examples:
+      | COMMAND | LOCATION |
+      | config  | local    |
+      | config  | global   |

--- a/features/config/ship_delete_remote_branch/upgrade.feature
+++ b/features/config/ship_delete_remote_branch/upgrade.feature
@@ -1,6 +1,5 @@
 Feature: automatically upgrade outdated configuration
 
-  @this
   Scenario Outline:
     Given <LOCATION> Git Town setting "ship-delete-remote-branch" is "true"
     When I run "git-town <COMMAND>"

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -31,7 +31,7 @@ Feature: show the configuration
     Given the configuration file:
       """
       push-new-branches = true
-      ship-delete-remote-branch = true
+      ship-delete-tracking-branch = true
       sync-upstream = true
 
       [branches]
@@ -74,14 +74,14 @@ Feature: show the configuration
     Given the main branch is "git-main"
     And the perennial branches are "git-perennial-1" and "git-perennial-2"
     And Git Town setting "push-new-branches" is "false"
-    And Git Town setting "ship-delete-remote-branch" is "false"
+    And Git Town setting "ship-delete-tracking-branch" is "false"
     And Git Town setting "sync-upstream" is "false"
     And Git Town setting "sync-perennial-strategy" is "merge"
     And Git Town setting "sync-feature-strategy" is "merge"
     And the configuration file:
       """
       push-new-branches = true
-      ship-delete-remote-branch = true
+      ship-tracking-remote-branch = true
       sync-upstream = true
 
       [branches]

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -81,7 +81,7 @@ Feature: show the configuration
     And the configuration file:
       """
       push-new-branches = true
-      ship-tracking-remote-branch = true
+      ship-delete-tracking-branch = true
       sync-upstream = true
 
       [branches]

--- a/features/ship/current_branch/features/ship_delete_remote_branch.feature
+++ b/features/ship/current_branch/features/ship_delete_remote_branch.feature
@@ -1,11 +1,11 @@
-Feature: ship-delete-remote-branch disabled
+Feature: ship-delete-tracking-branch disabled
 
   Background:
     Given the current branch is a feature branch "feature"
     And the commits
       | BRANCH  | LOCATION      | MESSAGE        |
       | feature | local, origin | feature commit |
-    And Git Town setting "ship-delete-remote-branch" is "false"
+    And Git Town setting "ship-delete-tracking-branch" is "false"
     When I run "git-town ship -m 'feature done'"
     And origin deletes the "feature" branch
 

--- a/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
+++ b/features/ship/supplied_branch/features/ship_delete_remote_branch_flag.feature
@@ -7,7 +7,7 @@ Feature: skip deleting the remote branch when shipping another branch
       | feature | local, origin | feature commit |
       | other   | local         | other commit   |
     And the current branch is "other"
-    And Git Town setting "ship-delete-remote-branch" is "false"
+    And Git Town setting "ship-delete-tracking-branch" is "false"
     When I run "git-town ship feature -m 'feature done'"
     And origin deletes the "feature" branch
 

--- a/src/config/configfile/data.go
+++ b/src/config/configfile/data.go
@@ -7,7 +7,7 @@ type Data struct {
 	SyncStrategy             *SyncStrategy `toml:"sync-strategy"`
 	PushHook                 *bool         `toml:"push-hook"`
 	PushNewbranches          *bool         `toml:"push-new-branches"`
-	ShipDeleteTrackingBranch *bool         `toml:"ship-delete-remote-branch"`
+	ShipDeleteTrackingBranch *bool         `toml:"ship-delete-tracking-branch"`
 	SyncBeforeShip           *bool         `toml:"sync-before-ship"`
 	SyncUpstream             *bool         `toml:"sync-upstream"`
 }

--- a/src/config/configfile/load_test.go
+++ b/src/config/configfile/load_test.go
@@ -17,7 +17,7 @@ func TestConfigfile(t *testing.T) {
 			give := `
 push-hook = true
 push-new-branches = true
-ship-delete-remote-branch = false
+ship-delete-tracking-branch = false
 sync-before-ship = false
 sync-upstream = true
 

--- a/src/config/configfile/save_test.go
+++ b/src/config/configfile/save_test.go
@@ -41,7 +41,7 @@ func TestSave(t *testing.T) {
 		want := `
 push-hook = true
 push-new-branches = false
-ship-delete-remote-branch = false
+ship-delete-tracking-branch = false
 sync-before-ship = false
 sync-upstream = true
 
@@ -88,7 +88,7 @@ sync-upstream = true
 		want := `
 push-hook = true
 push-new-branches = false
-ship-delete-remote-branch = false
+ship-delete-tracking-branch = false
 sync-before-ship = false
 sync-upstream = true
 

--- a/src/config/gitconfig/access.go
+++ b/src/config/gitconfig/access.go
@@ -105,6 +105,7 @@ func AddKeyToPartialConfig(key Key, value string, config *configdomain.PartialCo
 		KeyDeprecatedPerennialBranchNames,
 		KeyDeprecatedPullBranchStrategy,
 		KeyDeprecatedPushVerify,
+		KeyDeprecatedShipDeleteRemoteBranch,
 		KeyDeprecatedSyncStrategy:
 		// deprecated keys were handled before this is reached, here we simply do a check that the switch statement contains all keys
 		panic(fmt.Sprintf("unhandled deprecated config key %q", key))

--- a/src/config/gitconfig/key.go
+++ b/src/config/gitconfig/key.go
@@ -28,42 +28,43 @@ func (self *Key) UnmarshalJSON(b []byte) error {
 }
 
 const (
-	KeyAliasAppend                    = Key("alias.append")
-	KeyAliasDiffParent                = Key("alias.diff-parent")
-	KeyAliasHack                      = Key("alias.hack")
-	KeyAliasKill                      = Key("alias.kill")
-	KeyAliasPrepend                   = Key("alias.prepend")
-	KeyAliasPropose                   = Key("alias.propose")
-	KeyAliasRenameBranch              = Key("alias.rename-branch")
-	KeyAliasRepo                      = Key("alias.repo")
-	KeyAliasSetParent                 = Key("alias.set-parent")
-	KeyAliasShip                      = Key("alias.ship")
-	KeyAliasSync                      = Key("alias.sync")
-	KeyCodeHostingOriginHostname      = Key("git-town.code-hosting-origin-hostname")
-	KeyCodeHostingPlatform            = Key("git-town.code-hosting-platform")
-	KeyDeprecatedCodeHostingDriver    = Key("git-town.code-hosting-driver")
-	KeyDeprecatedMainBranchName       = Key("git-town.main-branch-name")
-	KeyDeprecatedNewBranchPushFlag    = Key("git-town.new-branch-push-flag")
-	KeyDeprecatedPerennialBranchNames = Key("git-town.perennial-branch-names")
-	KeyDeprecatedPullBranchStrategy   = Key("git-town.pull-branch-strategy")
-	KeyDeprecatedPushVerify           = Key("git-town.push-verify")
-	KeyDeprecatedSyncStrategy         = Key("git-town.sync-strategy")
-	KeyGiteaToken                     = Key("git-town.gitea-token")
-	KeyGithubToken                    = Key("git-town.github-token")
-	KeyGitlabToken                    = Key("git-town.gitlab-token")
-	KeyMainBranch                     = Key("git-town.main-branch")
-	KeyOffline                        = Key("git-town.offline")
-	KeyPerennialBranches              = Key("git-town.perennial-branches")
-	KeyPushHook                       = Key("git-town.push-hook")
-	KeyPushNewBranches                = Key("git-town.push-new-branches")
-	KeyShipDeleteTrackingBranch       = Key("git-town.ship-delete-tracking-branch")
-	KeySyncBeforeShip                 = Key("git-town.sync-before-ship")
-	KeySyncFeatureStrategy            = Key("git-town.sync-feature-strategy")
-	KeySyncPerennialStrategy          = Key("git-town.sync-perennial-strategy")
-	KeySyncStrategy                   = Key("git-town.sync-strategy")
-	KeySyncUpstream                   = Key("git-town.sync-upstream")
-	KeyGitUserEmail                   = Key("user.email")
-	KeyGitUserName                    = Key("user.name")
+	KeyAliasAppend                      = Key("alias.append")
+	KeyAliasDiffParent                  = Key("alias.diff-parent")
+	KeyAliasHack                        = Key("alias.hack")
+	KeyAliasKill                        = Key("alias.kill")
+	KeyAliasPrepend                     = Key("alias.prepend")
+	KeyAliasPropose                     = Key("alias.propose")
+	KeyAliasRenameBranch                = Key("alias.rename-branch")
+	KeyAliasRepo                        = Key("alias.repo")
+	KeyAliasSetParent                   = Key("alias.set-parent")
+	KeyAliasShip                        = Key("alias.ship")
+	KeyAliasSync                        = Key("alias.sync")
+	KeyCodeHostingOriginHostname        = Key("git-town.code-hosting-origin-hostname")
+	KeyCodeHostingPlatform              = Key("git-town.code-hosting-platform")
+	KeyDeprecatedCodeHostingDriver      = Key("git-town.code-hosting-driver")
+	KeyDeprecatedMainBranchName         = Key("git-town.main-branch-name")
+	KeyDeprecatedNewBranchPushFlag      = Key("git-town.new-branch-push-flag")
+	KeyDeprecatedPerennialBranchNames   = Key("git-town.perennial-branch-names")
+	KeyDeprecatedPullBranchStrategy     = Key("git-town.pull-branch-strategy")
+	KeyDeprecatedPushVerify             = Key("git-town.push-verify")
+	KeyDeprecatedShipDeleteRemoteBranch = Key("git-town.ship-delete-remote-branch")
+	KeyDeprecatedSyncStrategy           = Key("git-town.sync-strategy")
+	KeyGiteaToken                       = Key("git-town.gitea-token")
+	KeyGithubToken                      = Key("git-town.github-token")
+	KeyGitlabToken                      = Key("git-town.gitlab-token")
+	KeyMainBranch                       = Key("git-town.main-branch")
+	KeyOffline                          = Key("git-town.offline")
+	KeyPerennialBranches                = Key("git-town.perennial-branches")
+	KeyPushHook                         = Key("git-town.push-hook")
+	KeyPushNewBranches                  = Key("git-town.push-new-branches")
+	KeyShipDeleteTrackingBranch         = Key("git-town.ship-delete-tracking-branch")
+	KeySyncBeforeShip                   = Key("git-town.sync-before-ship")
+	KeySyncFeatureStrategy              = Key("git-town.sync-feature-strategy")
+	KeySyncPerennialStrategy            = Key("git-town.sync-perennial-strategy")
+	KeySyncStrategy                     = Key("git-town.sync-strategy")
+	KeySyncUpstream                     = Key("git-town.sync-upstream")
+	KeyGitUserEmail                     = Key("user.email")
+	KeyGitUserName                      = Key("user.name")
 )
 
 var keys = []Key{ //nolint:gochecknoglobals
@@ -75,6 +76,7 @@ var keys = []Key{ //nolint:gochecknoglobals
 	KeyDeprecatedPerennialBranchNames,
 	KeyDeprecatedPullBranchStrategy,
 	KeyDeprecatedPushVerify,
+	KeyDeprecatedShipDeleteRemoteBranch,
 	KeyDeprecatedSyncStrategy,
 	KeyGiteaToken,
 	KeyGithubToken,
@@ -164,11 +166,12 @@ func parseLineageKey(key string) *Key {
 
 // DeprecatedKeys defines the up-to-date counterparts to deprecated configuration settings.
 var DeprecatedKeys = map[Key]Key{ //nolint:gochecknoglobals
-	KeyDeprecatedCodeHostingDriver:    KeyCodeHostingPlatform,
-	KeyDeprecatedMainBranchName:       KeyMainBranch,
-	KeyDeprecatedNewBranchPushFlag:    KeyPushNewBranches,
-	KeyDeprecatedPerennialBranchNames: KeyPerennialBranches,
-	KeyDeprecatedPullBranchStrategy:   KeySyncPerennialStrategy,
-	KeyDeprecatedPushVerify:           KeyPushHook,
-	KeyDeprecatedSyncStrategy:         KeySyncFeatureStrategy,
+	KeyDeprecatedCodeHostingDriver:      KeyCodeHostingPlatform,
+	KeyDeprecatedMainBranchName:         KeyMainBranch,
+	KeyDeprecatedNewBranchPushFlag:      KeyPushNewBranches,
+	KeyDeprecatedPerennialBranchNames:   KeyPerennialBranches,
+	KeyDeprecatedPullBranchStrategy:     KeySyncPerennialStrategy,
+	KeyDeprecatedPushVerify:             KeyPushHook,
+	KeyDeprecatedShipDeleteRemoteBranch: KeyShipDeleteTrackingBranch,
+	KeyDeprecatedSyncStrategy:           KeySyncFeatureStrategy,
 }

--- a/src/config/gitconfig/key.go
+++ b/src/config/gitconfig/key.go
@@ -56,7 +56,7 @@ const (
 	KeyPerennialBranches              = Key("git-town.perennial-branches")
 	KeyPushHook                       = Key("git-town.push-hook")
 	KeyPushNewBranches                = Key("git-town.push-new-branches")
-	KeyShipDeleteTrackingBranch       = Key("git-town.ship-delete-remote-branch")
+	KeyShipDeleteTrackingBranch       = Key("git-town.ship-delete-tracking-branch")
 	KeySyncBeforeShip                 = Key("git-town.sync-before-ship")
 	KeySyncFeatureStrategy            = Key("git-town.sync-feature-strategy")
 	KeySyncPerennialStrategy          = Key("git-town.sync-perennial-strategy")

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -344,6 +344,17 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 		return fmt.Errorf(`expected global setting "push-new-branches" to be %v, but was %v`, want, *have)
 	})
 
+	suite.Step(`^global Git Town setting "ship-delete-tracking-branch" is (?:now|still) "([^"]*)"$`, func(wantStr string) error {
+		have := state.fixture.DevRepo.Config.GlobalGitConfig.ShipDeleteTrackingBranch
+		wantBool, err := strconv.ParseBool(wantStr)
+		asserts.NoError(err)
+		want := configdomain.ShipDeleteTrackingBranch(wantBool)
+		if cmp.Equal(*have, want) {
+			return nil
+		}
+		return fmt.Errorf(`expected global setting "ship-delete-tracking-branch" to be %v, but was %v`, want, *have)
+	})
+
 	suite.Step(`^global Git Town setting "sync-feature-strategy" is (?:now|still) "([^"]*)"$`, func(wantStr string) error {
 		have := state.fixture.DevRepo.Config.GlobalGitConfig.SyncFeatureStrategy
 		want, err := configdomain.NewSyncFeatureStrategy(wantStr)
@@ -636,6 +647,17 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			return nil
 		}
 		return fmt.Errorf(`expected local setting "push-new-branches" to be %v, but was %v`, want, have)
+	})
+
+	suite.Step(`^local Git Town setting "ship-delete-tracking-branch" is now "([^"]*)"$`, func(wantStr string) error {
+		have := state.fixture.DevRepo.Config.LocalGitConfig.ShipDeleteTrackingBranch
+		wantBool, err := strconv.ParseBool(wantStr)
+		asserts.NoError(err)
+		want := configdomain.ShipDeleteTrackingBranch(wantBool)
+		if *have != want {
+			return fmt.Errorf(`expected local setting "ship-delete-tracking-branch" to be %v, but was %v`, want, have)
+		}
+		return nil
 	})
 
 	suite.Step(`^local Git Town setting "sync-feature-strategy" is now "([^"]*)"$`, func(wantStr string) error {

--- a/website/src/SUMMARY.md
+++ b/website/src/SUMMARY.md
@@ -47,7 +47,7 @@
   - [push-new-branches](preferences/push-new-branches.md)
   - [parent](preferences/parent.md)
   - [pererennial-branches](preferences/perennial-branches.md)
-  - [ship-delete-remote-branch](preferences/ship-delete-remote-branch.md)
+  - [ship-delete-tracking-branch](preferences/ship-delete-tracking-branch.md)
   - [sync-feature-strategy](preferences/sync-feature-strategy.md)
   - [sync-perennial-strategy](preferences/sync-perennial-strategy.md)
   - [sync-upstream](preferences/sync-upstream.md)

--- a/website/src/commands/ship.md
+++ b/website/src/commands/ship.md
@@ -29,4 +29,4 @@ Git workspace.
 If your origin server deletes shipped branches, for example
 [GitHub's feature to automatically delete head branches](https://help.github.com/en/github/administering-a-repository/managing-the-automatic-deletion-of-branches),
 you can
-[disable deleting remote branches](../preferences/ship-delete-remote-branch.md).
+[disable deleting remote branches](../preferences/ship-delete-tracking-branch.md).

--- a/website/src/preferences.md
+++ b/website/src/preferences.md
@@ -12,6 +12,6 @@ Git Town uses these configuration settings:
 - [parent](preferences/parent.md)
 - [pererennial-branches](preferences/perennial-branches.md)
 - [sync-perennial-strategy](preferences/sync-perennial-strategy.md)
-- [ship-delete-remote-branch](preferences/ship-delete-remote-branch.md)
+- [ship-delete-tracking-branch](preferences/ship-delete-tracking-branch.md)
 - [sync-feature-strategy](preferences/sync-feature-strategy.md)
 - [sync-upstream](preferences/sync-upstream.md)

--- a/website/src/preferences/ship-delete-tracking-branch.md
+++ b/website/src/preferences/ship-delete-tracking-branch.md
@@ -1,7 +1,7 @@
-# ship-delete-remote-branch
+# ship-delete-tracking-branch
 
 ```
-git-town.ship-delete-remote-branch=<true|false>
+git-town.ship-delete-tracking-branch=<true|false>
 ```
 
 If set to `true` (default value), [git ship](../commands/ship.md) deletes the

--- a/website/src/quick-configuration.md
+++ b/website/src/quick-configuration.md
@@ -38,7 +38,7 @@ It can interfere with Git Town's attempts to also delete this branch after
 shipping it. To make Git Town play along, run:
 
 ```
-git config git-town.ship-delete-remote-branch false
+git config git-town.ship-delete-tracking-branch false
 ```
 
 ## Shell autocompletion


### PR DESCRIPTION
It's just more semantically correct. There are many remote branches. This config setting affects only whether ship deletes the tracking branch of the shipped branch.