### PR TITLE
Remove obsolete TODO

### DIFF
--- a/src/vm/interpreter/config/finished.go
+++ b/src/vm/interpreter/config/finished.go
@@ -13,8 +13,6 @@ import (
 
 // Finished is called when a Git Town command that only changes configuration has finished successfully.
 func Finished(args FinishedArgs) error {
-	// TODO: extract the code to load a config snapshot into a reusable function
-	//       since it exists in multiple places
 	configGitAccess := gitconfig.Access{Runner: args.Runner.Backend.Runner}
 	globalSnapshot, _, err := configGitAccess.LoadGlobal(false)
 	if err != nil {


### PR DESCRIPTION
We don't want to implement this TODO because the code is different now and reasonably well covered by the type system.