### PR TITLE
Remove all opcodes at once

### DIFF
--- a/src/gohacks/slice/remove_at.go
+++ b/src/gohacks/slice/remove_at.go
@@ -1,6 +1,14 @@
 package slice
 
-// RemoveAt provides the given list without the element at the given position.
-func RemoveAt[S ~[]C, C comparable](list S, index int) S { //nolint:ireturn
-	return append((list)[:index], (list)[index+1:]...)
+import "slices"
+
+// RemoveAt provides the given list without the elements at the given positions.
+func RemoveAt[S ~[]C, C comparable](list S, indexes ...int) S { //nolint:ireturn
+	result := make(S, 0, len(list)-len(indexes))
+	for l := range list {
+		if !slices.Contains(indexes, l) {
+			result = append(result, list[l])
+		}
+	}
+	return result
 }

--- a/src/gohacks/slice/remove_at_test.go
+++ b/src/gohacks/slice/remove_at_test.go
@@ -42,4 +42,20 @@ func TestRemoveAt(t *testing.T) {
 		want := gitdomain.SHAs{gitdomain.NewSHA("222222"), gitdomain.NewSHA("333333")}
 		must.Eq(t, want, have)
 	})
+
+	t.Run("multiple indexes", func(t *testing.T) {
+		t.Parallel()
+		list := []int{1, 2, 3, 4}
+		have := slice.RemoveAt(list, 0, 2)
+		want := []int{2, 4}
+		must.Eq(t, want, have)
+	})
+
+	t.Run("no indexes", func(t *testing.T) {
+		t.Parallel()
+		list := []int{1, 2, 3}
+		have := slice.RemoveAt(list)
+		want := []int{1, 2, 3}
+		must.Eq(t, want, have)
+	})
 }

--- a/src/vm/program/program.go
+++ b/src/vm/program/program.go
@@ -99,13 +99,9 @@ func (self *Program) PrependProgram(otherProgram Program) {
 
 // TODO: return the modified program here.
 func (self *Program) RemoveAllButLast(removeType string) {
-	opcodeTypes := self.OpcodeTypes()
-	occurrences := slice.FindAll(opcodeTypes, removeType)
-	occurrences = slice.TruncateLast(occurrences)
-	// TODO: call slice.RemoveElements here.
-	for o := len(occurrences) - 1; o >= 0; o-- {
-		*self = slice.RemoveAt(*self, occurrences[o])
-	}
+	allIndexes := slice.FindAll(self.OpcodeTypes(), removeType)
+	indexesToRemove := slice.TruncateLast(allIndexes)
+	*self = slice.RemoveAt(*self, indexesToRemove...)
 }
 
 // RemoveDuplicateCheckout removes checkout opcodes that immediately follow each other from this program.


### PR DESCRIPTION
Simpler and faster thanks to better abstraction.