### PR TITLE
Always force delete branches

### DIFF
--- a/features/append/features/parent_deleted.feature
+++ b/features/append/features/parent_deleted.feature
@@ -20,7 +20,7 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       |        | git checkout parent              |
       | parent | git merge --no-edit main         |
       |        | git checkout main                |
-      | main   | git branch -d parent             |
+      | main   | git branch -D parent             |
       |        | git checkout child               |
       | child  | git merge --no-edit origin/child |
       |        | git merge --no-edit main         |

--- a/features/append/features/tracking_branch_deleted.feature
+++ b/features/append/features/tracking_branch_deleted.feature
@@ -21,7 +21,7 @@ Feature: append a branch to a branch whose tracking branch was deleted
       |         | git checkout shipped     |
       | shipped | git merge --no-edit main |
       |         | git checkout main        |
-      | main    | git branch -d shipped    |
+      | main    | git branch -D shipped    |
       |         | git branch new main      |
       |         | git checkout new         |
       | new     | git stash pop            |

--- a/features/kill/current_branch/edge_cases/unknown_parent.feature
+++ b/features/kill/current_branch/edge_cases/unknown_parent.feature
@@ -9,5 +9,5 @@ Feature: ask for missing parent branch information
       | BRANCH  | COMMAND                  |
       | feature | git fetch --prune --tags |
       |         | git checkout main        |
-      | main    | git branch -d feature    |
+      | main    | git branch -D feature    |
     And no lineage exists now

--- a/features/kill/current_branch/features/verbose.feature
+++ b/features/kill/current_branch/features/verbose.feature
@@ -27,7 +27,6 @@ Feature: display all executed Git commands
       |         | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
       | current | frontend | git push origin :current                          |
       |         | frontend | git checkout other                                |
-      |         | backend  | git log main..current                             |
       | other   | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |
       |         | backend  | git show-ref --verify --quiet refs/heads/current  |
@@ -37,6 +36,6 @@ Feature: display all executed Git commands
       |         | backend  | git stash list                                    |
     And it prints:
       """
-      Ran 22 shell commands.
+      Ran 21 shell commands.
       """
     And the current branch is now "other"

--- a/features/prepend/features/branch_shipped.feature
+++ b/features/prepend/features/branch_shipped.feature
@@ -24,7 +24,7 @@ Feature: prepend a branch to a branch that was shipped at the remote
       |        | git checkout child                |
       | child  | git merge --no-edit parent        |
       |        | git checkout parent               |
-      | parent | git branch -d child               |
+      | parent | git branch -D child               |
       |        | git branch new parent             |
       |        | git checkout new                  |
     And it prints:

--- a/features/rename_branch/features/perennial_branch.feature
+++ b/features/rename_branch/features/perennial_branch.feature
@@ -27,7 +27,7 @@ Feature: rename a perennial branch
       |            | git checkout new            |
       | new        | git push -u origin new      |
       |            | git push origin :production |
-      |            | git branch -d production    |
+      |            | git branch -D production    |
     And the current branch is now "new"
     And the perennial branches are now "new"
     And these commits exist now

--- a/features/rename_branch/features/verbose.feature
+++ b/features/rename_branch/features/verbose.feature
@@ -28,8 +28,7 @@ Feature: display all executed Git commands
       |        | backend  | git config git-town-branch.new.parent main    |
       | new    | frontend | git push -u origin new                        |
       |        | frontend | git push origin :old                          |
-      |        | backend  | git log main..old                             |
-      | new    | frontend | git branch -D old                             |
+      |        | frontend | git branch -D old                             |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       |        | backend  | git checkout main                             |
       |        | backend  | git checkout new                              |
