### PR TITLE
Fix zsh completion command

### DIFF
--- a/website/src/commands/completions.md
+++ b/website/src/commands/completions.md
@@ -19,7 +19,7 @@ To load completions for each session, add the above line to your `.bashrc`.
 To load autocompletions for Zsh, run this command:
 
 ```
-git-town completions zsh | source
+source <(git-town completions zsh)
 ```
 
 To load completions for each session, add the above line to your `.zshrc`.


### PR DESCRIPTION
Zsh's `source` command does not work with pipes. Instead, one has to use process substitution to supply the autocompletion script. See [this StackOverflow question](https://unix.stackexchange.com/questions/176873/feed-source-command-with-a-pipe).