### PR TITLE
Hide half-finished compress command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,8 @@ This guide is for maintainers who make releases of Git Town.
   - update CHANGELOG.md
   - run `make stats-release` and copy the release stats and contributors into
     CHANGELOG.md
+  - verify that all newly added Git Town commands that might have been hidden
+    during development are not hidden anymore
   - verify that the website content reflects all the changes made
   - search-and-replace the old version with the new version
     - triple-digits: `13.0.1`

--- a/src/cmd/compress.go
+++ b/src/cmd/compress.go
@@ -28,10 +28,11 @@ func compressCmd() *cobra.Command {
 	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
 	cmd := cobra.Command{
-		Use:   "compress",
-		Args:  cobra.NoArgs,
-		Short: compressDesc,
-		Long:  cmdhelpers.Long(compressDesc, compressHelp),
+		Use:    "compress",
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		Short:  compressDesc,
+		Long:   cmdhelpers.Long(compressDesc, compressHelp),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return executeCompress(args, readDryRunFlag(cmd), readVerboseFlag(cmd))
 		},


### PR DESCRIPTION
This should be a best practice anyways. In this case it helps make a hotfix release for #3241.