### PR TITLE
Add alternative in wiki for UI based ships

### DIFF
--- a/website/src/stacked-changes.md
+++ b/website/src/stacked-changes.md
@@ -151,6 +151,10 @@ main
     3-rename-bar
 ```
 
+If you ship feature branches via the code hosting API or web UI, run
+`git sync --all` or `git sync` on the youngest child branch to update the
+lineage.
+
 ## Synchronizing our work with the rest of the world
 
 We have been at it for a while. Other developers on the team have made changes


### PR DESCRIPTION
Adding a small line of context inside the https://www.git-town.com/stacked-changes#shipping-the-refactor wiki, as it caused  some confusion for some people in our repository.

I checked out the [development wiki](https://github.com/git-town/git-town/blob/main/DEVELOPMENT.md) and tested the changes on the local development server (see image attached below) and ran `make fix`. Please let me know if any other steps are required.
<img width="785" alt="Screenshot 2024-04-02 at 7 56 17 PM" src="https://github.com/git-town/git-town/assets/152143503/e9f1f453-4f14-42fa-8c51-b66900c42844">

Thanks for maintaining such a great tool 🙏 