### PR TITLE
Simplify option code

### DIFF
--- a/features/compress/stack/branch_types/parked/on_child_branch.feature
+++ b/features/compress/stack/branch_types/parked/on_child_branch.feature
@@ -4,7 +4,7 @@ Feature: does not compress non-active parked branches in the stack
     Given a Git repo clone
     And the branches
       | NAME   | TYPE   | PARENT | LOCATIONS     |
-      | parked | parked |        | local, origin |
+      | parked | parked | main   | local, origin |
     And the commits
       | BRANCH | LOCATION      | MESSAGE  | FILE NAME | FILE CONTENT |
       | parked | local, origin | parked 1 | parked_1  | parked 1     |

--- a/features/compress/stack/branch_types/parked/on_parked_branch.feature
+++ b/features/compress/stack/branch_types/parked/on_parked_branch.feature
@@ -4,7 +4,7 @@ Feature: compresses active parked branches
     Given a Git repo clone
     And the branches
       | NAME   | TYPE   | PARENT | LOCATIONS     |
-      | parked | parked |        | local, origin |
+      | parked | parked | main   | local, origin |
     And the commits
       | BRANCH | LOCATION      | MESSAGE  | FILE NAME | FILE CONTENT |
       | parked | local, origin | parked 1 | parked_1  | parked 1     |

--- a/features/config/view.feature
+++ b/features/config/view.feature
@@ -14,8 +14,8 @@ Feature: show the configuration
       | observed-2     | observed     |        | local     |
       | contribution-1 | contribution |        | local     |
       | contribution-2 | contribution |        | local     |
-      | parked-1       | parked       |        | local     |
-      | parked-2       | parked       |        | local     |
+      | parked-1       | parked       | main   | local     |
+      | parked-2       | parked       | main   | local     |
     And the main branch is "main"
     And local Git Town setting "perennial-regex" is "release-.*"
     When I run "git-town config"

--- a/features/observe/give_no_branch/on_feature_branch.feature
+++ b/features/observe/give_no_branch/on_feature_branch.feature
@@ -3,8 +3,8 @@ Feature: observing the current branch
   Background:
     Given a Git repo clone
     And the branches
-      | NAME   | TYPE    | LOCATIONS |
-      | branch | feature | local     |
+      | NAME   | TYPE    | PARENT | LOCATIONS |
+      | branch | feature | main   | local     |
     And the current branch is "branch"
     And an uncommitted file
     When I run "git-town observe"

--- a/src/gohacks/prelude/option.go
+++ b/src/gohacks/prelude/option.go
@@ -54,6 +54,15 @@ func (self Option[T]) GetOrDefault() T { //nolint:ireturn
 	return empty
 }
 
+// GetOrElse provides a copy of the contained value.
+// If this option contains nothing, you get a copy of the given alternative value.
+func (self Option[T]) GetOrElse(other T) T { //nolint:ireturn
+	if value, has := self.Get(); has {
+		return value
+	}
+	return other
+}
+
 // GetOrPanic provides a copy of the contained value.
 // Panics if this option contains nothing.
 func (self Option[T]) GetOrPanic() T { //nolint:ireturn

--- a/src/gohacks/prelude/option.go
+++ b/src/gohacks/prelude/option.go
@@ -54,15 +54,6 @@ func (self Option[T]) GetOrDefault() T { //nolint:ireturn
 	return empty
 }
 
-// GetOrElse provides a copy of the contained value.
-// If this option contains nothing, you get a copy of the given alternative value.
-func (self Option[T]) GetOrElse(other T) T { //nolint:ireturn
-	if value, has := self.Get(); has {
-		return value
-	}
-	return other
-}
-
 // GetOrPanic provides a copy of the contained value.
 // Panics if this option contains nothing.
 func (self Option[T]) GetOrPanic() T { //nolint:ireturn

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -1476,7 +1476,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 				case configdomain.BranchTypeMainBranch:
 					panic("main branch exists already")
 				case configdomain.BranchTypeFeatureBranch:
-					repoToCreateBranchIn.CreateChildFeatureBranch(branchSetup.Name, branchSetup.Parent.GetOrElse("main"))
+					repoToCreateBranchIn.CreateChildFeatureBranch(branchSetup.Name, branchSetup.Parent.GetOrPanic())
 				case configdomain.BranchTypePerennialBranch:
 					repoToCreateBranchIn.CreatePerennialBranch(branchSetup.Name)
 				case configdomain.BranchTypeContributionBranch:


### PR DESCRIPTION
Ensuring that the E2E tests correctly specify the parent branch where needed.