### PR TITLE
Disable end-to-end tests that mess up the test runner output

### DIFF
--- a/.github/workflows/cuke.yml
+++ b/.github/workflows/cuke.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - run: make cuke
+      - run: make cukeall
         shell: 'script -q -e -c "bash {0}"' # this creates /dev/tty needed by BubbleTea

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:  # builds for the current platform
 clear: tools/rta@${RTA_VERSION}  # clears the build and lint caches
 	tools/rta golangci-lint cache clean
 
-cuke: build  # runs most end-to-end tests, best for development
+cuke: build  # runs all end-to-end tests except the ones that mess up the output, best for development
 	@env $(GO_BUILD_ARGS) skipmessy=1 go test -v
 
 cukeall: build  # runs all end-to-end tests

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ build:  # builds for the current platform
 clear: tools/rta@${RTA_VERSION}  # clears the build and lint caches
 	tools/rta golangci-lint cache clean
 
-cuke: build  # runs all end-to-end tests
+cuke: build  # runs most end-to-end tests, best for development
+	@env $(GO_BUILD_ARGS) skipmessy=1 go test -v
+
+cukeall: build  # runs all end-to-end tests
 	@env $(GO_BUILD_ARGS) go test -v
 
 cukethis: build  # runs the end-to-end tests that have a @this tag

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clear: tools/rta@${RTA_VERSION}  # clears the build and lint caches
 	tools/rta golangci-lint cache clean
 
 cuke: build  # runs all end-to-end tests except the ones that mess up the output, best for development
-	@env $(GO_BUILD_ARGS) skipmessy=1 go test -v
+	@env $(GO_BUILD_ARGS) skipmessyoutput=1 go test -v
 
 cukeall: build  # runs all end-to-end tests
 	@env $(GO_BUILD_ARGS) go test -v

--- a/features/append/on_feature_branch/clean_workspace/unknown_parent.feature
+++ b/features/append/on_feature_branch/clean_workspace/unknown_parent.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: ask for missing parent branch information
 
   Scenario:

--- a/features/append/on_feature_branch/clean_workspace/unknown_parent.feature
+++ b/features/append/on_feature_branch/clean_workspace/unknown_parent.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: ask for missing parent branch information
 
   Scenario:

--- a/features/config/setup/abort.feature
+++ b/features/config/setup/abort.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: aborting the setup assistant
 
   Background:

--- a/features/config/setup/abort.feature
+++ b/features/config/setup/abort.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: aborting the setup assistant
 
   Background:

--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: override an existing Git alias
 
   Background:

--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: override an existing Git alias
 
   Background:

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: change existing information in Git metadata
 
   Background:

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: change existing information in Git metadata
 
   Background:

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: Accepting all default values leads to a working setup
 
   Background:

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: Accepting all default values leads to a working setup
 
   Background:

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: enter the Gitea API token
 
   Scenario: auto-detected Gitea platform

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: enter the Gitea API token
 
   Scenario: auto-detected Gitea platform

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: enter the GitHub API token
 
   Scenario: auto-detected GitHub platform

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: enter the GitHub API token
 
   Scenario: auto-detected GitHub platform

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: enter the GitLab API token
 
   Scenario: auto-detected GitLab platform

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: enter the GitLab API token
 
   Scenario: auto-detected GitLab platform

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: migrate existing configuration in Git metadata to a config file
 
   Background:

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: migrate existing configuration in Git metadata to a config file
 
   Background:

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: remove existing configuration in Git metadata
 
   Background:

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: remove existing configuration in Git metadata
 
   Background:

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: remove an existing code hosting override
 
   Background:

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: remove an existing code hosting override
 
   Background:

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: don't ask for perennial branches if no branches that could be perennial exist
 
   Background:

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: don't ask for perennial branches if no branches that could be perennial exist
 
   Background:

--- a/features/diff_parent/current_branch/edge_cases/unknown_parent.feature
+++ b/features/diff_parent/current_branch/edge_cases/unknown_parent.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: ask for missing parent
 
   Scenario: on feature branch without parent

--- a/features/diff_parent/current_branch/edge_cases/unknown_parent.feature
+++ b/features/diff_parent/current_branch/edge_cases/unknown_parent.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: ask for missing parent
 
   Scenario: on feature branch without parent

--- a/features/diff_parent/supplied_branch/edge_cases/unknown_parent.feature
+++ b/features/diff_parent/supplied_branch/edge_cases/unknown_parent.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: ask for missing parent
 
   Scenario: branch without parent

--- a/features/diff_parent/supplied_branch/edge_cases/unknown_parent.feature
+++ b/features/diff_parent/supplied_branch/edge_cases/unknown_parent.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: ask for missing parent
 
   Scenario: branch without parent

