### PR TITLE
docs: Update README.md by removing Install under Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ Flow, and trunk-based development. Check out
 - [git set-parent](https://www.git-town.com/commands/set-parent.html) - updates
   a branch's parent
 
-#### Setup/configuration
+#### Configuration
 
-- [git town install](https://www.git-town.com/commands/install.html) - install
-  Git Town on your computer
 - [git town config](https://www.git-town.com/commands/config.html) - display or
   update your Git Town configuration
 - [git town version](https://www.git-town.com/commands/version.html) - display


### PR DESCRIPTION
# Proposed Changes

## Description
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Issue
* DRY: "Installation" is a section below and links to a page that provides for a variety of installation methods
* `git town install` is not a command per https://github.com/git-town/git-town/tree/main/features & https://www.git-town.com/install

### Changes
* Remove the broken install link under Setup/configuration
* Rename Setup/configuration to simply "Configuration"

## Type of change
* [ ] feat
* [ ] fix
* [ ] build
* [ ] chore
* [ ] ci
* [x] docs
* [ ] style
* [ ] refactor
* [ ] perf
* [ ] test

## Checklist before requesting a review
* [X] I have followed the guidelines in the Contributing document to the best of my ability
* [X] I have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change
* [X] I have updated the documentation accordingly.
* [X] I have performed a self-review of my code and/or documentation