### PR TITLE
Make the BubbleList use Stringers instead of strings

### DIFF
--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -18,20 +18,20 @@ const (
 )
 
 // BubbleList contains common elements of BubbleTea list implementations.
-type BubbleList[C fmt.Stringer] struct {
+type BubbleList[S fmt.Stringer] struct {
 	Status       dialogStatus
 	Colors       dialogColors  // colors to use for help text
 	Cursor       int           // index of the currently selected row
 	Dim          termenv.Style // style for dim output
-	Entries      []C           // the entries to select from
+	Entries      []S           // the entries to select from
 	EntryNumber  string        // the manually entered entry number
 	MaxDigits    int           // how many digits make up an entry number
 	NumberFormat string        // template for formatting the entry number
 }
 
-func newBubbleList[C fmt.Stringer](entries []C, cursor int) BubbleList[C] {
+func newBubbleList[S fmt.Stringer](entries []S, cursor int) BubbleList[S] {
 	numberLen := gohacks.NumberLength(len(entries))
-	return BubbleList[C]{
+	return BubbleList[S]{
 		Status:       dialogStatusActive,
 		Colors:       createColors(),
 		Cursor:       cursor,

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -106,6 +106,6 @@ func (self *BubbleList[S, C]) moveCursorUp() {
 	}
 }
 
-func (self BubbleList[S, C]) selectedEntry() C {
+func (self BubbleList[S, C]) selectedEntry() C { //nolint:ireturn
 	return self.Entries[self.Cursor]
 }

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -106,6 +106,6 @@ func (self *BubbleList[S]) moveCursorUp() {
 	}
 }
 
-func (self BubbleList[S]) selectedEntry() C { //nolint:ireturn
+func (self BubbleList[S]) selectedEntry() S { //nolint:ireturn
 	return self.Entries[self.Cursor]
 }

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -44,17 +44,17 @@ func newBubbleList[S fmt.Stringer](entries []S, cursor int) BubbleList[S] {
 }
 
 // Aborted indicates whether the user has aborted this dialog.
-func (self *BubbleList[C]) aborted() bool {
+func (self *BubbleList[S]) aborted() bool {
 	return self.Status == dialogStatusAborted
 }
 
 // entryNumberStr provides a colorized string to print the given entry number.
-func (self *BubbleList[C]) entryNumberStr(number int) string {
+func (self *BubbleList[S]) entryNumberStr(number int) string {
 	return self.Dim.Styled(fmt.Sprintf(self.NumberFormat, number))
 }
 
 // handleKey handles keypresses that are common for all bubbleLists.
-func (self *BubbleList[C]) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
+func (self *BubbleList[S]) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 	switch key.Type { //nolint:exhaustive
 	case tea.KeyUp, tea.KeyShiftTab:
 		self.moveCursorUp()
@@ -90,7 +90,7 @@ func (self *BubbleList[C]) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 	return false, nil
 }
 
-func (self *BubbleList[C]) moveCursorDown() {
+func (self *BubbleList[S]) moveCursorDown() {
 	if self.Cursor < len(self.Entries)-1 {
 		self.Cursor++
 	} else {
@@ -98,7 +98,7 @@ func (self *BubbleList[C]) moveCursorDown() {
 	}
 }
 
-func (self *BubbleList[C]) moveCursorUp() {
+func (self *BubbleList[S]) moveCursorUp() {
 	if self.Cursor > 0 {
 		self.Cursor--
 	} else {
@@ -106,6 +106,6 @@ func (self *BubbleList[C]) moveCursorUp() {
 	}
 }
 
-func (self BubbleList[C]) selectedEntry() C { //nolint:ireturn
+func (self BubbleList[S]) selectedEntry() C { //nolint:ireturn
 	return self.Entries[self.Cursor]
 }

--- a/src/cli/dialog/bubble_list.go
+++ b/src/cli/dialog/bubble_list.go
@@ -18,20 +18,20 @@ const (
 )
 
 // BubbleList contains common elements of BubbleTea list implementations.
-type BubbleList[S ~[]C, C fmt.Stringer] struct {
+type BubbleList[C fmt.Stringer] struct {
 	Status       dialogStatus
 	Colors       dialogColors  // colors to use for help text
 	Cursor       int           // index of the currently selected row
 	Dim          termenv.Style // style for dim output
-	Entries      S             // the entries to select from
+	Entries      []C           // the entries to select from
 	EntryNumber  string        // the manually entered entry number
 	MaxDigits    int           // how many digits make up an entry number
 	NumberFormat string        // template for formatting the entry number
 }
 
-func newBubbleList[S ~[]C, C fmt.Stringer](entries S, cursor int) BubbleList[S, C] {
+func newBubbleList[C fmt.Stringer](entries []C, cursor int) BubbleList[C] {
 	numberLen := gohacks.NumberLength(len(entries))
-	return BubbleList[S, C]{
+	return BubbleList[C]{
 		Status:       dialogStatusActive,
 		Colors:       createColors(),
 		Cursor:       cursor,
@@ -44,17 +44,17 @@ func newBubbleList[S ~[]C, C fmt.Stringer](entries S, cursor int) BubbleList[S, 
 }
 
 // Aborted indicates whether the user has aborted this dialog.
-func (self *BubbleList[S, C]) aborted() bool {
+func (self *BubbleList[C]) aborted() bool {
 	return self.Status == dialogStatusAborted
 }
 
 // entryNumberStr provides a colorized string to print the given entry number.
-func (self *BubbleList[S, C]) entryNumberStr(number int) string {
+func (self *BubbleList[C]) entryNumberStr(number int) string {
 	return self.Dim.Styled(fmt.Sprintf(self.NumberFormat, number))
 }
 
 // handleKey handles keypresses that are common for all bubbleLists.
-func (self *BubbleList[S, C]) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
+func (self *BubbleList[C]) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 	switch key.Type { //nolint:exhaustive
 	case tea.KeyUp, tea.KeyShiftTab:
 		self.moveCursorUp()
@@ -90,7 +90,7 @@ func (self *BubbleList[S, C]) handleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 	return false, nil
 }
 
-func (self *BubbleList[S, C]) moveCursorDown() {
+func (self *BubbleList[C]) moveCursorDown() {
 	if self.Cursor < len(self.Entries)-1 {
 		self.Cursor++
 	} else {
@@ -98,7 +98,7 @@ func (self *BubbleList[S, C]) moveCursorDown() {
 	}
 }
 
-func (self *BubbleList[S, C]) moveCursorUp() {
+func (self *BubbleList[C]) moveCursorUp() {
 	if self.Cursor > 0 {
 		self.Cursor--
 	} else {
@@ -106,6 +106,6 @@ func (self *BubbleList[S, C]) moveCursorUp() {
 	}
 }
 
-func (self BubbleList[S, C]) selectedEntry() C { //nolint:ireturn
+func (self BubbleList[C]) selectedEntry() C { //nolint:ireturn
 	return self.Entries[self.Cursor]
 }

--- a/src/cli/dialog/colors.go
+++ b/src/cli/dialog/colors.go
@@ -1,6 +1,8 @@
 package dialog
 
-import "github.com/muesli/termenv"
+import (
+	"github.com/muesli/termenv"
+)
 
 // Typical colors used in BubbleTea dialogs.
 type dialogColors struct {

--- a/src/cli/dialog/colors.go
+++ b/src/cli/dialog/colors.go
@@ -1,8 +1,6 @@
 package dialog
 
-import (
-	"github.com/muesli/termenv"
-)
+import "github.com/muesli/termenv"
 
 // Typical colors used in BubbleTea dialogs.
 type dialogColors struct {

--- a/src/cli/dialog/enter_aliases.go
+++ b/src/cli/dialog/enter_aliases.go
@@ -24,7 +24,7 @@ If you are not sure, select all :)
 func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliases configdomain.Aliases, dialogTestInput TestInput) (configdomain.Aliases, bool, error) {
 	program := tea.NewProgram(AliasesModel{
 		AllAliasableCommands: allAliasableCommands,
-		BubbleList:           newBubbleList[configdomain.AliasableCommand](allAliasableCommands, 0),
+		BubbleList:           newBubbleList(allAliasableCommands, 0),
 		CurrentSelections:    NewAliasSelections(allAliasableCommands, existingAliases),
 		OriginalAliases:      existingAliases,
 		selectedColor:        termenv.String().Foreground(termenv.ANSIGreen),

--- a/src/cli/dialog/enter_aliases.go
+++ b/src/cli/dialog/enter_aliases.go
@@ -24,7 +24,7 @@ If you are not sure, select all :)
 func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliases configdomain.Aliases, dialogTestInput TestInput) (configdomain.Aliases, bool, error) {
 	program := tea.NewProgram(AliasesModel{
 		AllAliasableCommands: allAliasableCommands,
-		BubbleList:           newBubbleList(allAliasableCommands.Strings(), 0),
+		BubbleList:           newBubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand](allAliasableCommands, 0),
 		CurrentSelections:    NewAliasSelections(allAliasableCommands, existingAliases),
 		OriginalAliases:      existingAliases,
 		selectedColor:        termenv.String().Foreground(termenv.ANSIGreen),
@@ -48,7 +48,7 @@ func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliase
 }
 
 type AliasesModel struct {
-	BubbleList
+	BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]
 	AllAliasableCommands configdomain.AliasableCommands // all Git Town commands that can be aliased
 	CurrentSelections    []AliasSelection               // the status of the list entries
 	OriginalAliases      configdomain.Aliases           // the Git Town aliases as they currently exist on disk
@@ -143,17 +143,17 @@ func (self AliasesModel) View() string {
 		selection := self.CurrentSelections[i]
 		switch {
 		case highlighted && selection == AliasSelectionNone:
-			s.WriteString(self.Colors.selection.Styled("> [ ] " + branch))
+			s.WriteString(self.Colors.selection.Styled("> [ ] " + branch.String()))
 		case highlighted && selection == AliasSelectionOther:
-			s.WriteString(self.Colors.selection.Styled("> [o] " + branch))
+			s.WriteString(self.Colors.selection.Styled("> [o] " + branch.String()))
 		case highlighted && selection == AliasSelectionGT:
-			s.WriteString(self.Colors.selection.Styled("> [x] " + branch))
+			s.WriteString(self.Colors.selection.Styled("> [x] " + branch.String()))
 		case !highlighted && selection == AliasSelectionNone:
-			s.WriteString("  [ ] " + branch)
+			s.WriteString("  [ ] " + branch.String())
 		case !highlighted && selection == AliasSelectionOther:
-			s.WriteString("  [o] " + branch)
+			s.WriteString("  [o] " + branch.String())
 		case !highlighted && selection == AliasSelectionGT:
-			s.WriteString(self.selectedColor.Styled("  [x] " + branch))
+			s.WriteString(self.selectedColor.Styled("  [x] " + branch.String()))
 		}
 		s.WriteRune('\n')
 	}

--- a/src/cli/dialog/enter_aliases.go
+++ b/src/cli/dialog/enter_aliases.go
@@ -24,7 +24,7 @@ If you are not sure, select all :)
 func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliases configdomain.Aliases, dialogTestInput TestInput) (configdomain.Aliases, bool, error) {
 	program := tea.NewProgram(AliasesModel{
 		AllAliasableCommands: allAliasableCommands,
-		BubbleList:           newBubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand](allAliasableCommands, 0),
+		BubbleList:           newBubbleList[configdomain.AliasableCommand](allAliasableCommands, 0),
 		CurrentSelections:    NewAliasSelections(allAliasableCommands, existingAliases),
 		OriginalAliases:      existingAliases,
 		selectedColor:        termenv.String().Foreground(termenv.ANSIGreen),
@@ -48,7 +48,7 @@ func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliase
 }
 
 type AliasesModel struct {
-	BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]
+	BubbleList[configdomain.AliasableCommand]
 	AllAliasableCommands configdomain.AliasableCommands // all Git Town commands that can be aliased
 	CurrentSelections    []AliasSelection               // the status of the list entries
 	OriginalAliases      configdomain.Aliases           // the Git Town aliases as they currently exist on disk

--- a/src/cli/dialog/enter_aliases_test.go
+++ b/src/cli/dialog/enter_aliases_test.go
@@ -128,7 +128,7 @@ func TestEnterAliases(t *testing.T) {
 					dialog.AliasSelectionNone,
 				},
 				OriginalAliases: configdomain.Aliases{},
-				BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[configdomain.AliasableCommand]{ //nolint:exhaustruct
 					Cursor: 0,
 				},
 			}
@@ -157,7 +157,7 @@ func TestEnterAliases(t *testing.T) {
 				OriginalAliases: configdomain.Aliases{
 					configdomain.AliasableCommandAppend: "town append",
 				},
-				BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[configdomain.AliasableCommand]{ //nolint:exhaustruct
 					Cursor: 0,
 				},
 			}
@@ -186,7 +186,7 @@ func TestEnterAliases(t *testing.T) {
 				OriginalAliases: configdomain.Aliases{
 					configdomain.AliasableCommandAppend: "other command",
 				},
-				BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[configdomain.AliasableCommand]{ //nolint:exhaustruct
 					Cursor: 0,
 				},
 			}
@@ -214,7 +214,7 @@ func TestEnterAliases(t *testing.T) {
 	t.Run("SelectAll", func(t *testing.T) {
 		t.Parallel()
 		model := dialog.AliasesModel{ //nolint:exhaustruct
-			BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
+			BubbleList: dialog.BubbleList[configdomain.AliasableCommand]{ //nolint:exhaustruct
 				Entries: configdomain.AliasableCommands{
 					configdomain.AliasableCommandAppend,
 					configdomain.AliasableCommandHack,
@@ -239,7 +239,7 @@ func TestEnterAliases(t *testing.T) {
 	t.Run("SelectNone", func(t *testing.T) {
 		t.Parallel()
 		model := dialog.AliasesModel{ //nolint:exhaustruct
-			BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
+			BubbleList: dialog.BubbleList[configdomain.AliasableCommand]{ //nolint:exhaustruct
 				Entries: configdomain.AliasableCommands{
 					configdomain.AliasableCommandAppend,
 					configdomain.AliasableCommandHack,

--- a/src/cli/dialog/enter_aliases_test.go
+++ b/src/cli/dialog/enter_aliases_test.go
@@ -128,7 +128,7 @@ func TestEnterAliases(t *testing.T) {
 					dialog.AliasSelectionNone,
 				},
 				OriginalAliases: configdomain.Aliases{},
-				BubbleList: dialog.BubbleList{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
 					Cursor: 0,
 				},
 			}
@@ -157,7 +157,7 @@ func TestEnterAliases(t *testing.T) {
 				OriginalAliases: configdomain.Aliases{
 					configdomain.AliasableCommandAppend: "town append",
 				},
-				BubbleList: dialog.BubbleList{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
 					Cursor: 0,
 				},
 			}
@@ -186,7 +186,7 @@ func TestEnterAliases(t *testing.T) {
 				OriginalAliases: configdomain.Aliases{
 					configdomain.AliasableCommandAppend: "other command",
 				},
-				BubbleList: dialog.BubbleList{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
 					Cursor: 0,
 				},
 			}
@@ -214,8 +214,12 @@ func TestEnterAliases(t *testing.T) {
 	t.Run("SelectAll", func(t *testing.T) {
 		t.Parallel()
 		model := dialog.AliasesModel{ //nolint:exhaustruct
-			BubbleList: dialog.BubbleList{ //nolint:exhaustruct
-				Entries: []string{"append", "hack", "diff-parent"},
+			BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
+				Entries: configdomain.AliasableCommands{
+					configdomain.AliasableCommandAppend,
+					configdomain.AliasableCommandHack,
+					configdomain.AliasableCommandSync,
+				},
 			},
 			CurrentSelections: []dialog.AliasSelection{
 				dialog.AliasSelectionNone,
@@ -235,8 +239,12 @@ func TestEnterAliases(t *testing.T) {
 	t.Run("SelectNone", func(t *testing.T) {
 		t.Parallel()
 		model := dialog.AliasesModel{ //nolint:exhaustruct
-			BubbleList: dialog.BubbleList{ //nolint:exhaustruct
-				Entries: []string{"append", "hack", "diff-parent"},
+			BubbleList: dialog.BubbleList[configdomain.AliasableCommands, configdomain.AliasableCommand]{ //nolint:exhaustruct
+				Entries: configdomain.AliasableCommands{
+					configdomain.AliasableCommandAppend,
+					configdomain.AliasableCommandHack,
+					configdomain.AliasableCommandDiffParent,
+				},
 			},
 			CurrentSelections: []dialog.AliasSelection{
 				dialog.AliasSelectionGT,

--- a/src/cli/dialog/enter_hosting.go
+++ b/src/cli/dialog/enter_hosting.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/gohacks/stringers"
 )
 
 const enterHostingPlatformHelp = `
@@ -14,19 +15,16 @@ Only change this setting if the auto-detection does not work for you.
 `
 
 // EnterMainBranch lets the user select a new main branch for this repo.
-func EnterHostingPlatform(platformName configdomain.HostingPlatform, inputs TestInput) (string, bool, error) {
-	selection, aborted, err := radioList(radioListArgs{
-		entries: []string{
-			configdomain.HostingPlatformAutoDetect,
-			configdomain.HostingPlatformBitBucket,
-			configdomain.HostingPlatformGitea,
-			configdomain.HostingPlatformGitHub,
-			configdomain.HostingPlatformGitLab,
-		},
-		defaultEntry: platformName.String(),
-		help:         enterHostingPlatformHelp,
-		testInput:    inputs,
-	})
-	fmt.Printf("Code hosting: %s\n", formattedSelection(selection, aborted))
+func EnterHostingPlatform(platformName configdomain.HostingPlatform, inputs TestInput) (configdomain.HostingPlatform, bool, error) {
+	entries := []configdomain.HostingPlatform{
+		configdomain.HostingPlatformAutoDetect,
+		configdomain.HostingPlatformBitBucket,
+		configdomain.HostingPlatformGitea,
+		configdomain.HostingPlatformGitHub,
+		configdomain.HostingPlatformGitLab,
+	}
+	cursor := stringers.IndexOrStart(entries, platformName)
+	selection, aborted, err := radioList(entries, cursor, enterHostingPlatformHelp, inputs)
+	fmt.Printf("Code hosting: %s\n", formattedSelection(selection.String(), aborted))
 	return selection, aborted, err
 }

--- a/src/cli/dialog/enter_main_branch.go
+++ b/src/cli/dialog/enter_main_branch.go
@@ -20,5 +20,5 @@ func EnterMainBranch(localBranches gitdomain.LocalBranchNames, oldMainBranch git
 	cursor := stringers.IndexOrStart(localBranches, oldMainBranch)
 	selection, aborted, err := radioList(localBranches, cursor, enterBranchHelp, inputs)
 	fmt.Printf("Main branch: %s\n", formattedSelection(selection.String(), aborted))
-	return gitdomain.LocalBranchName(selection), aborted, err
+	return selection, aborted, err
 }

--- a/src/cli/dialog/enter_main_branch.go
+++ b/src/cli/dialog/enter_main_branch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/git-town/git-town/v11/src/git/gitdomain"
+	"github.com/git-town/git-town/v11/src/gohacks/stringers"
 )
 
 const enterBranchHelp = `
@@ -16,12 +17,8 @@ In most repositories, this branch is called "main", "master", or "development".
 
 // EnterMainBranch lets the user select a new main branch for this repo.
 func EnterMainBranch(localBranches gitdomain.LocalBranchNames, oldMainBranch gitdomain.LocalBranchName, inputs TestInput) (gitdomain.LocalBranchName, bool, error) {
-	selection, aborted, err := radioList(radioListArgs{
-		entries:      localBranches.Strings(),
-		defaultEntry: oldMainBranch.String(),
-		help:         enterBranchHelp,
-		testInput:    inputs,
-	})
-	fmt.Printf("Main branch: %s\n", formattedSelection(selection, aborted))
+	cursor := stringers.IndexOrStart(localBranches, oldMainBranch)
+	selection, aborted, err := radioList(localBranches, cursor, enterBranchHelp, inputs)
+	fmt.Printf("Main branch: %s\n", formattedSelection(selection.String(), aborted))
 	return gitdomain.LocalBranchName(selection), aborted, err
 }

--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -21,7 +21,8 @@ Most of the time this is the main development branch (%v).
 func EnterParent(args EnterParentArgs) (gitdomain.LocalBranchName, bool, error) {
 	entries := EnterParentEntries(args)
 	cursor := stringers.IndexOrStart(entries, args.MainBranch)
-	selection, aborted, err := radioList(entries, cursor, fmt.Sprintf(enterParentHelpTemplate, args.Branch, args.MainBranch), args.DialogTestInput)
+	help := fmt.Sprintf(enterParentHelpTemplate, args.Branch, args.MainBranch)
+	selection, aborted, err := radioList(entries, cursor, help, args.DialogTestInput)
 	fmt.Printf("Selected parent branch for %q: %s\n", args.Branch, formattedSelection(selection.String(), aborted))
 	return selection, aborted, err
 }

--- a/src/cli/dialog/enter_parent.go
+++ b/src/cli/dialog/enter_parent.go
@@ -8,7 +8,7 @@ import (
 	"github.com/git-town/git-town/v11/src/gohacks/stringers"
 )
 
-var PerennialBranchOption = gitdomain.LocalBranchName("<none> (perennial branch)")
+var PerennialBranchOption = gitdomain.LocalBranchName("<none> (perennial branch)") //nolint:gochecknoglobals
 
 const enterParentHelpTemplate = `
 Please select the parent of branch %q or enter its number.
@@ -23,7 +23,7 @@ func EnterParent(args EnterParentArgs) (gitdomain.LocalBranchName, bool, error) 
 	cursor := stringers.IndexOrStart(entries, args.MainBranch)
 	selection, aborted, err := radioList(entries, cursor, fmt.Sprintf(enterParentHelpTemplate, args.Branch, args.MainBranch), args.DialogTestInput)
 	fmt.Printf("Selected parent branch for %q: %s\n", args.Branch, formattedSelection(selection.String(), aborted))
-	return gitdomain.LocalBranchName(selection), aborted, err
+	return selection, aborted, err
 }
 
 type EnterParentArgs struct {

--- a/src/cli/dialog/enter_parent_test.go
+++ b/src/cli/dialog/enter_parent_test.go
@@ -33,7 +33,7 @@ func TestEnterParent(t *testing.T) {
 				Lineage:         lineage,
 				MainBranch:      main,
 			})
-			want := []string{dialog.PerennialBranchOption, "main", "branch-1", "branch-3"}
+			want := gitdomain.LocalBranchNames{dialog.PerennialBranchOption, main, branch1, branch3}
 			must.Eq(t, want, have)
 		})
 		t.Run("omits all descendents of the branch for which to select the parent", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestEnterParent(t *testing.T) {
 				Lineage:         lineage,
 				MainBranch:      main,
 			})
-			want := []string{dialog.PerennialBranchOption, "main", "branch-1", "branch-1a", "branch-3"}
+			want := gitdomain.LocalBranchNames{dialog.PerennialBranchOption, main, branch1, branch1a, branch3}
 			must.Eq(t, want, have)
 		})
 	})

--- a/src/cli/dialog/enter_perennial_branches.go
+++ b/src/cli/dialog/enter_perennial_branches.go
@@ -53,7 +53,7 @@ func EnterPerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerenni
 }
 
 type perennialBranchesModel struct {
-	BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]
+	BubbleList[gitdomain.LocalBranchName]
 	selections    []int
 	selectedColor termenv.Style
 }

--- a/src/cli/dialog/enter_perennial_branches_test.go
+++ b/src/cli/dialog/enter_perennial_branches_test.go
@@ -15,7 +15,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is enabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 2, 3},
@@ -27,7 +27,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is disabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 3},
@@ -43,7 +43,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is disabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 3},
@@ -55,7 +55,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is enabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 2, 3},
@@ -71,7 +71,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("selected row is checked", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{2},
@@ -81,7 +81,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("selected row is not checked", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 1,
 				},
 				selections: []int{2},
@@ -103,7 +103,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 	t.Run("checkedEntries", func(t *testing.T) {
 		t.Parallel()
 		model := perennialBranchesModel{ //nolint:exhaustruct
-			BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+			BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 				Entries: gitdomain.NewLocalBranchNames("zero", "one", "two", "three"),
 			},
 			selections: []int{1, 3},
@@ -116,7 +116,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 	t.Run("toggleCurrentEntry", func(t *testing.T) {
 		t.Parallel()
 		model := perennialBranchesModel{ //nolint:exhaustruct
-			BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+			BubbleList: BubbleList[gitdomain.LocalBranchName]{ //nolint:exhaustruct
 				Cursor: 2,
 			},
 			selections: []int{1, 3},

--- a/src/cli/dialog/enter_perennial_branches_test.go
+++ b/src/cli/dialog/enter_perennial_branches_test.go
@@ -3,6 +3,7 @@ package dialog //nolint:testpackage
 import (
 	"testing"
 
+	"github.com/git-town/git-town/v11/src/git/gitdomain"
 	"github.com/shoenig/test/must"
 )
 
@@ -14,7 +15,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is enabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 2, 3},
@@ -26,7 +27,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is disabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 3},
@@ -42,7 +43,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is disabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 3},
@@ -54,7 +55,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("entry is enabled", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{1, 2, 3},
@@ -70,7 +71,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("selected row is checked", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 2,
 				},
 				selections: []int{2},
@@ -80,7 +81,7 @@ func TestPerennialBranchesModel(t *testing.T) {
 		t.Run("selected row is not checked", func(t *testing.T) {
 			t.Parallel()
 			model := perennialBranchesModel{ //nolint:exhaustruct
-				BubbleList: BubbleList{ //nolint:exhaustruct
+				BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
 					Cursor: 1,
 				},
 				selections: []int{2},
@@ -102,20 +103,20 @@ func TestPerennialBranchesModel(t *testing.T) {
 	t.Run("checkedEntries", func(t *testing.T) {
 		t.Parallel()
 		model := perennialBranchesModel{ //nolint:exhaustruct
-			BubbleList: BubbleList{ //nolint:exhaustruct
-				Entries: []string{"zero", "one", "two", "three"},
+			BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
+				Entries: gitdomain.NewLocalBranchNames("zero", "one", "two", "three"),
 			},
 			selections: []int{1, 3},
 		}
 		have := model.checkedEntries()
-		want := []string{"one", "three"}
+		want := gitdomain.NewLocalBranchNames("one", "three")
 		must.Eq(t, want, have)
 	})
 
 	t.Run("toggleCurrentEntry", func(t *testing.T) {
 		t.Parallel()
 		model := perennialBranchesModel{ //nolint:exhaustruct
-			BubbleList: BubbleList{ //nolint:exhaustruct
+			BubbleList: BubbleList[gitdomain.LocalBranchNames, gitdomain.LocalBranchName]{ //nolint:exhaustruct
 				Cursor: 2,
 			},
 			selections: []int{1, 3},

--- a/src/cli/dialog/enter_push_hook.go
+++ b/src/cli/dialog/enter_push_hook.go
@@ -41,10 +41,6 @@ func EnterPushHook(existing configdomain.PushHook, inputs TestInput) (configdoma
 
 type pushHookEntry string
 
-func (self pushHookEntry) String() string {
-	return string(self)
-}
-
 func (self pushHookEntry) PushHook() configdomain.PushHook {
 	switch self {
 	case pushHookEntryEnabled:
@@ -53,4 +49,8 @@ func (self pushHookEntry) PushHook() configdomain.PushHook {
 		return configdomain.PushHook(false)
 	}
 	panic("unhandled pushHookEntry: " + self)
+}
+
+func (self pushHookEntry) String() string {
+	return string(self)
 }

--- a/src/cli/dialog/enter_push_hook.go
+++ b/src/cli/dialog/enter_push_hook.go
@@ -24,7 +24,10 @@ const (
 )
 
 func EnterPushHook(existing configdomain.PushHook, inputs TestInput) (configdomain.PushHook, bool, error) {
-	entries := []pushHookEntry{pushHookEntryEnabled, pushHookEntryDisabled}
+	entries := []pushHookEntry{
+		pushHookEntryEnabled,
+		pushHookEntryDisabled,
+	}
 	var defaultPos int
 	if existing {
 		defaultPos = 0

--- a/src/cli/dialog/enter_push_hook.go
+++ b/src/cli/dialog/enter_push_hook.go
@@ -36,7 +36,7 @@ func EnterPushHook(existing configdomain.PushHook, inputs TestInput) (configdoma
 		return true, aborted, err
 	}
 	fmt.Printf("Push hook: %s\n", formattedSelection(selection.String(), aborted))
-	return selection.ToPushHook(), aborted, err
+	return selection.PushHook(), aborted, err
 }
 
 type pushHookEntry string
@@ -45,7 +45,7 @@ func (self pushHookEntry) String() string {
 	return string(self)
 }
 
-func (self pushHookEntry) ToPushHook() configdomain.PushHook {
+func (self pushHookEntry) PushHook() configdomain.PushHook {
 	switch self {
 	case pushHookEntryEnabled:
 		return configdomain.PushHook(true)

--- a/src/cli/dialog/enter_push_hook.go
+++ b/src/cli/dialog/enter_push_hook.go
@@ -18,6 +18,11 @@ More info at https://www.git-town.com/preferences/push-hook.
 Push hooks in Git Town are:
 `
 
+const (
+	pushHookEntryEnabled  pushHookEntry = "enabled"
+	pushHookEntryDisabled pushHookEntry = "disabled"
+)
+
 func EnterPushHook(existing configdomain.PushHook, inputs TestInput) (configdomain.PushHook, bool, error) {
 	entries := []pushHookEntry{pushHookEntryEnabled, pushHookEntryDisabled}
 	var defaultPos int
@@ -49,8 +54,3 @@ func (self pushHookEntry) ToPushHook() configdomain.PushHook {
 	}
 	panic("unhandled pushHookEntry: " + self)
 }
-
-const (
-	pushHookEntryEnabled  pushHookEntry = "enabled"
-	pushHookEntryDisabled pushHookEntry = "disabled"
-)

--- a/src/cli/dialog/enter_push_hook.go
+++ b/src/cli/dialog/enter_push_hook.go
@@ -19,23 +19,38 @@ Push hooks in Git Town are:
 `
 
 func EnterPushHook(existing configdomain.PushHook, inputs TestInput) (configdomain.PushHook, bool, error) {
-	entries := []string{"enabled", "disabled"}
+	entries := []pushHookEntry{pushHookEntryEnabled, pushHookEntryDisabled}
 	var defaultPos int
 	if existing {
 		defaultPos = 0
 	} else {
 		defaultPos = 1
 	}
-	selection, aborted, err := radioList(radioListArgs{
-		entries:      entries,
-		defaultEntry: entries[defaultPos],
-		help:         enterPushHookHelp,
-		testInput:    inputs,
-	})
+	selection, aborted, err := radioList(entries, defaultPos, enterPushHookHelp, inputs)
 	if err != nil || aborted {
 		return true, aborted, err
 	}
-	fmt.Printf("Push hook: %s\n", formattedSelection(selection, aborted))
-	result, err := configdomain.NewPushHook(selection, "user dialog")
-	return result, aborted, err
+	fmt.Printf("Push hook: %s\n", formattedSelection(selection.String(), aborted))
+	return selection.ToPushHook(), aborted, err
 }
+
+type pushHookEntry string
+
+func (self pushHookEntry) String() string {
+	return string(self)
+}
+
+func (self pushHookEntry) ToPushHook() configdomain.PushHook {
+	switch self {
+	case pushHookEntryEnabled:
+		return configdomain.PushHook(true)
+	case pushHookEntryDisabled:
+		return configdomain.PushHook(false)
+	}
+	panic("unhandled pushHookEntry: " + self)
+}
+
+const (
+	pushHookEntryEnabled  pushHookEntry = "enabled"
+	pushHookEntryDisabled pushHookEntry = "disabled"
+)

--- a/src/cli/dialog/enter_push_new_branches.go
+++ b/src/cli/dialog/enter_push_new_branches.go
@@ -38,12 +38,16 @@ func EnterPushNewBranches(existing configdomain.NewBranchPush, inputs TestInput)
 	if err != nil || aborted {
 		return true, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection.String(), ",")
-	fmt.Printf("Push new branches: %s\n", formattedSelection(cutSelection, aborted))
+	fmt.Printf("Push new branches: %s\n", formattedSelection(selection.Short(), aborted))
 	return selection.ToNewBranchPush(), aborted, err
 }
 
 type pushNewBranchesEntry string
+
+func (self pushNewBranchesEntry) Short() string {
+	begin, _, _ := strings.Cut(self.String(), ",")
+	return begin
+}
 
 func (self pushNewBranchesEntry) String() string {
 	return string(self)

--- a/src/cli/dialog/enter_push_new_branches.go
+++ b/src/cli/dialog/enter_push_new_branches.go
@@ -27,7 +27,10 @@ const (
 )
 
 func EnterPushNewBranches(existing configdomain.NewBranchPush, inputs TestInput) (configdomain.NewBranchPush, bool, error) {
-	entries := []pushNewBranchesEntry{PushNewBranchesEntryYes, PushNewBranchesEntryNo}
+	entries := []pushNewBranchesEntry{
+		PushNewBranchesEntryYes,
+		PushNewBranchesEntryNo,
+	}
 	var defaultPos int
 	if existing {
 		defaultPos = 0

--- a/src/cli/dialog/enter_push_new_branches.go
+++ b/src/cli/dialog/enter_push_new_branches.go
@@ -39,7 +39,7 @@ func EnterPushNewBranches(existing configdomain.NewBranchPush, inputs TestInput)
 		return true, aborted, err
 	}
 	fmt.Printf("Push new branches: %s\n", formattedSelection(selection.Short(), aborted))
-	return selection.ToNewBranchPush(), aborted, err
+	return selection.NewBranchPush(), aborted, err
 }
 
 type pushNewBranchesEntry string
@@ -53,7 +53,7 @@ func (self pushNewBranchesEntry) String() string {
 	return string(self)
 }
 
-func (self pushNewBranchesEntry) ToNewBranchPush() configdomain.NewBranchPush {
+func (self pushNewBranchesEntry) NewBranchPush() configdomain.NewBranchPush {
 	switch self {
 	case PushNewBranchesEntryYes:
 		return configdomain.NewBranchPush(true)

--- a/src/cli/dialog/enter_push_new_branches.go
+++ b/src/cli/dialog/enter_push_new_branches.go
@@ -21,6 +21,11 @@ on the first run of "git sync".
 
 `
 
+const (
+	pushNewBranchesEntryYes pushNewBranchesEntry = "yes, push new branches to origin"
+	pushNewBranchesEntryNo  pushNewBranchesEntry = "no, new branches remain local until synced"
+)
+
 func EnterPushNewBranches(existing configdomain.NewBranchPush, inputs TestInput) (configdomain.NewBranchPush, bool, error) {
 	entries := []pushNewBranchesEntry{pushNewBranchesEntryYes, pushNewBranchesEntryNo}
 	var defaultPos int
@@ -53,8 +58,3 @@ func (self pushNewBranchesEntry) ToNewBranchPush() configdomain.NewBranchPush {
 	}
 	panic("unhandled pushNewBranchesEntry: " + self)
 }
-
-const (
-	pushNewBranchesEntryYes pushNewBranchesEntry = "yes, push new branches to origin"
-	pushNewBranchesEntryNo  pushNewBranchesEntry = "no, new branches remain local until synced"
-)

--- a/src/cli/dialog/enter_push_new_branches.go
+++ b/src/cli/dialog/enter_push_new_branches.go
@@ -44,15 +44,6 @@ func EnterPushNewBranches(existing configdomain.NewBranchPush, inputs TestInput)
 
 type pushNewBranchesEntry string
 
-func (self pushNewBranchesEntry) Short() string {
-	begin, _, _ := strings.Cut(self.String(), ",")
-	return begin
-}
-
-func (self pushNewBranchesEntry) String() string {
-	return string(self)
-}
-
 func (self pushNewBranchesEntry) NewBranchPush() configdomain.NewBranchPush {
 	switch self {
 	case PushNewBranchesEntryYes:
@@ -61,4 +52,13 @@ func (self pushNewBranchesEntry) NewBranchPush() configdomain.NewBranchPush {
 		return configdomain.NewBranchPush(false)
 	}
 	panic("unhandled pushNewBranchesEntry: " + self)
+}
+
+func (self pushNewBranchesEntry) Short() string {
+	begin, _, _ := strings.Cut(self.String(), ",")
+	return begin
+}
+
+func (self pushNewBranchesEntry) String() string {
+	return string(self)
 }

--- a/src/cli/dialog/enter_push_new_branches.go
+++ b/src/cli/dialog/enter_push_new_branches.go
@@ -22,12 +22,12 @@ on the first run of "git sync".
 `
 
 const (
-	pushNewBranchesEntryYes pushNewBranchesEntry = "yes, push new branches to origin"
-	pushNewBranchesEntryNo  pushNewBranchesEntry = "no, new branches remain local until synced"
+	PushNewBranchesEntryYes pushNewBranchesEntry = "yes, push new branches to origin"
+	PushNewBranchesEntryNo  pushNewBranchesEntry = "no, new branches remain local until synced"
 )
 
 func EnterPushNewBranches(existing configdomain.NewBranchPush, inputs TestInput) (configdomain.NewBranchPush, bool, error) {
-	entries := []pushNewBranchesEntry{pushNewBranchesEntryYes, pushNewBranchesEntryNo}
+	entries := []pushNewBranchesEntry{PushNewBranchesEntryYes, PushNewBranchesEntryNo}
 	var defaultPos int
 	if existing {
 		defaultPos = 0
@@ -55,9 +55,9 @@ func (self pushNewBranchesEntry) String() string {
 
 func (self pushNewBranchesEntry) ToNewBranchPush() configdomain.NewBranchPush {
 	switch self {
-	case pushNewBranchesEntryYes:
+	case PushNewBranchesEntryYes:
 		return configdomain.NewBranchPush(true)
-	case pushNewBranchesEntryNo:
+	case PushNewBranchesEntryNo:
 		return configdomain.NewBranchPush(false)
 	}
 	panic("unhandled pushNewBranchesEntry: " + self)

--- a/src/cli/dialog/enter_push_new_branches_test.go
+++ b/src/cli/dialog/enter_push_new_branches_test.go
@@ -1,0 +1,20 @@
+package dialog_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/cli/dialog"
+	"github.com/shoenig/test/must"
+)
+
+func TestEnterPushNewBranches(t *testing.T) {
+	t.Parallel()
+	t.Run("pushNewBranchesEntry", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Short", func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, "yes", dialog.PushNewBranchesEntryYes.Short())
+			must.Eq(t, "no", dialog.PushNewBranchesEntryNo.Short())
+		})
+	})
+}

--- a/src/cli/dialog/enter_push_new_branches_test.go
+++ b/src/cli/dialog/enter_push_new_branches_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestEnterPushNewBranches(t *testing.T) {
 	t.Parallel()
+
 	t.Run("pushNewBranchesEntry", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Short", func(t *testing.T) {

--- a/src/cli/dialog/enter_ship_delete_tracking_branch.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch.go
@@ -22,7 +22,10 @@ const (
 )
 
 func EnterShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, inputs TestInput) (configdomain.ShipDeleteTrackingBranch, bool, error) {
-	entries := []shipDeleteTrackingBranchEntry{ShipDeleteTrackingBranchEntryYes, ShipDeleteTrackingBranchEntryNo}
+	entries := []shipDeleteTrackingBranchEntry{
+		ShipDeleteTrackingBranchEntryYes,
+		ShipDeleteTrackingBranchEntryNo,
+	}
 	var defaultPos int
 	if existing {
 		defaultPos = 0

--- a/src/cli/dialog/enter_ship_delete_tracking_branch.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch.go
@@ -17,12 +17,12 @@ merging pull requests through its UI.
 `
 
 const (
-	shipDeleteTrackingBranchEntryYes shipDeleteTrackingBranchEntry = `yes, "git ship" should delete tracking branches`
-	shipDeleteTrackingBranchEntryNo  shipDeleteTrackingBranchEntry = `no, my code hosting platform deletes tracking branches`
+	ShipDeleteTrackingBranchEntryYes shipDeleteTrackingBranchEntry = `yes, "git ship" should delete tracking branches`
+	ShipDeleteTrackingBranchEntryNo  shipDeleteTrackingBranchEntry = `no, my code hosting platform deletes tracking branches`
 )
 
 func EnterShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, inputs TestInput) (configdomain.ShipDeleteTrackingBranch, bool, error) {
-	entries := []shipDeleteTrackingBranchEntry{shipDeleteTrackingBranchEntryYes, shipDeleteTrackingBranchEntryNo}
+	entries := []shipDeleteTrackingBranchEntry{ShipDeleteTrackingBranchEntryYes, ShipDeleteTrackingBranchEntryNo}
 	var defaultPos int
 	if existing {
 		defaultPos = 0
@@ -50,9 +50,9 @@ func (self shipDeleteTrackingBranchEntry) String() string {
 
 func (self shipDeleteTrackingBranchEntry) ToShipDeleteTrackingBranch() configdomain.ShipDeleteTrackingBranch {
 	switch self {
-	case shipDeleteTrackingBranchEntryYes:
+	case ShipDeleteTrackingBranchEntryYes:
 		return configdomain.ShipDeleteTrackingBranch(true)
-	case shipDeleteTrackingBranchEntryNo:
+	case ShipDeleteTrackingBranchEntryNo:
 		return configdomain.ShipDeleteTrackingBranch(false)
 	}
 	panic("unhandled shipDeleteTrackingBranchEntry: " + self)

--- a/src/cli/dialog/enter_ship_delete_tracking_branch.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch.go
@@ -39,15 +39,6 @@ func EnterShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranc
 
 type shipDeleteTrackingBranchEntry string
 
-func (self shipDeleteTrackingBranchEntry) Short() string {
-	start, _, _ := strings.Cut(self.String(), ",")
-	return start
-}
-
-func (self shipDeleteTrackingBranchEntry) String() string {
-	return string(self)
-}
-
 func (self shipDeleteTrackingBranchEntry) ShipDeleteTrackingBranch() configdomain.ShipDeleteTrackingBranch {
 	switch self {
 	case ShipDeleteTrackingBranchEntryYes:
@@ -56,4 +47,13 @@ func (self shipDeleteTrackingBranchEntry) ShipDeleteTrackingBranch() configdomai
 		return configdomain.ShipDeleteTrackingBranch(false)
 	}
 	panic("unhandled shipDeleteTrackingBranchEntry: " + self)
+}
+
+func (self shipDeleteTrackingBranchEntry) Short() string {
+	start, _, _ := strings.Cut(self.String(), ",")
+	return start
+}
+
+func (self shipDeleteTrackingBranchEntry) String() string {
+	return string(self)
 }

--- a/src/cli/dialog/enter_ship_delete_tracking_branch.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch.go
@@ -33,12 +33,16 @@ func EnterShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranc
 	if err != nil || aborted {
 		return true, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection.String(), ",")
-	fmt.Printf("Ship deletes tracking branches: %s\n", formattedSelection(cutSelection, aborted))
+	fmt.Printf("Ship deletes tracking branches: %s\n", formattedSelection(selection.Short(), aborted))
 	return selection.ToShipDeleteTrackingBranch(), aborted, err
 }
 
 type shipDeleteTrackingBranchEntry string
+
+func (self shipDeleteTrackingBranchEntry) Short() string {
+	start, _, _ := strings.Cut(self.String(), ",")
+	return start
+}
 
 func (self shipDeleteTrackingBranchEntry) String() string {
 	return string(self)

--- a/src/cli/dialog/enter_ship_delete_tracking_branch.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch.go
@@ -34,7 +34,7 @@ func EnterShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranc
 		return true, aborted, err
 	}
 	fmt.Printf("Ship deletes tracking branches: %s\n", formattedSelection(selection.Short(), aborted))
-	return selection.ToShipDeleteTrackingBranch(), aborted, err
+	return selection.ShipDeleteTrackingBranch(), aborted, err
 }
 
 type shipDeleteTrackingBranchEntry string
@@ -48,7 +48,7 @@ func (self shipDeleteTrackingBranchEntry) String() string {
 	return string(self)
 }
 
-func (self shipDeleteTrackingBranchEntry) ToShipDeleteTrackingBranch() configdomain.ShipDeleteTrackingBranch {
+func (self shipDeleteTrackingBranchEntry) ShipDeleteTrackingBranch() configdomain.ShipDeleteTrackingBranch {
 	switch self {
 	case ShipDeleteTrackingBranchEntryYes:
 		return configdomain.ShipDeleteTrackingBranch(true)

--- a/src/cli/dialog/enter_ship_delete_tracking_branch.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch.go
@@ -16,6 +16,11 @@ merging pull requests through its UI.
 
 `
 
+const (
+	shipDeleteTrackingBranchEntryYes shipDeleteTrackingBranchEntry = `yes, "git ship" should delete tracking branches`
+	shipDeleteTrackingBranchEntryNo  shipDeleteTrackingBranchEntry = `no, my code hosting platform deletes tracking branches`
+)
+
 func EnterShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, inputs TestInput) (configdomain.ShipDeleteTrackingBranch, bool, error) {
 	entries := []shipDeleteTrackingBranchEntry{shipDeleteTrackingBranchEntryYes, shipDeleteTrackingBranchEntryNo}
 	var defaultPos int
@@ -48,8 +53,3 @@ func (self shipDeleteTrackingBranchEntry) ToShipDeleteTrackingBranch() configdom
 	}
 	panic("unhandled shipDeleteTrackingBranchEntry: " + self)
 }
-
-const (
-	shipDeleteTrackingBranchEntryYes shipDeleteTrackingBranchEntry = `yes, "git ship" should delete tracking branches`
-	shipDeleteTrackingBranchEntryNo  shipDeleteTrackingBranchEntry = `no, my code hosting platform deletes tracking branches`
-)

--- a/src/cli/dialog/enter_ship_delete_tracking_branch_test.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch_test.go
@@ -1,0 +1,20 @@
+package dialog_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/cli/dialog"
+	"github.com/shoenig/test/must"
+)
+
+func TestEnterShipDeleteTrackingBranch(t *testing.T) {
+	t.Parallel()
+	t.Run("ShipDeleteTrackingBranchEntry", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Short", func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, "yes", dialog.ShipDeleteTrackingBranchEntryYes.Short())
+			must.Eq(t, "no", dialog.ShipDeleteTrackingBranchEntryNo.Short())
+		})
+	})
+}

--- a/src/cli/dialog/enter_ship_delete_tracking_branch_test.go
+++ b/src/cli/dialog/enter_ship_delete_tracking_branch_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestEnterShipDeleteTrackingBranch(t *testing.T) {
 	t.Parallel()
+
 	t.Run("ShipDeleteTrackingBranchEntry", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Short", func(t *testing.T) {

--- a/src/cli/dialog/enter_sync_before_ship.go
+++ b/src/cli/dialog/enter_sync_before_ship.go
@@ -39,12 +39,16 @@ func EnterSyncBeforeShip(existing configdomain.SyncBeforeShip, inputs TestInput)
 	if err != nil || aborted {
 		return true, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection.String(), ",")
-	fmt.Printf("Sync before ship: %s\n", formattedSelection(cutSelection, aborted))
+	fmt.Printf("Sync before ship: %s\n", formattedSelection(selection.Short(), aborted))
 	return selection.ToSyncBeforeShip(), aborted, err
 }
 
 type syncBeforeShipEntry string
+
+func (self syncBeforeShipEntry) Short() string {
+	start, _, _ := strings.Cut(self.String(), ",")
+	return start
+}
 
 func (self syncBeforeShipEntry) String() string {
 	return string(self)

--- a/src/cli/dialog/enter_sync_before_ship.go
+++ b/src/cli/dialog/enter_sync_before_ship.go
@@ -22,6 +22,11 @@ But this also triggers another CI run and delays shipping.
 
 `
 
+const (
+	syncBeforeShipEntryYes syncBeforeShipEntry = `yes, "git ship" should also sync the branch`
+	syncBeforeShipEntryNo  syncBeforeShipEntry = `no, "git ship" should not sync the branch`
+)
+
 func EnterSyncBeforeShip(existing configdomain.SyncBeforeShip, inputs TestInput) (configdomain.SyncBeforeShip, bool, error) {
 	entries := []syncBeforeShipEntry{syncBeforeShipEntryYes, syncBeforeShipEntryNo}
 	var defaultPos int
@@ -54,8 +59,3 @@ func (self syncBeforeShipEntry) ToSyncBeforeShip() configdomain.SyncBeforeShip {
 	}
 	panic("unhandled syncBeforeShipEntry: " + self)
 }
-
-const (
-	syncBeforeShipEntryYes syncBeforeShipEntry = `yes, "git ship" should also sync the branch`
-	syncBeforeShipEntryNo  syncBeforeShipEntry = `no, "git ship" should not sync the branch`
-)

--- a/src/cli/dialog/enter_sync_before_ship.go
+++ b/src/cli/dialog/enter_sync_before_ship.go
@@ -23,12 +23,12 @@ But this also triggers another CI run and delays shipping.
 `
 
 const (
-	syncBeforeShipEntryYes syncBeforeShipEntry = `yes, "git ship" should also sync the branch`
-	syncBeforeShipEntryNo  syncBeforeShipEntry = `no, "git ship" should not sync the branch`
+	SyncBeforeShipEntryYes syncBeforeShipEntry = `yes, "git ship" should also sync the branch`
+	SyncBeforeShipEntryNo  syncBeforeShipEntry = `no, "git ship" should not sync the branch`
 )
 
 func EnterSyncBeforeShip(existing configdomain.SyncBeforeShip, inputs TestInput) (configdomain.SyncBeforeShip, bool, error) {
-	entries := []syncBeforeShipEntry{syncBeforeShipEntryYes, syncBeforeShipEntryNo}
+	entries := []syncBeforeShipEntry{SyncBeforeShipEntryYes, SyncBeforeShipEntryNo}
 	var defaultPos int
 	if existing {
 		defaultPos = 0
@@ -56,9 +56,9 @@ func (self syncBeforeShipEntry) String() string {
 
 func (self syncBeforeShipEntry) ToSyncBeforeShip() configdomain.SyncBeforeShip {
 	switch self {
-	case syncBeforeShipEntryYes:
+	case SyncBeforeShipEntryYes:
 		return configdomain.SyncBeforeShip(true)
-	case syncBeforeShipEntryNo:
+	case SyncBeforeShipEntryNo:
 		return configdomain.SyncBeforeShip(false)
 	}
 	panic("unhandled syncBeforeShipEntry: " + self)

--- a/src/cli/dialog/enter_sync_before_ship.go
+++ b/src/cli/dialog/enter_sync_before_ship.go
@@ -40,7 +40,7 @@ func EnterSyncBeforeShip(existing configdomain.SyncBeforeShip, inputs TestInput)
 		return true, aborted, err
 	}
 	fmt.Printf("Sync before ship: %s\n", formattedSelection(selection.Short(), aborted))
-	return selection.ToSyncBeforeShip(), aborted, err
+	return selection.SyncBeforeShip(), aborted, err
 }
 
 type syncBeforeShipEntry string
@@ -54,7 +54,7 @@ func (self syncBeforeShipEntry) String() string {
 	return string(self)
 }
 
-func (self syncBeforeShipEntry) ToSyncBeforeShip() configdomain.SyncBeforeShip {
+func (self syncBeforeShipEntry) SyncBeforeShip() configdomain.SyncBeforeShip {
 	switch self {
 	case SyncBeforeShipEntryYes:
 		return configdomain.SyncBeforeShip(true)

--- a/src/cli/dialog/enter_sync_before_ship.go
+++ b/src/cli/dialog/enter_sync_before_ship.go
@@ -28,7 +28,10 @@ const (
 )
 
 func EnterSyncBeforeShip(existing configdomain.SyncBeforeShip, inputs TestInput) (configdomain.SyncBeforeShip, bool, error) {
-	entries := []syncBeforeShipEntry{SyncBeforeShipEntryYes, SyncBeforeShipEntryNo}
+	entries := []syncBeforeShipEntry{
+		SyncBeforeShipEntryYes,
+		SyncBeforeShipEntryNo,
+	}
 	var defaultPos int
 	if existing {
 		defaultPos = 0

--- a/src/cli/dialog/enter_sync_before_ship_test.go
+++ b/src/cli/dialog/enter_sync_before_ship_test.go
@@ -1,0 +1,20 @@
+package dialog_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/cli/dialog"
+	"github.com/shoenig/test/must"
+)
+
+func TestEnterSyncBeforeShip(t *testing.T) {
+	t.Parallel()
+	t.Run("SyncBeforeShipEntry", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Short", func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, "yes", dialog.SyncBeforeShipEntryYes.Short())
+			must.Eq(t, "no", dialog.SyncBeforeShipEntryNo.Short())
+		})
+	})
+}

--- a/src/cli/dialog/enter_sync_before_ship_test.go
+++ b/src/cli/dialog/enter_sync_before_ship_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestEnterSyncBeforeShip(t *testing.T) {
 	t.Parallel()
+
 	t.Run("SyncBeforeShipEntry", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Short", func(t *testing.T) {

--- a/src/cli/dialog/enter_sync_feature_strategy.go
+++ b/src/cli/dialog/enter_sync_feature_strategy.go
@@ -29,12 +29,7 @@ func EnterSyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs 
 	default:
 		panic("unknown sync-feature-strategy: " + existing.String())
 	}
-	selection, aborted, err := radioList(radioListArgs{
-		entries:      entries,
-		defaultEntry: entries[defaultPos],
-		help:         enterSyncFeatureStrategyHelp,
-		testInput:    inputs,
-	})
+	selection, aborted, err := radioList(entries, defaultPos, enterSyncFeatureStrategyHelp, inputs)
 	if err != nil || aborted {
 		return configdomain.SyncFeatureStrategyMerge, aborted, err
 	}

--- a/src/cli/dialog/enter_sync_feature_strategy.go
+++ b/src/cli/dialog/enter_sync_feature_strategy.go
@@ -19,7 +19,7 @@ How should Git Town update feature branches?
 `
 
 func EnterSyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs TestInput) (configdomain.SyncFeatureStrategy, bool, error) {
-	entries := []string{`merge updates from the parent branch into feature branches`, `rebase feature branches against their parent branch`}
+	entries := []syncFeatureStrategyEntry{syncFeatureStrategyEntryMerge, syncFeatureStrategyEntryRebase}
 	var defaultPos int
 	switch existing {
 	case configdomain.SyncFeatureStrategyMerge:
@@ -33,8 +33,28 @@ func EnterSyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs 
 	if err != nil || aborted {
 		return configdomain.SyncFeatureStrategyMerge, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection, " ")
+	cutSelection, _, _ := strings.Cut(selection.String(), " ")
 	fmt.Printf("Sync feature branches: %s\n", formattedSelection(cutSelection, aborted))
-	parsedAnswer, err := configdomain.NewSyncFeatureStrategy(cutSelection)
-	return parsedAnswer, aborted, err
+	return selection.ToSyncFeatureStrategy(), aborted, err
 }
+
+type syncFeatureStrategyEntry string
+
+func (self syncFeatureStrategyEntry) String() string {
+	return string(self)
+}
+
+func (self syncFeatureStrategyEntry) ToSyncFeatureStrategy() configdomain.SyncFeatureStrategy {
+	switch self {
+	case syncFeatureStrategyEntryMerge:
+		return configdomain.SyncFeatureStrategyMerge
+	case syncFeatureStrategyEntryRebase:
+		return configdomain.SyncFeatureStrategyRebase
+	}
+	panic("unhandled syncFeatureStrategyEntry: " + self)
+}
+
+const (
+	syncFeatureStrategyEntryMerge  syncFeatureStrategyEntry = `merge updates from the parent branch into feature branches`
+	syncFeatureStrategyEntryRebase syncFeatureStrategyEntry = `rebase feature branches against their parent branch`
+)

--- a/src/cli/dialog/enter_sync_feature_strategy.go
+++ b/src/cli/dialog/enter_sync_feature_strategy.go
@@ -18,6 +18,11 @@ How should Git Town update feature branches?
 
 `
 
+const (
+	syncFeatureStrategyEntryMerge  syncFeatureStrategyEntry = `merge updates from the parent branch into feature branches`
+	syncFeatureStrategyEntryRebase syncFeatureStrategyEntry = `rebase feature branches against their parent branch`
+)
+
 func EnterSyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs TestInput) (configdomain.SyncFeatureStrategy, bool, error) {
 	entries := []syncFeatureStrategyEntry{syncFeatureStrategyEntryMerge, syncFeatureStrategyEntryRebase}
 	var defaultPos int
@@ -53,8 +58,3 @@ func (self syncFeatureStrategyEntry) ToSyncFeatureStrategy() configdomain.SyncFe
 	}
 	panic("unhandled syncFeatureStrategyEntry: " + self)
 }
-
-const (
-	syncFeatureStrategyEntryMerge  syncFeatureStrategyEntry = `merge updates from the parent branch into feature branches`
-	syncFeatureStrategyEntryRebase syncFeatureStrategyEntry = `rebase feature branches against their parent branch`
-)

--- a/src/cli/dialog/enter_sync_feature_strategy.go
+++ b/src/cli/dialog/enter_sync_feature_strategy.go
@@ -24,7 +24,10 @@ const (
 )
 
 func EnterSyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs TestInput) (configdomain.SyncFeatureStrategy, bool, error) {
-	entries := []syncFeatureStrategyEntry{syncFeatureStrategyEntryMerge, syncFeatureStrategyEntryRebase}
+	entries := []syncFeatureStrategyEntry{
+		syncFeatureStrategyEntryMerge,
+		syncFeatureStrategyEntryRebase,
+	}
 	var defaultPos int
 	switch existing {
 	case configdomain.SyncFeatureStrategyMerge:

--- a/src/cli/dialog/enter_sync_feature_strategy.go
+++ b/src/cli/dialog/enter_sync_feature_strategy.go
@@ -40,7 +40,7 @@ func EnterSyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs 
 	}
 	cutSelection, _, _ := strings.Cut(selection.String(), " ")
 	fmt.Printf("Sync feature branches: %s\n", formattedSelection(cutSelection, aborted))
-	return selection.ToSyncFeatureStrategy(), aborted, err
+	return selection.SyncFeatureStrategy(), aborted, err
 }
 
 type syncFeatureStrategyEntry string
@@ -49,7 +49,7 @@ func (self syncFeatureStrategyEntry) String() string {
 	return string(self)
 }
 
-func (self syncFeatureStrategyEntry) ToSyncFeatureStrategy() configdomain.SyncFeatureStrategy {
+func (self syncFeatureStrategyEntry) SyncFeatureStrategy() configdomain.SyncFeatureStrategy {
 	switch self {
 	case syncFeatureStrategyEntryMerge:
 		return configdomain.SyncFeatureStrategyMerge

--- a/src/cli/dialog/enter_sync_perennial_strategy.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy.go
@@ -27,12 +27,7 @@ func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inp
 	default:
 		panic("unknown sync-perennial-strategy: " + existing.String())
 	}
-	selection, aborted, err := radioList(radioListArgs{
-		entries:      entries,
-		defaultEntry: entries[defaultPos],
-		help:         enterSyncPerennialStrategyHelp,
-		testInput:    inputs,
-	})
+	selection, aborted, err := radioList(entries, defaultPos, enterSyncPerennialStrategyHelp, inputs)
 	if err != nil || aborted {
 		return configdomain.SyncPerennialStrategyRebase, aborted, err
 	}

--- a/src/cli/dialog/enter_sync_perennial_strategy.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy.go
@@ -17,12 +17,12 @@ to their tracking branch made somewhere else.
 `
 
 const (
-	syncPerennialStrategyEntryMerge  syncPerennialStrategyEntry = `merge updates from the tracking branch into perennial branches`
-	syncPerennialStrategyEntryRebase syncPerennialStrategyEntry = `rebase perennial branches against their tracking branch`
+	SyncPerennialStrategyEntryMerge  syncPerennialStrategyEntry = `merge updates from the tracking branch into perennial branches`
+	SyncPerennialStrategyEntryRebase syncPerennialStrategyEntry = `rebase perennial branches against their tracking branch`
 )
 
 func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs TestInput) (configdomain.SyncPerennialStrategy, bool, error) {
-	entries := []syncPerennialStrategyEntry{syncPerennialStrategyEntryMerge, syncPerennialStrategyEntryRebase}
+	entries := []syncPerennialStrategyEntry{SyncPerennialStrategyEntryMerge, SyncPerennialStrategyEntryRebase}
 	var defaultPos int
 	switch existing {
 	case configdomain.SyncPerennialStrategyMerge:
@@ -53,9 +53,9 @@ func (self syncPerennialStrategyEntry) String() string {
 
 func (self syncPerennialStrategyEntry) ToSyncPerennialStrategy() configdomain.SyncPerennialStrategy {
 	switch self {
-	case syncPerennialStrategyEntryMerge:
+	case SyncPerennialStrategyEntryMerge:
 		return configdomain.SyncPerennialStrategyMerge
-	case syncPerennialStrategyEntryRebase:
+	case SyncPerennialStrategyEntryRebase:
 		return configdomain.SyncPerennialStrategyRebase
 	}
 	panic("unhandled syncPerennialStrategyEntry: " + self)

--- a/src/cli/dialog/enter_sync_perennial_strategy.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy.go
@@ -37,7 +37,7 @@ func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inp
 		return configdomain.SyncPerennialStrategyRebase, aborted, err
 	}
 	fmt.Printf("Sync perennial branches: %s\n", formattedSelection(selection.Short(), aborted))
-	return selection.ToSyncPerennialStrategy(), aborted, err
+	return selection.SyncPerennialStrategy(), aborted, err
 }
 
 type syncPerennialStrategyEntry string
@@ -51,7 +51,7 @@ func (self syncPerennialStrategyEntry) String() string {
 	return string(self)
 }
 
-func (self syncPerennialStrategyEntry) ToSyncPerennialStrategy() configdomain.SyncPerennialStrategy {
+func (self syncPerennialStrategyEntry) SyncPerennialStrategy() configdomain.SyncPerennialStrategy {
 	switch self {
 	case SyncPerennialStrategyEntryMerge:
 		return configdomain.SyncPerennialStrategyMerge

--- a/src/cli/dialog/enter_sync_perennial_strategy.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy.go
@@ -17,7 +17,7 @@ to their tracking branch made somewhere else.
 `
 
 func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs TestInput) (configdomain.SyncPerennialStrategy, bool, error) {
-	entries := []string{`merge updates from the tracking branch into perennial branches`, `rebase perennial branches against their tracking branch`}
+	entries := []syncPerennialStrategyEntry{syncPerennialStrategyEntryMerge, syncPerennialStrategyEntryRebase}
 	var defaultPos int
 	switch existing {
 	case configdomain.SyncPerennialStrategyMerge:
@@ -31,8 +31,28 @@ func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inp
 	if err != nil || aborted {
 		return configdomain.SyncPerennialStrategyRebase, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection, " ")
+	cutSelection, _, _ := strings.Cut(selection.String(), " ")
 	fmt.Printf("Sync perennial branches: %s\n", formattedSelection(cutSelection, aborted))
-	parsedAnswer, err := configdomain.NewSyncPerennialStrategy(cutSelection)
-	return parsedAnswer, aborted, err
+	return selection.ToSyncPerennialStrategy(), aborted, err
 }
+
+type syncPerennialStrategyEntry string
+
+func (self syncPerennialStrategyEntry) String() string {
+	return string(self)
+}
+
+func (self syncPerennialStrategyEntry) ToSyncPerennialStrategy() configdomain.SyncPerennialStrategy {
+	switch self {
+	case syncPerennialStrategyEntryMerge:
+		return configdomain.SyncPerennialStrategyMerge
+	case syncPerennialStrategyEntryRebase:
+		return configdomain.SyncPerennialStrategyRebase
+	}
+	panic("unhandled syncPerennialStrategyEntry: " + self)
+}
+
+const (
+	syncPerennialStrategyEntryMerge  syncPerennialStrategyEntry = `merge updates from the tracking branch into perennial branches`
+	syncPerennialStrategyEntryRebase syncPerennialStrategyEntry = `rebase perennial branches against their tracking branch`
+)

--- a/src/cli/dialog/enter_sync_perennial_strategy.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy.go
@@ -16,6 +16,11 @@ to their tracking branch made somewhere else.
 
 `
 
+const (
+	syncPerennialStrategyEntryMerge  syncPerennialStrategyEntry = `merge updates from the tracking branch into perennial branches`
+	syncPerennialStrategyEntryRebase syncPerennialStrategyEntry = `rebase perennial branches against their tracking branch`
+)
+
 func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs TestInput) (configdomain.SyncPerennialStrategy, bool, error) {
 	entries := []syncPerennialStrategyEntry{syncPerennialStrategyEntryMerge, syncPerennialStrategyEntryRebase}
 	var defaultPos int
@@ -51,8 +56,3 @@ func (self syncPerennialStrategyEntry) ToSyncPerennialStrategy() configdomain.Sy
 	}
 	panic("unhandled syncPerennialStrategyEntry: " + self)
 }
-
-const (
-	syncPerennialStrategyEntryMerge  syncPerennialStrategyEntry = `merge updates from the tracking branch into perennial branches`
-	syncPerennialStrategyEntryRebase syncPerennialStrategyEntry = `rebase perennial branches against their tracking branch`
-)

--- a/src/cli/dialog/enter_sync_perennial_strategy.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy.go
@@ -36,12 +36,16 @@ func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inp
 	if err != nil || aborted {
 		return configdomain.SyncPerennialStrategyRebase, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection.String(), " ")
-	fmt.Printf("Sync perennial branches: %s\n", formattedSelection(cutSelection, aborted))
+	fmt.Printf("Sync perennial branches: %s\n", formattedSelection(selection.Short(), aborted))
 	return selection.ToSyncPerennialStrategy(), aborted, err
 }
 
 type syncPerennialStrategyEntry string
+
+func (self syncPerennialStrategyEntry) Short() string {
+	start, _, _ := strings.Cut(self.String(), " ")
+	return start
+}
 
 func (self syncPerennialStrategyEntry) String() string {
 	return string(self)

--- a/src/cli/dialog/enter_sync_perennial_strategy.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy.go
@@ -22,7 +22,10 @@ const (
 )
 
 func EnterSyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs TestInput) (configdomain.SyncPerennialStrategy, bool, error) {
-	entries := []syncPerennialStrategyEntry{SyncPerennialStrategyEntryMerge, SyncPerennialStrategyEntryRebase}
+	entries := []syncPerennialStrategyEntry{
+		SyncPerennialStrategyEntryMerge,
+		SyncPerennialStrategyEntryRebase,
+	}
 	var defaultPos int
 	switch existing {
 	case configdomain.SyncPerennialStrategyMerge:

--- a/src/cli/dialog/enter_sync_perennial_strategy_test.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy_test.go
@@ -1,0 +1,20 @@
+package dialog_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/cli/dialog"
+	"github.com/shoenig/test/must"
+)
+
+func TestSyncPerennialStrategy(t *testing.T) {
+	t.Parallel()
+	t.Run("SyncPerennialStrategyEntry", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Short", func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, "merge", dialog.SyncPerennialStrategyEntryMerge.Short())
+			must.Eq(t, "rebase", dialog.SyncPerennialStrategyEntryRebase.Short())
+		})
+	})
+}

--- a/src/cli/dialog/enter_sync_perennial_strategy_test.go
+++ b/src/cli/dialog/enter_sync_perennial_strategy_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestSyncPerennialStrategy(t *testing.T) {
 	t.Parallel()
+
 	t.Run("SyncPerennialStrategyEntry", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Short", func(t *testing.T) {

--- a/src/cli/dialog/enter_sync_upstream.go
+++ b/src/cli/dialog/enter_sync_upstream.go
@@ -20,7 +20,7 @@ and you want to keep it in sync with the repo it was forked from.
 `
 
 func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (configdomain.SyncUpstream, bool, error) {
-	entries := []string{`yes, receive updates from the upstream repo`, `no, don't receive updates from upstream`}
+	entries := []syncUpstreamEntry{syncUpstreamEntryYes, syncUpstreamEntryNo}
 	var defaultPos int
 	if existing {
 		defaultPos = 0
@@ -31,8 +31,28 @@ func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (co
 	if err != nil || aborted {
 		return true, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection, ",")
+	cutSelection, _, _ := strings.Cut(selection.String(), ",")
 	fmt.Printf("Sync with upstream: %s\n", formattedSelection(cutSelection, aborted))
-	parsedAnswer, err := configdomain.ParseSyncUpstream(cutSelection, "user dialog")
-	return parsedAnswer, aborted, err
+	return selection.ToSyncUpstream(), aborted, err
 }
+
+type syncUpstreamEntry string
+
+func (self syncUpstreamEntry) String() string {
+	return string(self)
+}
+
+func (self syncUpstreamEntry) ToSyncUpstream() configdomain.SyncUpstream {
+	switch self {
+	case syncUpstreamEntryYes:
+		return configdomain.SyncUpstream(true)
+	case syncUpstreamEntryNo:
+		return configdomain.SyncUpstream(false)
+	}
+	panic("unhandled syncUpstreamEntry: " + self)
+}
+
+const (
+	syncUpstreamEntryYes syncUpstreamEntry = `yes, receive updates from the upstream repo`
+	syncUpstreamEntryNo  syncUpstreamEntry = `no, don't receive updates from upstream`
+)

--- a/src/cli/dialog/enter_sync_upstream.go
+++ b/src/cli/dialog/enter_sync_upstream.go
@@ -38,7 +38,7 @@ func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (co
 	}
 	cutSelection, _, _ := strings.Cut(selection.String(), ",")
 	fmt.Printf("Sync with upstream: %s\n", formattedSelection(cutSelection, aborted))
-	return selection.ToSyncUpstream(), aborted, err
+	return selection.SyncUpstream(), aborted, err
 }
 
 type syncUpstreamEntry string
@@ -47,7 +47,7 @@ func (self syncUpstreamEntry) String() string {
 	return string(self)
 }
 
-func (self syncUpstreamEntry) ToSyncUpstream() configdomain.SyncUpstream {
+func (self syncUpstreamEntry) SyncUpstream() configdomain.SyncUpstream {
 	switch self {
 	case syncUpstreamEntryYes:
 		return configdomain.SyncUpstream(true)

--- a/src/cli/dialog/enter_sync_upstream.go
+++ b/src/cli/dialog/enter_sync_upstream.go
@@ -27,12 +27,7 @@ func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (co
 	} else {
 		defaultPos = 1
 	}
-	selection, aborted, err := radioList(radioListArgs{
-		entries:      entries,
-		defaultEntry: entries[defaultPos],
-		help:         enterSyncUpstreamHelp,
-		testInput:    inputs,
-	})
+	selection, aborted, err := radioList(entries, defaultPos, enterSyncUpstreamHelp, inputs)
 	if err != nil || aborted {
 		return true, aborted, err
 	}

--- a/src/cli/dialog/enter_sync_upstream.go
+++ b/src/cli/dialog/enter_sync_upstream.go
@@ -19,6 +19,11 @@ and you want to keep it in sync with the repo it was forked from.
 
 `
 
+const (
+	syncUpstreamEntryYes syncUpstreamEntry = `yes, receive updates from the upstream repo`
+	syncUpstreamEntryNo  syncUpstreamEntry = `no, don't receive updates from upstream`
+)
+
 func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (configdomain.SyncUpstream, bool, error) {
 	entries := []syncUpstreamEntry{syncUpstreamEntryYes, syncUpstreamEntryNo}
 	var defaultPos int
@@ -51,8 +56,3 @@ func (self syncUpstreamEntry) ToSyncUpstream() configdomain.SyncUpstream {
 	}
 	panic("unhandled syncUpstreamEntry: " + self)
 }
-
-const (
-	syncUpstreamEntryYes syncUpstreamEntry = `yes, receive updates from the upstream repo`
-	syncUpstreamEntryNo  syncUpstreamEntry = `no, don't receive updates from upstream`
-)

--- a/src/cli/dialog/enter_sync_upstream.go
+++ b/src/cli/dialog/enter_sync_upstream.go
@@ -25,7 +25,10 @@ const (
 )
 
 func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (configdomain.SyncUpstream, bool, error) {
-	entries := []syncUpstreamEntry{syncUpstreamEntryYes, syncUpstreamEntryNo}
+	entries := []syncUpstreamEntry{
+		syncUpstreamEntryYes,
+		syncUpstreamEntryNo,
+	}
 	var defaultPos int
 	if existing {
 		defaultPos = 0

--- a/src/cli/dialog/enter_sync_upstream.go
+++ b/src/cli/dialog/enter_sync_upstream.go
@@ -20,14 +20,14 @@ and you want to keep it in sync with the repo it was forked from.
 `
 
 const (
-	syncUpstreamEntryYes syncUpstreamEntry = `yes, receive updates from the upstream repo`
-	syncUpstreamEntryNo  syncUpstreamEntry = `no, don't receive updates from upstream`
+	SyncUpstreamEntryYes syncUpstreamEntry = `yes, receive updates from the upstream repo`
+	SyncUpstreamEntryNo  syncUpstreamEntry = `no, don't receive updates from upstream`
 )
 
 func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (configdomain.SyncUpstream, bool, error) {
 	entries := []syncUpstreamEntry{
-		syncUpstreamEntryYes,
-		syncUpstreamEntryNo,
+		SyncUpstreamEntryYes,
+		SyncUpstreamEntryNo,
 	}
 	var defaultPos int
 	if existing {
@@ -39,12 +39,16 @@ func EnterSyncUpstream(existing configdomain.SyncUpstream, inputs TestInput) (co
 	if err != nil || aborted {
 		return true, aborted, err
 	}
-	cutSelection, _, _ := strings.Cut(selection.String(), ",")
-	fmt.Printf("Sync with upstream: %s\n", formattedSelection(cutSelection, aborted))
+	fmt.Printf("Sync with upstream: %s\n", formattedSelection(selection.Short(), aborted))
 	return selection.SyncUpstream(), aborted, err
 }
 
 type syncUpstreamEntry string
+
+func (self syncUpstreamEntry) Short() string {
+	start, _, _ := strings.Cut(self.String(), ",")
+	return start
+}
 
 func (self syncUpstreamEntry) String() string {
 	return string(self)
@@ -52,9 +56,9 @@ func (self syncUpstreamEntry) String() string {
 
 func (self syncUpstreamEntry) SyncUpstream() configdomain.SyncUpstream {
 	switch self {
-	case syncUpstreamEntryYes:
+	case SyncUpstreamEntryYes:
 		return configdomain.SyncUpstream(true)
-	case syncUpstreamEntryNo:
+	case SyncUpstreamEntryNo:
 		return configdomain.SyncUpstream(false)
 	}
 	panic("unhandled syncUpstreamEntry: " + self)

--- a/src/cli/dialog/enter_sync_upstream_test.go
+++ b/src/cli/dialog/enter_sync_upstream_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestEnterSyncUpstream(t *testing.T) {
 	t.Parallel()
+
 	t.Run("SyncUpstreamEntry", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Short", func(t *testing.T) {

--- a/src/cli/dialog/enter_sync_upstream_test.go
+++ b/src/cli/dialog/enter_sync_upstream_test.go
@@ -1,0 +1,20 @@
+package dialog_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/cli/dialog"
+	"github.com/shoenig/test/must"
+)
+
+func TestEnterSyncUpstream(t *testing.T) {
+	t.Parallel()
+	t.Run("SyncUpstreamEntry", func(t *testing.T) {
+		t.Parallel()
+		t.Run("Short", func(t *testing.T) {
+			t.Parallel()
+			must.Eq(t, "yes", dialog.SyncUpstreamEntryYes.Short())
+			must.Eq(t, "no", dialog.SyncUpstreamEntryNo.Short())
+		})
+	})
+}

--- a/src/cli/dialog/radiolist.go
+++ b/src/cli/dialog/radiolist.go
@@ -8,8 +8,8 @@ import (
 )
 
 // EnterMainBranch lets the user select a new main branch for this repo.
-func radioList[C fmt.Stringer](entries []C, cursor int, help string, testInput TestInput) (selected C, aborted bool, err error) { //nolint:ireturn
-	program := tea.NewProgram(radioListModel[C]{
+func radioList[S fmt.Stringer](entries []S, cursor int, help string, testInput TestInput) (selected S, aborted bool, err error) { //nolint:ireturn
+	program := tea.NewProgram(radioListModel[S]{
 		BubbleList: newBubbleList(entries, cursor),
 		help:       help,
 	})
@@ -24,12 +24,12 @@ func radioList[C fmt.Stringer](entries []C, cursor int, help string, testInput T
 	if err != nil {
 		return entries[0], false, err
 	}
-	result := dialogResult.(radioListModel[C]) //nolint:forcetypeassert
+	result := dialogResult.(radioListModel[S]) //nolint:forcetypeassert
 	return result.selectedEntry(), result.aborted(), nil
 }
 
-type radioListModel[C fmt.Stringer] struct {
-	BubbleList[C]
+type radioListModel[S fmt.Stringer] struct {
+	BubbleList[S]
 	help string // help text to display before the radio list
 }
 

--- a/src/cli/dialog/radiolist.go
+++ b/src/cli/dialog/radiolist.go
@@ -8,7 +8,7 @@ import (
 )
 
 // EnterMainBranch lets the user select a new main branch for this repo.
-func radioList[S ~[]C, C fmt.Stringer](entries S, cursor int, help string, testInput TestInput) (selected C, aborted bool, err error) {
+func radioList[S ~[]C, C fmt.Stringer](entries S, cursor int, help string, testInput TestInput) (selected C, aborted bool, err error) { //nolint:ireturn
 	program := tea.NewProgram(radioListModel[S, C]{
 		BubbleList: newBubbleList(entries, cursor),
 		help:       help,

--- a/src/cli/dialog/radiolist.go
+++ b/src/cli/dialog/radiolist.go
@@ -33,11 +33,11 @@ type radioListModel[S fmt.Stringer] struct {
 	help string // help text to display before the radio list
 }
 
-func (self radioListModel[C]) Init() tea.Cmd {
+func (self radioListModel[S]) Init() tea.Cmd {
 	return nil
 }
 
-func (self radioListModel[C]) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
+func (self radioListModel[S]) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
 	keyMsg, isKeyMsg := msg.(tea.KeyMsg)
 	if !isKeyMsg {
 		return self, nil
@@ -56,7 +56,7 @@ func (self radioListModel[C]) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolin
 	return self, nil
 }
 
-func (self radioListModel[C]) View() string {
+func (self radioListModel[S]) View() string {
 	if self.Status != dialogStatusActive {
 		return ""
 	}

--- a/src/cli/dialog/radiolist.go
+++ b/src/cli/dialog/radiolist.go
@@ -1,49 +1,43 @@
 package dialog
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 // EnterMainBranch lets the user select a new main branch for this repo.
-func radioList(args radioListArgs) (selected string, aborted bool, err error) {
-	program := tea.NewProgram(radioListModel{
-		BubbleList: newBubbleList(args.entries, DetermineCursorPos(args.entries, args.defaultEntry)),
-		help:       args.help,
+func radioList[S ~[]C, C fmt.Stringer](entries S, cursor int, help string, testInput TestInput) (selected C, aborted bool, err error) {
+	program := tea.NewProgram(radioListModel[S, C]{
+		BubbleList: newBubbleList(entries, cursor),
+		help:       help,
 	})
-	if len(args.testInput) > 0 {
+	if len(testInput) > 0 {
 		go func() {
-			for _, input := range args.testInput {
+			for _, input := range testInput {
 				program.Send(input)
 			}
 		}()
 	}
 	dialogResult, err := program.Run()
 	if err != nil {
-		return "", false, err
+		return entries[0], false, err
 	}
-	result := dialogResult.(radioListModel) //nolint:forcetypeassert
+	result := dialogResult.(radioListModel[S, C]) //nolint:forcetypeassert
 	return result.selectedEntry(), result.aborted(), nil
 }
 
-type radioListArgs struct {
-	entries      []string
-	defaultEntry string
-	help         string
-	testInput    TestInput
-}
-
-type radioListModel struct {
-	BubbleList
+type radioListModel[S ~[]C, C fmt.Stringer] struct {
+	BubbleList[S, C]
 	help string // help text to display before the radio list
 }
 
-func (self radioListModel) Init() tea.Cmd {
+func (self radioListModel[S, C]) Init() tea.Cmd {
 	return nil
 }
 
-func (self radioListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
+func (self radioListModel[S, C]) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
 	keyMsg, isKeyMsg := msg.(tea.KeyMsg)
 	if !isKeyMsg {
 		return self, nil
@@ -62,7 +56,7 @@ func (self radioListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:i
 	return self, nil
 }
 
-func (self radioListModel) View() string {
+func (self radioListModel[S, C]) View() string {
 	if self.Status != dialogStatusActive {
 		return ""
 	}
@@ -71,9 +65,9 @@ func (self radioListModel) View() string {
 	for i, branch := range self.Entries {
 		s.WriteString(self.entryNumberStr(i))
 		if i == self.Cursor {
-			s.WriteString(self.Colors.selection.Styled("> " + branch))
+			s.WriteString(self.Colors.selection.Styled("> " + branch.String()))
 		} else {
-			s.WriteString("  " + branch)
+			s.WriteString("  " + branch.String())
 		}
 		s.WriteRune('\n')
 	}

--- a/src/cli/dialog/radiolist.go
+++ b/src/cli/dialog/radiolist.go
@@ -8,8 +8,8 @@ import (
 )
 
 // EnterMainBranch lets the user select a new main branch for this repo.
-func radioList[S ~[]C, C fmt.Stringer](entries S, cursor int, help string, testInput TestInput) (selected C, aborted bool, err error) { //nolint:ireturn
-	program := tea.NewProgram(radioListModel[S, C]{
+func radioList[C fmt.Stringer](entries []C, cursor int, help string, testInput TestInput) (selected C, aborted bool, err error) { //nolint:ireturn
+	program := tea.NewProgram(radioListModel[C]{
 		BubbleList: newBubbleList(entries, cursor),
 		help:       help,
 	})
@@ -24,20 +24,20 @@ func radioList[S ~[]C, C fmt.Stringer](entries S, cursor int, help string, testI
 	if err != nil {
 		return entries[0], false, err
 	}
-	result := dialogResult.(radioListModel[S, C]) //nolint:forcetypeassert
+	result := dialogResult.(radioListModel[C]) //nolint:forcetypeassert
 	return result.selectedEntry(), result.aborted(), nil
 }
 
-type radioListModel[S ~[]C, C fmt.Stringer] struct {
-	BubbleList[S, C]
+type radioListModel[C fmt.Stringer] struct {
+	BubbleList[C]
 	help string // help text to display before the radio list
 }
 
-func (self radioListModel[S, C]) Init() tea.Cmd {
+func (self radioListModel[C]) Init() tea.Cmd {
 	return nil
 }
 
-func (self radioListModel[S, C]) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
+func (self radioListModel[C]) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
 	keyMsg, isKeyMsg := msg.(tea.KeyMsg)
 	if !isKeyMsg {
 		return self, nil
@@ -56,7 +56,7 @@ func (self radioListModel[S, C]) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //no
 	return self, nil
 }
 
-func (self radioListModel[S, C]) View() string {
+func (self radioListModel[C]) View() string {
 	if self.Status != dialogStatusActive {
 		return ""
 	}

--- a/src/cli/dialog/select_squash_commit_author.go
+++ b/src/cli/dialog/select_squash_commit_author.go
@@ -12,7 +12,22 @@ func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []string
 	if len(authors) == 1 {
 		return authors[0], false, nil
 	}
-	selection, aborted, err := radioList(authors, "", fmt.Sprintf(messages.BranchAuthorMultiple, branch), dialogTestInputs)
-	fmt.Printf("Selected squash commit author: %s\n", formattedSelection(selection, aborted))
-	return selection, aborted, err
+	authorsList := squashCommitAuthorList(authors)
+	selection, aborted, err := radioList(authorsList, 0, fmt.Sprintf(messages.BranchAuthorMultiple, branch), dialogTestInputs)
+	fmt.Printf("Selected squash commit author: %s\n", formattedSelection(selection.String(), aborted))
+	return selection.String(), aborted, err
+}
+
+type squashCommitAuthor string
+
+func (self squashCommitAuthor) String() string {
+	return string(self)
+}
+
+func squashCommitAuthorList(authors []string) []squashCommitAuthor {
+	result := make([]squashCommitAuthor, len(authors))
+	for a, author := range authors {
+		result[a] = squashCommitAuthor(author)
+	}
+	return result
 }

--- a/src/cli/dialog/select_squash_commit_author.go
+++ b/src/cli/dialog/select_squash_commit_author.go
@@ -12,12 +12,7 @@ func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []string
 	if len(authors) == 1 {
 		return authors[0], false, nil
 	}
-	selection, aborted, err := radioList(radioListArgs{
-		entries:      authors,
-		defaultEntry: "",
-		help:         fmt.Sprintf(messages.BranchAuthorMultiple, branch),
-		testInput:    dialogTestInputs,
-	})
+	selection, aborted, err := radioList(authors, "", fmt.Sprintf(messages.BranchAuthorMultiple, branch), dialogTestInputs)
 	fmt.Printf("Selected squash commit author: %s\n", formattedSelection(selection, aborted))
 	return selection, aborted, err
 }

--- a/src/cli/dialog/switch_branch.go
+++ b/src/cli/dialog/switch_branch.go
@@ -142,6 +142,6 @@ type SwitchBranchEntry struct {
 	Indentation string
 }
 
-func (self SwitchBranchEntry) String() string {
-	return self.Indentation + self.Branch.String()
+func (sbe SwitchBranchEntry) String() string {
+	return sbe.Indentation + sbe.Branch.String()
 }

--- a/src/cli/dialog/switch_branch.go
+++ b/src/cli/dialog/switch_branch.go
@@ -27,7 +27,7 @@ func SwitchBranch(localBranches gitdomain.LocalBranchNames, initialBranch gitdom
 }
 
 type SwitchModel struct {
-	BubbleList[[]SwitchBranchEntry, SwitchBranchEntry]
+	BubbleList[SwitchBranchEntry]
 	InitialBranchPos int // position of the currently checked out branch in the list
 }
 

--- a/src/cli/dialog/switch_branch_test.go
+++ b/src/cli/dialog/switch_branch_test.go
@@ -17,10 +17,10 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("initialBranch is in the entry list", func(t *testing.T) {
 			t.Parallel()
 			entries := []dialog.SwitchBranchEntry{
-				dialog.SwitchBranchEntry{Branch: "main"},
-				dialog.SwitchBranchEntry{Branch: "alpha"},
-				dialog.SwitchBranchEntry{Branch: "alpha1"},
-				dialog.SwitchBranchEntry{Branch: "beta"},
+				{Branch: "main"},
+				{Branch: "alpha"},
+				{Branch: "alpha1"},
+				{Branch: "beta"},
 			}
 			initialBranch := gitdomain.NewLocalBranchName("alpha1")
 			have := dialog.SwitchBranchCursorPos(entries, initialBranch)
@@ -30,9 +30,9 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("initialBranch is not in the entry list", func(t *testing.T) {
 			t.Parallel()
 			entries := []dialog.SwitchBranchEntry{
-				dialog.SwitchBranchEntry{Branch: "main"},
-				dialog.SwitchBranchEntry{Branch: "alpha"},
-				dialog.SwitchBranchEntry{Branch: "beta"},
+				{Branch: "main"},
+				{Branch: "alpha"},
+				{Branch: "beta"},
 			}
 			initialBranch := gitdomain.NewLocalBranchName("other")
 			have := dialog.SwitchBranchCursorPos(entries, initialBranch)
@@ -55,15 +55,15 @@ func TestSwitchBranch(t *testing.T) {
 			localBranches := gitdomain.LocalBranchNames{branchA, branchB, main}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
 			want := []dialog.SwitchBranchEntry{
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "main",
 					Indentation: "",
 				},
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "alpha",
 					Indentation: "  ",
 				},
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "beta",
 					Indentation: "  ",
 				},
@@ -83,19 +83,19 @@ func TestSwitchBranch(t *testing.T) {
 			localBranches := gitdomain.LocalBranchNames{branchA, branchB, main, perennial1}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
 			want := []dialog.SwitchBranchEntry{
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "main",
 					Indentation: "",
 				},
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "alpha",
 					Indentation: "  ",
 				},
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "beta",
 					Indentation: "  ",
 				},
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "perennial-1",
 					Indentation: "",
 				},
@@ -114,15 +114,15 @@ func TestSwitchBranch(t *testing.T) {
 			localBranches := gitdomain.LocalBranchNames{grandchild, main}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
 			want := []dialog.SwitchBranchEntry{
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "main",
 					Indentation: "",
 				},
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "child",
 					Indentation: "  ",
 				},
-				dialog.SwitchBranchEntry{
+				{
 					Branch:      "grandchild",
 					Indentation: "    ",
 				},
@@ -138,7 +138,7 @@ func TestSwitchBranch(t *testing.T) {
 				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
 					Cursor: 0,
 					Entries: []dialog.SwitchBranchEntry{
-						dialog.SwitchBranchEntry{
+						{
 							Branch:      "main",
 							Indentation: "",
 						},
@@ -163,9 +163,9 @@ func TestSwitchBranch(t *testing.T) {
 				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
 					Cursor: 0,
 					Entries: []dialog.SwitchBranchEntry{
-						dialog.SwitchBranchEntry{Branch: "main", Indentation: ""},
-						dialog.SwitchBranchEntry{Branch: "one", Indentation: ""},
-						dialog.SwitchBranchEntry{Branch: "two", Indentation: ""},
+						{Branch: "main", Indentation: ""},
+						{Branch: "one", Indentation: ""},
+						{Branch: "two", Indentation: ""},
 					},
 					MaxDigits:    1,
 					NumberFormat: "%d",
@@ -189,13 +189,13 @@ func TestSwitchBranch(t *testing.T) {
 				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
 					Cursor: 0,
 					Entries: []dialog.SwitchBranchEntry{
-						dialog.SwitchBranchEntry{Branch: "main", Indentation: ""},
-						dialog.SwitchBranchEntry{Branch: "alpha", Indentation: "  "},
-						dialog.SwitchBranchEntry{Branch: "alpha1", Indentation: "    "},
-						dialog.SwitchBranchEntry{Branch: "alpha2", Indentation: "    "},
-						dialog.SwitchBranchEntry{Branch: "beta", Indentation: "  "},
-						dialog.SwitchBranchEntry{Branch: "beta1", Indentation: "    "},
-						dialog.SwitchBranchEntry{Branch: "other", Indentation: ""},
+						{Branch: "main", Indentation: ""},
+						{Branch: "alpha", Indentation: "  "},
+						{Branch: "alpha1", Indentation: "    "},
+						{Branch: "alpha2", Indentation: "    "},
+						{Branch: "beta", Indentation: "  "},
+						{Branch: "beta1", Indentation: "    "},
+						{Branch: "other", Indentation: ""},
 					},
 					MaxDigits:    1,
 					NumberFormat: "%d",

--- a/src/cli/dialog/switch_branch_test.go
+++ b/src/cli/dialog/switch_branch_test.go
@@ -105,7 +105,7 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("only the main branch exists", func(t *testing.T) {
 			t.Parallel()
 			model := dialog.SwitchModel{
-				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[dialog.SwitchBranchEntry]{ //nolint:exhaustruct
 					Cursor:       0,
 					Entries:      []dialog.SwitchBranchEntry{{Branch: "main", Indentation: ""}},
 					MaxDigits:    1,
@@ -125,7 +125,7 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("multiple top-level branches", func(t *testing.T) {
 			t.Parallel()
 			model := dialog.SwitchModel{
-				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[dialog.SwitchBranchEntry]{ //nolint:exhaustruct
 					Cursor: 0,
 					Entries: []dialog.SwitchBranchEntry{
 						{Branch: "main", Indentation: ""},
@@ -151,7 +151,7 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("nested branches", func(t *testing.T) {
 			t.Parallel()
 			model := dialog.SwitchModel{
-				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
+				BubbleList: dialog.BubbleList[dialog.SwitchBranchEntry]{ //nolint:exhaustruct
 					Cursor: 0,
 					Entries: []dialog.SwitchBranchEntry{
 						{Branch: "main", Indentation: ""},

--- a/src/cli/dialog/switch_branch_test.go
+++ b/src/cli/dialog/switch_branch_test.go
@@ -17,10 +17,10 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("initialBranch is in the entry list", func(t *testing.T) {
 			t.Parallel()
 			entries := []dialog.SwitchBranchEntry{
-				{Branch: "main"},
-				{Branch: "alpha"},
-				{Branch: "alpha1"},
-				{Branch: "beta"},
+				{Branch: "main", Indentation: ""},
+				{Branch: "alpha", Indentation: ""},
+				{Branch: "alpha1", Indentation: ""},
+				{Branch: "beta", Indentation: ""},
 			}
 			initialBranch := gitdomain.NewLocalBranchName("alpha1")
 			have := dialog.SwitchBranchCursorPos(entries, initialBranch)
@@ -30,9 +30,9 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("initialBranch is not in the entry list", func(t *testing.T) {
 			t.Parallel()
 			entries := []dialog.SwitchBranchEntry{
-				{Branch: "main"},
-				{Branch: "alpha"},
-				{Branch: "beta"},
+				{Branch: "main", Indentation: ""},
+				{Branch: "alpha", Indentation: ""},
+				{Branch: "beta", Indentation: ""},
 			}
 			initialBranch := gitdomain.NewLocalBranchName("other")
 			have := dialog.SwitchBranchCursorPos(entries, initialBranch)
@@ -55,18 +55,9 @@ func TestSwitchBranch(t *testing.T) {
 			localBranches := gitdomain.LocalBranchNames{branchA, branchB, main}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
 			want := []dialog.SwitchBranchEntry{
-				{
-					Branch:      "main",
-					Indentation: "",
-				},
-				{
-					Branch:      "alpha",
-					Indentation: "  ",
-				},
-				{
-					Branch:      "beta",
-					Indentation: "  ",
-				},
+				{Branch: "main", Indentation: ""},
+				{Branch: "alpha", Indentation: "  "},
+				{Branch: "beta", Indentation: "  "},
 			}
 			must.Eq(t, want, have)
 		})
@@ -83,22 +74,10 @@ func TestSwitchBranch(t *testing.T) {
 			localBranches := gitdomain.LocalBranchNames{branchA, branchB, main, perennial1}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
 			want := []dialog.SwitchBranchEntry{
-				{
-					Branch:      "main",
-					Indentation: "",
-				},
-				{
-					Branch:      "alpha",
-					Indentation: "  ",
-				},
-				{
-					Branch:      "beta",
-					Indentation: "  ",
-				},
-				{
-					Branch:      "perennial-1",
-					Indentation: "",
-				},
+				{Branch: "main", Indentation: ""},
+				{Branch: "alpha", Indentation: "  "},
+				{Branch: "beta", Indentation: "  "},
+				{Branch: "perennial-1", Indentation: ""},
 			}
 			must.Eq(t, want, have)
 		})
@@ -114,18 +93,9 @@ func TestSwitchBranch(t *testing.T) {
 			localBranches := gitdomain.LocalBranchNames{grandchild, main}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
 			want := []dialog.SwitchBranchEntry{
-				{
-					Branch:      "main",
-					Indentation: "",
-				},
-				{
-					Branch:      "child",
-					Indentation: "  ",
-				},
-				{
-					Branch:      "grandchild",
-					Indentation: "    ",
-				},
+				{Branch: "main", Indentation: ""},
+				{Branch: "child", Indentation: "  "},
+				{Branch: "grandchild", Indentation: "    "},
 			}
 			must.Eq(t, want, have)
 		})
@@ -136,13 +106,8 @@ func TestSwitchBranch(t *testing.T) {
 			t.Parallel()
 			model := dialog.SwitchModel{
 				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
-					Cursor: 0,
-					Entries: []dialog.SwitchBranchEntry{
-						{
-							Branch:      "main",
-							Indentation: "",
-						},
-					},
+					Cursor:       0,
+					Entries:      []dialog.SwitchBranchEntry{{Branch: "main", Indentation: ""}},
 					MaxDigits:    1,
 					NumberFormat: "%d",
 				},

--- a/src/cli/dialog/switch_branch_test.go
+++ b/src/cli/dialog/switch_branch_test.go
@@ -16,11 +16,11 @@ func TestSwitchBranch(t *testing.T) {
 		t.Parallel()
 		t.Run("initialBranch is in the entry list", func(t *testing.T) {
 			t.Parallel()
-			entries := []string{
-				"main",
-				"  alpha",
-				"    alpha1",
-				"  beta",
+			entries := []dialog.SwitchBranchEntry{
+				dialog.SwitchBranchEntry{Branch: "main"},
+				dialog.SwitchBranchEntry{Branch: "alpha"},
+				dialog.SwitchBranchEntry{Branch: "alpha1"},
+				dialog.SwitchBranchEntry{Branch: "beta"},
 			}
 			initialBranch := gitdomain.NewLocalBranchName("alpha1")
 			have := dialog.SwitchBranchCursorPos(entries, initialBranch)
@@ -29,10 +29,10 @@ func TestSwitchBranch(t *testing.T) {
 		})
 		t.Run("initialBranch is not in the entry list", func(t *testing.T) {
 			t.Parallel()
-			entries := []string{
-				"main",
-				"  alpha",
-				"  beta",
+			entries := []dialog.SwitchBranchEntry{
+				dialog.SwitchBranchEntry{Branch: "main"},
+				dialog.SwitchBranchEntry{Branch: "alpha"},
+				dialog.SwitchBranchEntry{Branch: "beta"},
 			}
 			initialBranch := gitdomain.NewLocalBranchName("other")
 			have := dialog.SwitchBranchCursorPos(entries, initialBranch)
@@ -54,10 +54,19 @@ func TestSwitchBranch(t *testing.T) {
 			}
 			localBranches := gitdomain.LocalBranchNames{branchA, branchB, main}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
-			want := []string{
-				"main",
-				"  alpha",
-				"  beta",
+			want := []dialog.SwitchBranchEntry{
+				dialog.SwitchBranchEntry{
+					Branch:      "main",
+					Indentation: "",
+				},
+				dialog.SwitchBranchEntry{
+					Branch:      "alpha",
+					Indentation: "  ",
+				},
+				dialog.SwitchBranchEntry{
+					Branch:      "beta",
+					Indentation: "  ",
+				},
 			}
 			must.Eq(t, want, have)
 		})
@@ -73,11 +82,23 @@ func TestSwitchBranch(t *testing.T) {
 			}
 			localBranches := gitdomain.LocalBranchNames{branchA, branchB, main, perennial1}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
-			want := []string{
-				"main",
-				"  alpha",
-				"  beta",
-				"perennial-1",
+			want := []dialog.SwitchBranchEntry{
+				dialog.SwitchBranchEntry{
+					Branch:      "main",
+					Indentation: "",
+				},
+				dialog.SwitchBranchEntry{
+					Branch:      "alpha",
+					Indentation: "  ",
+				},
+				dialog.SwitchBranchEntry{
+					Branch:      "beta",
+					Indentation: "  ",
+				},
+				dialog.SwitchBranchEntry{
+					Branch:      "perennial-1",
+					Indentation: "",
+				},
 			}
 			must.Eq(t, want, have)
 		})
@@ -92,10 +113,19 @@ func TestSwitchBranch(t *testing.T) {
 			}
 			localBranches := gitdomain.LocalBranchNames{grandchild, main}
 			have := dialog.SwitchBranchEntries(localBranches, lineage)
-			want := []string{
-				"main",
-				"  child",
-				"    grandchild",
+			want := []dialog.SwitchBranchEntry{
+				dialog.SwitchBranchEntry{
+					Branch:      "main",
+					Indentation: "",
+				},
+				dialog.SwitchBranchEntry{
+					Branch:      "child",
+					Indentation: "  ",
+				},
+				dialog.SwitchBranchEntry{
+					Branch:      "grandchild",
+					Indentation: "    ",
+				},
 			}
 			must.Eq(t, want, have)
 		})
@@ -105,9 +135,14 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("only the main branch exists", func(t *testing.T) {
 			t.Parallel()
 			model := dialog.SwitchModel{
-				BubbleList: dialog.BubbleList{ //nolint:exhaustruct
-					Cursor:       0,
-					Entries:      []string{"main"},
+				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
+					Cursor: 0,
+					Entries: []dialog.SwitchBranchEntry{
+						dialog.SwitchBranchEntry{
+							Branch:      "main",
+							Indentation: "",
+						},
+					},
 					MaxDigits:    1,
 					NumberFormat: "%d",
 				},
@@ -125,9 +160,13 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("multiple top-level branches", func(t *testing.T) {
 			t.Parallel()
 			model := dialog.SwitchModel{
-				BubbleList: dialog.BubbleList{ //nolint:exhaustruct
-					Cursor:       0,
-					Entries:      []string{"main", "one", "two"},
+				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
+					Cursor: 0,
+					Entries: []dialog.SwitchBranchEntry{
+						dialog.SwitchBranchEntry{Branch: "main", Indentation: ""},
+						dialog.SwitchBranchEntry{Branch: "one", Indentation: ""},
+						dialog.SwitchBranchEntry{Branch: "two", Indentation: ""},
+					},
 					MaxDigits:    1,
 					NumberFormat: "%d",
 				},
@@ -147,9 +186,17 @@ func TestSwitchBranch(t *testing.T) {
 		t.Run("nested branches", func(t *testing.T) {
 			t.Parallel()
 			model := dialog.SwitchModel{
-				BubbleList: dialog.BubbleList{ //nolint:exhaustruct
-					Cursor:       0,
-					Entries:      []string{"main", "  alpha", "    alpha1", "    alpha2", "  beta", "    beta1", "other"},
+				BubbleList: dialog.BubbleList[[]dialog.SwitchBranchEntry, dialog.SwitchBranchEntry]{ //nolint:exhaustruct
+					Cursor: 0,
+					Entries: []dialog.SwitchBranchEntry{
+						dialog.SwitchBranchEntry{Branch: "main", Indentation: ""},
+						dialog.SwitchBranchEntry{Branch: "alpha", Indentation: "  "},
+						dialog.SwitchBranchEntry{Branch: "alpha1", Indentation: "    "},
+						dialog.SwitchBranchEntry{Branch: "alpha2", Indentation: "    "},
+						dialog.SwitchBranchEntry{Branch: "beta", Indentation: "  "},
+						dialog.SwitchBranchEntry{Branch: "beta1", Indentation: "    "},
+						dialog.SwitchBranchEntry{Branch: "other", Indentation: ""},
+					},
 					MaxDigits:    1,
 					NumberFormat: "%d",
 				},

--- a/src/cli/dialog/unfinished_run_state.go
+++ b/src/cli/dialog/unfinished_run_state.go
@@ -51,12 +51,7 @@ func AskHowToHandleUnfinishedRunState(command string, endBranch gitdomain.LocalB
 		options = append(options, formattedOptions[ResponseSkip])
 	}
 	options = append(options, formattedOptions[ResponseUndo], formattedOptions[ResponseDiscard])
-	selection, aborted, err := radioList(radioListArgs{
-		entries:      options,
-		defaultEntry: "",
-		help:         fmt.Sprintf(unfinishedRunstateHelp, command, endBranch, humanize.Time(endTime)),
-		testInput:    dialogTestInput,
-	})
+	selection, aborted, err := radioList(options, "", fmt.Sprintf(unfinishedRunstateHelp, command, endBranch, humanize.Time(endTime)), dialogTestInput)
 	fmt.Printf("Handle unfinished command: %s\n", formattedSelection(selection, aborted))
 	for responseType, formattedResponseType := range formattedOptions {
 		if formattedResponseType == selection {

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -150,7 +150,7 @@ func setupCodeHosting(existingValue configdomain.HostingPlatform, runner *git.Pr
 		// no changes --> do nothing
 	case existingValue != "" && newValue == configdomain.HostingPlatformAutoDetect:
 		return aborted, runner.Frontend.DeleteCodeHostingPlatform()
-	case existingValue.String() != newValue:
+	case existingValue != newValue:
 		return aborted, runner.Frontend.SetCodeHostingPlatform(newValue)
 	}
 	return aborted, nil

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -224,8 +224,8 @@ func (self *FrontendCommands) RevertCommit(sha gitdomain.SHA) error {
 }
 
 // SetCodeHostingPlatform sets the given code hosting platform.
-func (self *FrontendCommands) SetCodeHostingPlatform(name string) error {
-	return self.Run("git", "config", gitconfig.KeyCodeHostingPlatform.String(), name)
+func (self *FrontendCommands) SetCodeHostingPlatform(name configdomain.HostingPlatform) error {
+	return self.Run("git", "config", gitconfig.KeyCodeHostingPlatform.String(), name.String())
 }
 
 // SetGitAlias sets the given Git alias.

--- a/src/gohacks/stringers/core.go
+++ b/src/gohacks/stringers/core.go
@@ -1,0 +1,2 @@
+// Package stringers provides helper functions for lists of fmt.Stringer instances
+package stringers

--- a/src/gohacks/stringers/core.go
+++ b/src/gohacks/stringers/core.go
@@ -1,2 +1,2 @@
-// Package stringers provides helper functions for lists of fmt.Stringer instances
+// Package stringers provides helper functions for lists of fmt.Stringer instances.
 package stringers

--- a/src/gohacks/stringers/index.go
+++ b/src/gohacks/stringers/index.go
@@ -10,11 +10,3 @@ func Index[S fmt.Stringer](elements []S, needle S) int {
 	}
 	return -1
 }
-
-func IndexOrStart[S fmt.Stringer](elements []S, needle S) int {
-	result := Index(elements, needle)
-	if result >= 0 {
-		return result
-	}
-	return 0
-}

--- a/src/gohacks/stringers/index.go
+++ b/src/gohacks/stringers/index.go
@@ -1,0 +1,20 @@
+package stringers
+
+import "fmt"
+
+func Index[S fmt.Stringer](elements []S, needle S) int {
+	for e, element := range elements {
+		if element.String() == needle.String() {
+			return e
+		}
+	}
+	return -1
+}
+
+func IndexOrStart[S fmt.Stringer](elements []S, needle S) int {
+	result := Index(elements, needle)
+	if result >= 0 {
+		return result
+	}
+	return 0
+}

--- a/src/gohacks/stringers/index_or_start.go
+++ b/src/gohacks/stringers/index_or_start.go
@@ -1,0 +1,11 @@
+package stringers
+
+import "fmt"
+
+func IndexOrStart[S fmt.Stringer](elements []S, needle S) int {
+	result := Index(elements, needle)
+	if result >= 0 {
+		return result
+	}
+	return 0
+}

--- a/src/gohacks/stringers/index_or_start_test.go
+++ b/src/gohacks/stringers/index_or_start_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestIndexOrStart(t *testing.T) {
 	t.Parallel()
+
 	t.Run("haystack contains the needle", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")
@@ -19,6 +20,7 @@ func TestIndexOrStart(t *testing.T) {
 		have = stringers.IndexOrStart(list, two)
 		must.Eq(t, 1, have)
 	})
+
 	t.Run("haystack does not contain the needle", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")
@@ -27,6 +29,7 @@ func TestIndexOrStart(t *testing.T) {
 		have := stringers.IndexOrStart(list, two)
 		must.Eq(t, 0, have)
 	})
+
 	t.Run("empty haystack", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")

--- a/src/gohacks/stringers/index_or_start_test.go
+++ b/src/gohacks/stringers/index_or_start_test.go
@@ -7,16 +7,16 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-func TestIndex(t *testing.T) {
+func TestIndexOrStart(t *testing.T) {
 	t.Parallel()
 	t.Run("haystack contains the needle", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")
 		two := testEntry("two")
 		list := []testEntry{one, two}
-		have := stringers.Index(list, one)
+		have := stringers.IndexOrStart(list, one)
 		must.Eq(t, 0, have)
-		have = stringers.Index(list, two)
+		have = stringers.IndexOrStart(list, two)
 		must.Eq(t, 1, have)
 	})
 	t.Run("haystack does not contain the needle", func(t *testing.T) {
@@ -24,20 +24,14 @@ func TestIndex(t *testing.T) {
 		one := testEntry("one")
 		two := testEntry("two")
 		list := []testEntry{one}
-		have := stringers.Index(list, two)
-		must.Eq(t, -1, have)
+		have := stringers.IndexOrStart(list, two)
+		must.Eq(t, 0, have)
 	})
 	t.Run("empty haystack", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")
 		list := []testEntry{}
-		have := stringers.Index(list, one)
-		must.Eq(t, -1, have)
+		have := stringers.IndexOrStart(list, one)
+		must.Eq(t, 0, have)
 	})
-}
-
-type testEntry string
-
-func (self testEntry) String() string {
-	return string(self)
 }

--- a/src/gohacks/stringers/index_test.go
+++ b/src/gohacks/stringers/index_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestIndex(t *testing.T) {
 	t.Parallel()
+
 	t.Run("haystack contains the needle", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")
@@ -19,6 +20,7 @@ func TestIndex(t *testing.T) {
 		have = stringers.Index(list, two)
 		must.Eq(t, 1, have)
 	})
+
 	t.Run("haystack does not contain the needle", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")
@@ -27,6 +29,7 @@ func TestIndex(t *testing.T) {
 		have := stringers.Index(list, two)
 		must.Eq(t, -1, have)
 	})
+
 	t.Run("empty haystack", func(t *testing.T) {
 		t.Parallel()
 		one := testEntry("one")

--- a/src/gohacks/stringers/index_test.go
+++ b/src/gohacks/stringers/index_test.go
@@ -1,0 +1,43 @@
+package stringers_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/gohacks/stringers"
+	"github.com/shoenig/test/must"
+)
+
+func TestIndex(t *testing.T) {
+	t.Parallel()
+	t.Run("haystack contains the needle", func(t *testing.T) {
+		t.Parallel()
+		one := TestEntry("one")
+		two := TestEntry("two")
+		list := []TestEntry{one, two}
+		have := stringers.Index(list, one)
+		must.Eq(t, 0, have)
+		have = stringers.Index(list, two)
+		must.Eq(t, 1, have)
+	})
+	t.Run("haystack does not contain the needle", func(t *testing.T) {
+		t.Parallel()
+		one := TestEntry("one")
+		two := TestEntry("two")
+		list := []TestEntry{one}
+		have := stringers.Index(list, two)
+		must.Eq(t, -1, have)
+	})
+	t.Run("empty haystack", func(t *testing.T) {
+		t.Parallel()
+		one := TestEntry("one")
+		list := []TestEntry{}
+		have := stringers.Index(list, one)
+		must.Eq(t, -1, have)
+	})
+}
+
+type TestEntry string
+
+func (self TestEntry) String() string {
+	return string(self)
+}

--- a/src/validate/knows_branch_ancestry.go
+++ b/src/validate/knows_branch_ancestry.go
@@ -35,7 +35,7 @@ func KnowsBranchAncestors(branch gitdomain.LocalBranchName, args KnowsBranchAnce
 			if aborted {
 				os.Exit(0)
 			}
-			if parent.String() == dialog.PerennialBranchOption {
+			if parent == dialog.PerennialBranchOption {
 				err = args.Backend.Config.AddToPerennialBranches(currentBranch)
 				if err != nil {
 					return false, err

--- a/tools/format_self/format.go
+++ b/tools/format_self/format.go
@@ -38,7 +38,11 @@ Available commands:
 
 // shouldIgnorePath indicates whether the file with the given path should be ignored (not formatted).
 func shouldIgnorePath(path string) bool {
-	return strings.HasPrefix(path, "vendor/") || path == "src/config/configdomain/push_hook.go" || path == "src/config/configdomain/offline.go" || path == "src/cli/print/logger.go"
+	return strings.HasPrefix(path, "vendor/") ||
+		path == "src/config/configdomain/push_hook.go" ||
+		path == "src/config/configdomain/offline.go" ||
+		path == "src/cli/print/logger.go" ||
+		path == "src/cli/dialog/switch_branch.go"
 }
 
 func formatFiles() {


### PR DESCRIPTION
Making the BubbleList receive `fmt.Stringer` instances instead of simple strings helps improve type correctness and cuts down quite a bit on stringly-typed coding and - even worse - string manipulation in order to determine results: rendering structured data into formatted strings, then removing the formatting (trimming) strings and parsing the same strings back into the same structured data - just to display a dialog.