### PR TITLE
Hide excessive linter call output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ help:  # prints all available targets
 
 lint: tools/rta@${RTA_VERSION}  # lints the main codebase concurrently
 	make --no-print-dir lint-smoke
-	tools/rta --available alphavet && go vet "-vettool=$(shell tools/rta --which alphavet)" $(shell go list ./... | grep -v src/cmd | grep -v /v11/tools/)
+	@tools/rta --available alphavet && go vet "-vettool=$(shell tools/rta --which alphavet)" $(shell go list ./... | grep -v src/cmd | grep -v /v11/tools/)
 	make --no-print-directory deadcode
 	make --no-print-directory lint-structs-sorted
 	git diff --check


### PR DESCRIPTION
The call to alphavet is excessively long, which makes the output of the linter hard to read.