### PR TITLE
Extract git.ProdRunner from OpenRepo

### DIFF
--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -9,6 +9,7 @@ import (
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/messages"
 	"github.com/git-town/git-town/v14/src/sync"
@@ -81,7 +82,7 @@ func executeAppend(arg string, dryRun, verbose bool) error {
 		InitialConfigSnapshot:   repo.ConfigSnapshot,
 		InitialStashSize:        initialStashSize,
 		RootDir:                 repo.RootDir,
-		Run:                     repo.Runner,
+		Run:                     data.runner,
 		RunState:                runState,
 		Verbose:                 verbose,
 	})
@@ -99,18 +100,19 @@ type appendData struct {
 	parentBranch              gitdomain.LocalBranchName
 	previousBranch            gitdomain.LocalBranchName
 	remotes                   gitdomain.Remotes
+	runner                    *git.ProdRunner
 	targetBranch              gitdomain.LocalBranchName
 }
 
 func determineAppendData(targetBranch gitdomain.LocalBranchName, repo *execute.OpenRepoResult, dryRun, verbose bool) (*appendData, gitdomain.BranchesSnapshot, gitdomain.StashSize, bool, error) {
 	fc := execute.FailureCollector{}
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 !repoStatus.OpenChanges,
 		HandleUnfinishedState: true,
@@ -123,34 +125,41 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo *execute.O
 	if err != nil || exit {
 		return nil, branchesSnapshot, stashSize, exit, err
 	}
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	remotes := fc.Remotes(repo.Runner.Backend.Remotes())
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
+	remotes := fc.Remotes(repo.Backend.Remotes())
 	if branchesSnapshot.Branches.HasLocalBranch(targetBranch) {
 		fc.Fail(messages.BranchAlreadyExistsLocally, targetBranch)
 	}
 	if branchesSnapshot.Branches.HasMatchingTrackingBranchFor(targetBranch) {
 		fc.Fail(messages.BranchAlreadyExistsRemotely, targetBranch)
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branchesSnapshot.Active},
-		Config:           repo.Runner.Config,
-		DefaultChoice:    repo.Runner.Config.Config.MainBranch,
+		Config:           repo.Config,
+		DefaultChoice:    repo.Config.Config.MainBranch,
 		DialogTestInputs: &dialogTestInputs,
 		LocalBranches:    branchesSnapshot.Branches.LocalBranches(),
-		MainBranch:       repo.Runner.Config.Config.MainBranch,
-		Runner:           repo.Runner,
+		MainBranch:       repo.Config.Config.MainBranch,
+		Runner:           &runner,
 	})
 	if err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
 	}
-	branchNamesToSync := repo.Runner.Config.Config.Lineage.BranchAndAncestors(branchesSnapshot.Active)
+	branchNamesToSync := repo.Config.Config.Lineage.BranchAndAncestors(branchesSnapshot.Active)
 	branchesToSync := fc.BranchInfos(branchesSnapshot.Branches.Select(branchNamesToSync...))
-	initialAndAncestors := repo.Runner.Config.Config.Lineage.BranchAndAncestors(branchesSnapshot.Active)
+	initialAndAncestors := repo.Config.Config.Lineage.BranchAndAncestors(branchesSnapshot.Active)
 	slices.Reverse(initialAndAncestors)
 	return &appendData{
 		allBranches:               branchesSnapshot.Branches,
 		branchesToSync:            branchesToSync,
-		config:                    repo.Runner.Config.Config,
+		config:                    repo.Config.Config,
 		dialogTestInputs:          dialogTestInputs,
 		dryRun:                    dryRun,
 		hasOpenChanges:            repoStatus.OpenChanges,
@@ -159,6 +168,7 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo *execute.O
 		parentBranch:              branchesSnapshot.Active,
 		previousBranch:            previousBranch,
 		remotes:                   remotes,
+		runner:                    &runner,
 		targetBranch:              targetBranch,
 	}, branchesSnapshot, stashSize, false, fc.Err
 }

--- a/src/cmd/append.go
+++ b/src/cmd/append.go
@@ -111,6 +111,13 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo *execute.O
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -118,6 +125,7 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo *execute.O
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -132,13 +140,6 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo *execute.O
 	}
 	if branchesSnapshot.Branches.HasMatchingTrackingBranchFor(targetBranch) {
 		fc.Fail(messages.BranchAlreadyExistsRemotely, targetBranch)
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branchesSnapshot.Active},

--- a/src/cmd/compress.go
+++ b/src/cmd/compress.go
@@ -129,6 +129,13 @@ func determineCompressBranchesData(repo *execute.OpenRepoResult, dryRun, verbose
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -136,6 +143,7 @@ func determineCompressBranchesData(repo *execute.OpenRepoResult, dryRun, verbose
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -195,6 +203,7 @@ func determineCompressBranchesData(repo *execute.OpenRepoResult, dryRun, verbose
 		hasOpenChanges:      repoStatus.OpenChanges,
 		initialBranch:       initialBranch,
 		previousBranch:      previousBranch,
+		runner:              &runner,
 	}, branchesSnapshot, stashSize, false, nil
 }
 

--- a/src/cmd/compress.go
+++ b/src/cmd/compress.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/gohacks/slice"
 	"github.com/git-town/git-town/v14/src/messages"
@@ -95,7 +96,7 @@ func executeCompress(dryRun, verbose bool, message gitdomain.CommitMessage, stac
 		InitialConfigSnapshot:   repo.ConfigSnapshot,
 		InitialStashSize:        initialStashSize,
 		RootDir:                 repo.RootDir,
-		Run:                     repo.Runner,
+		Run:                     data.runner,
 		RunState:                runState,
 		Verbose:                 verbose,
 	})
