### PR TITLE
More accurate test commit SHA handling

### DIFF
--- a/src/git/gitdomain/shas.go
+++ b/src/git/gitdomain/shas.go
@@ -4,8 +4,24 @@ import "strings"
 
 type SHAs []SHA
 
+func NewSHAs(ids ...string) SHAs {
+	result := make(SHAs, len(ids))
+	for i, id := range ids {
+		result[i] = NewSHA(id)
+	}
+	return result
+}
+
+func (self SHAs) First() SHA {
+	return self[0]
+}
+
 func (self SHAs) Join(sep string) string {
 	return strings.Join(self.Strings(), sep)
+}
+
+func (self SHAs) Last() SHA {
+	return self[len(self)]
 }
 
 func (self SHAs) Strings() []string {

--- a/src/git/gitdomain/shas.go
+++ b/src/git/gitdomain/shas.go
@@ -21,7 +21,7 @@ func (self SHAs) Join(sep string) string {
 }
 
 func (self SHAs) Last() SHA {
-	return self[len(self)]
+	return self[len(self)-1]
 }
 
 func (self SHAs) Strings() []string {

--- a/src/git/gitdomain/shas_test.go
+++ b/src/git/gitdomain/shas_test.go
@@ -10,6 +10,17 @@ import (
 func TestSHAs(t *testing.T) {
 	t.Parallel()
 
+	t.Run("NewSHAs", func(t *testing.T) {
+		t.Parallel()
+		have := gitdomain.NewSHAs("111111", "222222", "333333")
+		want := gitdomain.SHAs{
+			gitdomain.SHA("111111"),
+			gitdomain.SHA("222222"),
+			gitdomain.SHA("333333"),
+		}
+		must.Eq(t, want, have)
+	})
+
 	t.Run("Join", func(t *testing.T) {
 		t.Parallel()
 		t.Run("contains elements", func(t *testing.T) {

--- a/src/git/gitdomain/shas_test.go
+++ b/src/git/gitdomain/shas_test.go
@@ -50,6 +50,24 @@ func TestSHAs(t *testing.T) {
 		})
 	})
 
+	t.Run("Last", func(t *testing.T) {
+		t.Parallel()
+		t.Run("multiple elements", func(t *testing.T) {
+			t.Parallel()
+			shas := gitdomain.NewSHAs("111111", "222222")
+			have := shas.Last()
+			want := shas[1]
+			must.Eq(t, want, have)
+		})
+		t.Run("one element", func(t *testing.T) {
+			t.Parallel()
+			shas := gitdomain.NewSHAs("111111")
+			have := shas.Last()
+			want := shas[0]
+			must.Eq(t, want, have)
+		})
+	})
+
 	t.Run("Strings", func(t *testing.T) {
 		t.Parallel()
 		t.Run("contains elements", func(t *testing.T) {

--- a/src/git/gitdomain/shas_test.go
+++ b/src/git/gitdomain/shas_test.go
@@ -21,6 +21,14 @@ func TestSHAs(t *testing.T) {
 		must.Eq(t, want, have)
 	})
 
+	t.Run("First", func(t *testing.T) {
+		t.Parallel()
+		shas := gitdomain.NewSHAs("111111", "222222")
+		have := shas.First()
+		want := shas[0]
+		must.Eq(t, want, have)
+	})
+
 	t.Run("Join", func(t *testing.T) {
 		t.Parallel()
 		t.Run("contains elements", func(t *testing.T) {

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -394,12 +394,13 @@ func (self *TestCommands) RemoveUnnecessaryFiles() {
 }
 
 // SHAForCommit provides the SHA for the commit with the given name.
-func (self *TestCommands) SHAForCommit(name string) gitdomain.SHA {
+func (self *TestCommands) SHAsForCommit(name string) gitdomain.SHAs {
 	output := self.MustQuery("git", "log", "--reflog", "--format=%h", "--grep=^"+name+"$")
 	if output == "" {
 		panic(fmt.Sprintf("cannot find the SHA of commit %q", name))
 	}
-	return gitdomain.NewSHA(strings.Split(output, "\n")[0])
+	parts := strings.Split(output, "\n")
+	return gitdomain.NewSHAs(parts...)
 }
 
 // SetColorUI configures whether Git output contains color codes.

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -399,8 +399,7 @@ func (self *TestCommands) SHAsForCommit(name string) gitdomain.SHAs {
 	if output == "" {
 		panic(fmt.Sprintf("cannot find the SHA of commit %q", name))
 	}
-	parts := strings.Split(output, "\n")
-	return gitdomain.NewSHAs(parts...)
+	return gitdomain.NewSHAs(strings.Split(output, "\n")...)
 }
 
 // SetColorUI configures whether Git output contains color codes.

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -387,7 +387,9 @@ func TestTestCommands(t *testing.T) {
 			FileName:    "foo",
 			Message:     "commit",
 		})
-		sha := repo.SHAForCommit("commit")
+		shas := repo.SHAsForCommit("commit")
+		must.EqOp(t, 1, len(shas))
+		sha := shas.First()
 		must.EqOp(t, 7, len(sha))
 	})
 

--- a/test/datatable/core.go
+++ b/test/datatable/core.go
@@ -3,5 +3,5 @@ package datatable
 import "github.com/git-town/git-town/v13/src/git/gitdomain"
 
 type runner interface {
-	SHAForCommit(name string) gitdomain.SHA
+	SHAsForCommit(name string) gitdomain.SHAs
 }

--- a/test/datatable/data_table.go
+++ b/test/datatable/data_table.go
@@ -79,11 +79,13 @@ func (self *DataTable) Expand(localRepo runner, remoteRepo runner, worktreeRepo 
 				switch {
 				case strings.HasPrefix(match, "{{ sha "):
 					commitName := match[8 : len(match)-4]
-					sha := localRepo.SHAForCommit(commitName)
+					shas := localRepo.SHAsForCommit(commitName)
+					sha := shas.First()
 					cell = strings.Replace(cell, match, sha.String(), 1)
 				case strings.HasPrefix(match, "{{ sha-in-origin "):
 					commitName := match[18 : len(match)-4]
-					sha := remoteRepo.SHAForCommit(commitName)
+					shas := remoteRepo.SHAsForCommit(commitName)
+					sha := shas.First()
 					cell = strings.Replace(cell, match, sha.String(), 1)
 				case strings.HasPrefix(match, "{{ sha-before-run "):
 					commitName := match[19 : len(match)-4]
@@ -110,7 +112,8 @@ func (self *DataTable) Expand(localRepo runner, remoteRepo runner, worktreeRepo 
 					cell = strings.Replace(cell, match, sha.String(), 1)
 				case strings.HasPrefix(match, "{{ sha-in-worktree "):
 					commitName := match[20 : len(match)-4]
-					sha := worktreeRepo.SHAForCommit(commitName)
+					shas := worktreeRepo.SHAsForCommit(commitName)
+					sha := shas.First()
 					cell = strings.Replace(cell, match, sha.String(), 1)
 				case strings.HasPrefix(match, "{{ sha-in-worktree-before-run "):
 					commitName := match[31 : len(match)-4]


### PR DESCRIPTION
Expose the fact that there are multiple commits that have the same commit message to the client, and let the client decide which one to use.