### PR TITLE
Print deadcode output in bold red

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ deadcode: tools/rta@${RTA_VERSION}
 	@tools/rta deadcode github.com/git-town/git-town/tools/format_unittests &
 	@tools/rta deadcode github.com/git-town/git-town/tools/stats_release &
 	@tools/rta deadcode github.com/git-town/git-town/tools/structs_sorted &
-	@tput bold
-	@tput setaf 1
+	@tput bold || true
+	@tput setaf 1 || true
 	@tools/rta deadcode -test github.com/git-town/git-town/v14 | grep -v Memoized.AsFixture \
 	                                                           | grep -v BranchExists \
 	                                                           | grep -v 'Create$$' \
@@ -140,7 +140,7 @@ deadcode: tools/rta@${RTA_VERSION}
 	                                                           | grep -v NewSHAs \
 	                                                           | grep -v Paniced \
 	                                                           || true
-	@tput sgr0
+	@tput sgr0 || true
 
 tools/rta@${RTA_VERSION}:
 	@rm -f tools/rta*

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ deadcode: tools/rta@${RTA_VERSION}
 	@tools/rta deadcode github.com/git-town/git-town/tools/format_unittests &
 	@tools/rta deadcode github.com/git-town/git-town/tools/stats_release &
 	@tools/rta deadcode github.com/git-town/git-town/tools/structs_sorted &
+	@tput bold
+	@tput setaf 1
 	@tools/rta deadcode -test github.com/git-town/git-town/v14 | grep -v Memoized.AsFixture \
 	                                                           | grep -v BranchExists \
 	                                                           | grep -v 'Create$$' \
@@ -138,6 +140,7 @@ deadcode: tools/rta@${RTA_VERSION}
 	                                                           | grep -v NewSHAs \
 	                                                           | grep -v Paniced \
 	                                                           || true
+	@tput sgr0
 
 tools/rta@${RTA_VERSION}:
 	@rm -f tools/rta*


### PR DESCRIPTION
It's hard to miss in the lint output, and we cannot signal it via exit code in this case.