### PR TITLE
Update command to source completions in Bash

### DIFF
--- a/website/src/commands/completions.md
+++ b/website/src/commands/completions.md
@@ -9,7 +9,7 @@ Git Town in Bash, Zsh, Fish, or PowerShell. When set up, typing
 To load autocompletion for Bash, run this command:
 
 ```
-git-town completions bash | source
+source <(git-town completions bash)
 ```
 
 To load completions for each session, add the above line to your `.bashrc`.


### PR DESCRIPTION
When I run the original command in my shell, I get the following error:

```console
$ git-town completions bash | source
bash: source: filename argument required
source: usage: source filename [arguments]
```