### PR TITLE
Make stringslice.Collector robust against passing by value

### DIFF
--- a/src/cmd/hack.go
+++ b/src/cmd/hack.go
@@ -143,7 +143,7 @@ type createBranchArgs struct {
 	beginStashSize        gitdomain.StashSize
 	commandsCounter       *gohacks.Counter
 	dryRun                bool
-	finalMessages         *stringslice.Collector
+	finalMessages         stringslice.Collector
 	frontend              git.FrontendCommands
 	rootDir               gitdomain.RepoRootDir
 	verbose               bool

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -297,7 +297,7 @@ func (self *Config) SetSyncUpstream(value configdomain.SyncUpstream, global bool
 func NewConfig(args NewConfigArgs) (Config, *stringslice.Collector) {
 	config := configdomain.NewFullConfig(args.ConfigFile, args.GlobalConfig, args.LocalConfig)
 	configAccess := gitconfig.Access{Runner: args.Runner}
-	finalMessages := stringslice.Collector{}
+	finalMessages := stringslice.NewCollector()
 	return Config{
 		Config:          config,
 		ConfigFile:      args.ConfigFile,

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -294,7 +294,7 @@ func (self *Config) SetSyncUpstream(value configdomain.SyncUpstream, global bool
 	return self.GitConfig.SetLocalConfigValue(gitconfig.KeySyncUpstream, strconv.FormatBool(value.Bool()))
 }
 
-func NewConfig(args NewConfigArgs) (Config, *stringslice.Collector) {
+func NewConfig(args NewConfigArgs) (Config, stringslice.Collector) {
 	config := configdomain.NewFullConfig(args.ConfigFile, args.GlobalConfig, args.LocalConfig)
 	configAccess := gitconfig.Access{Runner: args.Runner}
 	finalMessages := stringslice.NewCollector()
@@ -306,7 +306,7 @@ func NewConfig(args NewConfigArgs) (Config, *stringslice.Collector) {
 		GlobalGitConfig: args.GlobalConfig,
 		LocalGitConfig:  args.LocalConfig,
 		originURLCache:  configdomain.OriginURLCache{},
-	}, &finalMessages
+	}, finalMessages
 }
 
 type NewConfigArgs struct {

--- a/src/execute/open_repo.go
+++ b/src/execute/open_repo.go
@@ -125,7 +125,7 @@ type OpenRepoResult struct {
 	CommandsCounter *gohacks.Counter
 	Config          config.Config
 	ConfigSnapshot  undoconfig.ConfigSnapshot
-	FinalMessages   *stringslice.Collector
+	FinalMessages   stringslice.Collector
 	Frontend        git.FrontendCommands
 	IsOffline       configdomain.Offline
 	RootDir         gitdomain.RepoRootDir

--- a/src/gohacks/stringslice/collector.go
+++ b/src/gohacks/stringslice/collector.go
@@ -3,18 +3,25 @@ package stringslice
 // Collector accumulates string instances one at a time.
 // The zero value is an empty collection.
 type Collector struct {
-	data []string
+	data *[]string
+}
+
+func NewCollector() Collector {
+	data := []string{}
+	return Collector{
+		data: &data,
+	}
 }
 
 // Add appends a string instance to this collector.
-func (self *Collector) Add(text string) {
-	self.data = append(self.data, text)
+func (self Collector) Add(text string) {
+	*self.data = append(*self.data, text)
 }
 
 // Result provides all accumulated string instances.
-func (self *Collector) Result() []string {
+func (self Collector) Result() []string {
 	if self.data == nil {
 		return []string{}
 	}
-	return self.data
+	return *self.data
 }

--- a/src/gohacks/stringslice/collector_test.go
+++ b/src/gohacks/stringslice/collector_test.go
@@ -9,9 +9,31 @@ import (
 
 func TestCollector(t *testing.T) {
 	t.Parallel()
-	collector := stringslice.Collector{}
-	must.Eq(t, []string{}, collector.Result())
-	collector.Add("one")
-	collector.Add("two")
-	must.Eq(t, []string{"one", "two"}, collector.Result())
+	t.Run("owned variable", func(t *testing.T) {
+		collector := stringslice.NewCollector()
+		must.Eq(t, []string{}, collector.Result())
+		collector.Add("one")
+		collector.Add("two")
+		must.Eq(t, []string{"one", "two"}, collector.Result())
+	})
+	t.Run("works with pass by value", func(t *testing.T) {
+		t.Parallel()
+		collector := stringslice.NewCollector()
+		passByValue(collector)
+		must.Eq(t, []string{"external"}, collector.Result())
+	})
+	t.Run("works with pass by reference", func(t *testing.T) {
+		t.Parallel()
+		collector := stringslice.NewCollector()
+		passByReference(&collector)
+		must.Eq(t, []string{"external"}, collector.Result())
+	})
+}
+
+func passByValue(collector stringslice.Collector) {
+	collector.Add("external")
+}
+
+func passByReference(collector *stringslice.Collector) {
+	collector.Add("external")
 }

--- a/src/gohacks/stringslice/collector_test.go
+++ b/src/gohacks/stringslice/collector_test.go
@@ -10,6 +10,7 @@ import (
 func TestCollector(t *testing.T) {
 	t.Parallel()
 	t.Run("owned variable", func(t *testing.T) {
+		t.Parallel()
 		collector := stringslice.NewCollector()
 		must.Eq(t, []string{}, collector.Result())
 		collector.Add("one")

--- a/src/gohacks/stringslice/collector_test.go
+++ b/src/gohacks/stringslice/collector_test.go
@@ -30,10 +30,10 @@ func TestCollector(t *testing.T) {
 	})
 }
 
-func passByValue(collector stringslice.Collector) {
+func passByReference(collector *stringslice.Collector) {
 	collector.Add("external")
 }
 
-func passByReference(collector *stringslice.Collector) {
+func passByValue(collector stringslice.Collector) {
 	collector.Add("external")
 }

--- a/src/skip/execute.go
+++ b/src/skip/execute.go
@@ -58,7 +58,7 @@ type ExecuteArgs struct {
 	Config          config.Config
 	Connector       hostingdomain.Connector
 	CurrentBranch   gitdomain.LocalBranchName
-	FinalMessages   *stringslice.Collector
+	FinalMessages   stringslice.Collector
 	Frontend        git.FrontendCommands
 	HasOpenChanges  bool
 	RootDir         gitdomain.RepoRootDir

--- a/src/undo/execute.go
+++ b/src/undo/execute.go
@@ -49,7 +49,7 @@ type ExecuteArgs struct {
 	Backend          git.BackendCommands
 	CommandsCounter  *gohacks.Counter
 	Config           config.Config
-	FinalMessages    *stringslice.Collector
+	FinalMessages    stringslice.Collector
 	Frontend         git.FrontendCommands
 	HasOpenChanges   bool
 	InitialStashSize gitdomain.StashSize

--- a/src/validate/config.go
+++ b/src/validate/config.go
@@ -88,14 +88,14 @@ func Config(args ConfigArgs) (validatedResult config.Config, aborted bool, err e
 type ConfigArgs struct {
 	Backend            *git.BackendCommands
 	BranchesToValidate gitdomain.LocalBranchNames
-	FinalMessages      *stringslice.Collector
+	FinalMessages      stringslice.Collector
 	LocalBranches      gitdomain.LocalBranchNames
 	TestInputs         *components.TestInputs
 	Unvalidated        config.Config
 }
 
 // cleanupPerennialParentEntries removes outdated entries from the configuration.
-func cleanupPerennialParentEntries(lineage configdomain.Lineage, perennialBranches gitdomain.LocalBranchNames, access gitconfig.Access, finalMessages *stringslice.Collector) error {
+func cleanupPerennialParentEntries(lineage configdomain.Lineage, perennialBranches gitdomain.LocalBranchNames, access gitconfig.Access, finalMessages stringslice.Collector) error {
 	for _, perennialBranch := range perennialBranches {
 		if lineage.Parent(perennialBranch).IsSome() {
 			if err := access.RemoveLocalConfigValue(gitconfig.NewParentKey(perennialBranch)); err != nil {

--- a/src/validate/handle_unfinished_state.go
+++ b/src/validate/handle_unfinished_state.go
@@ -92,7 +92,7 @@ type UnfinishedStateArgs struct {
 	Connector               hostingdomain.Connector
 	CurrentBranch           gitdomain.LocalBranchName
 	DialogTestInputs        components.TestInputs
-	FinalMessages           *stringslice.Collector
+	FinalMessages           stringslice.Collector
 	Frontend                git.FrontendCommands
 	HasOpenChanges          bool
 	InitialBranchesSnapshot gitdomain.BranchesSnapshot

--- a/src/vm/interpreter/config/finished.go
+++ b/src/vm/interpreter/config/finished.go
@@ -53,7 +53,7 @@ type FinishedArgs struct {
 	Command             string
 	CommandsCounter     *gohacks.Counter
 	EndConfigSnapshot   undoconfig.ConfigSnapshot
-	FinalMessages       *stringslice.Collector
+	FinalMessages       stringslice.Collector
 	RootDir             gitdomain.RepoRootDir
 	Verbose             bool
 }

--- a/src/vm/interpreter/full/execute.go
+++ b/src/vm/interpreter/full/execute.go
@@ -49,7 +49,7 @@ type ExecuteArgs struct {
 	Config                  config.Config
 	Connector               hostingdomain.Connector
 	DialogTestInputs        *components.TestInputs
-	FinalMessages           *stringslice.Collector
+	FinalMessages           stringslice.Collector
 	Frontend                git.FrontendCommands
 	HasOpenChanges          bool
 	InitialBranchesSnapshot gitdomain.BranchesSnapshot

--- a/src/vm/interpreter/light/execute.go
+++ b/src/vm/interpreter/light/execute.go
@@ -35,7 +35,7 @@ func Execute(args ExecuteArgs) {
 type ExecuteArgs struct {
 	Backend       git.BackendCommands
 	Config        config.Config
-	FinalMessages *stringslice.Collector
+	FinalMessages stringslice.Collector
 	Frontend      git.FrontendCommands
 	Lineage       configdomain.Lineage
 	Prog          program.Program

--- a/src/vm/shared/runargs.go
+++ b/src/vm/shared/runargs.go
@@ -15,7 +15,7 @@ type RunArgs struct {
 	Config                          *config.Config
 	Connector                       hostingdomain.Connector
 	DialogTestInputs                *components.TestInputs
-	FinalMessages                   *stringslice.Collector
+	FinalMessages                   stringslice.Collector
 	Frontend                        git.FrontendCommands
 	Lineage                         configdomain.Lineage
 	PrependOpcodes                  func(...Opcode)


### PR DESCRIPTION
Go has this really weird convention of allowing to pass mutable data by value. This PR hardens the stringslice.Collector struct against this mistake by keeping its content mutable even if it is passed by value.