--- a/features/ship/current_branch/features/multiple_authors.feature
+++ b/features/ship/current_branch/features/multiple_authors.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 @skipWindows
 Feature: ship a coworker's feature branch
 

--- a/features/ship/current_branch/features/multiple_authors.feature
+++ b/features/ship/current_branch/features/multiple_authors.feature
@@ -1,3 +1,4 @@
+@messy
 @skipWindows
 Feature: ship a coworker's feature branch
 

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
@@ -45,6 +45,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And the initial commits exist
     And the initial branches and lineage exist
 
+  @messy
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
@@ -45,7 +45,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And the initial commits exist
     And the initial branches and lineage exist
 
-  @messy
+  @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
@@ -53,6 +53,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       |         | origin        | feature commit             | feature_file     | feature content |
     And the initial branches and lineage exist
 
+  @messy
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
@@ -53,7 +53,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       |         | origin        | feature commit             | feature_file     | feature content |
     And the initial branches and lineage exist
 
-  @messy
+  @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -49,7 +49,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | local, origin | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
 
-  @messy
+  @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -49,6 +49,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | local, origin | conflicting main commit    | conflicting_file | main content    |
       | feature | local         | conflicting feature commit | conflicting_file | feature content |
 
+  @messy
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -41,7 +41,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And no rebase is in progress
     And the initial commits exist
 
-  @messy
+  @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -41,6 +41,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And no rebase is in progress
     And the initial commits exist
 
+  @messy
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -42,7 +42,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And no rebase is in progress
     And the initial commits exist
 
-  @messy
+  @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -42,6 +42,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And no rebase is in progress
     And the initial commits exist
 
+  @messy
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
       | DIALOG            | KEYS    |

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -1,4 +1,4 @@
-@messy
+@messyoutput
 Feature: enter a parent branch name when prompted
 
   Background:

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -1,3 +1,4 @@
+@messy
 Feature: enter a parent branch name when prompted
 
   Background:

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,7 @@ func TestMain(_ *testing.M) {
 	options.Paths = pflag.Args()
 	flagThis := os.Getenv("cukethis") != ""
 	flagSmoke := os.Getenv("smoke") != ""
+	flagSkipMessy := os.Getenv("skipmessy") != ""
 	switch {
 	case flagThis:
 		options.Format = "pretty"
@@ -31,11 +32,15 @@ func TestMain(_ *testing.M) {
 	default:
 		options.Format = "progress"
 	}
+	// options.Format = "pretty"
 	if runtime.GOOS == "windows" {
 		options.Tags = "~@skipWindows"
 		options.Concurrency = runtime.NumCPU()
 	} else {
 		options.Concurrency = runtime.NumCPU() * 4
+	}
+	if flagSkipMessy {
+		options.Tags = "~@messy"
 	}
 	if flagSmoke {
 		options.Tags = "@smoke"

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func TestMain(_ *testing.M) {
 	options.Paths = pflag.Args()
 	flagThis := os.Getenv("cukethis") != ""
 	flagSmoke := os.Getenv("smoke") != ""
-	flagSkipMessy := os.Getenv("skipmessy") != ""
+	flagSkipMessy := os.Getenv("skipmessyoutput") != ""
 	switch {
 	case flagThis:
 		options.Format = "pretty"
@@ -40,7 +40,7 @@ func TestMain(_ *testing.M) {
 		options.Concurrency = runtime.NumCPU() * 4
 	}
 	if flagSkipMessy {
-		options.Tags = "~@messy"
+		options.Tags = "~@messyoutput"
 	}
 	if flagSmoke {
 		options.Tags = "@smoke"

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func TestMain(_ *testing.M) {
 	options.Paths = pflag.Args()
 	flagThis := os.Getenv("cukethis") != ""
 	flagSmoke := os.Getenv("smoke") != ""
-	flagSkipMessy := os.Getenv("skipmessyoutput") != ""
+	flagSkipMessyOutput := os.Getenv("skipmessyoutput") != ""
 	switch {
 	case flagThis:
 		options.Format = "pretty"
@@ -39,7 +39,7 @@ func TestMain(_ *testing.M) {
 	} else {
 		options.Concurrency = runtime.NumCPU() * 4
 	}
-	if flagSkipMessy {
+	if flagSkipMessyOutput {
 		options.Tags = "~@messyoutput"
 	}
 	if flagSmoke {


### PR DESCRIPTION
I suspect that some of the (unnecessary) fanciness of the BubbleTea library - like re-rendering the UI 60 times per second - interferes with the test runner output. Even though it shouldn't since the test runner doesn't output any application output.