### PR TITLE
Load initial commits when not defined via table

### DIFF
--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -579,7 +579,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^I (?:run|ran) "(.+)"$`, func(command string) error {
-		if state.initialCommits == nil {
+		if state.initialCommits == nil && state.insideGitRepo {
 			currentCommits := state.fixture.CommitTable([]string{"BRANCH", "LOCATION", "MESSAGE", "FILE NAME", "FILE CONTENT"})
 			state.initialCommits = &currentCommits
 		}

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -579,6 +579,9 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^I (?:run|ran) "(.+)"$`, func(command string) error {
+		if state.initialCommits == nil {
+			state.initialCommits = state.fixture.CommitTable([]string{"BRANCH", "LOCATION", "MESSAGE", "FILE NAME", "FILE CONTENT"})
+		}
 		updateInitialSHAs(state)
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCode(command)
 		state.fixture.DevRepo.Config.Reload()

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -579,7 +579,7 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 	})
 
 	suite.Step(`^I (?:run|ran) "(.+)"$`, func(command string) error {
-		if state.initialCommits == nil && state.insideGitRepo {
+		if state.initialCommits == nil && state.insideGitRepo && state.fixture.SubmoduleRepo == nil {
 			currentCommits := state.fixture.CommitTable([]string{"BRANCH", "LOCATION", "MESSAGE", "FILE NAME", "FILE CONTENT"})
 			state.initialCommits = &currentCommits
 		}

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -580,7 +580,8 @@ func Steps(suite *godog.Suite, state *ScenarioState) {
 
 	suite.Step(`^I (?:run|ran) "(.+)"$`, func(command string) error {
 		if state.initialCommits == nil {
-			state.initialCommits = state.fixture.CommitTable([]string{"BRANCH", "LOCATION", "MESSAGE", "FILE NAME", "FILE CONTENT"})
+			currentCommits := state.fixture.CommitTable([]string{"BRANCH", "LOCATION", "MESSAGE", "FILE NAME", "FILE CONTENT"})
+			state.initialCommits = &currentCommits
 		}
 		updateInitialSHAs(state)
 		state.runOutput, state.runExitCode = state.fixture.DevRepo.MustQueryStringCode(command)

--- a/website/src/stacked-changes.md
+++ b/website/src/stacked-changes.md
@@ -152,7 +152,7 @@ main
 ```
 
 If you ship feature branches via the code hosting API or web UI, run
-`git sync --all` or `git sync` on the youngest child branch to update the
+`git sync --all`, or `git sync` on the youngest child branch, to update the
 lineage.
 
 ## Synchronizing our work with the rest of the world


### PR DESCRIPTION
Upcoming end-to-end tests for stacked changes cannot use the initial commit table format and therefore need to load the initial commits from the repo before the first Git Town command is run.