### PR TITLE
Enable dialog abort via ESC key

### DIFF
--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -58,7 +58,7 @@ func (self *BubbleList) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 	case tea.KeyDown, tea.KeyTab:
 		self.moveCursorDown()
 		return true, nil
-	case tea.KeyCtrlC:
+	case tea.KeyCtrlC, tea.KeyEsc:
 		self.Aborted = true
 		return true, tea.Quit
 	}

--- a/src/cli/dialog/enter_perennial_branches.go
+++ b/src/cli/dialog/enter_perennial_branches.go
@@ -117,9 +117,11 @@ func (self perennialBranchesModel) View() string {
 	s.WriteString(self.Colors.helpKey.Styled("enter"))
 	s.WriteString(self.Colors.help.Styled(" accept   "))
 	// abort
-	s.WriteString(self.Colors.helpKey.Styled("ctrl-c"))
-	s.WriteString(self.Colors.help.Styled("/"))
 	s.WriteString(self.Colors.helpKey.Styled("q"))
+	s.WriteString(self.Colors.help.Styled("/"))
+	s.WriteString(self.Colors.helpKey.Styled("esc"))
+	s.WriteString(self.Colors.help.Styled("/"))
+	s.WriteString(self.Colors.helpKey.Styled("ctrl-c"))
 	s.WriteString(self.Colors.help.Styled(" abort"))
 	return s.String()
 }

--- a/src/cli/dialog/radiolist.go
+++ b/src/cli/dialog/radiolist.go
@@ -95,9 +95,11 @@ func (self radioListModel) View() string {
 	s.WriteString(self.Colors.helpKey.Styled("o"))
 	s.WriteString(self.Colors.help.Styled(" accept   "))
 	// abort
+	s.WriteString(self.Colors.helpKey.Styled("q"))
+	s.WriteString(self.Colors.help.Styled("/"))
 	s.WriteString(self.Colors.helpKey.Styled("esc"))
 	s.WriteString(self.Colors.help.Styled("/"))
-	s.WriteString(self.Colors.helpKey.Styled("q"))
+	s.WriteString(self.Colors.helpKey.Styled("ctrl-c"))
 	s.WriteString(self.Colors.help.Styled(" abort"))
 	return s.String()
 }

--- a/src/cli/dialog/switch_branch.go
+++ b/src/cli/dialog/switch_branch.go
@@ -85,9 +85,11 @@ func (self SwitchModel) View() string {
 	s.WriteString(self.Colors.helpKey.Styled("o"))
 	s.WriteString(self.Colors.help.Styled(" accept   "))
 	// abort
+	s.WriteString(self.Colors.helpKey.Styled("q"))
+	s.WriteString(self.Colors.help.Styled("/"))
 	s.WriteString(self.Colors.helpKey.Styled("esc"))
 	s.WriteString(self.Colors.help.Styled("/"))
-	s.WriteString(self.Colors.helpKey.Styled("q"))
+	s.WriteString(self.Colors.helpKey.Styled("ctrl-c"))
 	s.WriteString(self.Colors.help.Styled(" abort"))
 	return s.String()
 }

--- a/src/cli/dialog/switch_branch_test.go
+++ b/src/cli/dialog/switch_branch_test.go
@@ -118,7 +118,7 @@ func TestSwitchBranch(t *testing.T) {
 > main
 
 
-  ↑/k up   ↓/j down   enter/o accept   esc/q abort`[1:]
+  ↑/k up   ↓/j down   enter/o accept   q/esc/ctrl-c abort`[1:]
 			must.EqOp(t, want, have)
 		})
 
@@ -140,7 +140,7 @@ func TestSwitchBranch(t *testing.T) {
   two
 
 
-  ↑/k up   ↓/j down   enter/o accept   esc/q abort`[1:]
+  ↑/k up   ↓/j down   enter/o accept   q/esc/ctrl-c abort`[1:]
 			must.EqOp(t, want, have)
 		})
 
@@ -166,7 +166,7 @@ func TestSwitchBranch(t *testing.T) {
   other
 
 
-  ↑/k up   ↓/j down   enter/o accept   esc/q abort`[1:]
+  ↑/k up   ↓/j down   enter/o accept   q/esc/ctrl-c abort`[1:]
 			must.EqOp(t, want, have)
 		})
 	})


### PR DESCRIPTION
We had to disable this temporarily while using multiple keyboard libraries concurrently. It seems to work robust now.