### PR TITLE
Make the slice functions pure

### DIFF
--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -11,7 +11,7 @@ import (
 // EnterParent lets the user select a new parent for the given branch.
 func EnterParent(branch, defaultParent gitdomain.LocalBranchName, lineage configdomain.Lineage, branches gitdomain.BranchInfos) (gitdomain.LocalBranchName, error) {
 	choices := branches.LocalBranches().Names()
-	slice.Hoist(&choices, defaultParent)
+	choices = slice.Hoist(choices, defaultParent)
 	filteredChoices := filterOutSelfAndDescendants(branch, choices, lineage)
 	choice, err := Select(SelectArgs{
 		Options: append([]string{PerennialBranchOption}, filteredChoices.Strings()...),

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -69,7 +69,7 @@ func (self *Config) Reload() {
 
 // RemoveFromPerennialBranches removes the given branch as a perennial branch.
 func (self *Config) RemoveFromPerennialBranches(branch gitdomain.LocalBranchName) error {
-	slice.Remove(&self.FullConfig.PerennialBranches, branch)
+	self.FullConfig.PerennialBranches = slice.Remove(self.FullConfig.PerennialBranches, branch)
 	return self.SetPerennialBranches(self.FullConfig.PerennialBranches)
 }
 

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -46,7 +46,7 @@ func (self Lineage) BranchesAndAncestors(branchNames gitdomain.LocalBranchNames)
 	result := branchNames
 	for _, branchName := range branchNames {
 		ancestors := self.Ancestors(branchName)
-		slice.AppendAllMissing(&result, ancestors)
+		result = slice.AppendAllMissing(result, ancestors)
 	}
 	self.OrderHierarchically(result)
 	return result

--- a/src/gohacks/slice/append_all_missing.go
+++ b/src/gohacks/slice/append_all_missing.go
@@ -1,6 +1,6 @@
 package slice
 
-// AppendAllMissing appends all elements of `additional` that aren't contained in `existing` to `existing`.
+// AppendAllMissing provides the given list with all missing elements of `additional` appended.
 func AppendAllMissing[S ~[]C, C comparable](existing S, additional S) S { //nolint:ireturn
 	result := existing
 	for a := range additional {

--- a/src/gohacks/slice/append_all_missing.go
+++ b/src/gohacks/slice/append_all_missing.go
@@ -1,10 +1,12 @@
 package slice
 
 // AppendAllMissing appends all elements of `additional` that aren't contained in `existing` to `existing`.
-func AppendAllMissing[S ~[]C, C comparable](existing *S, additional S) {
+func AppendAllMissing[S ~[]C, C comparable](existing S, additional S) S { //nolint:ireturn
+	result := existing
 	for a := range additional {
-		if !Contains(*existing, additional[a]) {
-			*existing = append(*existing, additional[a])
+		if !Contains(result, additional[a]) {
+			result = append(result, additional[a])
 		}
 	}
+	return result
 }

--- a/src/gohacks/slice/append_all_missing_test.go
+++ b/src/gohacks/slice/append_all_missing_test.go
@@ -15,35 +15,35 @@ func TestAppendAllMissing(t *testing.T) {
 		t.Parallel()
 		list := []string{"one", "two", "three"}
 		additional := []string{"two", "four", "five"}
-		slice.AppendAllMissing(&list, additional)
+		have := slice.AppendAllMissing(list, additional)
 		want := []string{"one", "two", "three", "four", "five"}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("empty slice", func(t *testing.T) {
 		t.Parallel()
 		list := make([]string, 0)
 		additional := []string{"one", "two", "three"}
-		slice.AppendAllMissing(&list, additional)
+		have := slice.AppendAllMissing(list, additional)
 		want := []string{"one", "two", "three"}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("zero slice", func(t *testing.T) {
 		t.Parallel()
 		var list []string
 		additional := []string{"one", "two", "three"}
-		slice.AppendAllMissing(&list, additional)
+		have := slice.AppendAllMissing(list, additional)
 		want := []string{"one", "two", "three"}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("aliased slice type", func(t *testing.T) {
 		t.Parallel()
 		list := gitdomain.SHAs{gitdomain.NewSHA("111111"), gitdomain.NewSHA("222222")}
 		give := gitdomain.SHAs{gitdomain.NewSHA("333333"), gitdomain.NewSHA("444444")}
-		slice.AppendAllMissing(&list, give)
+		have := slice.AppendAllMissing(list, give)
 		want := gitdomain.SHAs{gitdomain.NewSHA("111111"), gitdomain.NewSHA("222222"), gitdomain.NewSHA("333333"), gitdomain.NewSHA("444444")}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 }

--- a/src/gohacks/slice/contains.go
+++ b/src/gohacks/slice/contains.go
@@ -1,6 +1,6 @@
 package slice
 
-// Contains returns whether the given slice contains the given element.
+// Contains indicates whether the given slice contains the given element.
 func Contains[C comparable](list []C, value C) bool {
 	for l := range list {
 		if list[l] == value {

--- a/src/gohacks/slice/hoist.go
+++ b/src/gohacks/slice/hoist.go
@@ -1,10 +1,10 @@
 package slice
 
-// Hoist moves the given element in the given slice to the first position.
-func Hoist[S ~[]C, C comparable](list *S, needle C) {
-	result := make([]C, 0, len(*list))
+// Hoist provides the given list with the given element moved to the first position.
+func Hoist[S ~[]C, C comparable](list S, needle C) S { //nolint:ireturn
+	result := make([]C, 0, len(list))
 	hasNeedle := false
-	for _, element := range *list {
+	for _, element := range list {
 		if element == needle {
 			hasNeedle = true
 		} else {
@@ -14,5 +14,5 @@ func Hoist[S ~[]C, C comparable](list *S, needle C) {
 	if hasNeedle {
 		result = append([]C{needle}, result...)
 	}
-	*list = result
+	return result
 }

--- a/src/gohacks/slice/hoist_test.go
+++ b/src/gohacks/slice/hoist_test.go
@@ -14,32 +14,32 @@ func TestHoist(t *testing.T) {
 	t.Run("already hoisted", func(t *testing.T) {
 		t.Parallel()
 		list := []string{"initial", "one", "two"}
-		slice.Hoist(&list, "initial")
+		have := slice.Hoist(list, "initial")
 		want := []string{"initial", "one", "two"}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("contains the element to hoist", func(t *testing.T) {
 		t.Parallel()
 		list := []string{"alpha", "initial", "omega"}
-		slice.Hoist(&list, "initial")
+		have := slice.Hoist(list, "initial")
 		want := []string{"initial", "alpha", "omega"}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("empty list", func(t *testing.T) {
 		t.Parallel()
 		list := []string{}
-		slice.Hoist(&list, "initial")
+		have := slice.Hoist(list, "initial")
 		want := []string{}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("aliased slice type", func(t *testing.T) {
 		t.Parallel()
 		list := gitdomain.LocalBranchNames{gitdomain.NewLocalBranchName("alpha"), gitdomain.NewLocalBranchName("initial"), gitdomain.NewLocalBranchName("omega")}
-		slice.Hoist(&list, gitdomain.NewLocalBranchName("initial"))
+		have := slice.Hoist(list, gitdomain.NewLocalBranchName("initial"))
 		want := gitdomain.LocalBranchNames{gitdomain.NewLocalBranchName("initial"), gitdomain.NewLocalBranchName("alpha"), gitdomain.NewLocalBranchName("omega")}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 }

--- a/src/gohacks/slice/remove.go
+++ b/src/gohacks/slice/remove.go
@@ -1,6 +1,6 @@
 package slice
 
-// Remove removes the given element from the given slice.
+// Remove provides the given list without the given element.
 func Remove[S ~[]C, C comparable](list S, value C) S { //nolint:ireturn
 	listLen := len(list)
 	if listLen == 0 {

--- a/src/gohacks/slice/remove.go
+++ b/src/gohacks/slice/remove.go
@@ -1,16 +1,16 @@
 package slice
 
 // Remove removes the given element from the given slice.
-func Remove[S ~[]C, C comparable](list *S, value C) {
-	listLen := len(*list)
+func Remove[S ~[]C, C comparable](list S, value C) S { //nolint:ireturn
+	listLen := len(list)
 	if listLen == 0 {
-		return
+		return list
 	}
 	result := make([]C, 0, listLen-1)
-	for _, element := range *list {
+	for _, element := range list {
 		if element != value {
 			result = append(result, element)
 		}
 	}
-	*list = result
+	return result
 }

--- a/src/gohacks/slice/remove.go
+++ b/src/gohacks/slice/remove.go
@@ -2,11 +2,10 @@ package slice
 
 // Remove provides the given list without the given element.
 func Remove[S ~[]C, C comparable](list S, value C) S { //nolint:ireturn
-	listLen := len(list)
-	if listLen == 0 {
+	if len(list) == 0 {
 		return list
 	}
-	result := make([]C, 0, listLen-1)
+	result := make([]C, 0, len(list)-1)
 	for _, element := range list {
 		if element != value {
 			result = append(result, element)

--- a/src/gohacks/slice/remove_at.go
+++ b/src/gohacks/slice/remove_at.go
@@ -1,6 +1,6 @@
 package slice
 
-// RemoveAt removes the element at the given position from the given list.
+// RemoveAt provides the given list without the element at the given position.
 func RemoveAt[S ~[]C, C comparable](list S, index int) S { //nolint:ireturn
 	return append((list)[:index], (list)[index+1:]...)
 }

--- a/src/gohacks/slice/remove_at.go
+++ b/src/gohacks/slice/remove_at.go
@@ -1,6 +1,6 @@
 package slice
 
 // RemoveAt removes the element at the given position from the given list.
-func RemoveAt[S ~[]C, C comparable](list S, index int) S {
+func RemoveAt[S ~[]C, C comparable](list S, index int) S { //nolint:ireturn
 	return append((list)[:index], (list)[index+1:]...)
 }

--- a/src/gohacks/slice/remove_at.go
+++ b/src/gohacks/slice/remove_at.go
@@ -1,6 +1,6 @@
 package slice
 
 // RemoveAt removes the element at the given position from the given list.
-func RemoveAt[S ~[]C, C comparable](list *S, index int) {
-	*list = append((*list)[:index], (*list)[index+1:]...)
+func RemoveAt[S ~[]C, C comparable](list S, index int) S {
+	return append((list)[:index], (list)[index+1:]...)
 }

--- a/src/gohacks/slice/remove_at_test.go
+++ b/src/gohacks/slice/remove_at_test.go
@@ -14,32 +14,32 @@ func TestRemoveAt(t *testing.T) {
 	t.Run("index is within the list", func(t *testing.T) {
 		t.Parallel()
 		list := []int{1, 2, 3}
-		slice.RemoveAt(&list, 1)
+		have := slice.RemoveAt(list, 1)
 		want := []int{1, 3}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("index is at end of list", func(t *testing.T) {
 		t.Parallel()
 		list := []int{1, 2, 3}
-		slice.RemoveAt(&list, 2)
+		have := slice.RemoveAt(list, 2)
 		want := []int{1, 2}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("index is at beginning of list", func(t *testing.T) {
 		t.Parallel()
 		list := []int{1, 2, 3}
-		slice.RemoveAt(&list, 0)
+		have := slice.RemoveAt(list, 0)
 		want := []int{2, 3}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("slice alias type", func(t *testing.T) {
 		t.Parallel()
 		list := gitdomain.SHAs{gitdomain.NewSHA("111111"), gitdomain.NewSHA("222222"), gitdomain.NewSHA("333333")}
-		slice.RemoveAt(&list, 0)
+		have := slice.RemoveAt(list, 0)
 		want := gitdomain.SHAs{gitdomain.NewSHA("222222"), gitdomain.NewSHA("333333")}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 }

--- a/src/gohacks/slice/remove_test.go
+++ b/src/gohacks/slice/remove_test.go
@@ -14,24 +14,24 @@ func TestRemove(t *testing.T) {
 	t.Run("slice type", func(t *testing.T) {
 		t.Parallel()
 		list := []string{"one", "two", "three"}
-		slice.Remove(&list, "two")
+		have := slice.Remove(list, "two")
 		want := []string{"one", "three"}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("slice alias type", func(t *testing.T) {
 		t.Parallel()
 		list := gitdomain.SHAs{gitdomain.NewSHA("111111"), gitdomain.NewSHA("222222"), gitdomain.NewSHA("333333")}
-		slice.Remove(&list, gitdomain.NewSHA("222222"))
+		have := slice.Remove(list, gitdomain.NewSHA("222222"))
 		want := gitdomain.SHAs{gitdomain.NewSHA("111111"), gitdomain.NewSHA("333333")}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("empty slice", func(t *testing.T) {
 		t.Parallel()
 		list := []string{}
-		slice.Remove(&list, "foo")
+		have := slice.Remove(list, "foo")
 		want := []string{}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 }

--- a/src/gohacks/slice/truncate_last.go
+++ b/src/gohacks/slice/truncate_last.go
@@ -1,10 +1,10 @@
 package slice
 
-// TruncateLast removes the last element from the given list.
-func TruncateLast[S ~[]C, C comparable](list *S) {
-	listLength := len(*list)
+// TruncateLast provides the given list without its last element.
+func TruncateLast[S ~[]C, C comparable](list S) S { //nolint:ireturn
+	listLength := len(list)
 	if listLength == 0 {
-		return
+		return list
 	}
-	*list = (*list)[:listLength-1]
+	return list[:listLength-1]
 }

--- a/src/gohacks/slice/truncate_last_test.go
+++ b/src/gohacks/slice/truncate_last_test.go
@@ -14,32 +14,32 @@ func TestTruncateLast(t *testing.T) {
 	t.Run("list contains no elements", func(t *testing.T) {
 		t.Parallel()
 		list := []int{}
-		slice.TruncateLast(&list)
+		have := slice.TruncateLast(list)
 		want := []int{}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("list contains one element", func(t *testing.T) {
 		t.Parallel()
 		list := []int{1}
-		slice.TruncateLast(&list)
+		have := slice.TruncateLast(list)
 		want := []int{}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("list contains multiple elements", func(t *testing.T) {
 		t.Parallel()
 		list := []int{1, 2, 3}
-		slice.TruncateLast(&list)
+		have := slice.TruncateLast(list)
 		want := []int{1, 2}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 
 	t.Run("slice alias type", func(t *testing.T) {
 		t.Parallel()
 		list := gitdomain.SHAs{gitdomain.NewSHA("111111"), gitdomain.NewSHA("222222"), gitdomain.NewSHA("333333")}
-		slice.TruncateLast(&list)
+		have := slice.TruncateLast(list)
 		want := gitdomain.SHAs{gitdomain.NewSHA("111111"), gitdomain.NewSHA("222222")}
-		must.Eq(t, want, list)
+		must.Eq(t, want, have)
 	})
 }

--- a/src/vm/program/program.go
+++ b/src/vm/program/program.go
@@ -101,6 +101,7 @@ func (self *Program) RemoveAllButLast(removeType string) {
 	opcodeTypes := self.OpcodeTypes()
 	occurrences := slice.FindAll(opcodeTypes, removeType)
 	occurrences = slice.TruncateLast(occurrences)
+	// TODO: call slice.RemoveElements here.
 	for o := len(occurrences) - 1; o >= 0; o-- {
 		*self = slice.RemoveAt(*self, occurrences[o])
 	}

--- a/src/vm/program/program.go
+++ b/src/vm/program/program.go
@@ -97,6 +97,7 @@ func (self *Program) PrependProgram(otherProgram Program) {
 	*self = result
 }
 
+// TODO: return the modified program here.
 func (self *Program) RemoveAllButLast(removeType string) {
 	opcodeTypes := self.OpcodeTypes()
 	occurrences := slice.FindAll(opcodeTypes, removeType)

--- a/src/vm/program/program.go
+++ b/src/vm/program/program.go
@@ -100,7 +100,7 @@ func (self *Program) PrependProgram(otherProgram Program) {
 func (self *Program) RemoveAllButLast(removeType string) {
 	opcodeTypes := self.OpcodeTypes()
 	occurrences := slice.FindAll(opcodeTypes, removeType)
-	slice.TruncateLast(&occurrences)
+	occurrences = slice.TruncateLast(occurrences)
 	for o := len(occurrences) - 1; o >= 0; o-- {
 		*self = slice.RemoveAt(*self, occurrences[o])
 	}

--- a/src/vm/program/program.go
+++ b/src/vm/program/program.go
@@ -102,7 +102,7 @@ func (self *Program) RemoveAllButLast(removeType string) {
 	occurrences := slice.FindAll(opcodeTypes, removeType)
 	slice.TruncateLast(&occurrences)
 	for o := len(occurrences) - 1; o >= 0; o-- {
-		slice.RemoveAt(self, occurrences[o])
+		*self = slice.RemoveAt(*self, occurrences[o])
 	}
 }
 

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -306,7 +306,7 @@ func (self *TestCommands) LocalBranchesMainFirst(mainBranch gitdomain.LocalBranc
 	if err != nil {
 		return gitdomain.LocalBranchNames{}, err
 	}
-	slice.Hoist(&branches, mainBranch)
+	branches = slice.Hoist(branches, mainBranch)
 	return branches, nil
 }
 

--- a/test/cucumber/scenario_state.go
+++ b/test/cucumber/scenario_state.go
@@ -65,9 +65,9 @@ func (self *ScenarioState) InitialBranches() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("REPOSITORY", "BRANCHES")
 	self.initialLocalBranches.Sort()
-	slice.Hoist(&self.initialLocalBranches, gitdomain.NewLocalBranchName("main"))
+	self.initialLocalBranches = slice.Hoist(self.initialLocalBranches, gitdomain.NewLocalBranchName("main"))
 	self.initialRemoteBranches.Sort()
-	slice.Hoist(&self.initialRemoteBranches, gitdomain.NewLocalBranchName("main"))
+	self.initialRemoteBranches = slice.Hoist(self.initialRemoteBranches, gitdomain.NewLocalBranchName("main"))
 	localBranchesJoined := self.initialLocalBranches.Join(", ")
 	remoteBranchesJoined := self.initialRemoteBranches.Join(", ")
 	if localBranchesJoined == remoteBranchesJoined {

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -794,7 +794,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^origin deletes the "([^"]*)" branch$`, func(branch string) error {
-		slice.Remove(&state.initialRemoteBranches, gitdomain.NewLocalBranchName(branch))
+		state.initialRemoteBranches = slice.Remove(state.initialRemoteBranches, gitdomain.NewLocalBranchName(branch))
 		state.fixture.OriginRepo.RemoveBranch(gitdomain.NewLocalBranchName(branch))
 		return nil
 	})
@@ -806,7 +806,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 			return err
 		}
 		state.fixture.OriginRepo.RemoveBranch(gitdomain.NewLocalBranchName(branch))
-		slice.Remove(&state.initialRemoteBranches, gitdomain.NewLocalBranchName(branch))
+		state.initialRemoteBranches = slice.Remove(state.initialRemoteBranches, gitdomain.NewLocalBranchName(branch))
 		return nil
 	})
 

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -170,7 +170,7 @@ func (self *Fixture) Branches() datatable.DataTable {
 	asserts.NoError(err)
 	localBranches = localBranches.RemoveWorkspaceMarkers().Hoist(self.DevRepo.Config.MainBranch)
 	initialBranch := gitdomain.NewLocalBranchName("initial")
-	slice.Remove(&localBranches, initialBranch)
+	localBranches = slice.Remove(localBranches, initialBranch)
 	localBranchesJoined := localBranches.Join(", ")
 	if self.OriginRepo == nil {
 		result.AddRow("local", localBranchesJoined)
@@ -178,7 +178,7 @@ func (self *Fixture) Branches() datatable.DataTable {
 	}
 	originBranches, err := self.OriginRepo.LocalBranchesMainFirst(mainBranch)
 	asserts.NoError(err)
-	slice.Remove(&originBranches, initialBranch)
+	originBranches = slice.Remove(originBranches, initialBranch)
 	originBranchesJoined := originBranches.Join(", ")
 	if localBranchesJoined == originBranchesJoined {
 		result.AddRow("local, origin", localBranchesJoined)


### PR DESCRIPTION
Yes, this creates functions that return interfaces because Go generics suck. But it's more consistent with the Go stdlib and it avoids this weird pointer magic.