### PR TITLE
More precise args for finishing a VM run

### DIFF
--- a/src/vm/interpreter/full/execute.go
+++ b/src/vm/interpreter/full/execute.go
@@ -20,7 +20,15 @@ func Execute(args ExecuteArgs) error {
 	for {
 		nextStep := args.RunState.RunProgram.Pop()
 		if nextStep == nil {
-			return finished(args)
+			return finished(finishedArgs{
+				Backend:         args.Backend,
+				CommandsCounter: args.CommandsCounter,
+				FinalMessages:   args.FinalMessages,
+				Git:             args.Git,
+				RootDir:         args.RootDir,
+				RunState:        args.RunState,
+				Verbose:         args.Verbose,
+			})
 		}
 		stepName := gohacks.TypeName(nextStep)
 		if stepName == "SkipCurrentBranchProgram" {

--- a/src/vm/interpreter/full/finished.go
+++ b/src/vm/interpreter/full/finished.go
@@ -4,15 +4,21 @@ import (
 	"fmt"
 
 	"github.com/git-town/git-town/v14/src/cli/print"
+	"github.com/git-town/git-town/v14/src/config/configdomain"
 	"github.com/git-town/git-town/v14/src/config/gitconfig"
+	"github.com/git-town/git-town/v14/src/git"
+	"github.com/git-town/git-town/v14/src/git/gitdomain"
+	"github.com/git-town/git-town/v14/src/gohacks"
 	. "github.com/git-town/git-town/v14/src/gohacks/prelude"
+	"github.com/git-town/git-town/v14/src/gohacks/stringslice"
 	"github.com/git-town/git-town/v14/src/messages"
 	"github.com/git-town/git-town/v14/src/undo/undoconfig"
+	"github.com/git-town/git-town/v14/src/vm/runstate"
 	"github.com/git-town/git-town/v14/src/vm/statefile"
 )
 
 // finished is called when executing all steps has successfully finished.
-func finished(args ExecuteArgs) error {
+func finished(args finishedArgs) error {
 	endBranchesSnapshot, err := args.Git.BranchesSnapshot(args.Backend)
 	if err != nil {
 		return err
@@ -48,7 +54,17 @@ func finished(args ExecuteArgs) error {
 	return nil
 }
 
-func finishedDryRunCommand(args ExecuteArgs) error {
+type finishedArgs struct {
+	Backend         gitdomain.RunnerQuerier
+	CommandsCounter Mutable[gohacks.Counter]
+	FinalMessages   stringslice.Collector
+	Git             git.Commands
+	RootDir         gitdomain.RepoRootDir
+	RunState        runstate.RunState
+	Verbose         configdomain.Verbose
+}
+
+func finishedDryRunCommand(args finishedArgs) error {
 	args.RunState.MarkAsFinished()
 	err := statefile.Save(args.RunState, args.RootDir)
 	if err != nil {


### PR DESCRIPTION
Wrapping up a VM run doesn't require all the data needed to run the VM. This PR creates a custom args struct for finishing a VM run. This helps call the "finished" method manually later.