### PR TITLE
Hard-code the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,11 @@ RTA_VERSION = 0.3.0 # run-that-app version to use
 
 # internal data and state
 .DEFAULT_GOAL := help
-TODAY = $(shell date +'%Y-%m-%d')
-DEV_VERSION := $(shell git describe --tags 2> /dev/null || git rev-parse --short HEAD)
 RELEASE_VERSION := "12.0.0"
 GO_BUILD_ARGS = LANG=C GOGC=off
 
 build:  # builds for the current platform
-	@go install -ldflags "-X github.com/git-town/git-town/v12/src/cmd.version=${DEV_VERSION}-dev -X github.com/git-town/git-town/v12/src/cmd.buildDate=${TODAY}"
-
-buildwin:  # builds the binary on Windows
-	@go install -ldflags "-X github.com/git-town/git-town/v12/src/cmd.version=-dev -X github.com/git-town/git-town/v12/src/cmd.buildDate=1/2/3"
+	@go install
 
 clear:  # clears the build and lint caches
 	tools/rta golangci-lint cache clean
@@ -31,7 +26,7 @@ cuke-prof: build  # creates a flamegraph for the end-to-end tests
 	@rm git-town.test
 	@echo Please open https://www.speedscope.app and load the file godog.out
 
-cukewin: buildwin  # runs all end-to-end tests on Windows
+cukewin: build  # runs all end-to-end tests on Windows
 	go test . -v -count=1
 
 dependencies: tools/rta@${RTA_VERSION}  # prints the dependencies between the internal Go packages as a tree
@@ -75,7 +70,7 @@ lint: tools/rta@${RTA_VERSION}  # runs the linters concurrently
 smoke: build  # run the smoke tests
 	@env $(GO_BUILD_ARGS) smoke=1 go test . -v -count=1
 
-smokewin: buildwin  # runs the Windows smoke tests
+smokewin: build  # runs the Windows smoke tests
 	@env smoke=1 go test . -v -count=1
 
 stats: tools/rta@${RTA_VERSION}  # shows code statistics

--- a/features/version/version.feature
+++ b/features/version/version.feature
@@ -4,7 +4,7 @@ Feature: show the version of the current Git Town installation
   Scenario: outside a Git repository
     Given I am outside a Git repo
     When I run "git-town --version"
-    Then it prints something like:
+    Then it prints:
       """
-      Git Town .*-dev
+      Git Town 12.0.0
       """

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -13,12 +13,6 @@ const rootDesc = "Branching and workflow support for Git"
 const rootHelp = `
 Git Town helps create, sync, and ship changes efficiently and with minimal merge conflicts.`
 
-// The current Git Town version (set at compile time).
-var version string
-
-// The time this Git Town binary was compiled (set at compile time).
-var buildDate string //nolint:gochecknoglobals
-
 func rootCmd() cobra.Command {
 	addVersionFlag, readVersionFlag := flags.Version()
 	rootCmd := cobra.Command{
@@ -51,7 +45,7 @@ func rootCmd() cobra.Command {
 
 func executeRoot(cmd *cobra.Command, showVersion bool) error {
 	if showVersion {
-		fmt.Printf("Git Town %s (%s)\n", version, buildDate)
+		fmt.Println("Git Town 12.0.0")
 		return nil
 	}
 	return cmd.Help()

--- a/tools/release.ps1
+++ b/tools/release.ps1
@@ -20,7 +20,6 @@ function Main() {
   if ($ci) {
     Install-Tools
   }
-  $env:TODAY = (Get-Date).ToString("yyyy-MM-dd")
   Add-MSI
   .\rta goreleaser@$GoReleaserVersion --clean
 }


### PR DESCRIPTION
resolves #2429 

The current approach to inject the version and build date at link time from environment variables into the binary was set up when Git Town was built locally via a Makefile. Now, years and many iterations on the release process later, there are too many ongoing issues with this setup. This breaks and requires extensive manual debugging each time we adjust something in the build automation. Examples: The release binaries are cross-compiled by Goreleaser now, which calls another tool for the cross-compilation, which doesn't inject the necessary data. The Windows installer gets compiled via PowerShell on Windows, which currently also doesn't inject this data.

Patching all this up is of course possible. But the cost/benefit ratio isn't there to justify this level of complexity.

This PR replaces the flimsy configuration data injection with a simple hardcoded version without date. The release dates can be seen in the releases on GitHub and/or the created date of the Git Town binary. If anybody needs anything more, please get in touch.