### PR TITLE
Add end-to-end test for git switch -m

### DIFF
--- a/features/switch/abort.feature
+++ b/features/switch/abort.feature
@@ -4,7 +4,7 @@ Feature: switch branches
     Given the current branch is a feature branch "alpha"
     And a feature branch "beta"
     When I run "git-town switch" and enter into the dialogs:
-      | DIALOG  | KEYS     |
-      | welcome | down esc |
+      | KEYS     |
+      | down esc |
     Then it runs no commands
     And the current branch is still "alpha"

--- a/features/switch/merge_flag.feature
+++ b/features/switch/merge_flag.feature
@@ -4,8 +4,8 @@ Feature: switch branches
     Given the current branch is a feature branch "current"
     And a feature branch "other"
     And the commits
-      | BRANCH | LOCATION      | MESSAGE      |
-      | other  | local, origin | other commit |
+      | BRANCH | LOCATION | MESSAGE      |
+      | other  | local    | other commit |
     And an uncommitted file
     When I run "git-town switch -m" and enter into the dialogs:
       | KEYS       |

--- a/features/switch/merge_flag.feature
+++ b/features/switch/merge_flag.feature
@@ -1,6 +1,6 @@
 Feature: switch branches
 
-  Scenario: switching to another branch with conflicting open changes
+  Scenario: switching to another branch while merging open changes
     Given the current branch is a feature branch "current"
     And a feature branch "other"
     And the commits

--- a/features/switch/merge_flag.feature
+++ b/features/switch/merge_flag.feature
@@ -1,0 +1,16 @@
+Feature: switch branches
+
+  Scenario: switching to another branch with conflicting open changes
+    Given the current branch is a feature branch "current"
+    And a feature branch "other"
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE      |
+      | other  | local, origin | other commit |
+    And an uncommitted file
+    When I run "git-town switch -m" and enter into the dialogs:
+      | DIALOG | KEYS       |
+      |        | down enter |
+    Then it runs the commands
+      | BRANCH  | COMMAND               |
+      | current | git checkout other -m |
+    And the current branch is now "other"

--- a/features/switch/merge_flag.feature
+++ b/features/switch/merge_flag.feature
@@ -1,6 +1,5 @@
 Feature: switch branches
 
-  @this
   Scenario: switching to another branch while merging open changes
     Given the current branch is a feature branch "current"
     And a feature branch "other"

--- a/features/switch/merge_flag.feature
+++ b/features/switch/merge_flag.feature
@@ -1,5 +1,6 @@
 Feature: switch branches
 
+  @this
   Scenario: switching to another branch while merging open changes
     Given the current branch is a feature branch "current"
     And a feature branch "other"
@@ -8,8 +9,8 @@ Feature: switch branches
       | other  | local, origin | other commit |
     And an uncommitted file
     When I run "git-town switch -m" and enter into the dialogs:
-      | DIALOG | KEYS       |
-      |        | down enter |
+      | KEYS       |
+      | down enter |
     Then it runs the commands
       | BRANCH  | COMMAND               |
       | current | git checkout other -m |

--- a/features/switch/stay_on_branch.feature
+++ b/features/switch/stay_on_branch.feature
@@ -4,8 +4,8 @@ Feature: stay on the same branch
     Given the current branch is a feature branch "alpha"
     And a feature branch "beta"
     When I run "git-town switch" and enter into the dialogs:
-      | DIALOG | KEYS  |
-      |        | enter |
+      | KEYS  |
+      | enter |
     Then it runs the commands
       | BRANCH | COMMAND |
     And the current branch is still "alpha"

--- a/features/switch/switch_branches.feature
+++ b/features/switch/switch_branches.feature
@@ -4,8 +4,8 @@ Feature: switch branches
     Given the current branch is a feature branch "alpha"
     And a feature branch "beta"
     When I run "git-town switch" and enter into the dialogs:
-      | DIALOG  | KEYS       |
-      | welcome | down enter |
+      | KEYS       |
+      | down enter |
     Then it runs the commands
       | BRANCH | COMMAND           |
       | alpha  | git checkout beta |

