### PR TITLE
Do not capture SHA when shipping via connector

### DIFF
--- a/src/hosting/bitbucket/connector.go
+++ b/src/hosting/bitbucket/connector.go
@@ -56,8 +56,8 @@ func (self *Connector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", self.HostnameWithStandardPort(), self.Organization, self.Repository)
 }
 
-func (self *Connector) SquashMergeProposal(_ int, _ string) (mergeSHA gitdomain.SHA, err error) {
-	return gitdomain.EmptySHA(), errors.New(messages.HostingBitBucketNotImplemented)
+func (self *Connector) SquashMergeProposal(_ int, _ string) error {
+	return errors.New(messages.HostingBitBucketNotImplemented)
 }
 
 func (self *Connector) UpdateProposalTarget(_ int, _ gitdomain.LocalBranchName) error {

--- a/src/hosting/gitea/connector.go
+++ b/src/hosting/gitea/connector.go
@@ -63,24 +63,21 @@ func (self *Connector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", self.HostnameWithStandardPort(), self.Organization, self.Repository)
 }
 
-func (self *Connector) SquashMergeProposal(number int, message string) (mergeSHA gitdomain.SHA, err error) {
+func (self *Connector) SquashMergeProposal(number int, message string) error {
 	if number <= 0 {
-		return gitdomain.EmptySHA(), errors.New(messages.ProposalNoNumberGiven)
+		return errors.New(messages.ProposalNoNumberGiven)
 	}
 	commitMessageParts := commitmessage.Split(message)
-	_, _, err = self.client.MergePullRequest(self.Organization, self.Repository, int64(number), gitea.MergePullRequestOption{
+	_, _, err := self.client.MergePullRequest(self.Organization, self.Repository, int64(number), gitea.MergePullRequestOption{
 		Style:   gitea.MergeStyleSquash,
 		Title:   commitMessageParts.Title,
 		Message: commitMessageParts.Body,
 	})
 	if err != nil {
-		return gitdomain.EmptySHA(), err
+		return err
 	}
-	pullRequest, _, err := self.client.GetPullRequest(self.Organization, self.Repository, int64(number))
-	if err != nil {
-		return gitdomain.EmptySHA(), err
-	}
-	return gitdomain.NewSHA(*pullRequest.MergedCommitID), nil
+	_, _, err = self.client.GetPullRequest(self.Organization, self.Repository, int64(number))
+	return err
 }
 
 func (self *Connector) UpdateProposalTarget(_ int, _ gitdomain.LocalBranchName) error {

--- a/src/hosting/github/connector.go
+++ b/src/hosting/github/connector.go
@@ -74,7 +74,7 @@ func (self *Connector) SquashMergeProposal(number int, message string) (err erro
 		CommitTitle: commitMessageParts.Title,
 	})
 	self.log.Success()
-	return nil
+	return err
 }
 
 func (self *Connector) UpdateProposalTarget(number int, target gitdomain.LocalBranchName) error {

--- a/src/hosting/github/connector.go
+++ b/src/hosting/github/connector.go
@@ -63,23 +63,18 @@ func (self *Connector) RepositoryURL() string {
 	return fmt.Sprintf("https://%s/%s/%s", self.HostnameWithStandardPort(), self.Organization, self.Repository)
 }
 
-func (self *Connector) SquashMergeProposal(number int, message string) (mergeSHA gitdomain.SHA, err error) {
+func (self *Connector) SquashMergeProposal(number int, message string) (err error) {
 	if number <= 0 {
-		return gitdomain.EmptySHA(), errors.New(messages.ProposalNoNumberGiven)
+		return errors.New(messages.ProposalNoNumberGiven)
 	}
 	self.log.Start(messages.HostingGithubMergingViaAPI, number)
 	commitMessageParts := commitmessage.Split(message)
-	result, _, err := self.client.PullRequests.Merge(context.Background(), self.Organization, self.Repository, number, commitMessageParts.Body, &github.PullRequestOptions{
+	_, _, err = self.client.PullRequests.Merge(context.Background(), self.Organization, self.Repository, number, commitMessageParts.Body, &github.PullRequestOptions{
 		MergeMethod: "squash",
 		CommitTitle: commitMessageParts.Title,
 	})
-	sha := gitdomain.NewSHA(result.GetSHA())
-	if err != nil {
-		self.log.Failed(err)
-		return sha, err
-	}
 	self.log.Success()
-	return sha, nil
+	return nil
 }
 
 func (self *Connector) UpdateProposalTarget(number int, target gitdomain.LocalBranchName) error {

--- a/src/hosting/gitlab/connector.go
+++ b/src/hosting/gitlab/connector.go
@@ -42,13 +42,13 @@ func (self *Connector) FindProposal(branch, target gitdomain.LocalBranchName) (*
 	return &proposal, nil
 }
 
-func (self *Connector) SquashMergeProposal(number int, message string) (mergeSHA gitdomain.SHA, err error) {
+func (self *Connector) SquashMergeProposal(number int, message string) error {
 	if number <= 0 {
-		return gitdomain.EmptySHA(), errors.New(messages.ProposalNoNumberGiven)
+		return errors.New(messages.ProposalNoNumberGiven)
 	}
 	self.log.Start(messages.HostingGitlabMergingViaAPI, number)
 	// the GitLab API wants the full commit message in the body
-	result, _, err := self.client.MergeRequests.AcceptMergeRequest(self.projectPath(), number, &gitlab.AcceptMergeRequestOptions{
+	_, _, err := self.client.MergeRequests.AcceptMergeRequest(self.projectPath(), number, &gitlab.AcceptMergeRequestOptions{
 		SquashCommitMessage: gitlab.Ptr(message),
 		Squash:              gitlab.Ptr(true),
 		// the branch will be deleted by Git Town
@@ -56,10 +56,10 @@ func (self *Connector) SquashMergeProposal(number int, message string) (mergeSHA
 	})
 	if err != nil {
 		self.log.Failed(err)
-		return gitdomain.EmptySHA(), err
+		return err
 	}
 	self.log.Success()
-	return gitdomain.NewSHA(result.SHA), nil
+	return nil
 }
 
 func (self *Connector) UpdateProposalTarget(number int, target gitdomain.LocalBranchName) error {

--- a/src/hosting/hostingdomain/connector.go
+++ b/src/hosting/hostingdomain/connector.go
@@ -15,7 +15,7 @@ type Connector interface {
 
 	// SquashMergeProposal squash-merges the proposal with the given number
 	// using the given commit message.
-	SquashMergeProposal(number int, message string) (mergeSHA gitdomain.SHA, err error)
+	SquashMergeProposal(number int, message string) error
 
 	// NewProposalURL provides the URL of the page
 	// to create a new proposal online.

--- a/src/vm/opcode/connector_merge_proposal.go
+++ b/src/vm/opcode/connector_merge_proposal.go
@@ -68,7 +68,7 @@ func (self *ConnectorMergeProposal) Run(args shared.RunArgs) error {
 		}
 		self.enteredEmptyCommitMessage = false
 	}
-	_, self.mergeError = args.Connector.SquashMergeProposal(self.ProposalNumber, commitMessage)
+	self.mergeError = args.Connector.SquashMergeProposal(self.ProposalNumber, commitMessage)
 	return self.mergeError
 }
 


### PR DESCRIPTION
resolves #3113 

This SHA isn't used anymore, so we can solve this problem by removing the problematic code.