### PR TITLE
Display numbers in most dialogs

### DIFF
--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -1,17 +1,22 @@
 package dialog
 
 import (
+	"fmt"
 	"slices"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/git-town/git-town/v11/src/gohacks"
 )
 
 // bubbleList contains common elements of BubbleTea list implementations.
 type bubbleList struct {
-	aborted bool         // whether the user has aborted this dialog
-	colors  dialogColors // colors to use for help text
-	cursor  int          // index of the currently selected row
-	entries []string     // the entries to select from
+	aborted      bool         // whether the user has aborted this dialog
+	colors       dialogColors // colors to use for help text
+	cursor       int          // index of the currently selected row
+	entries      []string     // the entries to select from
+	entryNumber  string       // the currently entered branch number
+	maxDigits    int          // the maximal number of digits in the branch number
+	numberFormat string       // template for formatting the entry number
 }
 
 func newBubbleList(entries []string, initial string) bubbleList {
@@ -19,11 +24,15 @@ func newBubbleList(entries []string, initial string) bubbleList {
 	if cursor < 0 {
 		cursor = 0
 	}
+	numberLen := gohacks.NumberLength(len(entries))
 	return bubbleList{
-		aborted: false,
-		entries: entries,
-		colors:  createColors(),
-		cursor:  cursor,
+		aborted:      false,
+		colors:       createColors(),
+		cursor:       cursor,
+		entries:      entries,
+		entryNumber:  "",
+		maxDigits:    numberLen,
+		numberFormat: fmt.Sprintf("%%0%dd", numberLen),
 	}
 }
 

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -40,6 +40,10 @@ func newBubbleList(entries []string, initial string) bubbleList {
 	}
 }
 
+func (self *bubbleList) entryNumberStr(number int) string {
+	return self.dim.Styled(fmt.Sprintf(self.numberFormat, number))
+}
+
 func (self *bubbleList) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 	switch key.Type { //nolint:exhaustive
 	case tea.KeyUp, tea.KeyShiftTab:
@@ -52,7 +56,6 @@ func (self *bubbleList) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 		self.aborted = true
 		return true, tea.Quit
 	}
