### PR TITLE
Extract Memoized type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,8 @@ deadcode: tools/rta@${RTA_VERSION}
 	@tools/rta deadcode github.com/git-town/git-town/tools/format_unittests &
 	@tools/rta deadcode github.com/git-town/git-town/tools/stats_release &
 	@tools/rta deadcode github.com/git-town/git-town/tools/structs_sorted &
-	@tools/rta deadcode -test github.com/git-town/git-town/v14 | grep -v BranchExists \
+	@tools/rta deadcode -test github.com/git-town/git-town/v14 | grep -v Memoized.AsFixture \
+	                                                           | grep -v BranchExists \
 	                                                           | grep -v 'Create$$' \
 	                                                           | grep -v CreateFile \
 	                                                           | grep -v CreateGitTown \

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -236,8 +236,8 @@ func TestTestCommands(t *testing.T) {
 	t.Run("HasBranchesOutOfSync", func(t *testing.T) {
 		t.Run("branches are in sync", func(t *testing.T) {
 			t.Parallel()
-			env := fixture.NewStandardFixture(t.TempDir())
-			runner := env.DevRepo
+			fixture := fixture.NewMemoized(t.TempDir()).AsFixture()
+			runner := fixture.DevRepo
 			runner.CreateBranch(gitdomain.NewLocalBranchName("branch1"), gitdomain.NewLocalBranchName("main"))
 			runner.CheckoutBranch(gitdomain.NewLocalBranchName("branch1"))
 			runner.CreateFile("file1", "content")
@@ -250,29 +250,29 @@ func TestTestCommands(t *testing.T) {
 
 		t.Run("branch is ahead", func(t *testing.T) {
 			t.Parallel()
-			env := fixture.NewStandardFixture(t.TempDir())
-			env.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("branch1"), gitdomain.NewLocalBranchName("main"))
-			env.DevRepo.PushBranch()
-			env.DevRepo.CreateFile("file1", "content")
-			env.DevRepo.StageFiles("file1")
-			env.DevRepo.CommitStagedChanges("stuff")
-			have, _ := env.DevRepo.HasBranchesOutOfSync()
+			fixture := fixture.NewMemoized(t.TempDir()).AsFixture()
+			fixture.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("branch1"), gitdomain.NewLocalBranchName("main"))
+			fixture.DevRepo.PushBranch()
+			fixture.DevRepo.CreateFile("file1", "content")
+			fixture.DevRepo.StageFiles("file1")
+			fixture.DevRepo.CommitStagedChanges("stuff")
+			have, _ := fixture.DevRepo.HasBranchesOutOfSync()
 			must.True(t, have)
 		})
 
 		t.Run("branch is behind", func(t *testing.T) {
 			t.Parallel()
-			env := fixture.NewStandardFixture(t.TempDir())
-			env.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("branch1"), gitdomain.NewLocalBranchName("main"))
-			env.DevRepo.PushBranch()
-			originRepo := env.OriginRepo.GetOrPanic()
+			fixture := fixture.NewMemoized(t.TempDir()).AsFixture()
+			fixture.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("branch1"), gitdomain.NewLocalBranchName("main"))
+			fixture.DevRepo.PushBranch()
+			originRepo := fixture.OriginRepo.GetOrPanic()
 			originRepo.CheckoutBranch(gitdomain.NewLocalBranchName("main"))
 			originRepo.CreateFile("file1", "content")
 			originRepo.StageFiles("file1")
 			originRepo.CommitStagedChanges("stuff")
 			originRepo.CheckoutBranch(gitdomain.NewLocalBranchName("initial"))
-			env.DevRepo.Fetch()
-			have, _ := env.DevRepo.HasBranchesOutOfSync()
+			fixture.DevRepo.Fetch()
+			have, _ := fixture.DevRepo.HasBranchesOutOfSync()
 			must.True(t, have)
 		})
 	})

--- a/test/fixture/factory.go
+++ b/test/fixture/factory.go
@@ -24,7 +24,7 @@ type Factory struct {
 	dir string
 
 	// the memoized environment
-	memoized Fixture
+	memoized Memoized
 }
 
 // creates a new FixtureFactory instance
