### PR TITLE
Fix year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2018 the Git Town creators
+Copyright (c) 2014-2024 the Git Town creators
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright year in the installer felt wrong. Thus, I updated it.

![image](https://github.com/git-town/git-town/assets/1366654/d0921a75-be47-4d28-9997-4dd3c0f007a6)
