### PR TITLE
Store the initial commits as a DataTable instead of a Gherkin table

### DIFF
--- a/test/cucumber/scenario_state.go
+++ b/test/cucumber/scenario_state.go
@@ -18,7 +18,7 @@ type ScenarioState struct {
 	fixture fixture.Fixture
 
 	// initialCommits describes the commits in this Git environment before the WHEN steps ran.
-	initialCommits *messages.PickleStepArgument_PickleTable
+	initialCommits *datatable.DataTable
 
 	// initialCurrentBranch contains the name of the branch that was checked out before the WHEN steps ran
 	initialCurrentBranch gitdomain.LocalBranchName
@@ -104,7 +104,7 @@ func (self *ScenarioState) Reset(gitEnv fixture.Fixture) {
 
 // compareExistingCommits compares the commits in the Git environment of the given ScenarioState
 // against the given Gherkin table.
-func (self *ScenarioState) compareTable(table *messages.PickleStepArgument_PickleTable) error {
+func (self *ScenarioState) compareGherkinTable(table *messages.PickleStepArgument_PickleTable) error {
 	fields := helpers.TableFields(table)
 	commitTable := self.fixture.CommitTable(fields)
 	diff, errorCount := commitTable.EqualGherkin(table)


### PR DESCRIPTION
This format is more generic and paves the road to determining the initial commits in other ways besides the one commit table, which doesn't work for commit stacks.