### PR TITLE
Remove RunMany

### DIFF
--- a/src/git/gitdomain/runner.go
+++ b/src/git/gitdomain/runner.go
@@ -4,12 +4,7 @@ type Runner interface {
 	Run(executable string, args ...string) error
 }
 
-type ManyRunner interface {
-	RunMany(commands [][]string) error
-}
-
 type RunnerQuerier interface {
 	Runner
-	ManyRunner
 	Querier
 }

--- a/src/subshell/backend_runner.go
+++ b/src/subshell/backend_runner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/git-town/git-town/v14/src/gohacks"
 	. "github.com/git-town/git-town/v14/src/gohacks/prelude"
 	"github.com/git-town/git-town/v14/src/gohacks/stringslice"
-	"github.com/git-town/git-town/v14/src/messages"
 )
 
 // BackendRunner executes backend shell commands without output to the CLI.
@@ -37,19 +36,6 @@ func (self BackendRunner) QueryTrim(executable string, args ...string) (string, 
 func (self BackendRunner) Run(executable string, args ...string) error {
 	_, err := self.execute(executable, args...)
 	return err
-}
-
-// RunMany runs all given commands in current directory.
-// Commands are provided as a list of argv-style strings.
-// Failed commands abort immediately with the encountered error.
-func (self BackendRunner) RunMany(commands [][]string) error {
-	for _, argv := range commands {
-		err := self.Run(argv[0], argv[1:]...)
-		if err != nil {
-			return fmt.Errorf(messages.RunCommandProblem, argv, err)
-		}
-	}
-	return nil
 }
 
 func (self BackendRunner) execute(executable string, args ...string) ([]byte, error) {

--- a/src/subshell/backend_runner_test.go
+++ b/src/subshell/backend_runner_test.go
@@ -2,9 +2,7 @@ package subshell_test
 
 import (
 	"errors"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 
 	"github.com/git-town/git-town/v14/src/gohacks"
@@ -65,21 +63,5 @@ OUTPUT END
 			must.NoError(t, err)
 			must.EqOp(t, "hello world", output)
 		})
-	})
-
-	t.Run("RunMany", func(t *testing.T) {
-		t.Parallel()
-		tmpDir := t.TempDir()
-		runner := subshell.BackendRunner{Dir: Some(tmpDir), Verbose: false, CommandsCounter: gohacks.NewCounter()}
-		err := runner.RunMany([][]string{
-			{"mkdir", "tmp"},
-			{"touch", "tmp/first"},
-			{"touch", "tmp/second"},
-		})
-		must.NoError(t, err)
-		entries, err := os.ReadDir(filepath.Join(tmpDir, "tmp"))
-		must.NoError(t, err)
-		must.EqOp(t, "first", entries[0].Name())
-		must.EqOp(t, "second", entries[1].Name())
 	})
 }

--- a/src/subshell/frontend_dry_runner.go
+++ b/src/subshell/frontend_dry_runner.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/gohacks"
-	"github.com/git-town/git-town/v14/src/messages"
 )
 
 // FrontendDryRunner prints the given shell commands to the CLI as if they were executed
@@ -33,19 +32,6 @@ func (self *FrontendDryRunner) Run(executable string, args ...string) error {
 	if self.PrintCommands {
 		PrintCommand(currentBranch, self.OmitBranchNames, executable, args...)
 		fmt.Println("(dry run)")
-	}
-	return nil
-}
-
-// RunMany runs all given commands in current directory.
-// Commands are provided as a list of argv-style strings.
-// Failed commands abort immediately with the encountered error.
-func (self *FrontendDryRunner) RunMany(commands [][]string) error {
-	for _, argv := range commands {
-		err := self.Run(argv[0], argv[1:]...)
-		if err != nil {
-			return fmt.Errorf(messages.RunCommandProblem, argv, err)
-		}
 	}
 	return nil
 }

--- a/src/subshell/frontend_runner.go
+++ b/src/subshell/frontend_runner.go
@@ -12,7 +12,6 @@ import (
 	"github.com/git-town/git-town/v14/src/cli/colors"
 	"github.com/git-town/git-town/v14/src/git/gitdomain"
 	"github.com/git-town/git-town/v14/src/gohacks"
-	"github.com/git-town/git-town/v14/src/messages"
 )
 
 // FrontendRunner executes frontend shell commands.
@@ -93,17 +92,4 @@ func (self *FrontendRunner) Run(cmd string, args ...string) (err error) {
 		}
 	}()
 	return subProcess.Wait()