@@ -39,7 +38,7 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 26 shell commands.
+      Ran 25 shell commands.
       """
     And the current branch is now "new"
 

--- a/features/ship/current_branch/features/verbose.feature
+++ b/features/ship/current_branch/features/verbose.feature
@@ -39,8 +39,7 @@ Feature: display all executed Git commands
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git push                                          |
       |         | frontend | git push origin :feature                          |
-      |         | backend  | git log main..feature                             |
-      | main    | frontend | git branch -D feature                             |
+      |         | frontend | git branch -D feature                             |
       |         | backend  | git config --unset git-town-branch.feature.parent |
       |         | backend  | git show-ref --verify --quiet refs/heads/feature  |
       |         | backend  | git branch -vva                                   |
@@ -49,7 +48,7 @@ Feature: display all executed Git commands
       |         | backend  | git stash list                                    |
     And it prints:
       """
-      Ran 36 shell commands.
+      Ran 35 shell commands.
       """
     And the current branch is now "main"
 

--- a/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
+++ b/features/sync/all_branches/edge_cases/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
@@ -42,7 +42,7 @@ Feature: shipped changes conflict with multiple existing feature branches
       |        | git checkout beta                |
       | beta   | git merge --no-edit main         |
       |        | git checkout main                |
-      | main   | git branch -d beta               |
+      | main   | git branch -D beta               |
       |        | git checkout gamma               |
       | gamma  | git merge --no-edit origin/gamma |
       |        | git merge --no-edit main         |

--- a/features/sync/all_branches/features/multiple_shipped_branches.feature
+++ b/features/sync/all_branches/features/multiple_shipped_branches.feature
@@ -21,11 +21,11 @@ Feature: multiple shipped branches
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit main             |
       |           | git checkout main                    |
-      | main      | git branch -d feature-1              |
+      | main      | git branch -D feature-1              |
       |           | git checkout feature-2               |
       | feature-2 | git merge --no-edit main             |
       |           | git checkout main                    |
-      | main      | git branch -d feature-2              |
+      | main      | git branch -D feature-2              |
       |           | git checkout feature-3               |
       | feature-3 | git merge --no-edit origin/feature-3 |
       |           | git merge --no-edit main             |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/parent_deleted_grandchild_conflicts.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/edge_cases/parent_deleted_grandchild_conflicts.feature
@@ -20,7 +20,7 @@ Feature: a grandchild branch has conflicts while its parent was deleted remotely
       |            | git checkout child                    |
       | child      | git merge --no-edit main              |
       |            | git checkout main                     |
-      | main       | git branch -d child                   |
+      | main       | git branch -D child                   |
       |            | git checkout grandchild               |
       | grandchild | git merge --no-edit origin/grandchild |
       |            | git merge --no-edit main              |

--- a/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/multiple_ancestors_shipped.feature
+++ b/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/multiple_ancestors_shipped.feature
@@ -23,11 +23,11 @@ Feature: multiple shipped parent branches in a lineage
       |           | git checkout feature-1               |
       | feature-1 | git merge --no-edit main             |
       |           | git checkout main                    |
-      | main      | git branch -d feature-1              |
+      | main      | git branch -D feature-1              |
       |           | git checkout feature-2               |
       | feature-2 | git merge --no-edit main             |
       |           | git checkout main                    |
-      | main      | git branch -d feature-2              |
+      | main      | git branch -D feature-2              |
       |           | git checkout feature-3               |
       | feature-3 | git merge --no-edit origin/feature-3 |
       |           | git merge --no-edit main             |

--- a/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/perennial_branch.feature
+++ b/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/perennial_branch.feature
@@ -14,7 +14,7 @@ Feature: sync perennial branch that was deleted at the remote
       | BRANCH    | COMMAND                  |
       | feature-1 | git fetch --prune --tags |
       |           | git checkout main        |
-      | main      | git branch -d feature-1  |
+      | main      | git branch -D feature-1  |
       |           | git push --tags          |
     And it prints:
       """

--- a/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/shipped_parent.feature
+++ b/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/shipped_parent.feature
@@ -20,7 +20,7 @@ Feature: syncing a branch whose parent was shipped
       |        | git checkout parent              |
       | parent | git merge --no-edit main         |
       |        | git checkout main                |
-      | main   | git branch -d parent             |
+      | main   | git branch -D parent             |
       |        | git checkout child               |
       | child  | git merge --no-edit origin/child |
       |        | git merge --no-edit main         |

