### PR TITLE
Always remove config keys in alphabetical order

### DIFF
--- a/src/cmd/config/remove.go
+++ b/src/cmd/config/remove.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/git-town/git-town/v11/src/cli/flags"
@@ -43,7 +44,9 @@ func executeRemoveConfig(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	for _, aliasName := range maps.Keys(repo.Runner.Aliases) {
+	aliasNames := maps.Keys(repo.Runner.Aliases)
+	slices.Sort(aliasNames)
+	for _, aliasName := range aliasNames {
 		if strings.HasPrefix(repo.Runner.Aliases[aliasName], "town ") {
 			err = repo.Runner.Frontend.RemoveGitAlias(aliasName)
 			if err != nil {

--- a/src/cmd/config/remove.go
+++ b/src/cmd/config/remove.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v11/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v11/src/execute"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 )
 
 const removeConfigDesc = "Removes the Git Town configuration"
@@ -42,8 +43,9 @@ func executeRemoveConfig(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	for aliasName, aliasValue := range repo.Runner.Aliases {
-		if strings.HasPrefix(aliasValue, "town ") {
+	aliasNames := maps.Keys(repo.Runner.Aliases)
+	for _, aliasName := range aliasNames {
+		if strings.HasPrefix(repo.Runner.Aliases[aliasName], "town ") {
 			err = repo.Runner.Frontend.RemoveGitAlias(aliasName)
 			if err != nil {
 				return err

--- a/src/cmd/config/remove.go
+++ b/src/cmd/config/remove.go
@@ -43,8 +43,7 @@ func executeRemoveConfig(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	aliasNames := maps.Keys(repo.Runner.Aliases)
-	for _, aliasName := range aliasNames {
+	for _, aliasName := range maps.Keys(repo.Runner.Aliases) {
 		if strings.HasPrefix(repo.Runner.Aliases[aliasName], "town ") {
 			err = repo.Runner.Frontend.RemoveGitAlias(aliasName)
 			if err != nil {


### PR DESCRIPTION
This prevents a flaky end-to-end test