### PR TITLE
Correctly handle E2E errors

### DIFF
--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -71,7 +71,7 @@ func InitializeScenario(scenarioContext *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		if err != nil {
 			fmt.Printf("failed scenario %q in %s - investigate state in %s\n", scenario.Name, scenario.Uri, state.fixture.Dir)
-			return ctx, err
+			return ctx, nil
 		}
 		exitCode := state.runExitCode.GetOrPanic()
 		if exitCode != 0 && !state.runExitCodeChecked {

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -71,7 +71,7 @@ func InitializeScenario(scenarioContext *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		if err != nil {
 			fmt.Printf("failed scenario %q in %s - investigate state in %s\n", scenario.Name, scenario.Uri, state.fixture.Dir)
-			return ctx, nil
+			return ctx, nil //nolint:nilerr
 		}
 		exitCode := state.runExitCode.GetOrPanic()
 		if exitCode != 0 && !state.runExitCodeChecked {


### PR DESCRIPTION
The after hook should not return the error that happened somewhere else, and that it is merely informed about.