--- a/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/verbose.feature
+++ b/features/sync/current_branch/feature_branch/tracking_branch_deleted/features/verbose.feature
@@ -30,8 +30,7 @@ Feature: display all executed Git commands
       | old    | frontend | git merge --no-edit main                      |
       |        | backend  | git diff main..old                            |
       | old    | frontend | git checkout main                             |
-      |        | backend  | git log main..old                             |
-      | main   | frontend | git branch -d old                             |
+      | main   | frontend | git branch -D old                             |
       |        | backend  | git config --unset git-town-branch.old.parent |
       |        | backend  | git show-ref --quiet refs/heads/old           |
       |        | backend  | git branch -vva                               |
@@ -40,7 +39,7 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And it prints:
       """
-      Ran 26 shell commands.
+      Ran 25 shell commands.
       """
     And the current branch is now "main"
     And the branches are now

--- a/features/sync/current_branch/feature_branch/tracking_branch_deleted/tracking_branch_shipped.feature
+++ b/features/sync/current_branch/feature_branch/tracking_branch_deleted/tracking_branch_shipped.feature
@@ -23,7 +23,7 @@ Feature: sync a branch whose tracking branch was shipped
       |           | git checkout feature-1   |
       | feature-1 | git merge --no-edit main |
       |           | git checkout main        |
