### PR TITLE
Disable validation for undo command

### DIFF
--- a/src/cmd/undo.go
+++ b/src/cmd/undo.go
@@ -108,7 +108,7 @@ func determineUndoData(repo *execute.OpenRepoResult, verbose bool) (*undoData, g
 		Repo:                  repo,
 		RepoStatus:            repoStatus,
 		Runner:                &runner,
-		ValidateIsConfigured:  true,
+		ValidateIsConfigured:  false,
 		ValidateNoOpenChanges: false,
 		Verbose:               verbose,
 	})


### PR DESCRIPTION
Undo shouldn't need to validate any configuration since it overwrites it anyways.