### PR TITLE
Skip restoring the previous branch in case the previous branch is in another worktree

### DIFF
--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -6,7 +6,6 @@ Feature: sync a branch when the previous branch is active in another worktree
     And branch "previous" is active in another worktree
     When I run "git-town sync"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                                 |
@@ -21,16 +20,6 @@ Feature: sync a branch when the previous branch is active in another worktree
 
   Scenario: undo
     When I run "git-town undo"
-    Then it runs the commands
-      | BRANCH | COMMAND                                                                            |
-      | child  | git reset --hard {{ sha 'local child commit' }}                                    |
-      |        | git push --force-with-lease origin {{ sha-in-origin 'origin child commit' }}:child |
-    And the current branch is still "child"
-    And these commits exist now
-      | BRANCH | LOCATION                | MESSAGE              |
-      | main   | local, origin, worktree | origin main commit   |
-      |        |                         | local main commit    |
-      | child  | local                   | local child commit   |
-      |        | origin                  | origin child commit  |
-      | parent | origin                  | origin parent commit |
-      |        | worktree                | local parent commit  |
+    Then it runs no commands
+    And the current branch is still "current"
+    And no commits exist now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -12,18 +12,17 @@ Feature: sync a branch when the previous branch is active in another worktree
     And branch "previous" is active in another worktree
     When I run "git-town sync"
 
-  @this
+  @debug @this
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                                |
-      | child  | git fetch --prune --tags               |
-      |        | git checkout main                      |
-      | main   | git rebase origin/main                 |
-      |        | git push                               |
-      |        | git checkout child                     |
-      | child  | git merge --no-edit --ff origin/child  |
-      |        | git merge --no-edit --ff origin/parent |
-      |        | git push                               |
+      | BRANCH  | COMMAND                                 |
+      | current | git fetch --prune --tags                |
+      |         | git checkout main                       |
+      | main    | git rebase origin/main                  |
+      |         | git checkout current                    |
+      | current | git merge --no-edit --ff origin/current |
+      |         | git merge --no-edit --ff main           |
+      |         | git push                                |
     And the current branch is still "child"
     And these commits exist now
       | BRANCH | LOCATION                | MESSAGE                                                 |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -12,7 +12,7 @@ Feature: sync a branch when the previous branch is active in another worktree
     And branch "previous" is active in another worktree
     When I run "git-town sync"
 
-  @debug @this
+  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                                 |
@@ -23,18 +23,14 @@ Feature: sync a branch when the previous branch is active in another worktree
       | current | git merge --no-edit --ff origin/current |
       |         | git merge --no-edit --ff main           |
       |         | git push                                |
-    And the current branch is still "child"
+    And the current branch is still "current"
     And these commits exist now
-      | BRANCH | LOCATION                | MESSAGE                                                 |
-      | main   | local, origin, worktree | origin main commit                                      |
-      |        |                         | local main commit                                       |
-      | child  | local, origin           | local child commit                                      |
-      |        |                         | origin child commit                                     |
-      |        |                         | Merge remote-tracking branch 'origin/child' into child  |
-      |        |                         | origin parent commit                                    |
-      |        |                         | Merge remote-tracking branch 'origin/parent' into child |
-      | parent | origin                  | origin parent commit                                    |
-      |        | worktree                | local parent commit                                     |
+      | BRANCH   | LOCATION      | MESSAGE                                                    |
+      | current  | local, origin | local current commit                                       |
+      |          |               | origin current commit                                      |
+      |          |               | Merge remote-tracking branch 'origin/current' into current |
+      | previous | origin        | origin previous commit                                     |
+      |          | worktree      | local previous commit                                      |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -2,12 +2,6 @@ Feature: sync a branch when the previous branch is active in another worktree
 
   Background:
     Given the feature branches "current" and "previous"
-    And the commits
-      | BRANCH   | LOCATION | MESSAGE                |
-      | current  | local    | local current commit   |
-      |          | origin   | origin current commit  |
-      | previous | local    | local previous commit  |
-      |          | origin   | origin previous commit |
     And the current branch is "current" and the previous branch is "previous"
     And branch "previous" is active in another worktree
     When I run "git-town sync"
@@ -22,15 +16,8 @@ Feature: sync a branch when the previous branch is active in another worktree
       |         | git checkout current                    |
       | current | git merge --no-edit --ff origin/current |
       |         | git merge --no-edit --ff main           |
-      |         | git push                                |
     And the current branch is still "current"