-      | main      | git branch -d feature-1  |
+      | main      | git branch -D feature-1  |
       |           | git stash pop            |
     And it prints:
       """

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -191,7 +191,7 @@ func killFeatureBranch(prog *program.Program, finalUndoProgram *program.Program,
 		}
 		prog.Add(&opcodes.Checkout{Branch: config.branchWhenDone})
 	}
-	prog.Add(&opcodes.DeleteLocalBranch{Branch: config.branchToKill.LocalName, Force: false})
+	prog.Add(&opcodes.DeleteLocalBranch{Branch: config.branchToKill.LocalName})
 	if !config.dryRun {
 		sync.RemoveBranchFromLineage(sync.RemoveBranchFromLineageArgs{
 			Branch:  config.branchToKill.LocalName,

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -194,7 +194,7 @@ func renameBranchProgram(config *renameBranchConfig) program.Program {
 		result.Add(&opcodes.CreateTrackingBranch{Branch: config.newBranch})
 		result.Add(&opcodes.DeleteTrackingBranch{Branch: config.oldBranch.RemoteName})
 	}
-	result.Add(&opcodes.DeleteLocalBranch{Branch: config.oldBranch.LocalName, Force: false})
+	result.Add(&opcodes.DeleteLocalBranch{Branch: config.oldBranch.LocalName})
 	cmdhelpers.Wrap(&result, cmdhelpers.WrapOptions{
 		DryRun:                   config.dryRun,
 		RunInGitRoot:             false,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -317,7 +317,7 @@ func shipProgram(config *shipConfig, commitMessage string) program.Program {
 			prog.Add(&opcodes.DeleteTrackingBranch{Branch: config.branchToShip.RemoteName})
 		}
 	}
-	prog.Add(&opcodes.DeleteLocalBranch{Branch: config.branchToShip.LocalName, Force: false})
+	prog.Add(&opcodes.DeleteLocalBranch{Branch: config.branchToShip.LocalName})
 	if !config.dryRun {
 		prog.Add(&opcodes.DeleteParentBranch{Branch: config.branchToShip.LocalName})
 	}

--- a/src/git/backend_commands.go
+++ b/src/git/backend_commands.go
@@ -78,16 +78,6 @@ func (self *BackendCommands) BranchHasUnmergedChanges(branch, parent gitdomain.L
 	return out != "", nil
 }
 
-// BranchHasUnmergedCommits indicates whether the branch with the given name
-// contains commits that are not merged into the main branch.
-func (self *BackendCommands) BranchHasUnmergedCommits(branch gitdomain.LocalBranchName, parent gitdomain.Location) (bool, error) {
-	out, err := self.Runner.QueryTrim("git", "log", parent.String()+".."+branch.String())
-	if err != nil {
-		return false, fmt.Errorf(messages.BranchDiffProblem, branch, err)
-	}
-	return out != "", nil
-}
-
 // BranchesSnapshot provides detailed information about the sync status of all branches.
 func (self *BackendCommands) BranchesSnapshot() (gitdomain.BranchesSnapshot, error) { //nolint:nonamedreturns
 	output, err := self.Runner.Query("git", "branch", "-vva")

--- a/src/git/backend_commands_test.go
+++ b/src/git/backend_commands_test.go
@@ -82,49 +82,6 @@ func TestBackendCommands(t *testing.T) {
 		})
 	})
 
-	t.Run("BranchHasUnmergedCommits", func(t *testing.T) {
-		t.Parallel()
-		t.Run("branch without commits", func(t *testing.T) {
-			t.Parallel()
-			runtime := testruntime.Create(t)
-			branch := gitdomain.NewLocalBranchName("branch")
-			runtime.CreateBranch(branch, initial)
-			have, err := runtime.Backend.BranchHasUnmergedCommits(branch, initial.Location())
-			must.NoError(t, err)
-			must.False(t, have)
-		})
-		t.Run("branch with commits", func(t *testing.T) {
-			t.Parallel()
-			runtime := testruntime.Create(t)
-			runtime.CreateCommit(testgit.Commit{
-				Branch:      initial,
-				FileContent: "original content",
-				FileName:    "file1",
-				Message:     "commit 1",
-			})
-			branch := gitdomain.NewLocalBranchName("branch")
-			runtime.CreateBranch(branch, initial)
-			runtime.CreateCommit(testgit.Commit{
-				Branch:      branch,
-				FileContent: "modified content",
-				FileName:    "file1",
-				Message:     "commit 2",
-			})
-			have, err := runtime.Backend.BranchHasUnmergedCommits(branch, initial.Location())
-			must.NoError(t, err)
-			must.True(t, have, must.Sprint("branch with commits that make changes"))
-			runtime.CreateCommit(testgit.Commit{
-				Branch:      branch,
-				FileContent: "original content",
-				FileName:    "file1",
-				Message:     "commit 3",
-			})
-			have, err = runtime.Backend.BranchHasUnmergedCommits(branch, initial.Location())
-			must.NoError(t, err)
-			must.True(t, have, must.Sprint("branch with commits that make no changes"))
-		})
-	})
-
 	t.Run("CheckoutBranch", func(t *testing.T) {
 		t.Parallel()
 		runtime := testruntime.Create(t)

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -114,11 +114,8 @@ func (self *FrontendCommands) DeleteLastCommit() error {
 }
 
 // DeleteLocalBranch removes the local branch with the given name.
-func (self *FrontendCommands) DeleteLocalBranch(name gitdomain.LocalBranchName, force bool) error {
-	args := []string{"branch", "-d", name.String()}
-	if force {
-		args[1] = "-D"
-	}
+func (self *FrontendCommands) DeleteLocalBranch(name gitdomain.LocalBranchName) error {
+	args := []string{"branch", "-D", name.String()}
 	return self.Runner.Run("git", args...)
 }
 

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -115,8 +115,7 @@ func (self *FrontendCommands) DeleteLastCommit() error {
 
 // DeleteLocalBranch removes the local branch with the given name.
 func (self *FrontendCommands) DeleteLocalBranch(name gitdomain.LocalBranchName) error {
-	args := []string{"branch", "-D", name.String()}
-	return self.Runner.Run("git", args...)
+	return self.Runner.Run("git", "branch", "-D", name.String())
 }
 
 // DeleteOriginHostname removes the origin hostname override

--- a/src/sync/sync_deleted_branch.go
+++ b/src/sync/sync_deleted_branch.go
@@ -35,9 +35,6 @@ func syncDeletedPerennialBranchProgram(list *program.Program, branch gitdomain.B
 	})
 	list.Add(&opcodes.RemoveFromPerennialBranches{Branch: branch.LocalName})
 	list.Add(&opcodes.Checkout{Branch: args.Config.MainBranch})
-	list.Add(&opcodes.DeleteLocalBranch{
-		Branch: branch.LocalName,
-		Force:  false,
-	})
+	list.Add(&opcodes.DeleteLocalBranch{Branch: branch.LocalName})
 	list.Add(&opcodes.QueueMessage{Message: fmt.Sprintf(messages.BranchDeleted, branch.LocalName)})
 }

--- a/src/undo/undobranches/branch_changes.go
+++ b/src/undo/undobranches/branch_changes.go
@@ -167,10 +167,7 @@ func (self BranchChanges) UndoProgram(args BranchChangesUndoProgramArgs) program
 		if args.EndBranch == addedLocalBranch {
 			result.Add(&opcodes.Checkout{Branch: args.BeginBranch})
 		}
-		result.Add(&opcodes.DeleteLocalBranch{
-			Branch: addedLocalBranch,
-			Force:  true,
-		})
+		result.Add(&opcodes.DeleteLocalBranch{Branch: addedLocalBranch})
 	}
 
 	// Ignore remotely changed perennial branches because we can't force-push to them

--- a/src/undo/undobranches/branch_changes_test.go
+++ b/src/undo/undobranches/branch_changes_test.go
@@ -83,10 +83,7 @@ func TestChanges(t *testing.T) {
 		})
 		wantProgram := program.Program{
 			&opcodes.Checkout{Branch: gitdomain.NewLocalBranchName("main")},
-			&opcodes.DeleteLocalBranch{
-				Branch: gitdomain.NewLocalBranchName("branch-1"),
-				Force:  true,
-			},
+			&opcodes.DeleteLocalBranch{Branch: gitdomain.NewLocalBranchName("branch-1")},
 			&opcodes.CheckoutIfExists{Branch: gitdomain.NewLocalBranchName("main")},
 		}
 		must.Eq(t, wantProgram, haveProgram)
@@ -402,14 +399,8 @@ func TestChanges(t *testing.T) {
 			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
-			&opcodes.DeleteLocalBranch{
-				Branch: gitdomain.NewLocalBranchName("perennial-branch"),
-				Force:  true,
-			},
-			&opcodes.DeleteLocalBranch{
-				Branch: gitdomain.NewLocalBranchName("feature-branch"),
-				Force:  true,
-			},
+			&opcodes.DeleteLocalBranch{Branch: gitdomain.NewLocalBranchName("perennial-branch")},
+			&opcodes.DeleteLocalBranch{Branch: gitdomain.NewLocalBranchName("feature-branch")},
 			&opcodes.CheckoutIfExists{Branch: gitdomain.NewLocalBranchName("main")},
 		}
 		must.Eq(t, wantProgram, haveProgram)
@@ -482,15 +473,9 @@ func TestChanges(t *testing.T) {
 			&opcodes.DeleteTrackingBranch{
 				Branch: gitdomain.NewRemoteBranchName("origin/feature-branch"),
 			},
-			&opcodes.DeleteLocalBranch{
-				Branch: gitdomain.NewLocalBranchName("perennial-branch"),
-				Force:  true,
-			},
+			&opcodes.DeleteLocalBranch{Branch: gitdomain.NewLocalBranchName("perennial-branch")},
 			&opcodes.Checkout{Branch: gitdomain.NewLocalBranchName("main")},
-			&opcodes.DeleteLocalBranch{
-				Branch: gitdomain.NewLocalBranchName("feature-branch"),
-				Force:  true,
-			},
+			&opcodes.DeleteLocalBranch{Branch: gitdomain.NewLocalBranchName("feature-branch")},
 			&opcodes.CheckoutIfExists{Branch: gitdomain.NewLocalBranchName("main")},
 		}
 		must.Eq(t, wantProgram, haveProgram)

--- a/src/vm/opcodes/delete_branch_if_empty_at_runtime.go
+++ b/src/vm/opcodes/delete_branch_if_empty_at_runtime.go
@@ -27,10 +27,7 @@ func (self *DeleteBranchIfEmptyAtRuntime) Run(args shared.RunArgs) error {
 	} else {
 		args.PrependOpcodes(
 			&CheckoutParent{CurrentBranch: self.Branch},
-			&DeleteLocalBranch{
-				Branch: self.Branch,
-				Force:  false,
-			},
+			&DeleteLocalBranch{Branch: self.Branch},
 			&RemoveBranchFromLineage{
 				Branch: self.Branch,
 			},

--- a/src/vm/opcodes/delete_local_branch.go
+++ b/src/vm/opcodes/delete_local_branch.go
@@ -8,21 +8,9 @@ import (
 // DeleteLocalBranch deletes the branch with the given name.
 type DeleteLocalBranch struct {
 	Branch gitdomain.LocalBranchName
-	Force  bool
 	undeclaredOpcodeMethods
 }
 
 func (self *DeleteLocalBranch) Run(args shared.RunArgs) error {
-	useForce := self.Force
-	if !useForce {
-		parent := args.Lineage.Parent(self.Branch)
-		hasUnmergedCommits, err := args.Runner.Backend.BranchHasUnmergedCommits(self.Branch, parent.Location())
-		if err != nil {
-			return err
-		}
-		if hasUnmergedCommits {
-			useForce = true
-		}
-	}
-	return args.Runner.Frontend.DeleteLocalBranch(self.Branch, useForce)
+	return args.Runner.Frontend.DeleteLocalBranch(self.Branch)
 }

--- a/src/vm/statefile/save_load_test.go
+++ b/src/vm/statefile/save_load_test.go
@@ -76,10 +76,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.CreateTrackingBranch{
 					Branch: gitdomain.NewLocalBranchName("branch"),
 				},
-				&opcodes.DeleteLocalBranch{
-					Branch: gitdomain.NewLocalBranchName("branch"),
-					Force:  false,
-				},
+				&opcodes.DeleteLocalBranch{Branch: gitdomain.NewLocalBranchName("branch")},
 				&opcodes.DeleteParentBranch{
 					Branch: gitdomain.NewLocalBranchName("branch"),
 				},
@@ -270,8 +267,7 @@ func TestLoadSave(t *testing.T) {
     },
     {
       "data": {
-        "Branch": "branch",
-        "Force": false
+        "Branch": "branch"
       },
       "type": "DeleteLocalBranch"
     },

--- a/test/datatable/data_table_test.go
+++ b/test/datatable/data_table_test.go
@@ -72,8 +72,7 @@ func TestDataTable(t *testing.T) {
 		table.AddRow("old", "frontend", "git merge --no-edit main")
 		table.AddRow("", "backend", "git diff main..old")
 		table.AddRow("old", "frontend", "git checkout main")
-		table.AddRow("", "backend", "git log main..old")
-		table.AddRow("main", "frontend", "git branch -d old")
+		table.AddRow("main", "frontend", "git branch -D old")
 		table.AddRow("", "backend", "git config git-town.perennial-branches")
 		table.AddRow("", "backend", "git show-ref --quiet refs/heads/main")
 		table.AddRow("", "backend", "git show-ref --quiet refs/heads/old")
@@ -101,8 +100,7 @@ func TestDataTable(t *testing.T) {
 | old    | frontend | git merge --no-edit main                  |
 |        | backend  | git diff main..old                        |
 | old    | frontend | git checkout main                         |
-|        | backend  | git log main..old                         |
-| main   | frontend | git branch -d old                         |
+| main   | frontend | git branch -D old                         |
 |        | backend  | git config git-town.perennial-branches    |
 |        | backend  | git show-ref --quiet refs/heads/main      |
 |        | backend  | git show-ref --quiet refs/heads/old       |


### PR DESCRIPTION
It was nice and ambitious that we tried to do a normal delete where that's possible. There are just too many edge cases where our detection doesn't work reliably. The extra checks from doing a non-force delete never apply to Git Town because Git Town is already automation that verifies that the branch should be deleted. If Git Town wants to delete a branch, it is clear that this branch needs to go. Failure here isn't a helpful signal. So let's simplify this.

resolves #3097