### PR TITLE
More robust default commit data

### DIFF
--- a/features/kill/current_branch/edge_cases/unconfigured.feature
+++ b/features/kill/current_branch/edge_cases/unconfigured.feature
@@ -1,6 +1,5 @@
 Feature: ask for missing configuration
 
-  @this
   Scenario:
     Given Git Town is not configured
     When I run "git-town kill" and enter into the dialog:

--- a/features/kill/current_branch/edge_cases/unconfigured.feature
+++ b/features/kill/current_branch/edge_cases/unconfigured.feature
@@ -1,5 +1,6 @@
 Feature: ask for missing configuration
 
+  @this
   Scenario:
     Given Git Town is not configured
     When I run "git-town kill" and enter into the dialog:

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -654,7 +654,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^I add this commit to the current branch:$`, func(ctx context.Context, table *godog.Table) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		commit := git.FromGherkinTable(table, gitdomain.NewLocalBranchName("current"))[0]
+		commit := git.FromGherkinTable(table)[0]
 		devRepo.CreateFile(commit.FileName, commit.FileContent)
 		devRepo.StageFiles(commit.FileName)
 		devRepo.CommitStagedChanges(commit.Message)
@@ -1449,7 +1449,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		initialTable := datatable.FromGherkin(table)
 		state.initialCommits = Some(initialTable)
 		// create the commits
-		commits := git.FromGherkinTable(table, gitdomain.NewLocalBranchName("current"))
+		commits := git.FromGherkinTable(table)
 		state.fixture.CreateCommits(commits)
 		// restore the initial branch
 		initialBranch, hasInitialBranch := state.initialCurrentBranch.Get()
@@ -1511,7 +1511,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 
 	sc.Step(`^the coworker adds this commit to their current branch:$`, func(ctx context.Context, table *godog.Table) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
-		commits := git.FromGherkinTable(table, gitdomain.NewLocalBranchName("current"))
+		commits := git.FromGherkinTable(table)
 		commit := commits[0]
 		coworkerRepo := state.fixture.CoworkerRepo.GetOrPanic()
 		coworkerRepo.CreateFile(commit.FileName, commit.FileContent)
@@ -1644,7 +1644,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		}
 		devRepo.CheckoutBranch(branchName)
 		devRepo.PushBranchToRemote(branchName, gitdomain.RemoteOrigin)
-		for _, commit := range git.FromGherkinTable(table, branchName) {
+		for _, commit := range git.FromGherkinTable(table) {
 			devRepo.CreateFile(commit.FileName, commit.FileContent)
 			devRepo.StageFiles(commit.FileName)
 			devRepo.CommitStagedChanges(commit.Message)
@@ -1662,7 +1662,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		devRepo.CreateChildFeatureBranch(branch, parentBranch)
 		devRepo.CheckoutBranch(branch)
 		devRepo.PushBranchToRemote(branch, gitdomain.RemoteOrigin)
-		for _, commit := range git.FromGherkinTable(table, branch) {
+		for _, commit := range git.FromGherkinTable(table) {
 			devRepo.CreateFile(commit.FileName, commit.FileContent)
 			devRepo.StageFiles(commit.FileName)
 			devRepo.CommitStagedChanges(commit.Message)

--- a/test/git/commit.go
+++ b/test/git/commit.go
@@ -19,6 +19,8 @@ type Commit struct {
 	SHA         gitdomain.SHA `exhaustruct:"optional"`
 }
 
+var counter helpers.AtomicCounter
+
 // Set assigns the given value to the property with the given Gherkin table name.
 func (self *Commit) Set(name, value string) {
 	switch name {
@@ -40,25 +42,24 @@ func (self *Commit) Set(name, value string) {
 }
 
 // DefaultCommit provides a new Commit instance populated with the default values used in the absence of value specified by the test.
-func DefaultCommit(filenameSuffix string) Commit {
+func DefaultCommit() Commit {
 	return Commit{
 		Branch:      gitdomain.NewLocalBranchName("main"),
 		FileContent: "default file content",
-		FileName:    "default_file_name_" + filenameSuffix,
+		FileName:    "default_file_name_" + counter.ToString(),
 		Locations:   Locations{LocationLocal, LocationOrigin},
 		Message:     "default commit message",
 	}
 }
 
 // FromGherkinTable provides a Commit collection representing the data in the given Gherkin table.
-func FromGherkinTable(table *godog.Table, branchName gitdomain.LocalBranchName) []Commit {
+func FromGherkinTable(table *godog.Table) []Commit {
 	columnNames := helpers.TableFields(table)
 	lastBranch := ""
 	lastLocationName := ""
 	result := []Commit{}
-	counter := helpers.AtomicCounter{}
 	for _, row := range table.Rows[1:] {
-		commit := DefaultCommit(branchName.String() + counter.ToString())
+		commit := DefaultCommit()
 		for cellNo, cell := range row.Cells {
 			columnName := columnNames[cellNo]
 			cellValue := cell.Value

--- a/test/git/commit.go
+++ b/test/git/commit.go
@@ -19,7 +19,7 @@ type Commit struct {
 	SHA         gitdomain.SHA `exhaustruct:"optional"`
 }
 
-var counter helpers.AtomicCounter
+var counter helpers.AtomicCounter //nolint:gochecknoglobals
 
 // Set assigns the given value to the property with the given Gherkin table name.
 func (self *Commit) Set(name, value string) {


### PR DESCRIPTION
I noticed that creating default filenames for commits doesn't work when using multiple commit tables. This PR fixes that.