@@ -110,6 +111,7 @@ type compressBranchesData struct {
 	hasOpenChanges      bool
 	initialBranch       gitdomain.LocalBranchName
 	previousBranch      gitdomain.LocalBranchName
+	runner              *git.ProdRunner
 }
 
 type compressBranchData struct {
@@ -121,14 +123,14 @@ type compressBranchData struct {
 }
 
 func determineCompressBranchesData(repo *execute.OpenRepoResult, dryRun, verbose bool, message gitdomain.CommitMessage, compressEntireStack bool) (*compressBranchesData, gitdomain.BranchesSnapshot, gitdomain.StashSize, bool, error) {
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 true,
 		HandleUnfinishedState: true,
@@ -144,7 +146,7 @@ func determineCompressBranchesData(repo *execute.OpenRepoResult, dryRun, verbose
 	initialBranch := branchesSnapshot.Active.BranchName().LocalName()
 	var branchNamesToCompress gitdomain.LocalBranchNames
 	if compressEntireStack {
-		branchNamesToCompress = repo.Runner.Config.Config.Lineage.BranchLineageWithoutRoot(initialBranch)
+		branchNamesToCompress = repo.Config.Config.Lineage.BranchLineageWithoutRoot(initialBranch)
 	} else {
 		branchNamesToCompress = gitdomain.LocalBranchNames{initialBranch}
 	}
@@ -154,15 +156,15 @@ func determineCompressBranchesData(repo *execute.OpenRepoResult, dryRun, verbose
 		if !hasBranchInfo {
 			return nil, branchesSnapshot, stashSize, exit, fmt.Errorf(messages.CompressNoBranchInfo, branchNameToCompress)
 		}
-		branchType := repo.Runner.Config.Config.BranchType(branchNameToCompress.BranchName().LocalName())
+		branchType := repo.Config.Config.BranchType(branchNameToCompress.BranchName().LocalName())
 		if err := validateCanCompressBranchType(branchInfo.LocalName, branchType); err != nil {
 			return nil, branchesSnapshot, stashSize, exit, err
 		}
 		if err := validateBranchIsSynced(branchInfo.LocalName, branchInfo.SyncStatus); err != nil {
 			return nil, branchesSnapshot, stashSize, exit, err
 		}
-		parent := repo.Runner.Config.Config.Lineage.Parent(branchNameToCompress)
-		commits, err := repo.Runner.Backend.CommitsInBranch(branchNameToCompress.BranchName().LocalName(), parent)
+		parent := repo.Config.Config.Lineage.Parent(branchNameToCompress)
+		commits, err := repo.Backend.CommitsInBranch(branchNameToCompress.BranchName().LocalName(), parent)
 		if err != nil {
 			return nil, branchesSnapshot, stashSize, exit, err
 		}
@@ -187,7 +189,7 @@ func determineCompressBranchesData(repo *execute.OpenRepoResult, dryRun, verbose
 	return &compressBranchesData{
 		branchesToCompress:  branchesToCompress,
 		compressEntireStack: compressEntireStack,
-		config:              repo.Runner.Config.Config,
+		config:              repo.Config.Config,
 		dialogTestInputs:    dialogTestInputs,
 		dryRun:              dryRun,
 		hasOpenChanges:      repoStatus.OpenChanges,

--- a/src/cmd/config/remove.go
+++ b/src/cmd/config/remove.go
@@ -40,15 +40,15 @@ func executeRemoveConfig(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	err = repo.Runner.Config.GitConfig.RemoveLocalGitConfiguration(repo.Runner.Config.Config.Lineage)
+	err = repo.Config.GitConfig.RemoveLocalGitConfiguration(repo.Config.Config.Lineage)
 	if err != nil {
 		return err
 	}
-	aliasNames := maps.Keys(repo.Runner.Config.Config.Aliases)
+	aliasNames := maps.Keys(repo.Config.Config.Aliases)
 	slices.Sort(aliasNames)
 	for _, aliasName := range aliasNames {
-		if strings.HasPrefix(repo.Runner.Config.Config.Aliases[aliasName], "town ") {
-			err = repo.Runner.Frontend.RemoveGitAlias(aliasName)
+		if strings.HasPrefix(repo.Config.Config.Aliases[aliasName], "town ") {
+			err = repo.Frontend.RemoveGitAlias(aliasName)
 			if err != nil {
 				return err
 			}

--- a/src/cmd/config/root.go
+++ b/src/cmd/config/root.go
@@ -44,7 +44,7 @@ func executeDisplayConfig(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	printConfig(&repo.Runner.Config.Config)
+	printConfig(&repo.Config.Config)
 	return nil
 }
 

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -61,18 +61,11 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || exit {
 		return err
 	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
-	}
-	aborted, err := enterData(&runner, data)
+	aborted, err := enterData(data.runner, data)
 	if err != nil || aborted {
 		return err
 	}
-	err = saveAll(&runner, data.userInput)
+	err = saveAll(data.runner, data.userInput)
 	if err != nil {
 		return err
 	}
@@ -92,6 +85,7 @@ type setupData struct {
 	dialogInputs  components.TestInputs
 	hasConfigFile bool
 	localBranches gitdomain.BranchInfos
+	runner        *git.ProdRunner
 	userInput     userInput
 }
 
@@ -231,6 +225,7 @@ func loadSetupData(repo *execute.OpenRepoResult, verbose bool) (*setupData, bool
 		dialogInputs:  dialogTestInputs,
 		hasConfigFile: repo.Config.ConfigFile.IsSome(),
 		localBranches: branchesSnapshot.Branches,
+		runner:        &runner,
 		userInput:     defaultUserInput(),
 	}, exit, err
 }

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -61,21 +61,28 @@ func executeConfigSetup(verbose bool) error {
 	if err != nil || exit {
 		return err
 	}
-	aborted, err := enterData(repo.Runner, data)
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
+	aborted, err := enterData(&runner, data)
 	if err != nil || aborted {
 		return err
 	}
-	err = saveAll(repo.Runner, data.userInput)
+	err = saveAll(&runner, data.userInput)
 	if err != nil {
 		return err
 	}
 	return configInterpreter.Finished(configInterpreter.FinishedArgs{
-		Backend:             repo.Runner.Backend,
+		Backend:             repo.Backend,
 		BeginConfigSnapshot: repo.ConfigSnapshot,
 		Command:             "setup",
-		CommandsCounter:     repo.Runner.CommandsCounter,
+		CommandsCounter:     repo.CommandsCounter,
 		EndConfigSnapshot:   undoconfig.EmptyConfigSnapshot(),
-		FinalMessages:       repo.Runner.FinalMessages,
+		FinalMessages:       repo.FinalMessages,
 		RootDir:             repo.RootDir,
 		Verbose:             verbose,
 	})
@@ -197,12 +204,12 @@ func enterData(runner *git.ProdRunner, data *setupData) (aborted bool, err error
 
 func loadSetupData(repo *execute.OpenRepoResult, verbose bool) (*setupData, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, false, err
 	}
 	branchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 false,
 		HandleUnfinishedState: false,
@@ -214,7 +221,7 @@ func loadSetupData(repo *execute.OpenRepoResult, verbose bool) (*setupData, bool
 	})
 	return &setupData{
 		dialogInputs:  dialogTestInputs,
-		hasConfigFile: repo.Runner.Config.ConfigFile.IsSome(),
+		hasConfigFile: repo.Config.ConfigFile.IsSome(),
 		localBranches: branchesSnapshot.Branches,
 		userInput:     defaultUserInput(),
 	}, exit, err

--- a/src/cmd/config/setup.go
+++ b/src/cmd/config/setup.go
@@ -208,6 +208,13 @@ func loadSetupData(repo *execute.OpenRepoResult, verbose bool) (*setupData, bool
 	if err != nil {
 		return nil, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -215,6 +222,7 @@ func loadSetupData(repo *execute.OpenRepoResult, verbose bool) (*setupData, bool
 		HandleUnfinishedState: false,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  false,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -82,6 +82,13 @@ func determineContinueData(repo *execute.OpenRepoResult, verbose bool) (*continu
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	initialBranchesSnapshot, initialStashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -89,6 +96,7 @@ func determineContinueData(repo *execute.OpenRepoResult, verbose bool) (*continu
 		HandleUnfinishedState: false,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -110,13 +118,6 @@ func determineContinueData(repo *execute.OpenRepoResult, verbose bool) (*continu
 			Log:             print.Logger{},
 			OriginURL:       originURL,
 		})
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	return &continueData{
 		config:           repo.Config.Config,

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -59,7 +59,7 @@ func executeDiffParent(args []string, verbose bool) error {
 	if err != nil {
 		return err
 	}
-	print.Footer(verbose, repo.CommandsCounter.Count(), repo..FinalMessages.Result())
+	print.Footer(verbose, repo.CommandsCounter.Count(), repo.FinalMessages.Result())
 	return nil
 }
 
@@ -71,12 +71,12 @@ type diffParentData struct {
 // Does not return error because "Ensure" functions will call exit directly.
 func determineDiffParentData(args []string, repo *execute.OpenRepoResult, verbose bool) (*diffParentData, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo..Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, false, err
 	}
 	branchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo..Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 false,
 		HandleUnfinishedState: true,
@@ -97,17 +97,17 @@ func determineDiffParentData(args []string, repo *execute.OpenRepoResult, verbos
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branch},
-		Config:           repo..Config,
-		DefaultChoice:    repo..Config.Config.MainBranch,
+		Config:           repo.Config,
+		DefaultChoice:    repo.Config.Config.MainBranch,
 		DialogTestInputs: &dialogTestInputs,
 		LocalBranches:    branchesSnapshot.Branches.LocalBranches(),
-		MainBranch:       repo..Config.Config.MainBranch,
+		MainBranch:       repo.Config.Config.MainBranch,
 		Runner:           repo.Runner,
 	})
 	if err != nil {
 		return nil, false, err
 	}
-	parentBranch, hasParent := repo..Config.Config.Lineage.Parent(branch).Get()
+	parentBranch, hasParent := repo.Config.Config.Lineage.Parent(branch).Get()
 	if !hasParent {
 		return nil, false, errors.New(messages.DiffParentNoFeatureBranch)
 	}

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -55,11 +55,11 @@ func executeDiffParent(args []string, verbose bool) error {
 	if err != nil || exit {
 		return err
 	}
-	err = repo.Runner.Frontend.DiffParent(data.branch, data.parentBranch)
+	err = repo.Frontend.DiffParent(data.branch, data.parentBranch)
 	if err != nil {
 		return err
 	}
-	print.Footer(verbose, repo.Runner.CommandsCounter.Count(), repo.Runner.FinalMessages.Result())
+	print.Footer(verbose, repo.CommandsCounter.Count(), repo..FinalMessages.Result())
 	return nil
 }
 
@@ -71,12 +71,12 @@ type diffParentData struct {
 // Does not return error because "Ensure" functions will call exit directly.
 func determineDiffParentData(args []string, repo *execute.OpenRepoResult, verbose bool) (*diffParentData, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo..Backend.RepoStatus()
 	if err != nil {
 		return nil, false, err
 	}
 	branchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo..Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 false,
 		HandleUnfinishedState: true,
@@ -97,17 +97,17 @@ func determineDiffParentData(args []string, repo *execute.OpenRepoResult, verbos
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branch},
-		Config:           repo.Runner.Config,
-		DefaultChoice:    repo.Runner.Config.Config.MainBranch,
+		Config:           repo..Config,
+		DefaultChoice:    repo..Config.Config.MainBranch,
 		DialogTestInputs: &dialogTestInputs,
 		LocalBranches:    branchesSnapshot.Branches.LocalBranches(),
-		MainBranch:       repo.Runner.Config.Config.MainBranch,
+		MainBranch:       repo..Config.Config.MainBranch,
 		Runner:           repo.Runner,
 	})
 	if err != nil {
 		return nil, false, err
 	}
-	parentBranch, hasParent := repo.Runner.Config.Config.Lineage.Parent(branch).Get()
+	parentBranch, hasParent := repo..Config.Config.Lineage.Parent(branch).Get()
 	if !hasParent {
 		return nil, false, errors.New(messages.DiffParentNoFeatureBranch)
 	}

--- a/src/cmd/diff_parent.go
+++ b/src/cmd/diff_parent.go
@@ -77,6 +77,13 @@ func determineDiffParentData(args []string, repo *execute.OpenRepoResult, verbos
 	if err != nil {
 		return nil, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -84,6 +91,7 @@ func determineDiffParentData(args []string, repo *execute.OpenRepoResult, verbos
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -96,13 +104,6 @@ func determineDiffParentData(args []string, repo *execute.OpenRepoResult, verbos
 		if !branchesSnapshot.Branches.HasLocalBranch(branch) {
 			return nil, false, fmt.Errorf(messages.BranchDoesntExist, branch)
 		}
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branch},

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -73,17 +73,18 @@ func executeHack(args []string, dryRun, verbose bool) error {
 			beginStashSize:        initialStashSize,
 			dryRun:                dryRun,
 			rootDir:               repo.RootDir,
-			runner:                repo.Runner,
+			runner:                appendData.runner,
 			verbose:               verbose,
 		})
 	}
 	if doMakeFeatureBranch {
 		return makeFeatureBranch(makeFeatureBranchArgs{
 			beginConfigSnapshot: repo.ConfigSnapshot,
-			config:              repo.Runner.Config,
+			config:              repo.Config,
 			makeFeatureData:     makeFeatureBranchData,
 			repo:                repo,
 			rootDir:             repo.RootDir,
+			runner:              makeFeatureBranchData.runner,
 			verbose:             verbose,
 		})
 	}
@@ -96,6 +97,7 @@ type hackData = Either[appendData, makeFeatureData]
 
 // this configuration is for when "git hack" is used to make contribution, observed, or parked branches feature branches
 type makeFeatureData struct {
+	runner         *git.ProdRunner
 	targetBranches commandconfig.BranchesAndTypes
 }
 
@@ -141,12 +143,12 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	fc := execute.FailureCollector{}
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	var repoStatus gitdomain.RepoStatus
-	repoStatus, err = repo.Runner.Backend.RepoStatus()
+	repoStatus, err = repo.Backend.RepoStatus()
 	if err != nil {
 		return
 	}
 	branchesSnapshot, stashSize, exit, err = execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 len(args) == 1 && !repoStatus.OpenChanges,
 		HandleUnfinishedState: true,
@@ -159,17 +161,17 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if err != nil || exit {
 		return
 	}
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
 	targetBranches := gitdomain.NewLocalBranchNames(args...)
 	if len(targetBranches) == 0 {
 		data = Right[appendData, makeFeatureData](makeFeatureData{
-			targetBranches: commandconfig.NewBranchesAndTypes(gitdomain.LocalBranchNames{branchesSnapshot.Active}, repo.Runner.Config.Config),
+			targetBranches: commandconfig.NewBranchesAndTypes(gitdomain.LocalBranchNames{branchesSnapshot.Active}, repo.Config.Config),
 		})
 		return
 	}
 	if len(targetBranches) > 0 && branchesSnapshot.Branches.HasLocalBranches(targetBranches) {
 		data = Right[appendData, makeFeatureData](makeFeatureData{
-			targetBranches: commandconfig.NewBranchesAndTypes(targetBranches, repo.Runner.Config.Config),
+			targetBranches: commandconfig.NewBranchesAndTypes(targetBranches, repo.Config.Config),
 		})
 		return
 	}
@@ -178,7 +180,7 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 		return
 	}
 	targetBranch := targetBranches[0]
-	remotes := fc.Remotes(repo.Runner.Backend.Remotes())
+	remotes := fc.Remotes(repo.Backend.Remotes())
 	if branchesSnapshot.Branches.HasLocalBranch(targetBranch) {
 		err = fmt.Errorf(messages.BranchAlreadyExistsLocally, targetBranch)
 		return
@@ -187,20 +189,28 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 		err = fmt.Errorf(messages.BranchAlreadyExistsRemotely, targetBranch)
 		return
 	}
-	branchNamesToSync := gitdomain.LocalBranchNames{repo.Runner.Config.Config.MainBranch}
+	branchNamesToSync := gitdomain.LocalBranchNames{repo.Config.Config.MainBranch}
 	branchesToSync := fc.BranchInfos(branchesSnapshot.Branches.Select(branchNamesToSync...))
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	data = Left[appendData, makeFeatureData](appendData{
 		allBranches:               branchesSnapshot.Branches,
 		branchesToSync:            branchesToSync,
-		config:                    repo.Runner.Config.Config,
+		config:                    repo.Config.Config,
 		dialogTestInputs:          dialogTestInputs,
 		dryRun:                    dryRun,
 		hasOpenChanges:            repoStatus.OpenChanges,
 		initialBranch:             branchesSnapshot.Active,
-		newBranchParentCandidates: gitdomain.LocalBranchNames{repo.Runner.Config.Config.MainBranch},
-		parentBranch:              repo.Runner.Config.Config.MainBranch,
+		newBranchParentCandidates: gitdomain.LocalBranchNames{repo.Config.Config.MainBranch},
+		parentBranch:              repo.Config.Config.MainBranch,
 		previousBranch:            previousBranch,
 		remotes:                   remotes,
+		runner:                    &runner,
 		targetBranch:              targetBranch,
 	})
 	return
@@ -228,12 +238,12 @@ func makeFeatureBranch(args makeFeatureBranchArgs) error {
 		fmt.Printf(messages.HackBranchIsNowFeature, branchName)
 	}
 	return configInterpreter.Finished(configInterpreter.FinishedArgs{
-		Backend:             args.repo.Runner.Backend,
+		Backend:             args.repo.Backend,
 		BeginConfigSnapshot: args.beginConfigSnapshot,
 		Command:             "observe",
-		CommandsCounter:     args.repo.Runner.CommandsCounter,
+		CommandsCounter:     args.repo.CommandsCounter,
 		EndConfigSnapshot:   undoconfig.EmptyConfigSnapshot(),
-		FinalMessages:       args.repo.Runner.FinalMessages,
+		FinalMessages:       args.repo.FinalMessages,
 		RootDir:             args.rootDir,
 		Verbose:             args.verbose,
 	})
@@ -245,6 +255,7 @@ type makeFeatureBranchArgs struct {
 	makeFeatureData     makeFeatureData
 	repo                *execute.OpenRepoResult
 	rootDir             gitdomain.RepoRootDir
+	runner              *git.ProdRunner
 	verbose             bool
 }
 

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -147,6 +147,13 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if err != nil {
 		return
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err = execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -154,6 +161,7 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -191,13 +199,6 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	}
 	branchNamesToSync := gitdomain.LocalBranchNames{repo.Config.Config.MainBranch}
 	branchesToSync := fc.BranchInfos(branchesSnapshot.Branches.Select(branchNamesToSync...))
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
-	}
 	data = Left[appendData, makeFeatureData](appendData{
 		allBranches:               branchesSnapshot.Branches,
 		branchesToSync:            branchesToSync,

--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -173,12 +173,14 @@ func determineHackData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	targetBranches := gitdomain.NewLocalBranchNames(args...)
 	if len(targetBranches) == 0 {
 		data = Right[appendData, makeFeatureData](makeFeatureData{
+			runner:         &runner,
 			targetBranches: commandconfig.NewBranchesAndTypes(gitdomain.LocalBranchNames{branchesSnapshot.Active}, repo.Config.Config),
 		})
 		return
 	}
 	if len(targetBranches) > 0 && branchesSnapshot.Branches.HasLocalBranches(targetBranches) {
 		data = Right[appendData, makeFeatureData](makeFeatureData{
+			runner:         &runner,
 			targetBranches: commandconfig.NewBranchesAndTypes(targetBranches, repo.Config.Config),
 		})
 		return

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -114,6 +114,13 @@ func determineKillData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -121,6 +128,7 @@ func determineKillData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 		HandleUnfinishedState: false,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -135,13 +143,6 @@ func determineKillData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	}
 	if branchToKill.SyncStatus == gitdomain.SyncStatusOtherWorktree {
 		return nil, branchesSnapshot, stashSize, exit, fmt.Errorf(messages.KillBranchOtherWorktree, branchNameToKill)
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	if branchToKill.IsLocal() {
 		err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{

--- a/src/cmd/kill.go
+++ b/src/cmd/kill.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	. "github.com/git-town/git-town/v14/src/gohacks/prelude"
 	"github.com/git-town/git-town/v14/src/gohacks/slice"
@@ -87,7 +88,7 @@ func executeKill(args []string, dryRun, verbose bool) error {
 		InitialConfigSnapshot:   repo.ConfigSnapshot,
 		InitialStashSize:        initialStashSize,
 		RootDir:                 repo.RootDir,
-		Run:                     repo.Runner,
+		Run:                     data.runner,
 		RunState:                runState,
 		Verbose:                 verbose,
 	})
@@ -104,16 +105,17 @@ type killData struct {
 	initialBranch    gitdomain.LocalBranchName
 	parentBranch     Option[gitdomain.LocalBranchName]
 	previousBranch   gitdomain.LocalBranchName
+	runner           *git.ProdRunner
 }
 
 func determineKillData(args []string, repo *execute.OpenRepoResult, dryRun, verbose bool) (*killData, gitdomain.BranchesSnapshot, gitdomain.StashSize, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 true,
 		HandleUnfinishedState: false,
@@ -134,44 +136,52 @@ func determineKillData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if branchToKill.SyncStatus == gitdomain.SyncStatusOtherWorktree {
 		return nil, branchesSnapshot, stashSize, exit, fmt.Errorf(messages.KillBranchOtherWorktree, branchNameToKill)
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	if branchToKill.IsLocal() {
 		err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 			BranchesToVerify: gitdomain.LocalBranchNames{branchToKill.LocalName},
-			Config:           repo.Runner.Config,
-			DefaultChoice:    repo.Runner.Config.Config.MainBranch,
+			Config:           repo.Config,
+			DefaultChoice:    repo.Config.Config.MainBranch,
 			DialogTestInputs: &dialogTestInputs,
 			LocalBranches:    branchesSnapshot.Branches,
-			MainBranch:       repo.Runner.Config.Config.MainBranch,
-			Runner:           repo.Runner,
+			MainBranch:       repo.Config.Config.MainBranch,
+			Runner:           &runner,
 		})
 		if err != nil {
 			return nil, branchesSnapshot, stashSize, false, err
 		}
 	}
-	branchTypeToKill := repo.Runner.Config.Config.BranchType(branchNameToKill)
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
+	branchTypeToKill := repo.Config.Config.BranchType(branchNameToKill)
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
 	var branchWhenDone gitdomain.LocalBranchName
 	if branchNameToKill == branchesSnapshot.Active {
 		if previousBranch == branchesSnapshot.Active {
-			branchWhenDone = repo.Runner.Config.Config.MainBranch
+			branchWhenDone = repo.Config.Config.MainBranch
 		} else {
 			branchWhenDone = previousBranch
 		}
 	} else {
 		branchWhenDone = branchesSnapshot.Active
 	}
-	parentBranch := repo.Runner.Config.Config.Lineage.Parent(branchToKill.LocalName)
+	parentBranch := repo.Config.Config.Lineage.Parent(branchToKill.LocalName)
 	return &killData{
 		branchNameToKill: branchToKill,
 		branchTypeToKill: branchTypeToKill,
 		branchWhenDone:   branchWhenDone,
-		config:           repo.Runner.Config.Config,
+		config:           repo.Config.Config,
 		dialogTestInputs: dialogTestInputs,
 		dryRun:           dryRun,
 		hasOpenChanges:   repoStatus.OpenChanges,
 		initialBranch:    branchesSnapshot.Active,
 		parentBranch:     parentBranch,
 		previousBranch:   previousBranch,
+		runner:           &runner,
 	}, branchesSnapshot, stashSize, false, nil
 }
 

--- a/src/cmd/observe.go
+++ b/src/cmd/observe.go
@@ -70,25 +70,25 @@ func executeObserve(args []string, verbose bool) error {
 		return err
 	}
 	branchNames := data.branchesToObserve.Keys()
-	if err = repo.Runner.Config.AddToObservedBranches(branchNames...); err != nil {
+	if err = repo.Config.AddToObservedBranches(branchNames...); err != nil {
 		return err
 	}
-	if err = removeNonObserveBranchTypes(data.branchesToObserve, repo.Runner.Config); err != nil {
+	if err = removeNonObserveBranchTypes(data.branchesToObserve, repo.Config); err != nil {
 		return err
 	}
 	printObservedBranches(branchNames)
 	if !data.checkout.IsEmpty() {
-		if err = repo.Runner.Frontend.CheckoutBranch(data.checkout, false); err != nil {
+		if err = repo.Frontend.CheckoutBranch(data.checkout, false); err != nil {
 			return err
 		}
 	}
 	return configInterpreter.Finished(configInterpreter.FinishedArgs{
-		Backend:             repo.Runner.Backend,
+		Backend:             repo.Backend,
 		BeginConfigSnapshot: repo.ConfigSnapshot,
 		Command:             "observe",
-		CommandsCounter:     repo.Runner.CommandsCounter,
+		CommandsCounter:     repo.CommandsCounter,
 		EndConfigSnapshot:   undoconfig.EmptyConfigSnapshot(),
-		FinalMessages:       repo.Runner.FinalMessages,
+		FinalMessages:       repo.FinalMessages,
 		RootDir:             repo.RootDir,
 		Verbose:             verbose,
 	})
@@ -124,7 +124,7 @@ func removeNonObserveBranchTypes(branches map[gitdomain.LocalBranchName]configdo
 }
 
 func determineObserveData(args []string, repo *execute.OpenRepoResult) (observeData, error) {
-	branchesSnapshot, err := repo.Runner.Backend.BranchesSnapshot()
+	branchesSnapshot, err := repo.Backend.BranchesSnapshot()
 	if err != nil {
 		return observeData{}, err
 	}
@@ -132,16 +132,16 @@ func determineObserveData(args []string, repo *execute.OpenRepoResult) (observeD
 	checkout := gitdomain.EmptyLocalBranchName()
 	switch len(args) {
 	case 0:
-		branchesToObserve.Add(branchesSnapshot.Active, &repo.Runner.Config.Config)
+		branchesToObserve.Add(branchesSnapshot.Active, &repo.Config.Config)
 	case 1:
 		branch := gitdomain.NewLocalBranchName(args[0])
-		branchesToObserve.Add(branch, &repo.Runner.Config.Config)
+		branchesToObserve.Add(branch, &repo.Config.Config)
 		branchInfo := branchesSnapshot.Branches.FindByRemoteName(branch.TrackingBranch())
 		if branchInfo.SyncStatus == gitdomain.SyncStatusRemoteOnly {
 			checkout = branch
 		}
 	default:
-		branchesToObserve.AddMany(gitdomain.NewLocalBranchNames(args...), &repo.Runner.Config.Config)
+		branchesToObserve.AddMany(gitdomain.NewLocalBranchNames(args...), &repo.Config.Config)
 	}
 	return observeData{
 		allBranches:       branchesSnapshot.Branches,

--- a/src/cmd/offline.go
+++ b/src/cmd/offline.go
@@ -50,22 +50,29 @@ func executeOffline(args []string, verbose bool) error {
 	if err != nil {
 		return err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	switch len(args) {
 	case 0:
-		displayOfflineStatus(repo.Runner)
+		displayOfflineStatus(&runner)
 	case 1:
-		err = setOfflineStatus(args[0], repo.Runner)
+		err = setOfflineStatus(args[0], &runner)
 		if err != nil {
 			return err
 		}
 	}
 	return configInterpreter.Finished(configInterpreter.FinishedArgs{
-		Backend:             repo.Runner.Backend,
+		Backend:             repo.Backend,
 		BeginConfigSnapshot: repo.ConfigSnapshot,
 		Command:             "offline",
-		CommandsCounter:     repo.Runner.CommandsCounter,
+		CommandsCounter:     repo.CommandsCounter,
 		EndConfigSnapshot:   undoconfig.EmptyConfigSnapshot(),
-		FinalMessages:       repo.Runner.FinalMessages,
+		FinalMessages:       repo.FinalMessages,
 		RootDir:             repo.RootDir,
 		Verbose:             verbose,
 	})

--- a/src/cmd/park.go
+++ b/src/cmd/park.go
@@ -64,20 +64,20 @@ func executePark(args []string, verbose bool) error {
 		return err
 	}
 	branchNames := data.branchesToPark.Keys()
-	if err = repo.Runner.Config.AddToParkedBranches(branchNames...); err != nil {
+	if err = repo.Config.AddToParkedBranches(branchNames...); err != nil {
 		return err
 	}
-	if err = removeNonParkBranchTypes(data.branchesToPark, repo.Runner.Config); err != nil {
+	if err = removeNonParkBranchTypes(data.branchesToPark, repo.Config); err != nil {
 		return err
 	}
 	printParkedBranches(branchNames)
 	return configInterpreter.Finished(configInterpreter.FinishedArgs{
-		Backend:             repo.Runner.Backend,
+		Backend:             repo.Backend,
 		BeginConfigSnapshot: repo.ConfigSnapshot,
 		Command:             "park",
-		CommandsCounter:     repo.Runner.CommandsCounter,
+		CommandsCounter:     repo.CommandsCounter,
 		EndConfigSnapshot:   undoconfig.EmptyConfigSnapshot(),
-		FinalMessages:       repo.Runner.FinalMessages,
+		FinalMessages:       repo.FinalMessages,
 		RootDir:             repo.RootDir,
 		Verbose:             verbose,
 	})
@@ -112,15 +112,15 @@ func removeNonParkBranchTypes(branches map[gitdomain.LocalBranchName]configdomai
 }
 
 func determineParkData(args []string, repo *execute.OpenRepoResult) (parkData, error) {
-	branchesSnapshot, err := repo.Runner.Backend.BranchesSnapshot()
+	branchesSnapshot, err := repo.Backend.BranchesSnapshot()
 	if err != nil {
 		return parkData{}, err
 	}
 	branchesToPark := commandconfig.BranchesAndTypes{}
 	if len(args) == 0 {
-		branchesToPark.Add(branchesSnapshot.Active, &repo.Runner.Config.Config)
+		branchesToPark.Add(branchesSnapshot.Active, &repo.Config.Config)
 	} else {
-		branchesToPark.AddMany(gitdomain.NewLocalBranchNames(args...), &repo.Runner.Config.Config)
+		branchesToPark.AddMany(gitdomain.NewLocalBranchNames(args...), &repo.Config.Config)
 	}
 	return parkData{
 		allBranches:    branchesSnapshot.Branches,

--- a/src/cmd/prepend.go
+++ b/src/cmd/prepend.go
@@ -112,6 +112,13 @@ func determinePrependData(args []string, repo *execute.OpenRepoResult, dryRun, v
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
 	fc := execute.FailureCollector{}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -119,6 +126,7 @@ func determinePrependData(args []string, repo *execute.OpenRepoResult, dryRun, v
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -134,13 +142,6 @@ func determinePrependData(args []string, repo *execute.OpenRepoResult, dryRun, v
 	}
 	if branchesSnapshot.Branches.HasMatchingTrackingBranchFor(targetBranch) {
 		return nil, branchesSnapshot, stashSize, false, fmt.Errorf(messages.BranchAlreadyExistsRemotely, targetBranch)
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branchesSnapshot.Active},

--- a/src/cmd/propose.go
+++ b/src/cmd/propose.go
@@ -120,6 +120,13 @@ func determineProposeData(repo *execute.OpenRepoResult, dryRun, verbose bool) (*
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -127,6 +134,7 @@ func determineProposeData(repo *execute.OpenRepoResult, dryRun, verbose bool) (*
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -138,13 +146,6 @@ func determineProposeData(repo *execute.OpenRepoResult, dryRun, verbose bool) (*
 	remotes, err := repo.Backend.Remotes()
 	if err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branchesSnapshot.Active},

--- a/src/cmd/propose.go
+++ b/src/cmd/propose.go
@@ -12,6 +12,7 @@ import (
 	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/config/gitconfig"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/hosting"
 	"github.com/git-town/git-town/v14/src/hosting/hostingdomain"
@@ -93,7 +94,7 @@ func executePropose(dryRun, verbose bool) error {
 		InitialConfigSnapshot:   repo.ConfigSnapshot,
 		InitialStashSize:        initialStashSize,
 		RootDir:                 repo.RootDir,
-		Run:                     repo.Runner,
+		Run:                     data.runner,
 		RunState:                runState,
 		Verbose:                 verbose,
 	})
@@ -110,16 +111,17 @@ type proposeData struct {
 	initialBranch    gitdomain.LocalBranchName
 	previousBranch   gitdomain.LocalBranchName
 	remotes          gitdomain.Remotes
+	runner           *git.ProdRunner
 }
 
 func determineProposeData(repo *execute.OpenRepoResult, dryRun, verbose bool) (*proposeData, gitdomain.BranchesSnapshot, gitdomain.StashSize, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 true,
 		HandleUnfinishedState: true,
@@ -132,28 +134,35 @@ func determineProposeData(repo *execute.OpenRepoResult, dryRun, verbose bool) (*
 	if err != nil || exit {
 		return nil, branchesSnapshot, stashSize, exit, err
 	}
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	remotes, err := repo.Runner.Backend.Remotes()
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
+	remotes, err := repo.Backend.Remotes()
 	if err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branchesSnapshot.Active},
-		Config:           repo.Runner.Config,
-		DefaultChoice:    repo.Runner.Config.Config.MainBranch,
+		Config:           repo.Config,
+		DefaultChoice:    repo.Config.Config.MainBranch,
 		DialogTestInputs: &dialogTestInputs,
 		LocalBranches:    branchesSnapshot.Branches,
-		MainBranch:       repo.Runner.Config.Config.MainBranch,
-		Runner:           repo.Runner,
+		MainBranch:       repo.Config.Config.MainBranch,
+		Runner:           &runner,
 	})
 	if err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
 	}
 	var connector hostingdomain.Connector
-	if originURL, hasOriginURL := repo.Runner.Config.OriginURL().Get(); hasOriginURL {
+	if originURL, hasOriginURL := repo.Config.OriginURL().Get(); hasOriginURL {
 		connector, err = hosting.NewConnector(hosting.NewConnectorArgs{
-			FullConfig:      &repo.Runner.Config.Config,
-			HostingPlatform: repo.Runner.Config.Config.HostingPlatform,
+			FullConfig:      &repo.Config.Config,
+			HostingPlatform: repo.Config.Config.HostingPlatform,
 			Log:             print.Logger{},
 			OriginURL:       originURL,
 		})
@@ -164,12 +173,12 @@ func determineProposeData(repo *execute.OpenRepoResult, dryRun, verbose bool) (*
 	if connector == nil {
 		return nil, branchesSnapshot, stashSize, false, hostingdomain.UnsupportedServiceError()
 	}
-	branchNamesToSync := repo.Runner.Config.Config.Lineage.BranchAndAncestors(branchesSnapshot.Active)
+	branchNamesToSync := repo.Config.Config.Lineage.BranchAndAncestors(branchesSnapshot.Active)
 	branchesToSync, err := branchesSnapshot.Branches.Select(branchNamesToSync...)
 	return &proposeData{
 		allBranches:      branchesSnapshot.Branches,
 		branchesToSync:   branchesToSync,
-		config:           repo.Runner.Config.Config,
+		config:           repo.Config.Config,
 		connector:        connector,
 		dialogTestInputs: dialogTestInputs,
 		dryRun:           dryRun,
@@ -177,6 +186,7 @@ func determineProposeData(repo *execute.OpenRepoResult, dryRun, verbose bool) (*
 		initialBranch:    branchesSnapshot.Active,
 		previousBranch:   previousBranch,
 		remotes:          remotes,
+		runner:           &runner,
 	}, branchesSnapshot, stashSize, false, err
 }
 

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -119,6 +119,13 @@ func determineRenameBranchData(args []string, forceFlag bool, repo *execute.Open
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -126,6 +133,7 @@ func determineRenameBranchData(args []string, forceFlag bool, repo *execute.Open
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -166,13 +174,6 @@ func determineRenameBranchData(args []string, forceFlag bool, repo *execute.Open
 	}
 	if branchesSnapshot.Branches.HasMatchingTrackingBranchFor(newBranchName) {
 		return nil, branchesSnapshot, stashSize, false, fmt.Errorf(messages.BranchAlreadyExistsRemotely, newBranchName)
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	return &renameBranchData{
 		config:           repo.Config.Config,

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/messages"
 	"github.com/git-town/git-town/v14/src/undo/undoconfig"
@@ -94,7 +95,7 @@ func executeRenameBranch(args []string, dryRun, force, verbose bool) error {
 		InitialConfigSnapshot:   repo.ConfigSnapshot,
 		InitialStashSize:        initialStashSize,
 		RootDir:                 repo.RootDir,
-		Run:                     repo.Runner,
+		Run:                     data.runner,
 		RunState:                runState,
 		Verbose:                 verbose,
 	})
@@ -109,16 +110,17 @@ type renameBranchData struct {
 	newBranch        gitdomain.LocalBranchName
 	oldBranch        gitdomain.BranchInfo
 	previousBranch   gitdomain.LocalBranchName
+	runner           *git.ProdRunner
 }
 
 func determineRenameBranchData(args []string, forceFlag bool, repo *execute.OpenRepoResult, dryRun, verbose bool) (*renameBranchData, gitdomain.BranchesSnapshot, gitdomain.StashSize, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 true,
 		HandleUnfinishedState: true,
@@ -131,7 +133,7 @@ func determineRenameBranchData(args []string, forceFlag bool, repo *execute.Open
 	if err != nil || exit {
 		return nil, branchesSnapshot, stashSize, exit, err
 	}
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
 	var oldBranchName gitdomain.LocalBranchName
 	var newBranchName gitdomain.LocalBranchName
 	if len(args) == 1 {
@@ -141,11 +143,11 @@ func determineRenameBranchData(args []string, forceFlag bool, repo *execute.Open
 		oldBranchName = gitdomain.NewLocalBranchName(args[0])
 		newBranchName = gitdomain.NewLocalBranchName(args[1])
 	}
-	if repo.Runner.Config.Config.IsMainBranch(oldBranchName) {
+	if repo.Config.Config.IsMainBranch(oldBranchName) {
 		return nil, branchesSnapshot, stashSize, false, errors.New(messages.RenameMainBranch)
 	}
 	if !forceFlag {
-		if repo.Runner.Config.Config.IsPerennialBranch(oldBranchName) {
+		if repo.Config.Config.IsPerennialBranch(oldBranchName) {
 			return nil, branchesSnapshot, stashSize, false, fmt.Errorf(messages.RenamePerennialBranchWarning, oldBranchName)
 		}
 	}
@@ -165,8 +167,15 @@ func determineRenameBranchData(args []string, forceFlag bool, repo *execute.Open
 	if branchesSnapshot.Branches.HasMatchingTrackingBranchFor(newBranchName) {
 		return nil, branchesSnapshot, stashSize, false, fmt.Errorf(messages.BranchAlreadyExistsRemotely, newBranchName)
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	return &renameBranchData{
-		config:           repo.Runner.Config.Config,
+		config:           repo.Config.Config,
 		dialogTestInputs: dialogTestInputs,
 		dryRun:           dryRun,
 		hasOpenChanges:   repoStatus.OpenChanges,
@@ -174,6 +183,7 @@ func determineRenameBranchData(args []string, forceFlag bool, repo *execute.Open
 		newBranch:        newBranchName,
 		oldBranch:        oldBranch,
 		previousBranch:   previousBranch,
+		runner:           &runner,
 	}, branchesSnapshot, stashSize, false, err
 }
 

--- a/src/cmd/repo.go
+++ b/src/cmd/repo.go
@@ -55,26 +55,26 @@ func executeRepo(verbose bool) error {
 	if err != nil {
 		return err
 	}
-	browser.Open(data.connector.RepositoryURL(), repo.Runner.Frontend.Runner, repo.Runner.Backend.Runner)
-	print.Footer(verbose, repo.Runner.CommandsCounter.Count(), repo.Runner.FinalMessages.Result())
+	browser.Open(data.connector.RepositoryURL(), repo.Frontend.Runner, repo.Backend.Runner)
+	print.Footer(verbose, repo.CommandsCounter.Count(), repo.FinalMessages.Result())
 	return nil
 }
 
 func determineRepoData(repo *execute.OpenRepoResult) (*repoData, error) {
-	branchesSnapshot, err := repo.Runner.Backend.BranchesSnapshot()
+	branchesSnapshot, err := repo.Backend.BranchesSnapshot()
 	if err != nil {
 		return nil, err
 	}
 	dialogInputs := components.LoadTestInputs(os.Environ())
-	err = validate.IsConfigured(&repo.Runner.Backend, repo.Runner.Config, branchesSnapshot.Branches.LocalBranches().Names(), &dialogInputs)
+	err = validate.IsConfigured(&repo.Backend, repo.Config, branchesSnapshot.Branches.LocalBranches().Names(), &dialogInputs)
 	if err != nil {
 		return nil, err
 	}
 	var connector hostingdomain.Connector
-	if originURL, hasOriginURL := repo.Runner.Config.OriginURL().Get(); hasOriginURL {
+	if originURL, hasOriginURL := repo.Config.OriginURL().Get(); hasOriginURL {
 		connector, err = hosting.NewConnector(hosting.NewConnectorArgs{
-			FullConfig:      &repo.Runner.Config.Config,
-			HostingPlatform: repo.Runner.Config.Config.HostingPlatform,
+			FullConfig:      &repo.Config.Config,
+			HostingPlatform: repo.Config.Config.HostingPlatform,
 			Log:             print.Logger{},
 			OriginURL:       originURL,
 		})

--- a/src/cmd/set_parent.go
+++ b/src/cmd/set_parent.go
@@ -116,6 +116,13 @@ func determineSetParentData(repo *execute.OpenRepoResult, verbose bool) (*setPar
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -123,6 +130,7 @@ func determineSetParentData(repo *execute.OpenRepoResult, verbose bool) (*setPar
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -137,13 +145,6 @@ func determineSetParentData(repo *execute.OpenRepoResult, verbose bool) (*setPar
 		defaultChoice = existingParent
 	} else {
 		defaultChoice = mainBranch
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	return &setParentData{
 		currentBranch:    branchesSnapshot.Active,

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -148,6 +148,13 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -155,6 +162,7 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: len(args) == 0,
 		Verbose:               verbose,
@@ -178,13 +186,6 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	}
 	if err = validateShippableBranchType(repo.Config.Config.BranchType(branchNameToShip)); err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branchNameToShip},

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -12,6 +12,7 @@ import (
 	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/config/gitconfig"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	. "github.com/git-town/git-town/v14/src/gohacks/prelude"
 	"github.com/git-town/git-town/v14/src/gohacks/slice"
@@ -114,7 +115,7 @@ func executeShip(args []string, message gitdomain.CommitMessage, dryRun, verbose
 		InitialConfigSnapshot:   repo.ConfigSnapshot,
 		InitialStashSize:        initialStashSize,
 		RootDir:                 repo.RootDir,
-		Run:                     repo.Runner,
+		Run:                     data.runner,
 		RunState:                runState,
 		Verbose:                 verbose,
 	})
@@ -137,17 +138,18 @@ type shipData struct {
 	proposalMessage          string
 	proposalsOfChildBranches []hostingdomain.Proposal
 	remotes                  gitdomain.Remotes
+	runner                   *git.ProdRunner
 	targetBranch             gitdomain.BranchInfo
 }
 
 func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verbose bool) (*shipData, gitdomain.BranchesSnapshot, gitdomain.StashSize, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 true,
 		HandleUnfinishedState: true,
@@ -160,8 +162,8 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if err != nil || exit {
 		return nil, branchesSnapshot, stashSize, exit, err
 	}
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
-	remotes, err := repo.Runner.Backend.Remotes()
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
+	remotes, err := repo.Backend.Remotes()
 	if err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
 	}
@@ -174,22 +176,29 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if !hasBranchToShip {
 		return nil, branchesSnapshot, stashSize, false, fmt.Errorf(messages.BranchDoesntExist, branchNameToShip)
 	}
-	if err = validateShippableBranchType(repo.Runner.Config.Config.BranchType(branchNameToShip)); err != nil {
+	if err = validateShippableBranchType(repo.Config.Config.BranchType(branchNameToShip)); err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
+	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: gitdomain.LocalBranchNames{branchNameToShip},
-		Config:           repo.Runner.Config,
-		DefaultChoice:    repo.Runner.Config.Config.MainBranch,
+		Config:           repo.Config,
+		DefaultChoice:    repo.Config.Config.MainBranch,
 		DialogTestInputs: &dialogTestInputs,
 		LocalBranches:    branchesSnapshot.Branches,
-		MainBranch:       repo.Runner.Config.Config.MainBranch,
-		Runner:           repo.Runner,
+		MainBranch:       repo.Config.Config.MainBranch,
+		Runner:           &runner,
 	})
 	if err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
 	}
-	targetBranchName, hasTargetBranch := repo.Runner.Config.Config.Lineage.Parent(branchNameToShip).Get()
+	targetBranchName, hasTargetBranch := repo.Config.Config.Lineage.Parent(branchNameToShip).Get()
 	if !hasTargetBranch {
 		return nil, branchesSnapshot, stashSize, false, fmt.Errorf(messages.ShipBranchHasNoParent, branchNameToShip)
 	}
@@ -197,18 +206,18 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 	if !hasTargetBranch {
 		return nil, branchesSnapshot, stashSize, false, fmt.Errorf(messages.BranchDoesntExist, targetBranchName)
 	}
-	err = ensureParentBranchIsMainOrPerennialBranch(branchNameToShip, targetBranchName, &repo.Runner.Config.Config, repo.Runner.Config.Config.Lineage)
+	err = ensureParentBranchIsMainOrPerennialBranch(branchNameToShip, targetBranchName, &repo.Config.Config, repo.Config.Config.Lineage)
 	if err != nil {
 		return nil, branchesSnapshot, stashSize, false, err
 	}
 	var proposalOpt Option[hostingdomain.Proposal]
-	childBranches := repo.Runner.Config.Config.Lineage.Children(branchNameToShip)
+	childBranches := repo.Config.Config.Lineage.Children(branchNameToShip)
 	proposalsOfChildBranches := []hostingdomain.Proposal{}
 	var connector hostingdomain.Connector
-	if originURL, hasOriginURL := repo.Runner.Config.OriginURL().Get(); hasOriginURL {
+	if originURL, hasOriginURL := repo.Config.OriginURL().Get(); hasOriginURL {
 		connector, err = hosting.NewConnector(hosting.NewConnectorArgs{
-			FullConfig:      &repo.Runner.Config.Config,
-			HostingPlatform: repo.Runner.Config.Config.HostingPlatform,
+			FullConfig:      &repo.Config.Config,
+			HostingPlatform: repo.Config.Config.HostingPlatform,
 			Log:             print.Logger{},
 			OriginURL:       originURL,
 		})
@@ -246,7 +255,7 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 		branchToShip:             branchToShip,
 		canShipViaAPI:            canShipViaAPI,
 		childBranches:            childBranches,
-		config:                   repo.Runner.Config.Config,
+		config:                   repo.Config.Config,
 		connector:                connector,
 		dialogTestInputs:         dialogTestInputs,
 		dryRun:                   dryRun,
@@ -258,6 +267,7 @@ func determineShipData(args []string, repo *execute.OpenRepoResult, dryRun, verb
 		proposalMessage:          proposalMessage,
 		proposalsOfChildBranches: proposalsOfChildBranches,
 		remotes:                  remotes,
+		runner:                   &runner,
 		targetBranch:             targetBranch,
 	}, branchesSnapshot, stashSize, false, nil
 }

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -54,6 +54,13 @@ func executeSkip(verbose bool) error {
 	if err != nil {
 		return err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	initialBranchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -90,13 +97,6 @@ func executeSkip(verbose bool) error {
 		if err != nil {
 			return err
 		}
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	return skip.Execute(skip.ExecuteArgs{
 		Connector:      connector,

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-town/git-town/v14/src/cli/print"
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/hosting"
 	"github.com/git-town/git-town/v14/src/hosting/hostingdomain"
 	"github.com/git-town/git-town/v14/src/messages"
@@ -49,12 +50,12 @@ func executeSkip(verbose bool) error {
 		return err
 	}
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return err
 	}
 	initialBranchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 false,
 		HandleUnfinishedState: false,
@@ -79,10 +80,10 @@ func executeSkip(verbose bool) error {
 		return errors.New(messages.SkipBranchHasConflicts)
 	}
 	var connector hostingdomain.Connector
-	if originURL, hasOriginURL := repo.Runner.Config.OriginURL().Get(); hasOriginURL {
+	if originURL, hasOriginURL := repo.Config.OriginURL().Get(); hasOriginURL {
 		connector, err = hosting.NewConnector(hosting.NewConnectorArgs{
-			FullConfig:      &repo.Runner.Config.Config,
-			HostingPlatform: repo.Runner.Config.Config.HostingPlatform,
+			FullConfig:      &repo.Config.Config,
+			HostingPlatform: repo.Config.Config.HostingPlatform,
 			Log:             print.Logger{},
 			OriginURL:       originURL,
 		})
@@ -90,13 +91,20 @@ func executeSkip(verbose bool) error {
 			return err
 		}
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	return skip.Execute(skip.ExecuteArgs{
 		Connector:      connector,
 		CurrentBranch:  initialBranchesSnapshot.Active,
 		HasOpenChanges: repoStatus.OpenChanges,
 		RootDir:        repo.RootDir,
 		RunState:       runState,
-		Runner:         repo.Runner,
+		Runner:         &runner,
 		TestInputs:     dialogTestInputs,
 		Verbose:        verbose,
 	})

--- a/src/cmd/skip.go
+++ b/src/cmd/skip.go
@@ -68,6 +68,7 @@ func executeSkip(verbose bool) error {
 		HandleUnfinishedState: false,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,

--- a/src/cmd/status/root.go
+++ b/src/cmd/status/root.go
@@ -52,7 +52,7 @@ func executeStatus(verbose bool) error {
 		return err
 	}
 	displayStatus(*data)
-	print.Footer(verbose, repo.Runner.CommandsCounter.Count(), print.NoFinalMessages)
+	print.Footer(verbose, repo.CommandsCounter.Count(), print.NoFinalMessages)
 	return nil
 }
 

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -50,14 +50,14 @@ func executeSwitch(verbose, merge bool) error {
 	if err != nil || exit {
 		return err
 	}
-	branchToCheckout, abort, err := dialog.SwitchBranch(data.branchNames, data.initialBranch, repo.Runner.Config.Config.Lineage, initialBranches.Branches, data.uncommittedChanges, data.dialogInputs.Next())
+	branchToCheckout, abort, err := dialog.SwitchBranch(data.branchNames, data.initialBranch, repo.Config.Config.Lineage, initialBranches.Branches, data.uncommittedChanges, data.dialogInputs.Next())
 	if err != nil || abort {
 		return err
 	}
 	if branchToCheckout == data.initialBranch {
 		return nil
 	}
-	err = repo.Runner.Frontend.CheckoutBranch(branchToCheckout, merge)
+	err = repo.Frontend.CheckoutBranch(branchToCheckout, merge)
 	if err != nil {
 		exitCode := 1
 		var exitErr *exec.ExitError
@@ -78,12 +78,12 @@ type switchData struct {
 
 func determineSwitchData(repo *execute.OpenRepoResult, verbose bool) (*switchData, gitdomain.BranchesSnapshot, bool, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), false, err
 	}
 	branchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 false,
 		HandleUnfinishedState: true,

--- a/src/cmd/switch.go
+++ b/src/cmd/switch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-town/git-town/v14/src/cli/flags"
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/spf13/cobra"
 )
@@ -82,6 +83,13 @@ func determineSwitchData(repo *execute.OpenRepoResult, verbose bool) (*switchDat
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, _, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -89,6 +97,7 @@ func determineSwitchData(repo *execute.OpenRepoResult, verbose bool) (*switchDat
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -139,6 +139,13 @@ func determineSyncData(allFlag bool, repo *execute.OpenRepoResult, verbose bool)
 	if err != nil {
 		return nil, gitdomain.EmptyBranchesSnapshot(), 0, false, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	branchesSnapshot, stashSize, exit, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -146,6 +153,7 @@ func determineSyncData(allFlag bool, repo *execute.OpenRepoResult, verbose bool)
 		HandleUnfinishedState: true,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -167,13 +175,6 @@ func determineSyncData(allFlag bool, repo *execute.OpenRepoResult, verbose bool)
 	} else {
 		branchNamesToSync = gitdomain.LocalBranchNames{branchesSnapshot.Active}
 		shouldPushTags = repo.Config.Config.IsMainOrPerennialBranch(branchesSnapshot.Active)
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	err = execute.EnsureKnownBranchesAncestry(execute.EnsureKnownBranchesAncestryArgs{
 		BranchesToVerify: branchNamesToSync,

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -93,6 +93,13 @@ func determineUndoData(repo *execute.OpenRepoResult, verbose bool) (*undoData, g
 	if err != nil {
 		return nil, 0, repo.Config.Config.Lineage, err
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	initialBranchesSnapshot, initialStashSize, _, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
 		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
@@ -100,6 +107,7 @@ func determineUndoData(repo *execute.OpenRepoResult, verbose bool) (*undoData, g
 		HandleUnfinishedState: false,
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
+		Runner:                &runner,
 		ValidateIsConfigured:  true,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
@@ -119,13 +127,6 @@ func determineUndoData(repo *execute.OpenRepoResult, verbose bool) (*undoData, g
 		if err != nil {
 			return nil, initialStashSize, repo.Config.Config.Lineage, err
 		}
-	}
-	runner := git.ProdRunner{
-		Backend:         repo.Backend,
-		CommandsCounter: repo.CommandsCounter,
-		Config:          repo.Config,
-		FinalMessages:   repo.FinalMessages,
-		Frontend:        repo.Frontend,
 	}
 	return &undoData{
 		config:                  repo.Config.Config,

--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/execute"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/hosting"
 	"github.com/git-town/git-town/v14/src/hosting/hostingdomain"
@@ -51,7 +52,7 @@ func executeUndo(verbose bool) error {
 	}
 	var data *undoData
 	var initialStashSize gitdomain.StashSize
-	data, initialStashSize, repo.Runner.Config.Config.Lineage, err = determineUndoData(repo, verbose)
+	data, initialStashSize, repo.Config.Config.Lineage, err = determineUndoData(repo, verbose)
 	if err != nil {
 		return err
 	}
@@ -68,10 +69,10 @@ func executeUndo(verbose bool) error {
 		Config:           data.config,
 		HasOpenChanges:   data.hasOpenChanges,
 		InitialStashSize: initialStashSize,
-		Lineage:          repo.Runner.Config.Config.Lineage,
+		Lineage:          repo.Config.Config.Lineage,
 		RootDir:          repo.RootDir,
 		RunState:         runState,
-		Runner:           repo.Runner,
+		Runner:           data.runner,
 		Verbose:          verbose,
 	})
 }
@@ -83,16 +84,17 @@ type undoData struct {
 	hasOpenChanges          bool
 	initialBranchesSnapshot gitdomain.BranchesSnapshot
 	previousBranch          gitdomain.LocalBranchName
+	runner                  *git.ProdRunner
 }
 
 func determineUndoData(repo *execute.OpenRepoResult, verbose bool) (*undoData, gitdomain.StashSize, configdomain.Lineage, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
-	repoStatus, err := repo.Runner.Backend.RepoStatus()
+	repoStatus, err := repo.Backend.RepoStatus()
 	if err != nil {
-		return nil, 0, repo.Runner.Config.Config.Lineage, err
+		return nil, 0, repo.Config.Config.Lineage, err
 	}
 	initialBranchesSnapshot, initialStashSize, _, err := execute.LoadRepoSnapshot(execute.LoadRepoSnapshotArgs{
-		Config:                repo.Runner.Config,
+		Config:                repo.Config,
 		DialogTestInputs:      dialogTestInputs,
 		Fetch:                 false,
 		HandleUnfinishedState: false,
@@ -103,27 +105,35 @@ func determineUndoData(repo *execute.OpenRepoResult, verbose bool) (*undoData, g
 		Verbose:               verbose,
 	})
 	if err != nil {
-		return nil, initialStashSize, repo.Runner.Config.Config.Lineage, err
+		return nil, initialStashSize, repo.Config.Config.Lineage, err
 	}
-	previousBranch := repo.Runner.Backend.PreviouslyCheckedOutBranch()
+	previousBranch := repo.Backend.PreviouslyCheckedOutBranch()
 	var connector hostingdomain.Connector
-	if originURL, hasOriginURL := repo.Runner.Config.OriginURL().Get(); hasOriginURL {
+	if originURL, hasOriginURL := repo.Config.OriginURL().Get(); hasOriginURL {
 		connector, err = hosting.NewConnector(hosting.NewConnectorArgs{
-			FullConfig:      &repo.Runner.Config.Config,
-			HostingPlatform: repo.Runner.Config.Config.HostingPlatform,
+			FullConfig:      &repo.Config.Config,
+			HostingPlatform: repo.Config.Config.HostingPlatform,
 			Log:             print.Logger{},
 			OriginURL:       originURL,
 		})
 		if err != nil {
-			return nil, initialStashSize, repo.Runner.Config.Config.Lineage, err
+			return nil, initialStashSize, repo.Config.Config.Lineage, err
 		}
 	}
+	runner := git.ProdRunner{
+		Backend:         repo.Backend,
+		CommandsCounter: repo.CommandsCounter,
+		Config:          repo.Config,
+		FinalMessages:   repo.FinalMessages,
+		Frontend:        repo.Frontend,
+	}
 	return &undoData{
-		config:                  repo.Runner.Config.Config,
+		config:                  repo.Config.Config,
 		connector:               connector,
 		dialogTestInputs:        dialogTestInputs,
 		hasOpenChanges:          repoStatus.OpenChanges,
 		initialBranchesSnapshot: initialBranchesSnapshot,
 		previousBranch:          previousBranch,
-	}, initialStashSize, repo.Runner.Config.Config.Lineage, nil
+		runner:                  &runner,
+	}, initialStashSize, repo.Config.Config.Lineage, nil
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -19,9 +19,9 @@ import (
 // Config provides type-safe access to Git Town configuration settings
 // stored in the local and global Git configuration.
 type Config struct {
+	Config          configdomain.FullConfig            // the merged configuration data
 	ConfigFile      Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
 	DryRun          bool
-	Config          configdomain.FullConfig    // the merged configuration data
 	GitConfig       gitconfig.Access           // access to the Git configuration settings
 	GlobalGitConfig configdomain.PartialConfig // content of the global Git configuration
 	LocalGitConfig  configdomain.PartialConfig // content of the local Git configuration
@@ -301,9 +301,9 @@ func NewConfig(args NewConfigArgs) (*Config, *stringslice.Collector, error) {
 	finalMessages := stringslice.Collector{}
 	err := cleanupPerennialParentEntries(config.Lineage, config.MainAndPerennials(), configAccess, &finalMessages)
 	return &Config{
+		Config:          config,
 		ConfigFile:      args.ConfigFile,
 		DryRun:          args.DryRun,
-		Config:          config,
 		GitConfig:       configAccess,
 		GlobalGitConfig: args.GlobalConfig,
 		LocalGitConfig:  args.LocalConfig,

--- a/src/execute/load_repo_snapshot.go
+++ b/src/execute/load_repo_snapshot.go
@@ -3,6 +3,7 @@ package execute
 import (
 	"github.com/git-town/git-town/v14/src/cli/dialog/components"
 	"github.com/git-town/git-town/v14/src/config"
+	"github.com/git-town/git-town/v14/src/git"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/validate"
 )
@@ -11,12 +12,12 @@ import (
 func LoadRepoSnapshot(args LoadRepoSnapshotArgs) (gitdomain.BranchesSnapshot, gitdomain.StashSize, bool, error) {
 	var branchesSnapshot gitdomain.BranchesSnapshot
 	var err error
-	stashSize, err := args.Repo.Runner.Backend.StashSize()
+	stashSize, err := args.Repo.Backend.StashSize()
 	if err != nil {
 		return branchesSnapshot, stashSize, false, err
 	}
 	if args.HandleUnfinishedState {
-		branchesSnapshot, err = args.Repo.Runner.Backend.BranchesSnapshot()
+		branchesSnapshot, err = args.Repo.Backend.BranchesSnapshot()
 		if err != nil {
 			return branchesSnapshot, stashSize, false, err
 		}
@@ -31,7 +32,7 @@ func LoadRepoSnapshot(args LoadRepoSnapshotArgs) (gitdomain.BranchesSnapshot, gi
 			Lineage:                 args.Config.Config.Lineage,
 			PushHook:                args.Config.Config.PushHook,
 			RootDir:                 args.Repo.RootDir,
-			Run:                     args.Repo.Runner,
+			Run:                     args.Runner,
 			Verbose:                 args.Verbose,
 		})
 		if err != nil || exit {
@@ -46,30 +47,30 @@ func LoadRepoSnapshot(args LoadRepoSnapshotArgs) (gitdomain.BranchesSnapshot, gi
 	}
 	if args.Fetch {
 		var remotes gitdomain.Remotes
-		remotes, err := args.Repo.Runner.Backend.Remotes()
+		remotes, err := args.Repo.Backend.Remotes()
 		if err != nil {
 			return branchesSnapshot, stashSize, false, err
 		}
 		if remotes.HasOrigin() && !args.Repo.IsOffline.Bool() {
-			err = args.Repo.Runner.Frontend.Fetch()
+			err = args.Repo.Frontend.Fetch()
 			if err != nil {
 				return branchesSnapshot, stashSize, false, err
 			}
 		}
 		// must always reload the snapshot here because we fetched updates from the remote
-		branchesSnapshot, err = args.Repo.Runner.Backend.BranchesSnapshot()
+		branchesSnapshot, err = args.Repo.Backend.BranchesSnapshot()
 		if err != nil {
 			return branchesSnapshot, stashSize, false, err
 		}
 	}
 	if branchesSnapshot.IsEmpty() {
-		branchesSnapshot, err = args.Repo.Runner.Backend.BranchesSnapshot()
+		branchesSnapshot, err = args.Repo.Backend.BranchesSnapshot()
 		if err != nil {
 			return branchesSnapshot, stashSize, false, err
 		}
 	}
 	if args.ValidateIsConfigured {
-		err = validate.IsConfigured(&args.Repo.Runner.Backend, args.Config, branchesSnapshot.Branches.LocalBranches().Names(), &args.DialogTestInputs)
+		err = validate.IsConfigured(&args.Repo.Backend, args.Config, branchesSnapshot.Branches.LocalBranches().Names(), &args.DialogTestInputs)
 	}
 	return branchesSnapshot, stashSize, false, err
 }
@@ -81,6 +82,7 @@ type LoadRepoSnapshotArgs struct {
 	HandleUnfinishedState bool
 	Repo                  *OpenRepoResult
 	RepoStatus            gitdomain.RepoStatus
+	Runner                *git.ProdRunner
 	ValidateIsConfigured  bool
 	ValidateNoOpenChanges bool
 	Verbose               bool

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -136,8 +136,8 @@ type OpenRepoResult struct {
 	Config          *config.Config
 	ConfigSnapshot  undoconfig.ConfigSnapshot
 	FinalMessages   *stringslice.Collector
-	IsOffline       configdomain.Offline
 	Frontend        git.FrontendCommands
+	IsOffline       configdomain.Offline
 	RootDir         gitdomain.RepoRootDir
 }
 

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -110,9 +110,14 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 		}
 	}
 	return &OpenRepoResult{
-		ConfigSnapshot: configSnapshot,
-		IsOffline:      isOffline,
-		RootDir:        rootDir,
+		Backend:         backendCommands,
+		CommandsCounter: &commandsCounter,
+		Config:          config,
+		ConfigSnapshot:  configSnapshot,
+		FinalMessages:   finalMessages,
+		Frontend:        frontEndCommands,
+		IsOffline:       isOffline,
+		RootDir:         rootDir,
 	}, err
 }
 
@@ -128,8 +133,8 @@ type OpenRepoArgs struct {
 type OpenRepoResult struct {
 	Backend         git.BackendCommands
 	CommandsCounter *gohacks.Counter
-	ConfigSnapshot  undoconfig.ConfigSnapshot
 	Config          *config.Config
+	ConfigSnapshot  undoconfig.ConfigSnapshot
 	FinalMessages   *stringslice.Collector
 	IsOffline       configdomain.Offline
 	Frontend        git.FrontendCommands

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/git-town/git-town/v14/src/gohacks"
 	"github.com/git-town/git-town/v14/src/gohacks/cache"
 	. "github.com/git-town/git-town/v14/src/gohacks/prelude"
+	"github.com/git-town/git-town/v14/src/gohacks/stringslice"
 	"github.com/git-town/git-town/v14/src/messages"
 	"github.com/git-town/git-town/v14/src/subshell"
 	"github.com/git-town/git-town/v14/src/undo/undoconfig"
@@ -112,7 +113,6 @@ func OpenRepo(args OpenRepoArgs) (*OpenRepoResult, error) {
 		ConfigSnapshot: configSnapshot,
 		IsOffline:      isOffline,
 		RootDir:        rootDir,
-		Runner:         &prodRunner,
 	}, err
 }
 
@@ -126,10 +126,14 @@ type OpenRepoArgs struct {
 }
 
 type OpenRepoResult struct {
-	ConfigSnapshot undoconfig.ConfigSnapshot
-	IsOffline      configdomain.Offline
-	RootDir        gitdomain.RepoRootDir
-	Runner         *git.ProdRunner
+	Backend         git.BackendCommands
+	CommandsCounter *gohacks.Counter
+	ConfigSnapshot  undoconfig.ConfigSnapshot
+	Config          *config.Config
+	FinalMessages   *stringslice.Collector
+	IsOffline       configdomain.Offline
+	Frontend        git.FrontendCommands
+	RootDir         gitdomain.RepoRootDir
 }
 
 // newFrontendRunner provides a FrontendRunner instance that behaves according to the given configuration.


### PR DESCRIPTION
Currently, OpenRepo provides a ProdRunner instance because it has all the data to create one.
In the future, OpenRepo does not have all the data for this anymore because it doesn't validate the config data. It cannot validate the config data because some Git Town commands want to open the repo and operate on invalid configuration.

This PR prepares this move by moving the creation of ProdRunner out of OpenRepo. This helps keep the diff of the actual refactor small.