### PR TITLE
Fix undo on Windows

### DIFF
--- a/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
+++ b/features/kill/current_branch/edge_cases/deleted_tracking_branch.feature
@@ -38,7 +38,7 @@ Feature: the branch to kill has a deleted tracking branch
       | BRANCH | COMMAND                               |
       | other  | git branch old {{ sha 'WIP on old' }} |
       |        | git checkout old                      |
-      | old    | git reset --soft HEAD^                |
+      | old    | git reset --soft HEAD~1               |
     And the current branch is now "old"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE      |

--- a/features/kill/current_branch/features/local_branch.feature
+++ b/features/kill/current_branch/features/local_branch.feature
@@ -32,7 +32,7 @@ Feature: delete a local branch
       | BRANCH  | COMMAND                                       |
       | other   | git branch current {{ sha 'WIP on current' }} |
       |         | git checkout current                          |
-      | current | git reset --soft HEAD^                        |
+      | current | git reset --soft HEAD~1                       |
     And the current branch is now "current"
     And the uncommitted file still exists
     And the initial commits exist

--- a/features/kill/current_branch/features/local_repo.feature
+++ b/features/kill/current_branch/features/local_repo.feature
@@ -35,7 +35,7 @@ Feature: in a local repo
       | BRANCH  | COMMAND                                       |
       | main    | git branch feature {{ sha 'WIP on feature' }} |
       |         | git checkout feature                          |
-      | feature | git reset --soft HEAD^                        |
+      | feature | git reset --soft HEAD~1                       |
     And the current branch is now "feature"
     And the uncommitted file still exists
     And the initial commits exist

--- a/features/kill/current_branch/features/offline.feature
+++ b/features/kill/current_branch/features/offline.feature
@@ -38,7 +38,7 @@ Feature: offline mode
       | BRANCH  | COMMAND                                       |
       | main    | git branch feature {{ sha 'WIP on feature' }} |
       |         | git checkout feature                          |
-      | feature | git reset --soft HEAD^                        |
+      | feature | git reset --soft HEAD~1                       |
     And the current branch is now "feature"
     And the uncommitted file still exists
     And the initial commits exist

--- a/features/kill/current_branch/features/parent_branch.feature
+++ b/features/kill/current_branch/features/parent_branch.feature
@@ -47,7 +47,7 @@ Feature: delete a branch within a branch chain
       | alpha  | git push origin {{ sha 'beta commit' }}:refs/heads/beta |
       |        | git branch beta {{ sha 'WIP on beta' }}                 |
       |        | git checkout beta                                       |
-      | beta   | git reset --soft HEAD^                                  |
+      | beta   | git reset --soft HEAD~1                                 |
     And the current branch is now "beta"
     And the uncommitted file still exists
     And the initial commits exist

--- a/features/kill/current_branch/features/push_hook.feature
+++ b/features/kill/current_branch/features/push_hook.feature
@@ -18,7 +18,7 @@ Feature: undo deleting the current feature branch with disabled push-hook
       | other   | git push --no-verify origin {{ sha 'current commit' }}:refs/heads/current |
       |         | git branch current {{ sha 'WIP on current' }}                             |
       |         | git checkout current                                                      |
-      | current | git reset --soft HEAD^                                                    |
+      | current | git reset --soft HEAD~1                                                   |
     And the current branch is now "current"
     And the uncommitted file still exists
     And the initial commits exist
@@ -33,7 +33,7 @@ Feature: undo deleting the current feature branch with disabled push-hook
       | other   | git push origin {{ sha 'current commit' }}:refs/heads/current |
       |         | git branch current {{ sha 'WIP on current' }}                 |
       |         | git checkout current                                          |
-      | current | git reset --soft HEAD^                                        |
+      | current | git reset --soft HEAD~1                                       |
     And the current branch is now "current"
     And the uncommitted file still exists
     And the initial commits exist

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -40,7 +40,7 @@ Feature: delete the current feature branch
       |         | git branch current {{ sha 'WIP on current' }}                 |
       |         | git checkout current                                          |
       | current | git reset --soft HEAD~1                                       |
-    d the current branch is now "current"
+    And the current branch is now "current"
     And the uncommitted file still exists
     And the initial commits exist
     And the initial branches and lineage exist

--- a/features/kill/current_branch/kill.feature
+++ b/features/kill/current_branch/kill.feature
@@ -39,8 +39,8 @@ Feature: delete the current feature branch
       | other   | git push origin {{ sha 'current commit' }}:refs/heads/current |
       |         | git branch current {{ sha 'WIP on current' }}                 |
       |         | git checkout current                                          |
-      | current | git reset --soft HEAD^                                        |
-    And the current branch is now "current"
+      | current | git reset --soft HEAD~1                                       |
+    d the current branch is now "current"
     And the uncommitted file still exists
     And the initial commits exist
     And the initial branches and lineage exist

--- a/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
+++ b/features/kill/supplied_branch/edge_cases/on_supplied_branch.feature
@@ -38,7 +38,7 @@ Feature: delete the current branch
       | main    | git push origin {{ sha 'current commit' }}:refs/heads/current |
       |         | git branch current {{ sha 'WIP on current' }}                 |
       |         | git checkout current                                          |
-      | current | git reset --soft HEAD^                                        |
+      | current | git reset --soft HEAD~1                                       |
     And the current branch is now "current"
     And the uncommitted file still exists
     And the initial commits exist

--- a/features/kill/supplied_branch/features/local_branch.feature
+++ b/features/kill/supplied_branch/features/local_branch.feature
@@ -36,7 +36,7 @@ Feature: local branch
       | BRANCH | COMMAND                                 |
       | main   | git branch dead {{ sha 'WIP on dead' }} |
       |        | git checkout dead                       |
-      | dead   | git reset --soft HEAD^                  |
+      | dead   | git reset --soft HEAD~1                 |
     And the current branch is now "dead"
     And the uncommitted file still exists
     And the initial commits exist

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -248,5 +248,5 @@ func (self *FrontendCommands) Stash() error {
 }
 
 func (self *FrontendCommands) UndoLastCommit() error {
-	return self.Run("git", "reset", "--soft", "HEAD^")
+	return self.Run("git", "reset", "--soft", "HEAD~1")
 }


### PR DESCRIPTION
`HEAD^` for some reason causes problems on Windows. This does the same thing and is more compatible.