### PR TITLE
Fix link to Gitea token config in `git ship` docs

### DIFF
--- a/website/src/commands/ship.md
+++ b/website/src/commands/ship.md
@@ -20,10 +20,10 @@ via the CLI.
 
 If you have configured the API tokens for
 [GitHub](../preferences/github-token.md),
-[GitLab](../preferences/gitlab-token.md), or [Gitea](../preferences/gitea-toke
-and the branch to be shipped has an open proposal, this command merges the
-proposal for the current branch on your origin server rather than on the local
-Git workspace.
+[GitLab](../preferences/gitlab-token.md),
+or [Gitea](../preferences/gitea-token.md) and the branch to be shipped has an
+open proposal, this command merges the proposal for the current branch on your
+origin server rather than on the local Git workspace.
 
 If your origin server deletes shipped branches, for example
 [GitHub's feature to automatically delete head branches](https://help.github.com/en/github/administering-a-repository/managing-the-automatic-deletion-of-branches),


### PR DESCRIPTION
The link to the documentation for setting the Gitea token was previously truncated, leading to:

<img width="816" alt="Screenshot 2024-03-02 at 08 34 18" src="https://github.com/git-town/git-town/assets/5845679/139c4a49-97a7-4de1-8c58-2717b4a396d1">