-
 	switch keyStr := key.String(); keyStr {
 	case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
 		self.entryNumber += keyStr

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -17,7 +17,7 @@ type bubbleList struct {
 	cursor       int           // index of the currently selected row
 	dim          termenv.Style // style for dim output
 	entries      []string      // the entries to select from
-	entryNumber  string        // the currently entered branch number
+	entryNumber  string        // the manually entered entry number
 	maxDigits    int           // the maximal number of digits in the branch number
 	numberFormat string        // template for formatting the entry number
 }

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -36,7 +36,7 @@ func newBubbleList(entries []string, initial string) bubbleList {
 		entries:      entries,
 		entryNumber:  "",
 		maxDigits:    numberLen,
-		numberFormat: fmt.Sprintf("%%0%dd", numberLen),
+		numberFormat: fmt.Sprintf("%%0%dd ", numberLen),
 	}
 }
 

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -6,17 +6,19 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/git-town/git-town/v11/src/gohacks"
+	"github.com/muesli/termenv"
 )
 
 // bubbleList contains common elements of BubbleTea list implementations.
 type bubbleList struct {
-	aborted      bool         // whether the user has aborted this dialog
-	colors       dialogColors // colors to use for help text
-	cursor       int          // index of the currently selected row
-	entries      []string     // the entries to select from
-	entryNumber  string       // the currently entered branch number
-	maxDigits    int          // the maximal number of digits in the branch number
-	numberFormat string       // template for formatting the entry number
+	aborted      bool          // whether the user has aborted this dialog
+	colors       dialogColors  // colors to use for help text
+	cursor       int           // index of the currently selected row
+	dim          termenv.Style // for dim output
+	entries      []string      // the entries to select from
+	entryNumber  string        // the currently entered branch number
+	maxDigits    int           // the maximal number of digits in the branch number
+	numberFormat string        // template for formatting the entry number
 }
 
 func newBubbleList(entries []string, initial string) bubbleList {
@@ -29,6 +31,7 @@ func newBubbleList(entries []string, initial string) bubbleList {
 		aborted:      false,
 		colors:       createColors(),
 		cursor:       cursor,
+		dim:          termenv.String().Faint(),
 		entries:      entries,
 		entryNumber:  "",
 		maxDigits:    numberLen,

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -18,7 +18,7 @@ type bubbleList struct {
 	dim          termenv.Style // style for dim output
 	entries      []string      // the entries to select from
 	entryNumber  string        // the manually entered entry number
-	maxDigits    int           // the maximal number of digits in the branch number
+	maxDigits    int           // how many digits make up an entry number
 	numberFormat string        // template for formatting the entry number
 }
 

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"slices"
+	"strconv"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/git-town/git-town/v11/src/gohacks"
@@ -51,7 +52,18 @@ func (self *bubbleList) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 		self.aborted = true
 		return true, tea.Quit
 	}
-	switch key.String() {
+
+	switch keyStr := key.String(); keyStr {
+	case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+		self.entryNumber += keyStr
+		if len(self.entryNumber) > self.maxDigits {
+			self.entryNumber = self.entryNumber[1:]
+		}
+		number64, _ := strconv.ParseInt(self.entryNumber, 10, 0)
+		number := int(number64)
+		if number < len(self.entries) {
+			self.cursor = number
+		}
 	case "k", "A", "Z":
 		self.moveCursorUp()
 		return true, nil

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -15,7 +15,7 @@ type bubbleList struct {
 	aborted      bool          // whether the user has aborted this dialog
 	colors       dialogColors  // colors to use for help text
 	cursor       int           // index of the currently selected row
-	dim          termenv.Style // for dim output
+	dim          termenv.Style // style for dim output
 	entries      []string      // the entries to select from
 	entryNumber  string        // the currently entered branch number
 	maxDigits    int           // the maximal number of digits in the branch number

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -40,10 +40,12 @@ func newBubbleList(entries []string, initial string) bubbleList {
 	}
 }
 
+// entryNumberStr provides a colorized string to print the given entry number.
 func (self *bubbleList) entryNumberStr(number int) string {
 	return self.dim.Styled(fmt.Sprintf(self.numberFormat, number))
 }
 
+// handleKey handles keypresses that are common for all bubbleLists.
 func (self *bubbleList) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 	switch key.Type { //nolint:exhaustive
 	case tea.KeyUp, tea.KeyShiftTab:

--- a/src/cli/dialog/enter_main_branch.go
+++ b/src/cli/dialog/enter_main_branch.go
@@ -72,6 +72,11 @@ func (self mainBranchModel) View() string {
 	s.WriteString(self.colors.help.Styled("/"))
 	s.WriteString(self.colors.helpKey.Styled("j"))
 	s.WriteString(self.colors.help.Styled(" down   "))
+	// numbers
+	s.WriteString(self.colors.helpKey.Styled("0"))
+	s.WriteString(self.colors.help.Styled("-"))
+	s.WriteString(self.colors.helpKey.Styled("9"))
+	s.WriteString(self.colors.help.Styled(" jump   "))
 	// accept
 	s.WriteString(self.colors.helpKey.Styled("enter"))
 	s.WriteString(self.colors.help.Styled("/"))

--- a/src/cli/dialog/enter_main_branch.go
+++ b/src/cli/dialog/enter_main_branch.go
@@ -1,7 +1,6 @@
 package dialog
 
 import (
-	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -54,7 +53,7 @@ func (self mainBranchModel) View() string {
 	s.WriteString("and into which you ship feature branches when they are done.\n")
 	s.WriteString("In most repositories, this is the \"main\", \"master\", or \"development\" branch.\n\n")
 	for i, branch := range self.entries {
-		s.WriteString(self.dim.Styled(fmt.Sprintf(self.numberFormat, i)))
+		s.WriteString(self.entryNumberStr(i))
 		if i == self.cursor {
 			s.WriteString(self.colors.selection.Styled(" > " + branch))
 		} else {

--- a/src/cli/dialog/enter_main_branch.go
+++ b/src/cli/dialog/enter_main_branch.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -53,10 +54,11 @@ func (self mainBranchModel) View() string {
 	s.WriteString("and into which you ship feature branches when they are done.\n")
 	s.WriteString("In most repositories, this is the \"main\", \"master\", or \"development\" branch.\n\n")
 	for i, branch := range self.entries {
+		s.WriteString(self.dim.Styled(fmt.Sprintf(self.numberFormat, i)))
 		if i == self.cursor {
-			s.WriteString(self.colors.selection.Styled("> " + branch))
+			s.WriteString(self.colors.selection.Styled(" > " + branch))
 		} else {
-			s.WriteString("  " + branch)
+			s.WriteString("   " + branch)
 		}
 		s.WriteRune('\n')
 	}

--- a/src/cli/dialog/enter_main_branch.go
+++ b/src/cli/dialog/enter_main_branch.go
@@ -55,9 +55,9 @@ func (self mainBranchModel) View() string {
 	for i, branch := range self.entries {
 		s.WriteString(self.entryNumberStr(i))
 		if i == self.cursor {
-			s.WriteString(self.colors.selection.Styled(" > " + branch))
+			s.WriteString(self.colors.selection.Styled("> " + branch))
 		} else {
-			s.WriteString("   " + branch)
+			s.WriteString("  " + branch)
 		}
 		s.WriteRune('\n')
 	}

--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -57,19 +56,8 @@ func (self enterParentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint
 	if keyMsg.Type == tea.KeyEnter {
 		return self, tea.Quit
 	}
-	switch keyStr := keyMsg.String(); keyStr {
-	case "o":
+	if keyMsg.String() == "o" {
 		return self, tea.Quit
-	case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
-		self.entryNumber += keyStr
-		if len(self.entryNumber) > self.maxDigits {
-			self.entryNumber = self.entryNumber[1:]
-		}
-		number64, _ := strconv.ParseInt(self.entryNumber, 10, 0)
-		number := int(number64)
-		if number < len(self.entries) {
-			self.cursor = number
-		}
 	}
 	return self, nil
 }

--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -68,10 +68,10 @@ func (self enterParentModel) View() string {
 	for i, branch := range self.entries {
 		if i == self.cursor {
 			s.WriteString(self.entryNumberStr(i))
-			s.WriteString(self.colors.selection.Styled(" > " + branch))
+			s.WriteString(self.colors.selection.Styled("> " + branch))
 		} else {
 			s.WriteString(self.entryNumberStr(i))
-			s.WriteString("   " + branch)
+			s.WriteString("  " + branch)
 		}
 		s.WriteRune('\n')
 	}

--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -1,7 +1,6 @@
 package dialog
 
 import (
-	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -68,10 +67,10 @@ func (self enterParentModel) View() string {
 	s.WriteString("Most of the time this is the main development branch (" + self.mainBranch + ").\n\n")
 	for i, branch := range self.entries {
 		if i == self.cursor {
-			s.WriteString(self.dim.Styled(fmt.Sprintf(self.numberFormat, i)))
+			s.WriteString(self.entryNumberStr(i))
 			s.WriteString(self.colors.selection.Styled(" > " + branch))
 		} else {
-			s.WriteString(self.dim.Styled(fmt.Sprintf(self.numberFormat, i)))
+			s.WriteString(self.entryNumberStr(i))
 			s.WriteString("   " + branch)
 		}
 		s.WriteRune('\n')

--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -8,7 +8,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/git/gitdomain"
-	"github.com/git-town/git-town/v11/src/gohacks"
 	"github.com/muesli/termenv"
 )
 
@@ -17,14 +16,10 @@ const PerennialBranchOption = "<none> (perennial branch)"
 // EnterParent lets the user select the parent branch for the given branch.
 func EnterParent(args EnterParentArgs) (gitdomain.LocalBranchName, bool, error) {
 	parentCandidates := EnterParentEntries(args)
-	numberLen := gohacks.NumberLength(len(parentCandidates))
 	dialogData := enterParentModel{
-		bubbleList:   newBubbleList(parentCandidates, args.MainBranch.String()),
-		branch:       args.Branch.String(),
-		entryNumber:  "",
-		maxDigits:    numberLen,
-		mainBranch:   args.MainBranch.String(),
-		numberFormat: fmt.Sprintf("%%0%dd", numberLen),
+		bubbleList: newBubbleList(parentCandidates, args.MainBranch.String()),
+		branch:     args.Branch.String(),
+		mainBranch: args.MainBranch.String(),
 	}
 	dialogResult, err := tea.NewProgram(dialogData).Run()
 	if err != nil {
@@ -44,11 +39,8 @@ type EnterParentArgs struct {
 
 type enterParentModel struct {
 	bubbleList
-	branch       string // the branch for which to enter the parent
-	entryNumber  string // the currently entered branch number
-	mainBranch   string // name of the main branch
-	maxDigits    int    // the maximal number of digits in the branch number
-	numberFormat string // template for formatting the number
+	branch     string // the branch for which to enter the parent
+	mainBranch string // name of the main branch
 }
 
 func (self enterParentModel) Init() tea.Cmd {

--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -8,7 +8,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/git/gitdomain"
-	"github.com/muesli/termenv"
 )
 
 const PerennialBranchOption = "<none> (perennial branch)"
@@ -79,13 +78,12 @@ func (self enterParentModel) View() string {
 	s := strings.Builder{}
 	s.WriteString("\nPlease select the parent of branch \"" + self.branch + "\" or enter its number.\n")
 	s.WriteString("Most of the time this is the main development branch (" + self.mainBranch + ").\n\n")
-	dim := termenv.String().Faint()
 	for i, branch := range self.entries {
 		if i == self.cursor {
-			s.WriteString(dim.Styled(fmt.Sprintf(self.numberFormat, i)))
+			s.WriteString(self.dim.Styled(fmt.Sprintf(self.numberFormat, i)))
 			s.WriteString(self.colors.selection.Styled(" > " + branch))
 		} else {
-			s.WriteString(dim.Styled(fmt.Sprintf(self.numberFormat, i)))
+			s.WriteString(self.dim.Styled(fmt.Sprintf(self.numberFormat, i)))
 			s.WriteString("   " + branch)
 		}
 		s.WriteRune('\n')

--- a/src/cli/dialog/enter_perennial_branches.go
+++ b/src/cli/dialog/enter_perennial_branches.go
@@ -68,6 +68,7 @@ func (self perennialBranchesModel) View() string {
 	for i, branch := range self.entries {
 		selected := self.cursor == i
 		checked := self.isRowChecked(i)
+		s.WriteString(self.entryNumberStr(i))
 		switch {
 		case selected && checked:
 			s.WriteString(self.colors.selection.Styled("> [x] " + branch))

--- a/src/cli/dialog/enter_perennial_branches.go
+++ b/src/cli/dialog/enter_perennial_branches.go
@@ -97,6 +97,11 @@ func (self perennialBranchesModel) View() string {
 	s.WriteString(self.colors.help.Styled("/"))
 	s.WriteString(self.colors.helpKey.Styled("o"))
 	s.WriteString(self.colors.help.Styled(" toggle   "))
+	// numbers
+	s.WriteString(self.colors.helpKey.Styled("0"))
+	s.WriteString(self.colors.help.Styled("-"))
+	s.WriteString(self.colors.helpKey.Styled("9"))
+	s.WriteString(self.colors.help.Styled(" jump   "))
 	// accept
 	s.WriteString(self.colors.helpKey.Styled("enter"))
 	s.WriteString(self.colors.help.Styled(" accept   "))


### PR DESCRIPTION
This displays accessibility-friendly numbers in most dialogs. The only exception is the switch dialog since there are more accessibility-friendly alternatives for switching branches outside of Git Town.