### PR TITLE
Clean up keycode hacks

### DIFF
--- a/src/cli/dialog/components/bubble_list.go
+++ b/src/cli/dialog/components/bubble_list.go
@@ -83,10 +83,10 @@ func (self *BubbleList[S]) HandleKey(key tea.KeyMsg) (bool, tea.Cmd) {
 		if number < len(self.Entries) {
 			self.Cursor = number
 		}
-	case "k", "A", "Z":
+	case "k":
 		self.moveCursorUp()
 		return true, nil
-	case "j", "B":
+	case "j":
 		self.moveCursorDown()
 		return true, nil
 	case "u":


### PR DESCRIPTION
These hacks were workarounds when there were two libraries reading keycodes and interfering with each other. Now there is only one library, so these ugly hacks are no longer necessary.