-    And these commits exist now
-      | BRANCH   | LOCATION      | MESSAGE                                                    |
-      | current  | local, origin | local current commit                                       |
-      |          |               | origin current commit                                      |
-      |          |               | Merge remote-tracking branch 'origin/current' into current |
-      | previous | origin        | origin previous commit                                     |
-      |          | worktree      | local previous commit                                      |
+    And no commits exist now
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -1,0 +1,54 @@
+Feature: sync a branch when the previous branch is active in another worktree
+
+  Background:
+    Given feature branches "current" and "previous"
+    And the commits
+      | BRANCH   | LOCATION | MESSAGE                |
+      | current  | local    | local current commit   |
+      |          | origin   | origin current commit  |
+      | previous | local    | local previous commit  |
+      |          | origin   | origin previous commit |
+    And branch "previous" is active in another worktree
+    And the current branch is "current" and the previous branch is "previous"
+    When I run "git-town sync"
+
+  @this
+  Scenario: result
+    Then it runs the commands
+      | BRANCH | COMMAND                                |
+      | child  | git fetch --prune --tags               |
+      |        | git checkout main                      |
+      | main   | git rebase origin/main                 |
+      |        | git push                               |
+      |        | git checkout child                     |
+      | child  | git merge --no-edit --ff origin/child  |
+      |        | git merge --no-edit --ff origin/parent |
+      |        | git push                               |
+    And the current branch is still "child"
+    And these commits exist now
+      | BRANCH | LOCATION                | MESSAGE                                                 |
+      | main   | local, origin, worktree | origin main commit                                      |
+      |        |                         | local main commit                                       |
+      | child  | local, origin           | local child commit                                      |
+      |        |                         | origin child commit                                     |
+      |        |                         | Merge remote-tracking branch 'origin/child' into child  |
+      |        |                         | origin parent commit                                    |
+      |        |                         | Merge remote-tracking branch 'origin/parent' into child |
+      | parent | origin                  | origin parent commit                                    |
+      |        | worktree                | local parent commit                                     |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then it runs the commands
+      | BRANCH | COMMAND                                                                            |
+      | child  | git reset --hard {{ sha 'local child commit' }}                                    |
+      |        | git push --force-with-lease origin {{ sha-in-origin 'origin child commit' }}:child |
+    And the current branch is still "child"
+    And these commits exist now
+      | BRANCH | LOCATION                | MESSAGE              |
+      | main   | local, origin, worktree | origin main commit   |
+      |        |                         | local main commit    |
+      | child  | local                   | local child commit   |
+      |        | origin                  | origin child commit  |
+      | parent | origin                  | origin parent commit |
+      |        | worktree                | local parent commit  |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -8,8 +8,8 @@ Feature: sync a branch when the previous branch is active in another worktree
       |          | origin   | origin current commit  |
       | previous | local    | local previous commit  |
       |          | origin   | origin previous commit |
-    And branch "previous" is active in another worktree
     And the current branch is "current" and the previous branch is "previous"
+    And branch "previous" is active in another worktree
     When I run "git-town sync"
 
   @this

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -1,7 +1,7 @@
 Feature: sync a branch when the previous branch is active in another worktree
 
   Background:
-    Given feature branches "current" and "previous"
+    Given the feature branches "current" and "previous"
     And the commits
       | BRANCH   | LOCATION | MESSAGE                |
       | current  | local    | local current commit   |

--- a/src/cmd/sync.go
+++ b/src/cmd/sync.go
@@ -181,9 +181,9 @@ func determineSyncData(allFlag bool, repo execute.OpenRepoResult, verbose bool) 
 	var previousBranchOpt Option[gitdomain.LocalBranchName]
 	if previousBranchInfo, hasPreviousBranchInfo := branchesSnapshot.Branches.FindByLocalName(previousBranch).Get(); hasPreviousBranchInfo {
 		switch previousBranchInfo.SyncStatus {
-		case gitdomain.SyncStatusDeletedAtRemote, gitdomain.SyncStatusLocalOnly, gitdomain.SyncStatusNotInSync, gitdomain.SyncStatusUpToDate:
+		case gitdomain.SyncStatusLocalOnly, gitdomain.SyncStatusNotInSync, gitdomain.SyncStatusUpToDate:
 			previousBranchOpt = Some(previousBranchInfo.LocalName)
-		case gitdomain.SyncStatusRemoteOnly, gitdomain.SyncStatusOtherWorktree:
+		case gitdomain.SyncStatusDeletedAtRemote, gitdomain.SyncStatusRemoteOnly, gitdomain.SyncStatusOtherWorktree:
 			previousBranchOpt = None[gitdomain.LocalBranchName]()
 		}
 	}

--- a/src/sync/sync_branches.go
+++ b/src/sync/sync_branches.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"github.com/git-town/git-town/v14/src/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
+	. "github.com/git-town/git-town/v14/src/gohacks/prelude"
 	"github.com/git-town/git-town/v14/src/vm/opcodes"
 )
 
