### PR TITLE
Separate hosting platform detection from connector instantiation

### DIFF
--- a/src/hosting/bitbucket/connector.go
+++ b/src/hosting/bitbucket/connector.go
@@ -20,9 +20,6 @@ type Connector struct {
 // NewConnector provides a Bitbucket connector instance if the current repo is hosted on Bitbucket,
 // otherwise nil.
 func NewConnector(args NewConnectorArgs) (*Connector, error) {
-	if args.OriginURL == nil || (args.OriginURL.Host != "bitbucket.org" && args.HostingPlatform != configdomain.HostingPlatformBitbucket) {
-		return nil, nil //nolint:nilnil
-	}
 	return &Connector{
 		Config: hostingdomain.Config{
 			Hostname:     args.OriginURL.Host,

--- a/src/hosting/bitbucket/connector.go
+++ b/src/hosting/bitbucket/connector.go
@@ -45,10 +45,6 @@ func (self *Connector) FindProposal(_, _ gitdomain.LocalBranchName) (*hostingdom
 	return nil, fmt.Errorf(messages.HostingBitBucketNotImplemented)
 }
 
-func (self *Connector) HostingPlatformName() string {
-	return "Bitbucket"
-}
-
 func (self *Connector) NewProposalURL(branch, parentBranch gitdomain.LocalBranchName) (string, error) {
 	return fmt.Sprintf("%s/pull-requests/new?source=%s&dest=%s%%2F%s%%3A%s",
 			self.RepositoryURL(),

--- a/src/hosting/bitbucket/connector_test.go
+++ b/src/hosting/bitbucket/connector_test.go
@@ -46,27 +46,6 @@ func TestBitbucketConnector(t *testing.T) {
 			}
 			must.EqOp(t, wantConfig, have.Config)
 		})
-
-		t.Run("repo is hosted by another hosting platform --> no connector", func(t *testing.T) {
-			t.Parallel()
-			have, err := bitbucket.NewConnector(bitbucket.NewConnectorArgs{
-				HostingPlatform: configdomain.HostingPlatformNone,
-				OriginURL:       giturl.Parse("git@github.com:git-town/git-town.git"),
-			})
-			must.Nil(t, have)
-			must.NoError(t, err)
-		})
-
-		t.Run("no origin remote --> no connector", func(t *testing.T) {
-			t.Parallel()
-			var originURL *giturl.Parts
-			have, err := bitbucket.NewConnector(bitbucket.NewConnectorArgs{
-				HostingPlatform: configdomain.HostingPlatformNone,
-				OriginURL:       originURL,
-			})
-			must.Nil(t, have)
-			must.NoError(t, err)
-		})
 	})
 
 	t.Run("NewProposalURL", func(t *testing.T) {

--- a/src/hosting/bitbucket/detect.go
+++ b/src/hosting/bitbucket/detect.go
@@ -1,0 +1,11 @@
+package bitbucket
+
+import (
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+)
+
+// Detect indicates whether the current repository is hosted on a GitHub server.
+func Detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatform) bool {
+	return originURL != nil && (originURL.Host == "bitbucket.org" || hostingPlatform == configdomain.HostingPlatformBitbucket)
+}

--- a/src/hosting/bitbucket/detect_test.go
+++ b/src/hosting/bitbucket/detect_test.go
@@ -1,0 +1,21 @@
+package bitbucket_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+	"github.com/git-town/git-town/v11/src/hosting/bitbucket"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+	t.Run("Bitbucket SaaS", func(t *testing.T) {
+		t.Parallel()
+		have, err := bitbucket.Detect(configdomain.HostingPlatformNone,
+			OriginURL:       giturl.Parse("username@bitbucket.org:git-town/docs.git"),
+		})
+
+	})
+
+}

--- a/src/hosting/bitbucket/detect_test.go
+++ b/src/hosting/bitbucket/detect_test.go
@@ -6,16 +6,29 @@ import (
 	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/git/giturl"
 	"github.com/git-town/git-town/v11/src/hosting/bitbucket"
+	"github.com/shoenig/test/must"
 )
 
 func TestDetect(t *testing.T) {
 	t.Parallel()
 	t.Run("Bitbucket SaaS", func(t *testing.T) {
 		t.Parallel()
-		have, err := bitbucket.Detect(configdomain.HostingPlatformNone,
-			OriginURL:       giturl.Parse("username@bitbucket.org:git-town/docs.git"),
+		t.Run("Bitbucket SaaS", func(t *testing.T) {
+			t.Parallel()
+			must.True(t, bitbucket.Detect(giturl.Parse("username@bitbucket.org:git-town/docs.git"), configdomain.HostingPlatformNone))
 		})
-
+		t.Run("hosted service type provided manually", func(t *testing.T) {
+			t.Parallel()
+			must.True(t, bitbucket.Detect(giturl.Parse("git@custom-url.com:git-town/docs.git"), configdomain.HostingPlatformBitbucket))
+		})
+		t.Run("repo is hosted by another hosting platform", func(t *testing.T) {
+			t.Parallel()
+			must.False(t, bitbucket.Detect(giturl.Parse("git@github.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
+		})
+		t.Run(" no origin remote", func(t *testing.T) {
+			t.Parallel()
+			var originURL *giturl.Parts
+			must.False(t, bitbucket.Detect(originURL, configdomain.HostingPlatformNone))
+		})
 	})
-
 }

--- a/src/hosting/bitbucket/detect_test.go
+++ b/src/hosting/bitbucket/detect_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestDetect(t *testing.T) {
 	t.Parallel()
+
 	t.Run("Bitbucket SaaS", func(t *testing.T) {
 		t.Parallel()
 		t.Run("Bitbucket SaaS", func(t *testing.T) {

--- a/src/hosting/bitbucket/detect_test.go
+++ b/src/hosting/bitbucket/detect_test.go
@@ -26,7 +26,7 @@ func TestDetect(t *testing.T) {
 			t.Parallel()
 			must.False(t, bitbucket.Detect(giturl.Parse("git@github.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
 		})
-		t.Run(" no origin remote", func(t *testing.T) {
+		t.Run("no origin remote", func(t *testing.T) {
 			t.Parallel()
 			var originURL *giturl.Parts
 			must.False(t, bitbucket.Detect(originURL, configdomain.HostingPlatformNone))

--- a/src/hosting/detect.go
+++ b/src/hosting/detect.go
@@ -4,6 +4,7 @@ import (
 	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/git/giturl"
 	"github.com/git-town/git-town/v11/src/hosting/bitbucket"
+	"github.com/git-town/git-town/v11/src/hosting/gitea"
 	"github.com/git-town/git-town/v11/src/hosting/github"
 	"github.com/git-town/git-town/v11/src/hosting/gitlab"
 	"github.com/git-town/git-town/v11/src/hosting/hostingdomain"
@@ -11,13 +12,15 @@ import (
 
 func detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatform) hostingdomain.Platform {
 	switch {
+	case bitbucket.Detect(originURL, hostingPlatform):
+		return hostingdomain.PlatformBitbucket
+	case gitea.Detect(originURL, hostingPlatform):
+		return hostingdomain.PlatformGitea
 	case github.Detect(originURL, hostingPlatform):
 		return hostingdomain.PlatformGithub
 	case gitlab.Detect(originURL, hostingPlatform):
 		return hostingdomain.PlatformGitlab
-	case bitbucket.Detect(originURL, hostingPlatform):
-		return hostingdomain.PlatformBitbucket
-
+	default:
+		return hostingdomain.PlatformNone
 	}
-	return hostingdomain.PlatformNone
 }

--- a/src/hosting/detect.go
+++ b/src/hosting/detect.go
@@ -4,6 +4,7 @@ import (
 	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/git/giturl"
 	"github.com/git-town/git-town/v11/src/hosting/github"
+	"github.com/git-town/git-town/v11/src/hosting/gitlab"
 	"github.com/git-town/git-town/v11/src/hosting/hostingdomain"
 )
 
@@ -11,6 +12,8 @@ func detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatfor
 	switch {
 	case github.Detect(originURL, hostingPlatform):
 		return hostingdomain.PlatformGithub
+	case gitlab.Detect(originURL, hostingPlatform):
+		return hostingdomain.PlatformGitlab
 	}
 	return hostingdomain.PlatformNone
 }

--- a/src/hosting/detect.go
+++ b/src/hosting/detect.go
@@ -1,0 +1,16 @@
+package hosting
+
+import (
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+	"github.com/git-town/git-town/v11/src/hosting/github"
+	"github.com/git-town/git-town/v11/src/hosting/hostingdomain"
+)
+
+func detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatform) hostingdomain.Platform {
+	switch {
+	case github.Detect(originURL, hostingPlatform):
+		return hostingdomain.PlatformGithub
+	}
+	return hostingdomain.PlatformNone
+}

--- a/src/hosting/detect.go
+++ b/src/hosting/detect.go
@@ -3,6 +3,7 @@ package hosting
 import (
 	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/git/giturl"
+	"github.com/git-town/git-town/v11/src/hosting/bitbucket"
 	"github.com/git-town/git-town/v11/src/hosting/github"
 	"github.com/git-town/git-town/v11/src/hosting/gitlab"
 	"github.com/git-town/git-town/v11/src/hosting/hostingdomain"
@@ -14,6 +15,9 @@ func detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatfor
 		return hostingdomain.PlatformGithub
 	case gitlab.Detect(originURL, hostingPlatform):
 		return hostingdomain.PlatformGitlab
+	case bitbucket.Detect(originURL, hostingPlatform):
+		return hostingdomain.PlatformBitbucket
+
 	}
 	return hostingdomain.PlatformNone
 }

--- a/src/hosting/gitea/connector.go
+++ b/src/hosting/gitea/connector.go
@@ -52,10 +52,6 @@ func (self *Connector) FindProposal(branch, target gitdomain.LocalBranchName) (*
 	}, nil
 }
 
-func (self *Connector) HostingPlatformName() string {
-	return "Gitea"
-}
-
 func (self *Connector) NewProposalURL(branch, parentBranch gitdomain.LocalBranchName) (string, error) {
 	toCompare := parentBranch.String() + "..." + branch.String()
 	return fmt.Sprintf("%s/compare/%s", self.RepositoryURL(), url.PathEscape(toCompare)), nil

--- a/src/hosting/gitea/connector.go
+++ b/src/hosting/gitea/connector.go
@@ -108,9 +108,6 @@ func FilterPullRequests(pullRequests []*gitea.PullRequest, organization string, 
 // NewGiteaConfig provides Gitea configuration data if the current repo is hosted on Gitea,
 // otherwise nil.
 func NewConnector(args NewConnectorArgs) (*Connector, error) {
-	if args.OriginURL == nil || (args.OriginURL.Host != "gitea.com" && args.HostingPlatform != configdomain.HostingPlatformGitea) {
-		return nil, nil //nolint:nilnil
-	}
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: args.APIToken.String()})
 	httpClient := oauth2.NewClient(context.Background(), tokenSource)
 	giteaClient := gitea.NewClientWithHTTP(fmt.Sprintf("https://%s", args.OriginURL.Host), httpClient)

--- a/src/hosting/gitea/detect.go
+++ b/src/hosting/gitea/detect.go
@@ -1,0 +1,11 @@
+package gitea
+
+import (
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+)
+
+// Detect indicates whether the current repository is hosted on a GitHub server.
+func Detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatform) bool {
+	return originURL != nil && (originURL.Host == "gitea.com" || hostingPlatform == configdomain.HostingPlatformGitea)
+}

--- a/src/hosting/gitea/detect_test.go
+++ b/src/hosting/gitea/detect_test.go
@@ -11,14 +11,17 @@ import (
 
 func TestDetect(t *testing.T) {
 	t.Parallel()
+
 	t.Run("hosted service type provided manually", func(t *testing.T) {
 		t.Parallel()
 		must.True(t, gitea.Detect(giturl.Parse("git@custom-url.com:git-town/docs.git"), configdomain.HostingPlatformGitea))
 	})
+
 	t.Run("repo is hosted by another hosting platform", func(t *testing.T) {
 		t.Parallel()
 		must.False(t, gitea.Detect(giturl.Parse("git@github.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
 	})
+
 	t.Run("no origin remote", func(t *testing.T) {
 		t.Parallel()
 		var originURL *giturl.Parts

--- a/src/hosting/gitea/detect_test.go
+++ b/src/hosting/gitea/detect_test.go
@@ -1,0 +1,27 @@
+package gitea_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+	"github.com/git-town/git-town/v11/src/hosting/gitea"
+	"github.com/shoenig/test/must"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+	t.Run("hosted service type provided manually", func(t *testing.T) {
+		t.Parallel()
+		must.True(t, gitea.Detect(giturl.Parse("git@custom-url.com:git-town/docs.git"), configdomain.HostingPlatformGitea))
+	})
+	t.Run("repo is hosted by another hosting platform", func(t *testing.T) {
+		t.Parallel()
+		must.False(t, gitea.Detect(giturl.Parse("git@github.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
+	})
+	t.Run("no origin remote", func(t *testing.T) {
+		t.Parallel()
+		var originURL *giturl.Parts
+		must.False(t, gitea.Detect(originURL, configdomain.HostingPlatformNone))
+	})
+}

--- a/src/hosting/github/connector.go
+++ b/src/hosting/github/connector.go
@@ -49,10 +49,6 @@ func (self *Connector) FindProposal(branch, target gitdomain.LocalBranchName) (*
 	return &proposal, nil
 }
 
-func (self *Connector) HostingPlatformName() string {
-	return "GitHub"
-}
-
 func (self *Connector) NewProposalURL(branch, parentBranch gitdomain.LocalBranchName) (string, error) {
 	toCompare := branch.String()
 	if parentBranch != self.MainBranch {

--- a/src/hosting/github/connector.go
+++ b/src/hosting/github/connector.go
@@ -115,9 +115,6 @@ func GetAPIToken(gitConfigToken configdomain.GitHubToken) configdomain.GitHubTok
 // NewConnector provides a fully configured GithubConnector instance
 // if the current repo is hosted on Github, otherwise nil.
 func NewConnector(args NewConnectorArgs) (*Connector, error) {
-	if args.OriginURL == nil || (args.OriginURL.Host != "github.com" && args.HostingPlatform != configdomain.HostingPlatformGitHub) {
-		return nil, nil //nolint:nilnil
-	}
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: args.APIToken.String()})
 	httpClient := oauth2.NewClient(context.Background(), tokenSource)
 	return &Connector{

--- a/src/hosting/github/connector_test.go
+++ b/src/hosting/github/connector_test.go
@@ -121,31 +121,4 @@ func TestNewConnector(t *testing.T) {
 		}
 		must.EqOp(t, wantConfig, have.Config)
 	})
-
-	t.Run("repo is hosted by another hosting platform --> no connector", func(t *testing.T) {
-		t.Parallel()
-		have, err := github.NewConnector(github.NewConnectorArgs{
-			HostingPlatform: configdomain.HostingPlatformNone,
-			OriginURL:       giturl.Parse("git@gitlab.com:git-town/git-town.git"),
-			APIToken:        "",
-			MainBranch:      gitdomain.NewLocalBranchName("mainBranch"),
-			Log:             print.NoLogger{},
-		})
-		must.Nil(t, have)
-		must.NoError(t, err)
-	})
-
-	t.Run("no origin remote --> no connector", func(t *testing.T) {
-		t.Parallel()
-		var originURL *giturl.Parts
-		have, err := github.NewConnector(github.NewConnectorArgs{
-			HostingPlatform: configdomain.HostingPlatformNone,
-			OriginURL:       originURL,
-			APIToken:        "",
-			MainBranch:      gitdomain.NewLocalBranchName("mainBranch"),
-			Log:             print.NoLogger{},
-		})
-		must.Nil(t, have)
-		must.NoError(t, err)
-	})
 }

--- a/src/hosting/github/detect.go
+++ b/src/hosting/github/detect.go
@@ -1,0 +1,11 @@
+package github
+
+import (
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+)
+
+// Detect indicates whether the current repository is hosted on a GitHub server.
+func Detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatform) bool {
+	return originURL != nil && (originURL.Host == "github.com" || hostingPlatform == configdomain.HostingPlatformGitHub)
+}

--- a/src/hosting/github/detect_test.go
+++ b/src/hosting/github/detect_test.go
@@ -1,0 +1,31 @@
+package github_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+	"github.com/git-town/git-town/v11/src/hosting/github"
+	"github.com/shoenig/test/must"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+	t.Run("GitHub SaaS", func(t *testing.T) {
+		t.Parallel()
+		must.True(t, github.Detect(giturl.Parse("git@github.com:git-town/docs.git"), configdomain.HostingPlatformNone))
+	})
+	t.Run("hosted service type provided manually", func(t *testing.T) {
+		t.Parallel()
+		must.True(t, github.Detect(giturl.Parse("git@custom-url.com:git-town/docs.git"), configdomain.HostingPlatformGitHub))
+	})
+	t.Run("repo is hosted by another hosting platform", func(t *testing.T) {
+		t.Parallel()
+		must.False(t, github.Detect(giturl.Parse("git@gitlab.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
+	})
+	t.Run("no origin remote", func(t *testing.T) {
+		t.Parallel()
+		var originURL *giturl.Parts
+		must.False(t, github.Detect(originURL, configdomain.HostingPlatformNone))
+	})
+}

--- a/src/hosting/github/detect_test.go
+++ b/src/hosting/github/detect_test.go
@@ -11,18 +11,22 @@ import (
 
 func TestDetect(t *testing.T) {
 	t.Parallel()
+
 	t.Run("GitHub SaaS", func(t *testing.T) {
 		t.Parallel()
 		must.True(t, github.Detect(giturl.Parse("git@github.com:git-town/docs.git"), configdomain.HostingPlatformNone))
 	})
+
 	t.Run("hosted service type provided manually", func(t *testing.T) {
 		t.Parallel()
 		must.True(t, github.Detect(giturl.Parse("git@custom-url.com:git-town/docs.git"), configdomain.HostingPlatformGitHub))
 	})
+
 	t.Run("repo is hosted by another hosting platform", func(t *testing.T) {
 		t.Parallel()
 		must.False(t, github.Detect(giturl.Parse("git@gitlab.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
 	})
+
 	t.Run("no origin remote", func(t *testing.T) {
 		t.Parallel()
 		var originURL *giturl.Parts

--- a/src/hosting/gitlab/config.go
+++ b/src/hosting/gitlab/config.go
@@ -18,10 +18,6 @@ func (self *Config) DefaultProposalMessage(proposal hostingdomain.Proposal) stri
 	return fmt.Sprintf("%s (!%d)", proposal.Title, proposal.Number)
 }
 
-func (self *Config) HostingPlatformName() string {
-	return "GitLab"
-}
-
 func (self *Config) NewProposalURL(branch, parentBranch gitdomain.LocalBranchName) (string, error) {
 	query := url.Values{}
 	query.Add("merge_request[source_branch]", branch.String())

--- a/src/hosting/gitlab/connector.go
+++ b/src/hosting/gitlab/connector.go
@@ -76,9 +76,6 @@ func (self *Connector) UpdateProposalTarget(number int, target gitdomain.LocalBr
 // NewGitlabConfig provides GitLab configuration data if the current repo is hosted on GitLab,
 // otherwise nil.
 func NewConnector(args NewConnectorArgs) (*Connector, error) {
-	if args.OriginURL == nil || (args.OriginURL.Host != "gitlab.com" && args.HostingPlatform != configdomain.HostingPlatformGitLab) {
-		return nil, nil //nolint:nilnil
-	}
 	gitlabConfig := Config{
 		APIToken: args.APIToken,
 		Config: hostingdomain.Config{

--- a/src/hosting/gitlab/connector_test.go
+++ b/src/hosting/gitlab/connector_test.go
@@ -121,29 +121,4 @@ func TestNewGitlabConnector(t *testing.T) {
 		}
 		must.EqOp(t, wantConfig, have.Config)
 	})
-
-	t.Run("repo is hosted by another hosting platform --> no connector", func(t *testing.T) {
-		t.Parallel()
-		have, err := gitlab.NewConnector(gitlab.NewConnectorArgs{
-			HostingPlatform: configdomain.HostingPlatformNone,
-			OriginURL:       giturl.Parse("git@github.com:git-town/git-town.git"),
-			APIToken:        "",
-			Log:             print.NoLogger{},
-		})
-		must.Nil(t, have)
-		must.NoError(t, err)
-	})
-
-	t.Run("no origin remote --> no connector", func(t *testing.T) {
-		t.Parallel()
-		var originURL *giturl.Parts
-		have, err := gitlab.NewConnector(gitlab.NewConnectorArgs{
-			HostingPlatform: configdomain.HostingPlatformNone,
-			OriginURL:       originURL,
-			APIToken:        "",
-			Log:             print.NoLogger{},
-		})
-		must.Nil(t, have)
-		must.NoError(t, err)
-	})
 }

--- a/src/hosting/gitlab/detect.go
+++ b/src/hosting/gitlab/detect.go
@@ -1,0 +1,11 @@
+package gitlab
+
+import (
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+)
+
+// Detect indicates whether the current repository is hosted on a GitLab server.
+func Detect(originURL *giturl.Parts, hostingPlatform configdomain.HostingPlatform) bool {
+	return originURL != nil && (originURL.Host == "gitlab.com" || hostingPlatform == configdomain.HostingPlatformGitLab)
+}

--- a/src/hosting/gitlab/detect_test.go
+++ b/src/hosting/gitlab/detect_test.go
@@ -11,14 +11,17 @@ import (
 
 func TestDetect(t *testing.T) {
 	t.Parallel()
+
 	t.Run("GitLab SaaS", func(t *testing.T) {
 		t.Parallel()
 		must.True(t, gitlab.Detect(giturl.Parse("git@gitlab.com:git-town/docs.git"), configdomain.HostingPlatformNone))
 	})
+
 	t.Run("hosted service type provided manually", func(t *testing.T) {
 		t.Parallel()
 		must.True(t, gitlab.Detect(giturl.Parse("git@custom-url.com:git-town/docs.git"), configdomain.HostingPlatformGitLab))
 	})
+
 	t.Run("repo is hosted by another hosting platform", func(t *testing.T) {
 		t.Parallel()
 		must.False(t, gitlab.Detect(giturl.Parse("git@github.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
@@ -29,5 +32,4 @@ func TestDetect(t *testing.T) {
 		var originURL *giturl.Parts
 		must.False(t, gitlab.Detect(originURL, configdomain.HostingPlatformNone))
 	})
-
 }

--- a/src/hosting/gitlab/detect_test.go
+++ b/src/hosting/gitlab/detect_test.go
@@ -1,0 +1,33 @@
+package gitlab_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v11/src/config/configdomain"
+	"github.com/git-town/git-town/v11/src/git/giturl"
+	"github.com/git-town/git-town/v11/src/hosting/gitlab"
+	"github.com/shoenig/test/must"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+	t.Run("GitLab SaaS", func(t *testing.T) {
+		t.Parallel()
+		must.True(t, gitlab.Detect(giturl.Parse("git@gitlab.com:git-town/docs.git"), configdomain.HostingPlatformNone))
+	})
+	t.Run("hosted service type provided manually", func(t *testing.T) {
+		t.Parallel()
+		must.True(t, gitlab.Detect(giturl.Parse("git@custom-url.com:git-town/docs.git"), configdomain.HostingPlatformGitLab))
+	})
+	t.Run("repo is hosted by another hosting platform", func(t *testing.T) {
+		t.Parallel()
+		must.False(t, gitlab.Detect(giturl.Parse("git@github.com:git-town/git-town.git"), configdomain.HostingPlatformNone))
+	})
+
+	t.Run("no origin remote", func(t *testing.T) {
+		t.Parallel()
+		var originURL *giturl.Parts
+		must.False(t, gitlab.Detect(originURL, configdomain.HostingPlatformNone))
+	})
+
+}

--- a/src/hosting/hostingdomain/connector.go
+++ b/src/hosting/hostingdomain/connector.go
@@ -13,10 +13,6 @@ type Connector interface {
 	// Returns nil if no proposal exists.
 	FindProposal(branch, target gitdomain.LocalBranchName) (*Proposal, error)
 
-	// HostingPlatformName provides the name of the code hosting platform
-	// supported by the respective connector implementation.
-	HostingPlatformName() string
-
 	// SquashMergeProposal squash-merges the proposal with the given number
 	// using the given commit message.
 	SquashMergeProposal(number int, message string) (mergeSHA gitdomain.SHA, err error)

--- a/src/hosting/hostingdomain/platform.go
+++ b/src/hosting/hostingdomain/platform.go
@@ -9,7 +9,3 @@ const (
 	PlatformBitbucket Platform = "Bitbucket"
 	PlatformNone      Platform = "None"
 )
-
-func (self Platform) String() string {
-	return string(self)
-}

--- a/src/hosting/hostingdomain/platform.go
+++ b/src/hosting/hostingdomain/platform.go
@@ -1,0 +1,14 @@
+package hostingdomain
+
+type Platform string
+
+const (
+	PlatformGitea     Platform = "Gitea"
+	PlatformGithub    Platform = "GitHub"
+	PlatformGitlab    Platform = "GitLab"
+	PlatformBitbucket Platform = "Bitbucket"
+)
+
+func (self Platform) String() string {
+	return string(self)
+}

--- a/src/hosting/hostingdomain/platform.go
+++ b/src/hosting/hostingdomain/platform.go
@@ -7,6 +7,7 @@ const (
 	PlatformGithub    Platform = "GitHub"
 	PlatformGitlab    Platform = "GitLab"
 	PlatformBitbucket Platform = "Bitbucket"
+	PlatformNone      Platform = "None"
 )
 
 func (self Platform) String() string {

--- a/src/hosting/new_connector.go
+++ b/src/hosting/new_connector.go
@@ -12,40 +12,37 @@ import (
 
 // NewConnector provides an instance of the code hosting connector to use based on the given gitConfig.
 func NewConnector(args NewConnectorArgs) (hostingdomain.Connector, error) {
-	githubConnector, err := github.NewConnector(github.NewConnectorArgs{
-		HostingPlatform: args.HostingPlatform,
-		APIToken:        github.GetAPIToken(args.GitHubToken),
-		MainBranch:      args.MainBranch,
-		OriginURL:       args.OriginURL,
-		Log:             args.Log,
-	})
-	if githubConnector != nil || err != nil {
-		return githubConnector, err
-	}
-	gitlabConnector, err := gitlab.NewConnector(gitlab.NewConnectorArgs{
-		HostingPlatform: args.HostingPlatform,
-		OriginURL:       args.OriginURL,
-		APIToken:        args.GitLabToken,
-		Log:             args.Log,
-	})
-	if gitlabConnector != nil || err != nil {
-		return gitlabConnector, err
-	}
-	bitbucketConnector, err := bitbucket.NewConnector(bitbucket.NewConnectorArgs{
-		OriginURL:       args.OriginURL,
-		HostingPlatform: args.HostingPlatform,
-	})
-	if bitbucketConnector != nil || err != nil {
-		return bitbucketConnector, err
-	}
-	giteaConnector, err := gitea.NewConnector(gitea.NewConnectorArgs{
-		OriginURL:       args.OriginURL,
-		HostingPlatform: args.HostingPlatform,
-		APIToken:        args.GiteaToken,
-		Log:             args.Log,
-	})
-	if giteaConnector != nil || err != nil {
-		return giteaConnector, err
+	platform := detect(args.OriginURL, args.HostingPlatform)
+	switch platform {
+	case hostingdomain.PlatformBitbucket:
+		return bitbucket.NewConnector(bitbucket.NewConnectorArgs{
+			OriginURL:       args.OriginURL,
+			HostingPlatform: args.HostingPlatform,
+		})
+	case hostingdomain.PlatformGitea:
+		return gitea.NewConnector(gitea.NewConnectorArgs{
+			OriginURL:       args.OriginURL,
+			HostingPlatform: args.HostingPlatform,
+			APIToken:        args.GiteaToken,
+			Log:             args.Log,
+		})
+	case hostingdomain.PlatformGithub:
+		return github.NewConnector(github.NewConnectorArgs{
+			HostingPlatform: args.HostingPlatform,
+			APIToken:        github.GetAPIToken(args.GitHubToken),
+			MainBranch:      args.MainBranch,
+			OriginURL:       args.OriginURL,
+			Log:             args.Log,
+		})
+	case hostingdomain.PlatformGitlab:
+		return gitlab.NewConnector(gitlab.NewConnectorArgs{
+			HostingPlatform: args.HostingPlatform,
+			OriginURL:       args.OriginURL,
+			APIToken:        args.GitLabToken,
+			Log:             args.Log,
+		})
+	case hostingdomain.PlatformNone:
+		return nil, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
- these are two different things, they should be separate
- they are tested differently
- constructors should do no work, just construct objects
- the setup assistant needs detection separately