-}
-
-// RunMany runs all given commands in current directory.
-// Commands are provided as a list of argv-style strings.
-// Failed commands abort immediately with the encountered error.
-func (self *FrontendRunner) RunMany(commands [][]string) error {
-	for _, argv := range commands {
-		err := self.Run(argv[0], argv[1:]...)
-		if err != nil {
-			return fmt.Errorf(messages.RunCommandProblem, argv, err)
-		}
-	}
-	return nil
 }

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -147,13 +147,8 @@ func (self *TestCommands) CreateContributionBranches(names ...gitdomain.LocalBra
 
 // CreateFeatureBranch creates a feature branch with the given name in this repository.
 func (self *TestCommands) CreateFeatureBranch(name gitdomain.LocalBranchName) {
-	err := self.RunMany([][]string{
-		{"git", "branch", name.String(), "main"},
-		{"git", "config", "git-town-branch." + name.String() + ".parent", "main"},
-	})
-	if err != nil {
-		panic(err)
-	}
+	self.MustRun("git", "branch", name.String(), "main")
+	self.MustRun("git", "config", "git-town-branch."+name.String()+".parent", "main")
 }
 
 // CreateFile creates a file with the given name and content in this repository.
@@ -441,10 +436,8 @@ func (self *TestCommands) StageFiles(names ...string) {
 
 // StashOpenFiles stashes the open files away.
 func (self *TestCommands) StashOpenFiles() {
-	self.MustRunMany([][]string{
-		{"git", "add", "-A"},
-		{"git", "stash"},
-	})
+	self.MustRun("git", "add", "-A")
+	self.MustRun("git", "stash")
 }
 
 // Tags provides a list of the tags in this repository.

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -91,10 +91,11 @@ func NewStandardFixture(dir string) Fixture {
 	}
 	// initialize the repo in the folder
 	originRepo := testruntime.Initialize(gitEnv.originRepoPath(), gitEnv.Dir, gitEnv.binPath())
-	err = originRepo.RunMany([][]string{
-		{"git", "commit", "--allow-empty", "-m", "initial commit"},
-		{"git", "branch", "main", "initial"},
-	})
+	err = originRepo.Run("git", "commit", "--allow-empty", "-m", "initial commit")
+	if err != nil {
+		log.Fatalf("cannot initialize origin directory at %q: %v", gitEnv.originRepoPath(), err)
+	}
+	err = originRepo.Run("git", "branch", "main", "initial")
 	if err != nil {
 		log.Fatalf("cannot initialize origin directory at %q: %v", gitEnv.originRepoPath(), err)
 	}
@@ -145,10 +146,8 @@ func (self *Fixture) AddSubmoduleRepo() {
 		log.Fatalf("cannot create directory %q: %v", self.submoduleRepoPath(), err)
 	}
 	submoduleRepo := testruntime.Initialize(self.submoduleRepoPath(), self.Dir, self.binPath())
-	submoduleRepo.MustRunMany([][]string{
-		{"git", "config", "--global", "protocol.file.allow", "always"},
-		{"git", "commit", "--allow-empty", "-m", "initial commit"},
-	})
+	submoduleRepo.MustRun("git", "config", "--global", "protocol.file.allow", "always")
+	submoduleRepo.MustRun("git", "commit", "--allow-empty", "-m", "initial commit")
 	self.SubmoduleRepo = SomeP(&submoduleRepo)
 }
 
@@ -284,12 +283,10 @@ func (self Fixture) developerRepoPath() string {
 func (self Fixture) initializeWorkspace(repo *testruntime.TestRuntime) {
 	asserts.NoError(repo.Config.SetMainBranch(gitdomain.NewLocalBranchName("main")))
 	asserts.NoError(repo.Config.SetPerennialBranches(gitdomain.LocalBranchNames{}))
-	repo.MustRunMany([][]string{
-		{"git", "checkout", "main"},
-		// NOTE: the developer repos receives the initial branch from origin
-		//       but we don't want it here because it isn't used in tests.
-		{"git", "branch", "-d", "initial"},
-	})
+	repo.MustRun("git", "checkout", "main")
+	// NOTE: the developer repos receives the initial branch from origin
+	//       but we don't want it here because it isn't used in tests.
+	repo.MustRun("git", "branch", "-d", "initial")
 }
 
 // originRepoPath provides the full path to the Git repository with the given name.

--- a/test/subshell/test_runner.go
+++ b/test/subshell/test_runner.go
@@ -138,10 +138,6 @@ func (self *TestRunner) MustRun(name string, arguments ...string) {
 	}
 }
 
-func (self *TestRunner) MustRunMany(commands [][]string) {
-	asserts.NoError(self.RunMany(commands))
-}
-
 // Query provides the output of the given command.
 // Overrides will be used and removed when done.
 func (self *TestRunner) Query(name string, arguments ...string) (string, error) {
@@ -250,16 +246,6 @@ func (self *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string)
 func (self *TestRunner) Run(name string, arguments ...string) error {
 	_, err := self.QueryWith(&Options{IgnoreOutput: true}, name, arguments...)
 	return err
-}
-
-func (self *TestRunner) RunMany(commands [][]string) error {
-	for _, argv := range commands {
-		err := self.Run(argv[0], argv[1:]...)
-		if err != nil {
-			return fmt.Errorf("error running command %q: %w", argv, err)
-		}
-	}
-	return nil
 }
 
 // SetTestOrigin adds the given environment variable to subsequent runs of commands.

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -63,11 +63,9 @@ func CreateGitTown(t *testing.T) TestRuntime {
 // including necessary Git configuration to make commits. Creates missing folders as needed.
 func Initialize(workingDir, homeDir, binDir string) TestRuntime {
 	runtime := New(workingDir, homeDir, binDir)
-	runtime.MustRunMany([][]string{
-		{"git", "init", "--initial-branch=initial"},
-		{"git", "config", "--global", "user.name", "user"},
-		{"git", "config", "--global", "user.email", "email@example.com"},
-	})
+	runtime.MustRun("git", "init", "--initial-branch=initial")
+	runtime.MustRun("git", "config", "--global", "user.name", "user")
+	runtime.MustRun("git", "config", "--global", "user.email", "email@example.com")
 	return runtime
 }
 


### PR DESCRIPTION
This additional abstraction doesn't add enough value to justify the complexity it adds. It was a "creative" way to work around Go's verbose error handling and this isn't a good approach. Business logic is actually shorter without it.