### PR TITLE
Run golangci-lint sequentially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,9 @@ deadcode: tools/rta@${RTA_VERSION}
 	                                                           || true
 
 golangci-lint: tools/rta@${RTA_VERSION}
-	@(cd tools/format_self && ../rta golangci-lint@1.55.2 run) &
-	@(cd tools/format_unittests && ../rta golangci-lint@1.55.2 run) &
-	@(cd tools/structs_sorted && ../rta golangci-lint@1.55.2 run) &
+	@(cd tools/format_self && ../rta golangci-lint@1.55.2 run)
+	@(cd tools/format_unittests && ../rta golangci-lint@1.55.2 run)
+	@(cd tools/structs_sorted && ../rta golangci-lint@1.55.2 run)
 	@tools/rta golangci-lint run
 
 tools/rta@${RTA_VERSION}:


### PR DESCRIPTION
Running it concurrently leads to flaky failures where it complains that it's running concurrently.