### PR TITLE
Encapsulate lineage

### DIFF
--- a/src/cli/dialog/lineage.go
+++ b/src/cli/dialog/lineage.go
@@ -10,7 +10,7 @@ import (
 // Prompts missing lineage information from the user.
 // Returns the new lineage and perennial branches to add to the config storage.
 func Lineage(args LineageArgs) (additionalLineage configdomain.Lineage, additionalPerennials gitdomain.LocalBranchNames, aborted bool, err error) {
-	additionalLineage = make(configdomain.Lineage)
+	additionalLineage = configdomain.NewLineage()
 	branchesToVerify := args.BranchesToVerify
 	for i := 0; i < len(branchesToVerify); i++ {
 		branchToVerify := branchesToVerify[i]
@@ -38,7 +38,7 @@ func Lineage(args LineageArgs) (additionalLineage configdomain.Lineage, addition
 		case ParentOutcomePerennialBranch:
 			additionalPerennials = append(additionalPerennials, branchToVerify)
 		case ParentOutcomeSelectedParent:
-			additionalLineage[branchToVerify] = selectedBranch
+			additionalLineage.AddParent(branchToVerify, selectedBranch)
 			branchesToVerify = append(branchesToVerify, selectedBranch)
 		}
 	}

--- a/src/cli/dialog/parent_test.go
+++ b/src/cli/dialog/parent_test.go
@@ -22,11 +22,10 @@ func TestParent(t *testing.T) {
 			branch3 := gitdomain.NewLocalBranchName("branch-3")
 			main := gitdomain.NewLocalBranchName("main")
 			localBranches := gitdomain.LocalBranchNames{branch1, branch2, branch3, main}
-			lineage := configdomain.Lineage{
-				branch1: main,
-				branch2: main,
-				branch3: main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(branch1, main)
+			lineage.AddParent(branch2, main)
+			lineage.AddParent(branch3, main)
 			have := dialog.ParentCandidateNames(dialog.ParentArgs{
 				Branch:          branch2,
 				DefaultChoice:   main,
@@ -47,13 +46,12 @@ func TestParent(t *testing.T) {
 			branch3 := gitdomain.NewLocalBranchName("branch-3")
 			main := gitdomain.NewLocalBranchName("main")
 			localBranches := gitdomain.LocalBranchNames{branch1, branch1a, branch2, branch2a, branch3, main}
-			lineage := configdomain.Lineage{
-				branch1:  main,
-				branch1a: branch1,
-				branch2:  main,
-				branch2a: branch2,
-				branch3:  main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(branch1, main)
+			lineage.AddParent(branch1a, branch1)
+			lineage.AddParent(branch2, main)
+			lineage.AddParent(branch2a, branch2)
+			lineage.AddParent(branch3, main)
 			have := dialog.ParentCandidateNames(dialog.ParentArgs{
 				Branch:          branch2,
 				DefaultChoice:   main,

--- a/src/cli/dialog/switch_branch.go
+++ b/src/cli/dialog/switch_branch.go
@@ -13,7 +13,6 @@ import (
 	"github.com/git-town/git-town/v14/src/gohacks/slice"
 	"github.com/git-town/git-town/v14/src/messages"
 	"github.com/muesli/termenv"
-	"golang.org/x/exp/maps"
 )
 
 type SwitchBranchEntry struct {
@@ -164,14 +163,14 @@ func SwitchBranchCursorPos(entries []SwitchBranchEntry, initialBranch gitdomain.
 
 // SwitchBranchEntries provides the entries for the "switch branch" components.
 func SwitchBranchEntries(localBranches gitdomain.LocalBranchNames, lineage configdomain.Lineage, allBranches gitdomain.BranchInfos) []SwitchBranchEntry {
-	entries := make([]SwitchBranchEntry, 0, len(lineage))
+	entries := make([]SwitchBranchEntry, 0, lineage.Len())
 	roots := lineage.Roots()
 	// add all entries from the lineage
 	for _, root := range roots {
 		layoutBranches(&entries, root, "", lineage, allBranches)
 	}
 	// add missing local branches
-	branchesInLineage := maps.Keys(lineage)
+	branchesInLineage := lineage.Branches()
 	for _, localBranch := range localBranches {
 		if slices.Contains(roots, localBranch) {
 			continue

--- a/src/cli/dialog/switch_branch_test.go
+++ b/src/cli/dialog/switch_branch_test.go
@@ -50,10 +50,9 @@ func TestSwitchBranch(t *testing.T) {
 			alpha := gitdomain.NewLocalBranchName("alpha")
 			beta := gitdomain.NewLocalBranchName("beta")
 			main := gitdomain.NewLocalBranchName("main")
-			lineage := configdomain.Lineage{
-				alpha: main,
-				beta:  main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(alpha, main)
+			lineage.AddParent(beta, main)
 			localBranches := gitdomain.LocalBranchNames{alpha, beta, main}
 			allBranches := gitdomain.BranchInfos{
 				gitdomain.BranchInfo{LocalName: Some(alpha), SyncStatus: gitdomain.SyncStatusLocalOnly},
@@ -73,10 +72,9 @@ func TestSwitchBranch(t *testing.T) {
 			alpha := gitdomain.NewLocalBranchName("alpha")
 			beta := gitdomain.NewLocalBranchName("beta")
 			main := gitdomain.NewLocalBranchName("main")
-			lineage := configdomain.Lineage{
-				alpha: main,
-				beta:  main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(alpha, main)
+			lineage.AddParent(beta, main)
 			localBranches := gitdomain.LocalBranchNames{alpha, beta, main}
 			allBranches := gitdomain.BranchInfos{
 				gitdomain.BranchInfo{LocalName: Some(alpha), SyncStatus: gitdomain.SyncStatusLocalOnly},
@@ -97,10 +95,9 @@ func TestSwitchBranch(t *testing.T) {
 			beta := gitdomain.NewLocalBranchName("beta")
 			perennial1 := gitdomain.NewLocalBranchName("perennial-1")
 			main := gitdomain.NewLocalBranchName("main")
-			lineage := configdomain.Lineage{
-				alpha: main,
-				beta:  main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(alpha, main)
+			lineage.AddParent(beta, main)
 			localBranches := gitdomain.LocalBranchNames{alpha, beta, main, perennial1}
 			allBranches := gitdomain.BranchInfos{
 				gitdomain.BranchInfo{LocalName: Some(alpha), SyncStatus: gitdomain.SyncStatusLocalOnly},
@@ -122,10 +119,9 @@ func TestSwitchBranch(t *testing.T) {
 			child := gitdomain.NewLocalBranchName("child")
 			grandchild := gitdomain.NewLocalBranchName("grandchild")
 			main := gitdomain.NewLocalBranchName("main")
-			lineage := configdomain.Lineage{
-				child:      main,
-				grandchild: child,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(child, main)
+			lineage.AddParent(grandchild, child)
 			localBranches := gitdomain.LocalBranchNames{grandchild, main}
 			allBranches := gitdomain.BranchInfos{
 				gitdomain.BranchInfo{LocalName: None[gitdomain.LocalBranchName](), RemoteName: Some(child.BranchName().RemoteName()), SyncStatus: gitdomain.SyncStatusRemoteOnly},

--- a/src/cmd/config/root.go
+++ b/src/cmd/config/root.go
@@ -74,7 +74,7 @@ func printConfig(config configdomain.UnvalidatedConfig) {
 	print.Entry("GitLab token", format.OptionalStringerSetting(config.GitLabToken))
 	print.Entry("Gitea token", format.OptionalStringerSetting(config.GiteaToken))
 	fmt.Println()
-	if len(config.Lineage) > 0 {
+	if config.Lineage.Len() > 0 {
 		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.Lineage))
 	}
 }

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -14,6 +14,11 @@ type Lineage struct {
 	data map[gitdomain.LocalBranchName]gitdomain.LocalBranchName
 }
 
+type LineageEntry struct {
+	child  gitdomain.LocalBranchName
+	parent gitdomain.LocalBranchName
+}
+
 func NewLineage() Lineage {
 	return Lineage{
 		data: make(map[gitdomain.LocalBranchName]gitdomain.LocalBranchName),
@@ -102,6 +107,17 @@ func (self Lineage) Descendants(branch gitdomain.LocalBranchName) gitdomain.Loca
 	for _, child := range self.Children(branch) {
 		result = append(result, child)
 		result = append(result, self.Descendants(child)...)
+	}
+	return result
+}
+
+func (self Lineage) Entries() []LineageEntry {
+	result := make([]LineageEntry, 0, self.Len())
+	for branch, parent := range self.data {
+		result = append(result, LineageEntry{
+			child:  branch,
+			parent: parent,
+		})
 	}
 	return result
 }

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -14,11 +14,6 @@ type Lineage struct {
 	data map[gitdomain.LocalBranchName]gitdomain.LocalBranchName
 }
 
-type LineageEntry struct {
-	Child  gitdomain.LocalBranchName
-	Parent gitdomain.LocalBranchName
-}
-
 func NewLineage() Lineage {
 	return Lineage{
 		data: make(map[gitdomain.LocalBranchName]gitdomain.LocalBranchName),

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -133,12 +133,6 @@ func (self Lineage) HasParents(branch gitdomain.LocalBranchName) bool {
 	return false
 }
 
-func (self *Lineage) initializeIfNeeded() {
-	if self.data == nil {
-		self.data = make(map[gitdomain.LocalBranchName]gitdomain.LocalBranchName)
-	}
-}
-
 // IsAncestor indicates whether the given branch is an ancestor of the other given branch.
 func (self Lineage) IsAncestor(ancestor, other gitdomain.LocalBranchName) bool {
 	current := other
@@ -214,5 +208,11 @@ func (self Lineage) addChildrenHierarchically(result *gitdomain.LocalBranchNames
 	}
 	for _, child := range self.Children(currentBranch) {
 		self.addChildrenHierarchically(result, child, allBranches)
+	}
+}
+
+func (self *Lineage) initializeIfNeeded() {
+	if self.data == nil {
+		self.data = make(map[gitdomain.LocalBranchName]gitdomain.LocalBranchName)
 	}
 }

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -111,10 +111,6 @@ func (self Lineage) Descendants(branch gitdomain.LocalBranchName) gitdomain.Loca
 	return result
 }
 
-func (self Lineage) IsEmpty() bool {
-	return self.data == nil || self.Len() == 0
-}
-
 func (self Lineage) Entries() []LineageEntry {
 	result := make([]LineageEntry, 0, self.Len())
 	for branch, parent := range self.data {
@@ -149,6 +145,10 @@ func (self Lineage) IsAncestor(ancestor, other gitdomain.LocalBranchName) bool {
 		}
 		current = parent
 	}
+}
+
+func (self Lineage) IsEmpty() bool {
+	return self.data == nil || self.Len() == 0
 }
 
 func (self Lineage) Len() int {

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -14,6 +14,16 @@ type Lineage struct {
 	data map[gitdomain.LocalBranchName]gitdomain.LocalBranchName
 }
 
+func NewLineage() Lineage {
+	return Lineage{
+		data: make(map[gitdomain.LocalBranchName]gitdomain.LocalBranchName),
+	}
+}
+
+func (self *Lineage) AddParent(branch, parent gitdomain.LocalBranchName) {
+	self.data[branch] = parent
+}
+
 // Ancestors provides the names of all parent branches of the branch with the given name.
 func (self Lineage) Ancestors(branch gitdomain.LocalBranchName) gitdomain.LocalBranchNames {
 	current := branch
@@ -57,6 +67,11 @@ func (self Lineage) BranchNames() gitdomain.LocalBranchNames {
 	result := gitdomain.LocalBranchNames(maps.Keys(self.data))
 	result.Sort()
 	return result
+}
+
+// provides all branches for which the parent is known
+func (self Lineage) Branches() gitdomain.LocalBranchNames {
+	return maps.Keys(self.data)
 }
 
 // BranchesAndAncestors provides the full lineage for the branches with the given names,
@@ -114,6 +129,10 @@ func (self Lineage) IsAncestor(ancestor, other gitdomain.LocalBranchName) bool {
 		}
 		current = parent
 	}
+}
+
+func (self Lineage) Len() int {
+	return len(self.data)
 }
 
 // OrderHierarchically provides the given branches sorted so that ancestor branches come before their descendants.

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -26,6 +26,7 @@ func NewLineage() Lineage {
 }
 
 func (self *Lineage) AddParent(branch, parent gitdomain.LocalBranchName) {
+	self.initializeIfNeeded()
 	self.data[branch] = parent
 }
 
@@ -130,6 +131,12 @@ func (self Lineage) HasParents(branch gitdomain.LocalBranchName) bool {
 		}
 	}
 	return false
+}
+
+func (self *Lineage) initializeIfNeeded() {
+	if self.data == nil {
+		self.data = make(map[gitdomain.LocalBranchName]gitdomain.LocalBranchName)
+	}
 }
 
 // IsAncestor indicates whether the given branch is an ancestor of the other given branch.

--- a/src/config/configdomain/lineage.go
+++ b/src/config/configdomain/lineage.go
@@ -15,8 +15,8 @@ type Lineage struct {
 }
 
 type LineageEntry struct {
-	child  gitdomain.LocalBranchName
-	parent gitdomain.LocalBranchName
+	Child  gitdomain.LocalBranchName
+	Parent gitdomain.LocalBranchName
 }
 
 func NewLineage() Lineage {
@@ -111,12 +111,16 @@ func (self Lineage) Descendants(branch gitdomain.LocalBranchName) gitdomain.Loca
 	return result
 }
 
+func (self Lineage) IsEmpty() bool {
+	return self.data == nil || self.Len() == 0
+}
+
 func (self Lineage) Entries() []LineageEntry {
 	result := make([]LineageEntry, 0, self.Len())
 	for branch, parent := range self.data {
 		result = append(result, LineageEntry{
-			child:  branch,
-			parent: parent,
+			Child:  branch,
+			Parent: parent,
 		})
 	}
 	return result

--- a/src/config/configdomain/lineage_entry.go
+++ b/src/config/configdomain/lineage_entry.go
@@ -1,0 +1,8 @@
+package configdomain
+
+import "github.com/git-town/git-town/v14/src/git/gitdomain"
+
+type LineageEntry struct {
+	Child  gitdomain.LocalBranchName
+	Parent gitdomain.LocalBranchName
+}

--- a/src/config/configdomain/lineage_test.go
+++ b/src/config/configdomain/lineage_test.go
@@ -20,29 +20,26 @@ func TestLineage(t *testing.T) {
 		t.Parallel()
 		t.Run("provides all ancestor branches, oldest first", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				three: two,
-				two:   one,
-				one:   main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(three, two)
+			lineage.AddParent(two, one)
+			lineage.AddParent(one, main)
 			have := lineage.Ancestors(three)
 			want := gitdomain.LocalBranchNames{main, one, two}
 			must.Eq(t, want, have)
 		})
 		t.Run("one ancestor", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one: main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
 			have := lineage.Ancestors(one)
 			want := gitdomain.LocalBranchNames{main}
 			must.Eq(t, want, have)
 		})
 		t.Run("no ancestors", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one: main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
 			have := lineage.Ancestors(two)
 			want := gitdomain.LocalBranchNames{}
 			must.Eq(t, want, have)
@@ -53,26 +50,26 @@ func TestLineage(t *testing.T) {
 		t.Parallel()
 		t.Run("provides all ancestor branches, oldest first", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{}
-			lineage[three] = two
-			lineage[two] = one
-			lineage[one] = main
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(three, two)
+			lineage.AddParent(two, one)
+			lineage.AddParent(one, main)
 			have := lineage.AncestorsWithoutRoot(three)
 			want := gitdomain.LocalBranchNames{one, two}
 			must.Eq(t, want, have)
 		})
 		t.Run("one ancestor", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{}
-			lineage[one] = main
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
 			have := lineage.AncestorsWithoutRoot(one)
 			want := gitdomain.LocalBranchNames{}
 			must.Eq(t, want, have)
 		})
 		t.Run("no ancestors", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{}
-			lineage[one] = main
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
 			have := lineage.AncestorsWithoutRoot(two)
 			want := gitdomain.LocalBranchNames{}
 			must.Eq(t, want, have)
@@ -81,9 +78,8 @@ func TestLineage(t *testing.T) {
 
 	t.Run("BranchAndAncestors", func(t *testing.T) {
 		t.Parallel()
-		lineage := configdomain.Lineage{
-			one: main,
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(one, main)
 		have := lineage.BranchAndAncestors(one)
 		want := gitdomain.LocalBranchNames{main, one}
 		must.Eq(t, want, have)
@@ -93,11 +89,10 @@ func TestLineage(t *testing.T) {
 		t.Parallel()
 		t.Run("deep lineage, multiple branches", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one:   main,
-				two:   one,
-				three: two,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
 			give := gitdomain.LocalBranchNames{two, one}
 			have := lineage.BranchesAndAncestors(give)
 			want := gitdomain.LocalBranchNames{main, one, two}
@@ -105,11 +100,10 @@ func TestLineage(t *testing.T) {
 		})
 		t.Run("deep lineage, multiple branches out of order", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one:   main,
-				two:   one,
-				three: two,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
 			give := gitdomain.LocalBranchNames{one, two, main, three}
 			have := lineage.BranchesAndAncestors(give)
 			want := gitdomain.LocalBranchNames{main, one, two, three}
@@ -117,11 +111,10 @@ func TestLineage(t *testing.T) {
 		})
 		t.Run("deep lineage, single branch", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one:   main,
-				two:   one,
-				three: two,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
 			give := gitdomain.LocalBranchNames{three}
 			have := lineage.BranchesAndAncestors(give)
 			want := gitdomain.LocalBranchNames{main, one, two, three}
@@ -132,14 +125,13 @@ func TestLineage(t *testing.T) {
 			first := gitdomain.NewLocalBranchName("first")
 			second := gitdomain.NewLocalBranchName("second")
 			third := gitdomain.NewLocalBranchName("third")
-			lineage := configdomain.Lineage{
-				one:    main,
-				two:    one,
-				three:  two,
-				first:  main,
-				second: first,
-				third:  second,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
+			lineage.AddParent(first, main)
+			lineage.AddParent(second, first)
+			lineage.AddParent(third, second)
 			give := gitdomain.LocalBranchNames{main, first, one, second, third, three, two}
 			have := lineage.BranchesAndAncestors(give)
 			want := gitdomain.LocalBranchNames{main, first, second, third, one, two, three}
@@ -149,9 +141,8 @@ func TestLineage(t *testing.T) {
 
 	t.Run("BranchAndAncestors", func(t *testing.T) {
 		t.Parallel()
-		lineage := configdomain.Lineage{
-			one: main,
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(one, main)
 		have := lineage.BranchAndAncestors(one)
 		want := gitdomain.LocalBranchNames{main, one}
 		must.Eq(t, want, have)
@@ -168,19 +159,17 @@ func TestLineage(t *testing.T) {
 		})
 		t.Run("one branch and root exist", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one: main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
 			have := lineage.BranchLineageWithoutRoot(one)
 			want := gitdomain.LocalBranchNames{one}
 			must.Eq(t, want, have)
 		})
 		t.Run("multiple branches", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one: main,
-				two: one,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
 			want := gitdomain.LocalBranchNames{one, two}
 			t.Run("given root", func(t *testing.T) {
 				t.Parallel()
@@ -202,11 +191,10 @@ func TestLineage(t *testing.T) {
 
 	t.Run("BranchNames", func(t *testing.T) {
 		t.Parallel()
-		lineage := configdomain.Lineage{
-			one:   main,
-			two:   main,
-			three: main,
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(one, main)
+		lineage.AddParent(two, main)
+		lineage.AddParent(three, main)
 		have := lineage.BranchNames()
 		want := gitdomain.LocalBranchNames{one, three, two}
 		must.Eq(t, want, have)
@@ -218,20 +206,18 @@ func TestLineage(t *testing.T) {
 			t.Parallel()
 			twoA := gitdomain.NewLocalBranchName("twoA")
 			twoB := gitdomain.NewLocalBranchName("twoB")
-			lineage := configdomain.Lineage{
-				twoA: one,
-				twoB: one,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(twoA, one)
+			lineage.AddParent(twoB, one)
 			have := lineage.Children(one)
 			want := gitdomain.LocalBranchNames{twoA, twoB}
 			must.Eq(t, want, have)
 		})
 		t.Run("provides only the immediate children, i.e. no grandchildren", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				two:   one,
-				three: two,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
 			have := lineage.Children(one)
 			want := gitdomain.LocalBranchNames{two}
 			must.Eq(t, want, have)
@@ -249,9 +235,8 @@ func TestLineage(t *testing.T) {
 		t.Parallel()
 		t.Run("has a parent", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				two: one,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(two, one)
 			must.True(t, lineage.HasParents(two))
 		})
 		t.Run("has no parent", func(t *testing.T) {
@@ -267,10 +252,9 @@ func TestLineage(t *testing.T) {
 			t.Parallel()
 			branch := gitdomain.NewLocalBranchName("branch")
 			other := gitdomain.NewLocalBranchName("other")
-			lineage := configdomain.Lineage{
-				branch: main,
-				other:  main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(branch, main)
+			lineage.AddParent(other, main)
 			have := lineage.Descendants(branch)
 			want := gitdomain.LocalBranchNames{}
 			must.Eq(t, want, have)
@@ -281,12 +265,11 @@ func TestLineage(t *testing.T) {
 			child1 := gitdomain.NewLocalBranchName("child1")
 			child2 := gitdomain.NewLocalBranchName("child2")
 			other := gitdomain.NewLocalBranchName("other")
-			lineage := configdomain.Lineage{
-				branch: main,
-				child1: branch,
-				child2: branch,
-				other:  main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(branch, main)
+			lineage.AddParent(child1, branch)
+			lineage.AddParent(child2, branch)
+			lineage.AddParent(other, main)
 			have := lineage.Descendants(branch)
 			want := gitdomain.LocalBranchNames{child1, child2}
 			must.Eq(t, want, have)
@@ -301,16 +284,15 @@ func TestLineage(t *testing.T) {
 			child2a := gitdomain.NewLocalBranchName("child2a")
 			child2b := gitdomain.NewLocalBranchName("child2b")
 			other := gitdomain.NewLocalBranchName("other")
-			lineage := configdomain.Lineage{
-				branch:  main,
-				child1:  branch,
-				child1a: child1,
-				child1b: child1,
-				child2:  branch,
-				child2a: child2,
-				child2b: child2,
-				other:   main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(branch, main)
+			lineage.AddParent(child1, branch)
+			lineage.AddParent(child1a, child1)
+			lineage.AddParent(child1b, child1)
+			lineage.AddParent(child2, branch)
+			lineage.AddParent(child2a, child2)
+			lineage.AddParent(child2b, child2)
+			lineage.AddParent(other, main)
 			have := lineage.Descendants(branch)
 			want := gitdomain.LocalBranchNames{child1, child1a, child1b, child2, child2a, child2b}
 			must.Eq(t, want, have)
@@ -321,26 +303,23 @@ func TestLineage(t *testing.T) {
 		t.Run("recognizes greatgrandparent", func(t *testing.T) {
 			t.Parallel()
 			four := gitdomain.NewLocalBranchName("four")
-			lineage := configdomain.Lineage{
-				four:  three,
-				three: two,
-				two:   one,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(four, three)
+			lineage.AddParent(three, two)
+			lineage.AddParent(two, one)
 			must.True(t, lineage.IsAncestor(one, four))
 		})
 		t.Run("child branches are not ancestors", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				two: one,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(two, one)
 			must.True(t, lineage.IsAncestor(one, two))
 		})
 		t.Run("unrelated branches are not ancestors", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				two:   one,
-				three: one,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, one)
 			must.False(t, lineage.IsAncestor(two, three))
 		})
 	})
@@ -351,14 +330,13 @@ func TestLineage(t *testing.T) {
 			first := gitdomain.NewLocalBranchName("first")
 			second := gitdomain.NewLocalBranchName("second")
 			third := gitdomain.NewLocalBranchName("third")
-			lineage := configdomain.Lineage{
-				one:    main,
-				two:    one,
-				three:  two,
-				first:  main,
-				second: first,
-				third:  second,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
+			lineage.AddParent(first, main)
+			lineage.AddParent(second, first)
+			lineage.AddParent(third, second)
 			give := lineage.BranchNames()
 			want := gitdomain.LocalBranchNames{first, second, third, one, two, three}
 			have := lineage.OrderHierarchically(give)
@@ -367,12 +345,11 @@ func TestLineage(t *testing.T) {
 		t.Run("single lineage", func(t *testing.T) {
 			t.Parallel()
 			four := gitdomain.NewLocalBranchName("four")
-			lineage := configdomain.Lineage{
-				one:   main,
-				two:   one,
-				three: two,
-				four:  three,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
+			lineage.AddParent(four, three)
 			give := gitdomain.LocalBranchNames{four, one}
 			want := gitdomain.LocalBranchNames{one, four}
 			have := lineage.OrderHierarchically(give)
@@ -380,11 +357,10 @@ func TestLineage(t *testing.T) {
 		})
 		t.Run("elements out of order", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one:   main,
-				two:   one,
-				three: two,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
+			lineage.AddParent(two, one)
+			lineage.AddParent(three, two)
 			give := gitdomain.LocalBranchNames{one, two, main, three}
 			want := gitdomain.LocalBranchNames{main, one, two, three}
 			have := lineage.OrderHierarchically(give)
@@ -411,9 +387,8 @@ func TestLineage(t *testing.T) {
 		t.Parallel()
 		t.Run("feature branch", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one: main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
 			have := lineage.Parent(one)
 			want := Some(main)
 			must.Eq(t, want, have)
@@ -443,18 +418,16 @@ func TestLineage(t *testing.T) {
 			branch1a := gitdomain.NewLocalBranchName("branch-1a")
 			branch1b := gitdomain.NewLocalBranchName("branch-1b")
 			branch2 := gitdomain.NewLocalBranchName("branch-2")
-			have := configdomain.Lineage{
-				branch1:  main,
-				branch1a: branch1,
-				branch1b: branch1,
-				branch2:  main,
-			}
+			have := configdomain.NewLineage()
+			have.AddParent(branch1, main)
+			have.AddParent(branch1a, branch1)
+			have.AddParent(branch1b, branch1)
+			have.AddParent(branch2, main)
 			have.RemoveBranch(branch1)
-			want := configdomain.Lineage{
-				branch1a: main,
-				branch1b: main,
-				branch2:  main,
-			}
+			want := configdomain.NewLineage()
+			want.AddParent(branch1a, main)
+			want.AddParent(branch1b, main)
+			want.AddParent(branch2, main)
 			must.Eq(t, want, have)
 		})
 		t.Run("branch is a child branch", func(t *testing.T) {
@@ -462,14 +435,12 @@ func TestLineage(t *testing.T) {
 			main := gitdomain.NewLocalBranchName("main")
 			branch1 := gitdomain.NewLocalBranchName("branch-1")
 			branch2 := gitdomain.NewLocalBranchName("branch-2")
-			have := configdomain.Lineage{
-				branch1: main,
-				branch2: main,
-			}
+			have := configdomain.NewLineage()
+			have.AddParent(branch1, main)
+			have.AddParent(branch2, main)
 			have.RemoveBranch(branch1)
-			want := configdomain.Lineage{
-				branch2: main,
-			}
+			want := configdomain.NewLineage()
+			want.AddParent(branch2, main)
 			must.Eq(t, want, have)
 		})
 		t.Run("branch is not in lineage", func(t *testing.T) {
@@ -477,13 +448,11 @@ func TestLineage(t *testing.T) {
 			main := gitdomain.NewLocalBranchName("main")
 			branch1 := gitdomain.NewLocalBranchName("branch-1")
 			branch2 := gitdomain.NewLocalBranchName("branch-2")
-			have := configdomain.Lineage{
-				branch1: main,
-			}
+			have := configdomain.NewLineage()
+			have.AddParent(branch1, main)
 			have.RemoveBranch(branch2)
-			want := configdomain.Lineage{
-				branch1: main,
-			}
+			want := configdomain.NewLineage()
+			want.AddParent(branch1, main)
 			must.Eq(t, want, have)
 		})
 	})
@@ -495,21 +464,19 @@ func TestLineage(t *testing.T) {
 			prod := gitdomain.NewLocalBranchName("prod")
 			hotfix1 := gitdomain.NewLocalBranchName("hotfix1")
 			hotfix2 := gitdomain.NewLocalBranchName("hotfix2")
-			lineage := configdomain.Lineage{
-				two:     one,
-				one:     main,
-				hotfix1: prod,
-				hotfix2: prod,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(two, one)
+			lineage.AddParent(one, main)
+			lineage.AddParent(hotfix1, prod)
+			lineage.AddParent(hotfix2, prod)
 			have := lineage.Roots()
 			want := gitdomain.LocalBranchNames{main, prod}
 			must.Eq(t, want, have)
 		})
 		t.Run("no stacked changes", func(t *testing.T) {
 			t.Parallel()
-			lineage := configdomain.Lineage{
-				one: main,
-			}
+			lineage := configdomain.NewLineage()
+			lineage.AddParent(one, main)
 			have := lineage.Roots()
 			want := gitdomain.LocalBranchNames{main}
 			must.Eq(t, want, have)

--- a/src/config/configdomain/unvalidated_config.go
+++ b/src/config/configdomain/unvalidated_config.go
@@ -110,7 +110,7 @@ func (self *UnvalidatedConfig) Merge(other PartialConfig) {
 		self.Aliases[key] = value
 	}
 	for _, entry := range other.Lineage.Entries() {
-		self.Lineage.AddParent(entry.child, entry.parent)
+		self.Lineage.AddParent(entry.Child, entry.Parent)
 	}
 	self.ContributionBranches = append(self.ContributionBranches, other.ContributionBranches...)
 	if other.HostingOriginHostname.IsSome() {

--- a/src/config/configdomain/unvalidated_config.go
+++ b/src/config/configdomain/unvalidated_config.go
@@ -197,7 +197,7 @@ func DefaultConfig() UnvalidatedConfig {
 		GiteaToken:               None[GiteaToken](),
 		HostingOriginHostname:    None[HostingOriginHostname](),
 		HostingPlatform:          None[HostingPlatform](),
-		Lineage:                  Lineage{},
+		Lineage:                  NewLineage(),
 		MainBranch:               None[gitdomain.LocalBranchName](),
 		ObservedBranches:         gitdomain.NewLocalBranchNames(),
 		Offline:                  false,

--- a/src/config/configdomain/unvalidated_config.go
+++ b/src/config/configdomain/unvalidated_config.go
@@ -53,7 +53,7 @@ func (self *UnvalidatedConfig) BranchType(branch gitdomain.LocalBranchName) Bran
 
 // ContainsLineage indicates whether this configuration contains any lineage entries.
 func (self *UnvalidatedConfig) ContainsLineage() bool {
-	return len(self.Lineage) > 0
+	return self.Lineage.Len() > 0
 }
 
 func (self *UnvalidatedConfig) IsContributionBranch(branch gitdomain.LocalBranchName) bool {
@@ -109,8 +109,8 @@ func (self *UnvalidatedConfig) Merge(other PartialConfig) {
 	for key, value := range other.Aliases {
 		self.Aliases[key] = value
 	}
-	for child, parent := range other.Lineage {
-		self.Lineage[child] = parent
+	for _, entry := range other.Lineage.Entries() {
+		self.Lineage.AddParent(entry.child, entry.parent)
 	}
 	self.ContributionBranches = append(self.ContributionBranches, other.ContributionBranches...)
 	if other.HostingOriginHostname.IsSome() {

--- a/src/config/configfile/save_test.go
+++ b/src/config/configfile/save_test.go
@@ -44,7 +44,7 @@ func TestSave(t *testing.T) {
 		give := configdomain.UnvalidatedConfig{
 			HostingOriginHostname:    None[configdomain.HostingOriginHostname](),
 			HostingPlatform:          None[configdomain.HostingPlatform](),
-			Lineage:                  map[gitdomain.LocalBranchName]gitdomain.LocalBranchName{},
+			Lineage:                  configdomain.NewLineage(),
 			MainBranch:               None[gitdomain.LocalBranchName](),
 			ObservedBranches:         gitdomain.LocalBranchNames{},
 			Offline:                  false,

--- a/src/config/gitconfig/access.go
+++ b/src/config/gitconfig/access.go
@@ -25,9 +25,6 @@ type Access struct {
 
 func (self *Access) AddKeyToPartialConfig(key Key, value string, config *configdomain.PartialConfig) error {
 	if strings.HasPrefix(key.String(), LineageKeyPrefix) {
-		if config.Lineage.IsEmpty() {
-			config.Lineage = configdomain.NewLineage()
-		}
 		childName := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(key.String(), LineageKeyPrefix), LineageKeySuffix))
 		if childName == "" {
 			// empty lineage entries are invalid --> delete it

--- a/src/config/gitconfig/access.go
+++ b/src/config/gitconfig/access.go
@@ -26,7 +26,7 @@ type Access struct {
 func (self *Access) AddKeyToPartialConfig(key Key, value string, config *configdomain.PartialConfig) error {
 	if strings.HasPrefix(key.String(), LineageKeyPrefix) {
 		if config.Lineage.IsEmpty() {
-			config.Lineage = configdomain.Lineage{}
+			config.Lineage = configdomain.NewLineage()
 		}
 		childName := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(key.String(), LineageKeyPrefix), LineageKeySuffix))
 		if childName == "" {

--- a/src/config/gitconfig/access.go
+++ b/src/config/gitconfig/access.go
@@ -25,7 +25,7 @@ type Access struct {
 
 func (self *Access) AddKeyToPartialConfig(key Key, value string, config *configdomain.PartialConfig) error {
 	if strings.HasPrefix(key.String(), LineageKeyPrefix) {
-		if config.Lineage == nil {
+		if config.Lineage.IsEmpty() {
 			config.Lineage = configdomain.Lineage{}
 		}
 		childName := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(key.String(), LineageKeyPrefix), LineageKeySuffix))
@@ -40,7 +40,7 @@ func (self *Access) AddKeyToPartialConfig(key Key, value string, config *configd
 			return self.RemoveLocalConfigValue(key)
 		}
 		parent := gitdomain.NewLocalBranchName(value)
-		config.Lineage[child] = parent
+		config.Lineage.AddParent(child, parent)
 		return nil
 	}
 	var err error
@@ -177,8 +177,8 @@ func (self *Access) RemoveLocalGitConfiguration(lineage configdomain.Lineage) er
 		}
 		return fmt.Errorf(messages.ConfigRemoveError, err)
 	}
-	for child := range lineage {
-		key := fmt.Sprintf("git-town-branch.%s.parent", child)
+	for _, entry := range lineage.Entries() {
+		key := fmt.Sprintf("git-town-branch.%s.parent", entry.Child)
 		err = self.Run("git", "config", "--unset", key)
 		if err != nil {
 			return fmt.Errorf(messages.ConfigRemoveError, err)
@@ -274,11 +274,11 @@ func (self *Access) load(global bool, updateOutdated bool) (SingleSnapshot, conf
 		}
 	}
 	// verify lineage
-	if updateOutdated && config.Lineage != nil {
-		for child, parent := range config.Lineage {
-			if child == parent {
-				fmt.Println(colors.Cyan().Styled(fmt.Sprintf(messages.ConfigLineageParentIsChild, child)))
-				_ = self.RemoveLocalConfigValue(NewParentKey(child))
+	if updateOutdated {
+		for _, entry := range config.Lineage.Entries() {
+			if entry.Child == entry.Parent {
+				fmt.Println(colors.Cyan().Styled(fmt.Sprintf(messages.ConfigLineageParentIsChild, entry.Child)))
+				_ = self.RemoveLocalConfigValue(NewParentKey(entry.Child))
 			}
 		}
 	}

--- a/src/config/unvalidated_config.go
+++ b/src/config/unvalidated_config.go
@@ -187,7 +187,7 @@ func (self *UnvalidatedConfig) SetParent(branch, parentBranch gitdomain.LocalBra
 	if self.DryRun {
 		return nil
 	}
-	self.Config.Lineage[branch] = parentBranch
+	self.Config.Lineage.AddParent(branch, parentBranch)
 	return self.GitConfig.SetLocalConfigValue(gitconfig.NewParentKey(branch), parentBranch.String())
 }
 

--- a/src/config/unvalidated_config.go
+++ b/src/config/unvalidated_config.go
@@ -104,11 +104,11 @@ func (self *UnvalidatedConfig) RemoveMainBranch() {
 
 // RemoveOutdatedConfiguration removes outdated Git Town configuration.
 func (self *UnvalidatedConfig) RemoveOutdatedConfiguration(localBranches gitdomain.LocalBranchNames) error {
-	for child, parent := range self.Config.Lineage {
-		hasChildBranch := localBranches.Contains(child)
-		hasParentBranch := localBranches.Contains(parent)
+	for _, entry := range self.Config.Lineage.Entries() {
+		hasChildBranch := localBranches.Contains(entry.Child)
+		hasParentBranch := localBranches.Contains(entry.Parent)
 		if !hasChildBranch || !hasParentBranch {
-			self.RemoveParent(child)
+			self.RemoveParent(entry.Child)
 		}
 	}
 	return nil
@@ -116,9 +116,7 @@ func (self *UnvalidatedConfig) RemoveOutdatedConfiguration(localBranches gitdoma
 
 // RemoveParent removes the parent branch entry for the given branch from the Git configuration.
 func (self *UnvalidatedConfig) RemoveParent(branch gitdomain.LocalBranchName) {
-	if self.LocalGitConfig.Lineage != nil {
-		self.LocalGitConfig.Lineage.RemoveBranch(branch)
-	}
+	self.LocalGitConfig.Lineage.RemoveBranch(branch)
 	_ = self.GitConfig.RemoveLocalConfigValue(gitconfig.NewParentKey(branch))
 }
 

--- a/src/config/validated_config_test.go
+++ b/src/config/validated_config_test.go
@@ -70,9 +70,8 @@ func TestValidatedConfig(t *testing.T) {
 			branch := gitdomain.NewLocalBranchName("branch-1")
 			repo.CreateFeatureBranch(branch)
 			repo.Config.Reload()
-			want := configdomain.Lineage{
-				branch: gitdomain.NewLocalBranchName("main"),
-			}
+			want := configdomain.NewLineage()
+			want.AddParent(branch, gitdomain.NewLocalBranchName("main"))
 			must.Eq(t, want, repo.Config.Config.Lineage)
 		})
 	})

--- a/src/config/validated_config_test.go
+++ b/src/config/validated_config_test.go
@@ -36,10 +36,9 @@ func TestValidatedConfig(t *testing.T) {
 		repo.CreateFeatureBranch(gitdomain.NewLocalBranchName("feature2"))
 		repo.Config.Reload()
 		have := repo.Config.Config.Lineage
-		want := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature1"): gitdomain.NewLocalBranchName("main"),
-			gitdomain.NewLocalBranchName("feature2"): gitdomain.NewLocalBranchName("main"),
-		}
+		want := configdomain.NewLineage()
+		want.AddParent(gitdomain.NewLocalBranchName("feature1"), gitdomain.NewLocalBranchName("main"))
+		want.AddParent(gitdomain.NewLocalBranchName("feature2"), gitdomain.NewLocalBranchName("main"))
 		must.Eq(t, want, have)
 	})
 

--- a/src/messages/en.go
+++ b/src/messages/en.go
@@ -138,6 +138,7 @@ END OUTPUT FROM 'git branch -vva'
 	PreviousCommandProblem                = "The last Git Town command (%s) hit a problem %v ago.\n"
 	ProposalMultipleFound                 = "found %d proposals from branch %q to branch %q"
 	ProposalNoNumberGiven                 = "no proposal number given"
+	ProposalNoParent                      = "branch %q has no parent and can therefore not be proposed"
 	ProposalNotFoundForBranch             = "cannot determine proposal for branch %q: %w"
 	ProposalTargetBranchUpdateProblem     = "cannot update the target branch of proposal %d via the API"
 	ProposalURLProblem                    = "cannot determine proposal URL from %q to %q: %w"

--- a/src/undo/undobranches/branch_changes_test.go
+++ b/src/undo/undobranches/branch_changes_test.go
@@ -61,9 +61,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("branch-1"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("branch-1"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{

--- a/src/undo/undobranches/branch_changes_test.go
+++ b/src/undo/undobranches/branch_changes_test.go
@@ -207,9 +207,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -299,9 +298,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -385,9 +383,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -455,9 +452,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -550,9 +546,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -683,9 +678,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -794,9 +788,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -896,9 +889,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -1016,9 +1008,8 @@ func TestChanges(t *testing.T) {
 			},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -1114,9 +1105,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -1212,9 +1202,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -1298,9 +1287,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -1386,9 +1374,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -1469,9 +1456,8 @@ func TestChanges(t *testing.T) {
 			InconsistentlyChanged: undodomain.InconsistentChanges{},
 		}
 		must.Eq(t, wantChanges, haveChanges)
-		lineage := configdomain.Lineage{
-			gitdomain.NewLocalBranchName("feature-branch"): gitdomain.NewLocalBranchName("main"),
-		}
+		lineage := configdomain.NewLineage()
+		lineage.AddParent(gitdomain.NewLocalBranchName("feature-branch"), gitdomain.NewLocalBranchName("main"))
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{

--- a/src/validate/config.go
+++ b/src/validate/config.go
@@ -55,8 +55,8 @@ func Config(args ConfigArgs) (config.ValidatedConfig, bool, error) {
 	if err != nil || exit {
 		return config.EmptyValidatedConfig(), exit, err
 	}
-	for branch, parent := range additionalLineage {
-		if err = args.Unvalidated.SetParent(branch, parent); err != nil {
+	for _, entry := range additionalLineage.Entries() {
+		if err = args.Unvalidated.SetParent(entry.Child, entry.Parent); err != nil {
 			return config.EmptyValidatedConfig(), false, err
 		}
 	}

--- a/src/vm/opcodes/create_proposal.go
+++ b/src/vm/opcodes/create_proposal.go
@@ -1,9 +1,12 @@
 package opcodes
 
 import (
+	"fmt"
+
 	"github.com/git-town/git-town/v14/src/browser"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/hosting/hostingdomain"
+	"github.com/git-town/git-town/v14/src/messages"
 	"github.com/git-town/git-town/v14/src/vm/shared"
 )
 
@@ -21,7 +24,10 @@ func (self *CreateProposal) CreateContinueProgram() []shared.Opcode {
 }
 
 func (self *CreateProposal) Run(args shared.RunArgs) error {
-	parentBranch := args.Config.Config.Lineage[self.Branch]
+	parentBranch, hasParentBranch := args.Config.Config.Lineage.Parent(self.Branch).Get()
+	if !hasParentBranch {
+		return fmt.Errorf(messages.ProposalNoParent, self.Branch)
+	}
 	connector, hasConnector := args.Connector.Get()
 	if !hasConnector {
 		return hostingdomain.UnsupportedServiceError()

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -315,12 +315,9 @@ func (self *TestCommands) LineageTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("BRANCH", "PARENT")
 	_, localGitConfig, _ := self.Config.GitConfig.LoadLocal(false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	if localGitConfig.Lineage == nil {
-		return result
-	}
 	lineage := localGitConfig.Lineage
 	for _, branchName := range lineage.BranchNames() {
-		result.AddRow(branchName.String(), lineage[branchName].String())
+		result.AddRow(branchName.String(), lineage.Parent(branchName).String())
 	}
 	result.Sort()
 	return result

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -159,8 +159,8 @@ func TestTestCommands(t *testing.T) {
 		runtime.Config.Reload()
 		must.False(t, runtime.Config.Config.IsMainOrPerennialBranch(gitdomain.NewLocalBranchName("f1")))
 		lineageHave := runtime.Config.Config.Lineage
-		lineageWant := configdomain.Lineage{}
-		lineageWant[gitdomain.NewLocalBranchName("f1")] = gitdomain.NewLocalBranchName("main")
+		lineageWant := configdomain.NewLineage()
+		lineageWant.AddParent(gitdomain.NewLocalBranchName("f1"), gitdomain.NewLocalBranchName("main"))
 		must.Eq(t, lineageWant, lineageHave)
 	})
 


### PR DESCRIPTION
The API of the lineage implementation leaks a lot of implementation details. This PR hides them to enable a refactor of the way Lineage is structured.