@@ -41,7 +41,7 @@ func CreateFactory() Factory {
 	return Factory{
 		counter:  helpers.AtomicCounter{},
 		dir:      evalBaseDir,
-		memoized: NewStandardFixture(filepath.Join(evalBaseDir, "memoized")),
+		memoized: NewMemoized(filepath.Join(evalBaseDir, "memoized")),
 	}
 }
 
@@ -49,7 +49,7 @@ func CreateFactory() Factory {
 func (self *Factory) CreateFixture(scenarioName string) Fixture {
 	envDirName := filesystem.FolderName(scenarioName) + "_" + self.counter.ToString()
 	envPath := filepath.Join(self.dir, envDirName)
-	return CloneFixture(self.memoized, envPath)
+	return self.memoized.CloneInto(envPath)
 }
 
 func (self *Factory) Remove() {

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -14,7 +14,6 @@ import (
 	"github.com/git-town/git-town/v14/test/asserts"
 	"github.com/git-town/git-town/v14/test/commands"
 	"github.com/git-town/git-town/v14/test/datatable"
-	"github.com/git-town/git-town/v14/test/filesystem"
 	testgit "github.com/git-town/git-town/v14/test/git"
 	"github.com/git-town/git-town/v14/test/helpers"
 	"github.com/git-town/git-town/v14/test/subshell"
@@ -48,77 +47,6 @@ type Fixture struct {
 
 	// UpstreamRepo is the optional Git repository that contains the upstream for this environment.
 	UpstreamRepo OptionP[testruntime.TestRuntime]
-}
-
-// CloneFixture provides a Fixture instance in the given directory,
-// containing a copy of the given Fixture.
-func CloneFixture(original Fixture, dir string) Fixture {
-	filesystem.CopyDirectory(original.Dir, dir)
-	binDir := binPath(dir)
-	originDir := originRepoPath(dir)
-	originRepo := testruntime.New(originDir, dir, "")
-	developerDir := developerRepoPath(dir)
-	devRepo := testruntime.New(developerDir, dir, binDir)
-	// Since we copied the files from the memoized directory,
-	// we have to set the "origin" remote to the copied origin repo here.
-	devRepo.MustRun("git", "remote", "remove", gitdomain.RemoteOrigin.String())
-	devRepo.AddRemote(gitdomain.RemoteOrigin, originDir)
-	devRepo.Fetch()
-	// and connect the main branches again
-	devRepo.ConnectTrackingBranch(gitdomain.NewLocalBranchName("main"))
-	return Fixture{
-		CoworkerRepo:   NoneP[testruntime.TestRuntime](),
-		DevRepo:        devRepo,
-		Dir:            dir,
-		OriginRepo:     SomeP(&originRepo),
-		SecondWorktree: NoneP[testruntime.TestRuntime](),
-		SubmoduleRepo:  NoneP[testruntime.TestRuntime](),
-		UpstreamRepo:   NoneP[testruntime.TestRuntime](),
-	}
-}
-
-// NewStandardFixture provides a Fixture in the given directory,
-// fully populated as a standardized setup for scenarios.
-//
-// The origin repo has the initial branch checked out.
-// Git repos cannot receive pushes of the currently checked out branch
-// because that will change files in the current workspace.
-// The tests don't use the initial branch.
-func NewStandardFixture(dir string) Fixture {
-	// create the folder
-	// create the fixture
-	originPath := originRepoPath(dir)
-	binPath := binPath(dir)
-	devRepoPath := developerRepoPath(dir)
-	// create the origin repo
-	err := os.MkdirAll(originPath, 0o744)
-	if err != nil {
-		log.Fatalf("cannot create directory %q: %v", originPath, err)
-	}
-	// initialize the repo in the folder
-	originRepo := testruntime.Initialize(originPath, dir, binPath)
-	err = originRepo.Run("git", "commit", "--allow-empty", "-m", "initial commit")
-	if err != nil {
-		log.Fatalf("cannot initialize origin directory at %q: %v", originPath, err)
-	}
-	err = originRepo.Run("git", "branch", "main", "initial")
-	if err != nil {
-		log.Fatalf("cannot initialize origin directory at %q: %v", originPath, err)
-	}
-	// clone the "developer" repo
-	devRepo := testruntime.Clone(originRepo.TestRunner, devRepoPath)
-	initializeWorkspace(&devRepo)
-	devRepo.RemoveUnnecessaryFiles()
-	originRepo.RemoveUnnecessaryFiles()
-	return Fixture{
-		CoworkerRepo:   NoneP[testruntime.TestRuntime](),
-		DevRepo:        devRepo,
-		Dir:            dir,
-		OriginRepo:     SomeP(&originRepo),
-		SecondWorktree: NoneP[testruntime.TestRuntime](),
-		SubmoduleRepo:  NoneP[testruntime.TestRuntime](),
-		UpstreamRepo:   NoneP[testruntime.TestRuntime](),
-	}
 }
 
 // AddCoworkerRepo adds a coworker repository.

--- a/test/fixture/fixture_test.go
+++ b/test/fixture/fixture_test.go
@@ -124,8 +124,8 @@ func TestFixture(t *testing.T) {
 		t.Parallel()
 		// create Fixture instance
 		dir := t.TempDir()
-		memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
-		cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
+		memoized := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+		cloned := memoized.CloneInto(filepath.Join(dir, "cloned"))
 		// create the origin branch
 		cloned.OriginRepo.GetOrPanic().CreateBranch(gitdomain.NewLocalBranchName("b1"), gitdomain.NewLocalBranchName("main"))
 		// verify it is in the origin branches

--- a/test/fixture/fixture_test.go
+++ b/test/fixture/fixture_test.go
@@ -69,8 +69,8 @@ func TestFixture(t *testing.T) {
 		t.Parallel()
 		// create Fixture instance
 		dir := t.TempDir()
-		memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
-		cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
+		memoized := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+		cloned := memoized.CloneInto(filepath.Join(dir, "cloned"))
 		// create the commits
 		mainBranch := gitdomain.NewLocalBranchName("main")
 		cloned.CreateCommits([]git.Commit{

--- a/test/fixture/fixture_test.go
+++ b/test/fixture/fixture_test.go
@@ -143,8 +143,8 @@ func TestFixture(t *testing.T) {
 			t.Parallel()
 			// create Fixture instance
 			dir := t.TempDir()
-			memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
-			cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
+			memoized := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+			cloned := memoized.CloneInto(filepath.Join(dir, "cloned"))
 			// create a few commits
 			cloned.DevRepo.CreateCommit(git.Commit{
 				Branch:      gitdomain.NewLocalBranchName("main"),
@@ -174,8 +174,8 @@ func TestFixture(t *testing.T) {
 			t.Parallel()
 			// create Fixture instance
 			dir := t.TempDir()
-			memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
-			cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
+			memoized := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+			cloned := memoized.CloneInto(filepath.Join(dir, "cloned"))
 			cloned.AddUpstream()
 			// create a few commits
 			cloned.DevRepo.CreateCommit(git.Commit{

--- a/test/fixture/fixture_test.go
+++ b/test/fixture/fixture_test.go
@@ -18,8 +18,8 @@ func TestFixture(t *testing.T) {
 	t.Run("CloneFixture", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
-		cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
+		memoized := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+		cloned := memoized.CloneInto(filepath.Join(dir, "cloned"))
 		asserts.IsGitRepo(t, filepath.Join(dir, "cloned", "origin"))
 		asserts.IsGitRepo(t, filepath.Join(dir, "cloned", "developer"))
 		asserts.BranchExists(t, filepath.Join(dir, "cloned", "developer"), "main")

--- a/test/fixture/fixture_test.go
+++ b/test/fixture/fixture_test.go
@@ -18,8 +18,8 @@ func TestFixture(t *testing.T) {
 	t.Run("CloneFixture", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		memoizedGitEnv := fixture.NewStandardFixture(filepath.Join(dir, "memoized"))
-		cloned := fixture.CloneFixture(memoizedGitEnv, filepath.Join(dir, "cloned"))
+		memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+		cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
 		asserts.IsGitRepo(t, filepath.Join(dir, "cloned", "origin"))
 		asserts.IsGitRepo(t, filepath.Join(dir, "cloned", "developer"))
 		asserts.BranchExists(t, filepath.Join(dir, "cloned", "developer"), "main")
@@ -27,37 +27,20 @@ func TestFixture(t *testing.T) {
 		cloned.DevRepo.PushBranchToRemote(gitdomain.NewLocalBranchName("main"), gitdomain.RemoteOrigin)
 	})
 
-	t.Run("NewStandardFixture", func(t *testing.T) {
-		t.Parallel()
-		gitEnvRootDir := t.TempDir()
-		result := fixture.NewStandardFixture(gitEnvRootDir)
-		// verify the origin repo
-		asserts.IsGitRepo(t, filepath.Join(gitEnvRootDir, "origin"))
-		branch, err := result.OriginRepo.GetOrPanic().CurrentBranch(result.DevRepo.TestRunner)
-		must.NoError(t, err)
-		must.EqOp(t, gitdomain.NewLocalBranchName("main"), branch)
-		// verify the developer repo
-		asserts.IsGitRepo(t, filepath.Join(gitEnvRootDir, "developer"))
-		assertHasGitConfiguration(t, gitEnvRootDir)
-		branch, err = result.DevRepo.CurrentBranch(result.DevRepo.TestRunner)
-		must.NoError(t, err)
-		must.EqOp(t, gitdomain.NewLocalBranchName("main"), branch)
-	})
-
 	t.Run("Branches", func(t *testing.T) {
 		t.Run("different branches in dev and origin repo", func(t *testing.T) {
 			t.Parallel()
 			// create Fixture instance
 			dir := t.TempDir()
-			gitEnv := fixture.NewStandardFixture(filepath.Join(dir, ""))
+			fixture := fixture.NewMemoized(filepath.Join(dir, "")).AsFixture()
 			// create the branches
-			gitEnv.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("d1"), gitdomain.NewLocalBranchName("main"))
-			gitEnv.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("d2"), gitdomain.NewLocalBranchName("main"))
-			originRepo := gitEnv.OriginRepo.GetOrPanic()
+			fixture.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("d1"), gitdomain.NewLocalBranchName("main"))
+			fixture.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("d2"), gitdomain.NewLocalBranchName("main"))
+			originRepo := fixture.OriginRepo.GetOrPanic()
 			originRepo.CreateBranch(gitdomain.NewLocalBranchName("o1"), gitdomain.NewLocalBranchName("initial"))
 			originRepo.CreateBranch(gitdomain.NewLocalBranchName("o2"), gitdomain.NewLocalBranchName("initial"))
 			// get branches
-			table := gitEnv.Branches()
+			table := fixture.Branches()
 			// verify
 			expected := "| REPOSITORY | BRANCHES     |\n| local      | main, d1, d2 |\n| origin     | main, o1, o2 |\n"
 			must.EqOp(t, expected, table.String())
@@ -67,15 +50,15 @@ func TestFixture(t *testing.T) {
 			t.Parallel()
 			// create Fixture instance
 			dir := t.TempDir()
-			gitEnv := fixture.NewStandardFixture(filepath.Join(dir, ""))
+			fixture := fixture.NewMemoized(filepath.Join(dir, "")).AsFixture()
 			// create the branches
-			gitEnv.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("b1"), gitdomain.NewLocalBranchName("main"))
-			gitEnv.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("b2"), gitdomain.NewLocalBranchName("main"))
-			originRepo := gitEnv.OriginRepo.GetOrPanic()
+			fixture.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("b1"), gitdomain.NewLocalBranchName("main"))
+			fixture.DevRepo.CreateBranch(gitdomain.NewLocalBranchName("b2"), gitdomain.NewLocalBranchName("main"))
+			originRepo := fixture.OriginRepo.GetOrPanic()
 			originRepo.CreateBranch(gitdomain.NewLocalBranchName("b1"), gitdomain.NewLocalBranchName("main"))
 			originRepo.CreateBranch(gitdomain.NewLocalBranchName("b2"), gitdomain.NewLocalBranchName("main"))
 			// get branches
-			table := gitEnv.Branches()
+			table := fixture.Branches()
 			// verify
 			expected := "| REPOSITORY    | BRANCHES     |\n| local, origin | main, b1, b2 |\n"
 			must.EqOp(t, expected, table.String())
@@ -86,8 +69,8 @@ func TestFixture(t *testing.T) {
 		t.Parallel()
 		// create Fixture instance
 		dir := t.TempDir()
-		memoizedGitEnv := fixture.NewStandardFixture(filepath.Join(dir, "memoized"))
-		cloned := fixture.CloneFixture(memoizedGitEnv, filepath.Join(dir, "cloned"))
+		memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+		cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
 		// create the commits
 		mainBranch := gitdomain.NewLocalBranchName("main")
 		cloned.CreateCommits([]git.Commit{
@@ -141,8 +124,8 @@ func TestFixture(t *testing.T) {
 		t.Parallel()
 		// create Fixture instance
 		dir := t.TempDir()
-		memoizedGitEnv := fixture.NewStandardFixture(filepath.Join(dir, "memoized"))
-		cloned := fixture.CloneFixture(memoizedGitEnv, filepath.Join(dir, "cloned"))
+		memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+		cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
 		// create the origin branch
 		cloned.OriginRepo.GetOrPanic().CreateBranch(gitdomain.NewLocalBranchName("b1"), gitdomain.NewLocalBranchName("main"))
 		// verify it is in the origin branches
@@ -160,8 +143,8 @@ func TestFixture(t *testing.T) {
 			t.Parallel()
 			// create Fixture instance
 			dir := t.TempDir()
-			memoizedGitEnv := fixture.NewStandardFixture(filepath.Join(dir, "memoized"))
-			cloned := fixture.CloneFixture(memoizedGitEnv, filepath.Join(dir, "cloned"))
+			memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+			cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
 			// create a few commits
 			cloned.DevRepo.CreateCommit(git.Commit{
 				Branch:      gitdomain.NewLocalBranchName("main"),
@@ -191,8 +174,8 @@ func TestFixture(t *testing.T) {
 			t.Parallel()
 			// create Fixture instance
 			dir := t.TempDir()
-			memoizedGitEnv := fixture.NewStandardFixture(filepath.Join(dir, "memoized"))
-			cloned := fixture.CloneFixture(memoizedGitEnv, filepath.Join(dir, "cloned"))
+			memoizedGitEnv := fixture.NewMemoized(filepath.Join(dir, "memoized"))
+			cloned := memoizedGitEnv.CloneInto(filepath.Join(dir, "cloned"))
 			cloned.AddUpstream()
 			// create a few commits
 			cloned.DevRepo.CreateCommit(git.Commit{

--- a/test/fixture/memoized.go
+++ b/test/fixture/memoized.go
@@ -50,8 +50,7 @@ func NewMemoized(dir string) Memoized {
 	return Memoized{dir}
 }
 
-// CloneFixture provides a Fixture instance in the given directory,
-// containing a copy of the given Fixture.
+// CloneInto provides a copy of this Memoized in the given directory.
 func (self Memoized) CloneInto(dir string) Fixture {
 	filesystem.CopyDirectory(self.Dir, dir)
 	binDir := binPath(dir)

--- a/test/fixture/memoized.go
+++ b/test/fixture/memoized.go
@@ -1,0 +1,94 @@
+package fixture
+
+import (
+	"log"
+	"os"
+
+	"github.com/git-town/git-town/v14/src/git/gitdomain"
+	. "github.com/git-town/git-town/v14/src/gohacks/prelude"
+	"github.com/git-town/git-town/v14/test/filesystem"
+	"github.com/git-town/git-town/v14/test/testruntime"
+)
+
+// A fully populated standardized template for Git repos used by scenarios.
+type Memoized struct {
+	Dir string
+}
+
+// NewMemoized provides a Memoized instance in the given directory.
+//
+// The origin repo has the initial branch checked out.
+// Git repos cannot receive pushes of the currently checked out branch
+// because that will change files in the current workspace.
+// The tests don't use the initial branch.
+func NewMemoized(dir string) Memoized {
+	originPath := originRepoPath(dir)
+	binPath := binPath(dir)
+	devRepoPath := developerRepoPath(dir)
+	// create the origin repo
+	err := os.MkdirAll(originPath, 0o744)
+	if err != nil {
+		log.Fatalf("cannot create directory %q: %v", originPath, err)
+	}
+	// initialize the repo in the folder
+	originRepo := testruntime.Initialize(originPath, dir, binPath)
+	err = originRepo.Run("git", "commit", "--allow-empty", "-m", "initial commit")
+	if err != nil {
+		log.Fatalf("cannot initialize origin directory at %q: %v", originPath, err)
+	}
+	err = originRepo.Run("git", "branch", "main", "initial")
+	if err != nil {
+		log.Fatalf("cannot initialize origin directory at %q: %v", originPath, err)
+	}
+	// clone the "developer" repo
+	devRepo := testruntime.Clone(originRepo.TestRunner, devRepoPath)
+	initializeWorkspace(&devRepo)
+	devRepo.RemoveUnnecessaryFiles()
+	originRepo.RemoveUnnecessaryFiles()
+	return Memoized{dir}
+}
+
+// CloneFixture provides a Fixture instance in the given directory,
+// containing a copy of the given Fixture.
+func (self Memoized) CloneInto(dir string) Fixture {
+	filesystem.CopyDirectory(self.Dir, dir)
+	binDir := binPath(dir)
+	originDir := originRepoPath(dir)
+	originRepo := testruntime.New(originDir, dir, "")
+	developerDir := developerRepoPath(dir)
+	devRepo := testruntime.New(developerDir, dir, binDir)
+	// Since we copied the files from the memoized directory,
+	// we have to set the "origin" remote to the copied origin repo here.
+	devRepo.MustRun("git", "remote", "remove", gitdomain.RemoteOrigin.String())
+	devRepo.AddRemote(gitdomain.RemoteOrigin, originDir)
+	devRepo.Fetch()
+	// and connect the main branches again
+	devRepo.ConnectTrackingBranch(gitdomain.NewLocalBranchName("main"))
+	return Fixture{
+		CoworkerRepo:   NoneP[testruntime.TestRuntime](),
+		DevRepo:        devRepo,
+		Dir:            dir,
+		OriginRepo:     SomeP(&originRepo),
+		SecondWorktree: NoneP[testruntime.TestRuntime](),
+		SubmoduleRepo:  NoneP[testruntime.TestRuntime](),
+		UpstreamRepo:   NoneP[testruntime.TestRuntime](),
+	}
+}
+
+// allows using this memoized environment as a Fixture
+func (self Memoized) AsFixture() Fixture {
+	binDir := binPath(self.Dir)
+	developerDir := developerRepoPath(self.Dir)
+	originDir := originRepoPath(self.Dir)
+	originRepo := testruntime.New(originDir, self.Dir, "")
+	devRepo := testruntime.New(developerDir, self.Dir, binDir)
+	return Fixture{
+		CoworkerRepo:   NoneP[testruntime.TestRuntime](),
+		DevRepo:        devRepo,
+		Dir:            self.Dir,
+		OriginRepo:     SomeP(&originRepo),
+		SecondWorktree: NoneP[testruntime.TestRuntime](),
+		SubmoduleRepo:  NoneP[testruntime.TestRuntime](),
+		UpstreamRepo:   NoneP[testruntime.TestRuntime](),
+	}
+}

--- a/test/fixture/memoized.go
+++ b/test/fixture/memoized.go
@@ -50,6 +50,24 @@ func NewMemoized(dir string) Memoized {
 	return Memoized{dir}
 }
 
+// allows using this memoized environment as a Fixture
+func (self Memoized) AsFixture() Fixture {
+	binDir := binPath(self.Dir)
+	developerDir := developerRepoPath(self.Dir)
+	originDir := originRepoPath(self.Dir)
+	originRepo := testruntime.New(originDir, self.Dir, "")
+	devRepo := testruntime.New(developerDir, self.Dir, binDir)
+	return Fixture{
+		CoworkerRepo:   NoneP[testruntime.TestRuntime](),
+		DevRepo:        devRepo,
+		Dir:            self.Dir,
+		OriginRepo:     SomeP(&originRepo),
+		SecondWorktree: NoneP[testruntime.TestRuntime](),
+		SubmoduleRepo:  NoneP[testruntime.TestRuntime](),
+		UpstreamRepo:   NoneP[testruntime.TestRuntime](),
+	}
+}
+
 // provides a copy of this Memoized in the given directory
 func (self Memoized) CloneInto(dir string) Fixture {
 	filesystem.CopyDirectory(self.Dir, dir)
@@ -69,24 +87,6 @@ func (self Memoized) CloneInto(dir string) Fixture {
 		CoworkerRepo:   NoneP[testruntime.TestRuntime](),
 		DevRepo:        devRepo,
 		Dir:            dir,
-		OriginRepo:     SomeP(&originRepo),
-		SecondWorktree: NoneP[testruntime.TestRuntime](),
-		SubmoduleRepo:  NoneP[testruntime.TestRuntime](),
-		UpstreamRepo:   NoneP[testruntime.TestRuntime](),
-	}
-}
-
-// allows using this memoized environment as a Fixture
-func (self Memoized) AsFixture() Fixture {
-	binDir := binPath(self.Dir)
-	developerDir := developerRepoPath(self.Dir)
-	originDir := originRepoPath(self.Dir)
-	originRepo := testruntime.New(originDir, self.Dir, "")
-	devRepo := testruntime.New(developerDir, self.Dir, binDir)
-	return Fixture{
-		CoworkerRepo:   NoneP[testruntime.TestRuntime](),
-		DevRepo:        devRepo,
-		Dir:            self.Dir,
 		OriginRepo:     SomeP(&originRepo),
 		SecondWorktree: NoneP[testruntime.TestRuntime](),
 		SubmoduleRepo:  NoneP[testruntime.TestRuntime](),

--- a/test/fixture/memoized.go
+++ b/test/fixture/memoized.go
@@ -50,7 +50,7 @@ func NewMemoized(dir string) Memoized {
 	return Memoized{dir}
 }
 
-// CloneInto provides a copy of this Memoized in the given directory.
+// provides a copy of this Memoized in the given directory
 func (self Memoized) CloneInto(dir string) Fixture {
 	filesystem.CopyDirectory(self.Dir, dir)
 	binDir := binPath(dir)

--- a/test/fixture/memoized.go
+++ b/test/fixture/memoized.go
@@ -10,7 +10,9 @@ import (
 	"github.com/git-town/git-town/v14/test/testruntime"
 )
 
-// A fully populated standardized template for Git repos used by scenarios.
+// A fully populated Git repos template for testing.
+// This is just the template that can be efficiently cloned.
+// To perform Git operations, clone or derive a Fixture from it.
 type Memoized struct {
 	Dir string
 }

--- a/test/fixture/memoized_test.go
+++ b/test/fixture/memoized_test.go
@@ -1,0 +1,28 @@
+package fixture_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/git-town/git-town/v14/src/git/gitdomain"
+	"github.com/git-town/git-town/v14/test/asserts"
+	"github.com/git-town/git-town/v14/test/fixture"
+	"github.com/shoenig/test/must"
+)
+
+func TestNewStandardFixture(t *testing.T) {
+	t.Parallel()
+	gitEnvRootDir := t.TempDir()
+	result := fixture.NewMemoized(gitEnvRootDir).AsFixture()
+	// verify the origin repo
+	asserts.IsGitRepo(t, filepath.Join(gitEnvRootDir, "origin"))
+	branch, err := result.OriginRepo.GetOrPanic().CurrentBranch(result.DevRepo.TestRunner)
+	must.NoError(t, err)
+	must.EqOp(t, gitdomain.NewLocalBranchName("main"), branch)
+	// verify the developer repo
+	asserts.IsGitRepo(t, filepath.Join(gitEnvRootDir, "developer"))
+	assertHasGitConfiguration(t, gitEnvRootDir)
+	branch, err = result.DevRepo.CurrentBranch(result.DevRepo.TestRunner)
+	must.NoError(t, err)
+	must.EqOp(t, gitdomain.NewLocalBranchName("main"), branch)
+}


### PR DESCRIPTION
Making illegal states unrepresentable in the type system. The old setup allowed cloning an already used fixture. This shouldn't be possible. The fix is to distinguish the memoized environment from a Fixture that gets cloned from it. Fixtures are now single-use.