### PR TITLE
fix wrong install path in install.sh

### DIFF
--- a/website/src/install.sh
+++ b/website/src/install.sh
@@ -83,7 +83,7 @@ download_url() {
 		CPU=intel_64
 		EXT=zip
 	fi
-	echo "https://github.com/git-town/git-town/releases/download/v${VERSION}/git-town_${VERSION}_${OS}_${CPU}.${EXT}"
+	echo "https://github.com/git-town/git-town/releases/download/v${VERSION}/git-town_${OS}_${CPU}.${EXT}"
 }
 
 download_and_extract() {


### PR DESCRIPTION
- fixes https://github.com/git-town/git-town/issues/3233
The download path seems wrong this pr fixes it.

However, after running the script. I am getting this error:

```bash
> git town config setup
git: 'town' is not a git command. See 'git --help'.

The most similar command is
        notes
```