### PR TITLE
Simplify dialog function signatures

### DIFF
--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -87,7 +87,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupShipDeleteTrackingBranch(config.ShipDeleteTrackingBranch, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupShipDeleteTrackingBranch(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -197,8 +197,8 @@ func setupPushNewBranches(runner *git.ProdRunner, config *setupConfig) (bool, er
 	return aborted, runner.SetNewBranchPush(newValue, false)
 }
 
-func setupShipDeleteTrackingBranch(existingValue configdomain.ShipDeleteTrackingBranch, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.ShipDeleteTrackingBranch(existingValue, inputs)
+func setupShipDeleteTrackingBranch(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newValue, aborted, err := enter.ShipDeleteTrackingBranch(runner.ShipDeleteTrackingBranch, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -51,7 +51,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupMainBranch(config.MainBranch, config.localBranches.Names(), repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupMainBranch(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -157,11 +157,12 @@ func setupHostingPlatform(existingValue configdomain.HostingPlatform, runner *gi
 	return aborted, nil
 }
 
-func setupMainBranch(existingValue gitdomain.LocalBranchName, allBranches gitdomain.LocalBranchNames, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
+func setupMainBranch(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	existingValue := runner.FullConfig.MainBranch
 	if existingValue.IsEmpty() {
 		existingValue, _ = runner.Backend.DefaultBranch()
 	}
-	newMainBranch, aborted, err := enter.MainBranch(allBranches, existingValue, inputs)
+	newMainBranch, aborted, err := enter.MainBranch(config.localBranches.Names(), existingValue, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -59,7 +59,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupHostingPlatform(config.HostingPlatform, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupHostingPlatform(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -141,8 +141,9 @@ func setupAliases(runner *git.ProdRunner, config *setupConfig) (bool, error) {
 	return aborted, nil
 }
 
-func setupHostingPlatform(existingValue configdomain.HostingPlatform, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.HostingPlatform(existingValue, inputs)
+func setupHostingPlatform(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	existingValue := runner.FullConfig.HostingPlatform
+	newValue, aborted, err := enter.HostingPlatform(existingValue, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -83,7 +83,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupSyncBeforeShip(config.SyncBeforeShip, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupSyncBeforeShip(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -205,8 +205,8 @@ func setupShipDeleteTrackingBranch(existingValue configdomain.ShipDeleteTracking
 	return aborted, runner.SetShipDeleteTrackingBranch(newValue, false)
 }
 
-func setupSyncBeforeShip(existingValue configdomain.SyncBeforeShip, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.SyncBeforeShip(existingValue, inputs)
+func setupSyncBeforeShip(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newValue, aborted, err := enter.SyncBeforeShip(runner.SyncBeforeShip, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -79,7 +79,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupPushHook(config.PushHook, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupPushHook(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -181,8 +181,8 @@ func setupPerennialBranches(runner *git.ProdRunner, config *setupConfig) (bool, 
 	return aborted, err
 }
 
-func setupPushHook(existingValue configdomain.PushHook, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newPushHook, aborted, err := enter.PushHook(existingValue, inputs)
+func setupPushHook(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newPushHook, aborted, err := enter.PushHook(runner.PushHook, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -55,7 +55,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupPerennialBranches(repo.Runner.PerennialBranches, repo.Runner.MainBranch, config.localBranches.Names(), repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupPerennialBranches(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -170,8 +170,8 @@ func setupMainBranch(runner *git.ProdRunner, config *setupConfig) (bool, error) 
 	return aborted, runner.SetMainBranch(newMainBranch)
 }
 
-func setupPerennialBranches(existingValue gitdomain.LocalBranchNames, mainBranch gitdomain.LocalBranchName, allBranches gitdomain.LocalBranchNames, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.PerennialBranches(allBranches, existingValue, mainBranch, inputs)
+func setupPerennialBranches(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newValue, aborted, err := enter.PerennialBranches(config.localBranches.Names(), runner.PerennialBranches, runner.MainBranch, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -71,7 +71,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupSyncUpstream(config.SyncUpstream, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupSyncUpstream(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -229,8 +229,8 @@ func setupSyncPerennialStrategy(runner *git.ProdRunner, config *setupConfig) (bo
 	return aborted, runner.SetSyncPerennialStrategy(newValue)
 }
 
-func setupSyncUpstream(existingValue configdomain.SyncUpstream, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.SyncUpstream(existingValue, inputs)
+func setupSyncUpstream(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newValue, aborted, err := enter.SyncUpstream(runner.SyncUpstream, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -113,6 +113,7 @@ func loadSetupConfig(repo *execute.OpenRepoResult, verbose bool) (setupConfig, b
 	return setupConfig{
 		localBranches: branchesSnapshot.Branches,
 		dialogInputs:  dialogInputs,
+		newConfig:     configdomain.PartialConfig{},
 	}, exit, err
 }
 

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -63,7 +63,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupSyncFeatureStrategy(config.SyncFeatureStrategy, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupSyncFeatureStrategy(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -213,8 +213,8 @@ func setupSyncBeforeShip(existingValue configdomain.SyncBeforeShip, runner *git.
 	return aborted, runner.SetSyncBeforeShip(newValue, false)
 }
 
-func setupSyncFeatureStrategy(existingValue configdomain.SyncFeatureStrategy, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.SyncFeatureStrategy(existingValue, inputs)
+func setupSyncFeatureStrategy(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newValue, aborted, err := enter.SyncFeatureStrategy(runner.SyncFeatureStrategy, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -97,7 +97,6 @@ func executeConfigSetup(verbose bool) error {
 type setupConfig struct {
 	localBranches gitdomain.BranchInfos
 	dialogInputs  dialog.TestInputs
-	newConfig     configdomain.PartialConfig // configuration entered by the user
 }
 
 func loadSetupConfig(repo *execute.OpenRepoResult, verbose bool) (setupConfig, bool, error) {
@@ -113,7 +112,6 @@ func loadSetupConfig(repo *execute.OpenRepoResult, verbose bool) (setupConfig, b
 	return setupConfig{
 		localBranches: branchesSnapshot.Branches,
 		dialogInputs:  dialogInputs,
-		newConfig:     configdomain.PartialConfig{},
 	}, exit, err
 }
 

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -75,7 +75,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupPushNewBranches(config.NewBranchPush, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupPushNewBranches(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -189,8 +189,8 @@ func setupPushHook(existingValue configdomain.PushHook, runner *git.ProdRunner, 
 	return aborted, runner.SetPushHookLocally(newPushHook)
 }
 
-func setupPushNewBranches(existingValue configdomain.NewBranchPush, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.PushNewBranches(existingValue, inputs)
+func setupPushNewBranches(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newValue, aborted, err := enter.PushNewBranches(runner.NewBranchPush, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -117,13 +117,13 @@ func loadSetupConfig(repo *execute.OpenRepoResult, verbose bool) (setupConfig, b
 
 func setupAliases(runner *git.ProdRunner, config *setupConfig) (bool, error) {
 	aliasableCommands := configdomain.AllAliasableCommands()
-	newAliases, aborted, err := enter.Aliases(aliasableCommands, runner.FullConfig.Aliases, config.dialogInputs.Next())
+	newAliases, aborted, err := enter.Aliases(aliasableCommands, runner.Aliases, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}
 	for _, aliasableCommand := range aliasableCommands {
 		newAlias, hasNew := newAliases[aliasableCommand]
-		oldAlias, hasOld := runner.FullConfig.Aliases[aliasableCommand]
+		oldAlias, hasOld := runner.Aliases[aliasableCommand]
 		switch {
 		case hasOld && !hasNew:
 			err := runner.Frontend.RemoveGitAlias(aliasableCommand)
@@ -141,7 +141,7 @@ func setupAliases(runner *git.ProdRunner, config *setupConfig) (bool, error) {
 }
 
 func setupHostingPlatform(runner *git.ProdRunner, config *setupConfig) (bool, error) {
-	existingValue := runner.FullConfig.HostingPlatform
+	existingValue := runner.HostingPlatform
 	newValue, aborted, err := enter.HostingPlatform(existingValue, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
@@ -158,7 +158,7 @@ func setupHostingPlatform(runner *git.ProdRunner, config *setupConfig) (bool, er
 }
 
 func setupMainBranch(runner *git.ProdRunner, config *setupConfig) (bool, error) {
-	existingValue := runner.FullConfig.MainBranch
+	existingValue := runner.MainBranch
 	if existingValue.IsEmpty() {
 		existingValue, _ = runner.Backend.DefaultBranch()
 	}

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -67,7 +67,7 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || aborted {
 		return err
 	}
-	aborted, err = setupSyncPerennialStrategy(config.SyncPerennialStrategy, repo.Runner, config.dialogInputs.Next())
+	aborted, err = setupSyncPerennialStrategy(repo.Runner, &config)
 	if err != nil || aborted {
 		return err
 	}
@@ -221,8 +221,8 @@ func setupSyncFeatureStrategy(runner *git.ProdRunner, config *setupConfig) (bool
 	return aborted, runner.SetSyncFeatureStrategy(newValue)
 }
 
-func setupSyncPerennialStrategy(existingValue configdomain.SyncPerennialStrategy, runner *git.ProdRunner, inputs dialog.TestInput) (bool, error) {
-	newValue, aborted, err := enter.SyncPerennialStrategy(existingValue, inputs)
+func setupSyncPerennialStrategy(runner *git.ProdRunner, config *setupConfig) (bool, error) {
+	newValue, aborted, err := enter.SyncPerennialStrategy(runner.SyncPerennialStrategy, config.dialogInputs.Next())
 	if err != nil || aborted {
 		return aborted, err
 	}


### PR DESCRIPTION
The individual dialog functions aren't pure, so no need to inject all dependencies so fine-grained. In the future, they are going to modify the setup config anyways.