--- a/src/cli/flags/switch_merge.go
+++ b/src/cli/flags/switch_merge.go
@@ -1,42 +1,6 @@
 package flags
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-)
-
-const (
-	mergeMessageLong  = "merge"
-	mergeMessageShort = "m"
-	mergeDesc         = `When switching branches, if you have local modifications to one or more files that are different between the current branch and the branch to which you are switching, the command refuses to switch branches in order to preserve your modifications in context. However,
-with this option, a three-way merge between the current branch, your working tree contents, and the new branch is done, and you will be on the new branch.`
-)
-
-// SwitchMerge returns two functions: addFlag and readFlag.
-// addFlag is a function that takes a *cobra.Command argument and adds a bool flag
-// with the long name "merge" and short name "m" to the command's persistent flags.
-// The flag's default value is false and it has a description defined by the
-// constant mergeDesc.
-// readFlag is a function that takes a *cobra.Command argument and returns
-// the boolean value for the "merge" flag. It uses the GetBool method of the command's flags
-// to retrieve the value and panics if there is an error or if the flag is not found.
-// The returned boolean value indicates whether the flag is set or not.
-func SwitchMerge() (AddFunc, ReadSwitchMergeFlagFunc) {
-	addFlag := func(cmd *cobra.Command) {
-		cmd.PersistentFlags().BoolP(mergeMessageLong, mergeMessageShort, false, mergeDesc)
-	}
-	readFlag := func(cmd *cobra.Command) bool {
-		value, err := cmd.Flags().GetBool(mergeMessageLong)
-		if err != nil {
-			panic(fmt.Sprintf("command %q does not have a string %q flag", cmd.Name(), mergeMessageLong))
-		}
-		return value
-	}
-	return addFlag, readFlag
+// SwitchMerge provides type-safe access to the CLI arguments of type gitdomain.ReadSwitchMergeFlagFunc.
+func SwitchMerge() (AddFunc, ReadBoolFlagFunc) {
+	return Bool("merge", "m", "merge uncommitted changes into the target branch", FlagTypePersistent)
 }
-
-// ReadSwitchMergeFlagFunc represents a function type that takes a *cobra.Command
-// argument and returns a boolean value. The function is used to read a switch
-// or merge flag from the command and determine whether it is set or not.
-type ReadSwitchMergeFlagFunc func(*cobra.Command) bool

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -22,7 +22,7 @@ func switchCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:     "switch",
 		GroupID: "basic",
-		Args:    cobra.ArbitraryArgs,
+		Args:    cobra.NoArgs,
 		Short:   switchDesc,
 		Long:    cmdhelpers.Long(switchDesc),
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -57,11 +57,7 @@ func executeSwitch(verbose, merge bool) error {
 	if branchToCheckout == config.initialBranch {
 		return nil
 	}
-	if merge {
-		err = repo.Runner.Frontend.CheckoutBranch(branchToCheckout, true)
-	} else {
-		err = repo.Runner.Frontend.CheckoutBranch(branchToCheckout, false)
-	}
+	err = repo.Runner.Frontend.CheckoutBranch(branchToCheckout, merge)
 	if err != nil {
 		exitCode := 1
 		var exitErr *exec.ExitError

--- a/src/git/frontend_commands.go
+++ b/src/git/frontend_commands.go
@@ -35,22 +35,8 @@ func (self *FrontendCommands) AbortRebase() error {
 	return self.Runner.Run("git", "rebase", "--abort")
 }
 
-// CheckoutBranch checks out the given local branch name and optionally performs a merge.
-// It runs the git checkout command with the branch name as well as an optional -m flag if merge is true.
-// After the checkout, it sets the cached current branch to the given name.
-// If any error occurs during the checkout, it returns an error with a formatted error message.
-// Error message format is defined in messages.BranchCheckoutProblem.
-// Args:
-// - name: The local branch name to be checked out.
-// - merge: A boolean flag indicating whether to perform a merge after the checkout.
-// Returns:
-// - error: If the checkout is unsuccessful, it returns an error with formatted error message.
-// Example usage:
-//
-//	err := frontendCommands.checkoutBranch(branchName, true)
-//	if err != nil {
-//	  log.Error(err)
-//	}
+// CheckoutBranch checks out the Git branch with the given name in this repo,
+// optionally using a three-way merge.
 func (self *FrontendCommands) CheckoutBranch(name gitdomain.LocalBranchName, merge bool) error {
 	args := []string{"checkout", name.String()}
 	if merge {


### PR DESCRIPTION
part of #3321

I added end-to-end tests for git switch yesterday. This PR adds the missing test for the -m switch that was contributed yesterday as well.