### PR TITLE
Lint the main codebase first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ deadcode: tools/rta@${RTA_VERSION}
 	                                                           || true
 
 golangci-lint: tools/rta@${RTA_VERSION}
+	@echo lint main codebase
+	@tools/rta golangci-lint run
 	@echo lint tools/format_self
 	@(cd tools/format_self && ../rta golangci-lint@1.55.2 run)
 	@echo lint tools/format_unittests
@@ -133,8 +135,6 @@ golangci-lint: tools/rta@${RTA_VERSION}
 	@(cd tools/stats_release && ../rta golangci-lint@1.55.2 run)
 	@echo lint tools/structs_sorted
 	@(cd tools/structs_sorted && ../rta golangci-lint@1.55.2 run)
-	@echo lint main codebase
-	@tools/rta golangci-lint run
 
 tools/rta@${RTA_VERSION}:
 	@rm -f tools/rta*


### PR DESCRIPTION
That's the most relevant result for most usecases. It should come first.