@@ -11,19 +12,30 @@ func BranchesProgram(args BranchesProgramArgs) {
 	for _, branch := range args.BranchesToSync {
 		BranchProgram(branch, args.BranchProgramArgs)
 	}
-	args.Program.Add(&opcodes.CheckoutFirstExisting{
-		Branches:   gitdomain.LocalBranchNames{args.InitialBranch, args.PreviousBranch},
-		MainBranch: args.Config.MainBranch,
-	})
+	previousBranch, hasPreviousBranch := args.PreviousBranch.Get()
+	finalBranchCandidates := gitdomain.LocalBranchNames{args.InitialBranch}
+	if hasPreviousBranch {
+		finalBranchCandidates = append(finalBranchCandidates, previousBranch)
+	}
+	if hasPreviousBranch {
+		args.Program.Add(&opcodes.CheckoutFirstExisting{
+			Branches:   finalBranchCandidates,
+			MainBranch: args.Config.MainBranch,
+		})
+	}
 	if args.Remotes.HasOrigin() && args.ShouldPushTags && args.Config.IsOnline() {
 		args.Program.Add(&opcodes.PushTags{})
+	}
+	previousbranchCandidates := gitdomain.LocalBranchNames{}
+	if hasPreviousBranch {
+		previousbranchCandidates = append(previousbranchCandidates, previousBranch)
 	}
 	cmdhelpers.Wrap(args.Program, cmdhelpers.WrapOptions{
 		DryRun:           args.DryRun,
 		RunInGitRoot:     true,
 		StashOpenChanges: args.HasOpenChanges,
 		// TODO: only add args.PreviousBranch if it isn't in another workspace
-		PreviousBranchCandidates: gitdomain.LocalBranchNames{args.PreviousBranch},
+		PreviousBranchCandidates: previousbranchCandidates,
 	})
 }
 
@@ -33,6 +45,6 @@ type BranchesProgramArgs struct {
 	DryRun         bool
 	HasOpenChanges bool
 	InitialBranch  gitdomain.LocalBranchName
-	PreviousBranch gitdomain.LocalBranchName
+	PreviousBranch Option[gitdomain.LocalBranchName]
 	ShouldPushTags bool
 }

--- a/src/sync/sync_branches.go
+++ b/src/sync/sync_branches.go
@@ -19,9 +19,10 @@ func BranchesProgram(args BranchesProgramArgs) {
 		args.Program.Add(&opcodes.PushTags{})
 	}
 	cmdhelpers.Wrap(args.Program, cmdhelpers.WrapOptions{
-		DryRun:                   args.DryRun,
-		RunInGitRoot:             true,
-		StashOpenChanges:         args.HasOpenChanges,
+		DryRun:           args.DryRun,
+		RunInGitRoot:     true,
+		StashOpenChanges: args.HasOpenChanges,
+		// TODO: only add args.PreviousBranch if it isn't in another workspace
 		PreviousBranchCandidates: gitdomain.LocalBranchNames{args.PreviousBranch},
 	})
 }

--- a/src/sync/sync_branches.go
+++ b/src/sync/sync_branches.go
@@ -12,29 +12,23 @@ func BranchesProgram(args BranchesProgramArgs) {
 	for _, branch := range args.BranchesToSync {
 		BranchProgram(branch, args.BranchProgramArgs)
 	}
-	previousBranch, hasPreviousBranch := args.PreviousBranch.Get()
+	previousbranchCandidates := gitdomain.LocalBranchNames{}
 	finalBranchCandidates := gitdomain.LocalBranchNames{args.InitialBranch}
-	if hasPreviousBranch {
+	if previousBranch, hasPreviousBranch := args.PreviousBranch.Get(); hasPreviousBranch {
 		finalBranchCandidates = append(finalBranchCandidates, previousBranch)
+		previousbranchCandidates = append(previousbranchCandidates, previousBranch)
 	}
-	if hasPreviousBranch {
-		args.Program.Add(&opcodes.CheckoutFirstExisting{
-			Branches:   finalBranchCandidates,
-			MainBranch: args.Config.MainBranch,
-		})
-	}
+	args.Program.Add(&opcodes.CheckoutFirstExisting{
+		Branches:   finalBranchCandidates,
+		MainBranch: args.Config.MainBranch,
+	})
 	if args.Remotes.HasOrigin() && args.ShouldPushTags && args.Config.IsOnline() {
 		args.Program.Add(&opcodes.PushTags{})
 	}
-	previousbranchCandidates := gitdomain.LocalBranchNames{}
-	if hasPreviousBranch {
-		previousbranchCandidates = append(previousbranchCandidates, previousBranch)
-	}
 	cmdhelpers.Wrap(args.Program, cmdhelpers.WrapOptions{
-		DryRun:           args.DryRun,
-		RunInGitRoot:     true,
-		StashOpenChanges: args.HasOpenChanges,
-		// TODO: only add args.PreviousBranch if it isn't in another workspace
+		DryRun:                   args.DryRun,
+		RunInGitRoot:             true,
+		StashOpenChanges:         args.HasOpenChanges,
 		PreviousBranchCandidates: previousbranchCandidates,
 	})
 }


### PR DESCRIPTION
resolves parts of #3297 