### PR TITLE
Don't use local config in the TestRuntime

### DIFF
--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v11/src/config"
-	"github.com/git-town/git-town/v11/src/config/gitconfig"
+	"github.com/git-town/git-town/v11/src/config/configdomain"
 	"github.com/git-town/git-town/v11/src/git"
 	"github.com/git-town/git-town/v11/src/git/gitdomain"
 	"github.com/git-town/git-town/v11/src/gohacks/cache"
@@ -77,15 +77,17 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 		HomeDir:    homeDir,
 		BinDir:     binDir,
 	}
-	configGitAccess := gitconfig.Access{Runner: &runner}
-	_, globalConfig, err := configGitAccess.LoadGlobal()
-	if err != nil {
-		panic(err)
-	}
-	_, localConfig, err := configGitAccess.LoadLocal()
-	if err != nil {
-		panic(err)
-	}
+	// configGitAccess := gitconfig.Access{Runner: &runner}
+	// _, globalConfig, err := configGitAccess.LoadGlobal()
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// _, localConfig, err := configGitAccess.LoadLocal()
+	// if err != nil {
+	// 	panic(err)
+	// }
+	globalConfig := configdomain.EmptyPartialConfig()
+	localConfig := configdomain.EmptyPartialConfig()
 	config, err := config.NewConfig(globalConfig, localConfig, false, &runner)
 	if err != nil {
 		panic(err)

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -77,15 +77,6 @@ func New(workingDir, homeDir, binDir string) TestRuntime {
 		HomeDir:    homeDir,
 		BinDir:     binDir,
 	}
-	// configGitAccess := gitconfig.Access{Runner: &runner}
-	// _, globalConfig, err := configGitAccess.LoadGlobal()
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// _, localConfig, err := configGitAccess.LoadLocal()
-	// if err != nil {
-	// 	panic(err)
-	// }
 	globalConfig := configdomain.EmptyPartialConfig()
 	localConfig := configdomain.EmptyPartialConfig()
 	config, err := config.NewConfig(globalConfig, localConfig, false, &runner)


### PR DESCRIPTION
The end-to-end test runner runs in the directory of the Git Town source code. It should not pick up the local configuration of the Git Town source code repo in tests.