### PR TITLE
Lowercase the description of all CLI flags

### DIFF
--- a/src/cli/flags/all.go
+++ b/src/cli/flags/all.go
@@ -2,5 +2,5 @@ package flags
 
 // type-safe access to the "--all" command-line flag
 func All() (AddFunc, ReadBoolFlagFunc) {
-	return Bool("all", "a", "Sync all local branches", FlagTypeNonPersistent)
+	return Bool("all", "a", "sync all local branches", FlagTypeNonPersistent)
 }

--- a/src/cli/flags/dryrun.go
+++ b/src/cli/flags/dryrun.go
@@ -13,7 +13,7 @@ const dryRunLong = "dry-run"
 // type-safe access to the CLI arguments of type gitdomain.DryRun
 func DryRun() (AddFunc, ReadDryRunFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.PersistentFlags().BoolP(dryRunLong, "", false, "Print but do not run the Git commands")
+		cmd.PersistentFlags().BoolP(dryRunLong, "", false, "print but do not run the Git commands")
 	}
 	readFlag := func(cmd *cobra.Command) configdomain.DryRun {
 		value, err := cmd.Flags().GetBool(dryRunLong)

--- a/src/cli/flags/no_push.go
+++ b/src/cli/flags/no_push.go
@@ -13,7 +13,7 @@ const noPushLong = "no-push"
 // type-safe access to the CLI arguments of type gitdomain.NoPush
 func NoPush() (AddFunc, ReadNoPushFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.PersistentFlags().BoolP(noPushLong, "", false, "Do not push local branches")
+		cmd.PersistentFlags().BoolP(noPushLong, "", false, "do not push local branches")
 	}
 	readFlag := func(cmd *cobra.Command) configdomain.PushBranches {
 		value, err := cmd.Flags().GetBool(noPushLong)

--- a/src/cli/flags/proposal_body.go
+++ b/src/cli/flags/proposal_body.go
@@ -16,7 +16,7 @@ const (
 // type-safe access to the CLI arguments of type gitdomain.ProposalBody
 func ProposalBody() (AddFunc, ReadProposalBodyFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.PersistentFlags().StringP(bodyLong, bodyShort, "", "Provide a body for the proposal")
+		cmd.PersistentFlags().StringP(bodyLong, bodyShort, "", "provide a body for the proposal")
 	}
 	readFlag := func(cmd *cobra.Command) gitdomain.ProposalBody {
 		value, err := cmd.Flags().GetString(bodyLong)

--- a/src/cli/flags/proposal_title.go
+++ b/src/cli/flags/proposal_title.go
@@ -16,7 +16,7 @@ const (
 // type-safe access to the CLI arguments of type gitdomain.ProposalTitle
 func ProposalTitle() (AddFunc, ReadProposalTitleFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.PersistentFlags().StringP(titleLong, titleShort, "", "Provide a title for the proposal")
+		cmd.PersistentFlags().StringP(titleLong, titleShort, "", "provide a title for the proposal")
 	}
 	readFlag := func(cmd *cobra.Command) gitdomain.ProposalTitle {
 		value, err := cmd.Flags().GetString(titleLong)

--- a/src/cli/flags/verbose.go
+++ b/src/cli/flags/verbose.go
@@ -16,7 +16,7 @@ const (
 // type-safe access to the CLI arguments of type configdomain.Verbose
 func Verbose() (AddFunc, ReadVerboseFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.PersistentFlags().BoolP(verboseLong, verboseShort, false, "Display all Git commands run under the hood")
+		cmd.PersistentFlags().BoolP(verboseLong, verboseShort, false, "display all Git commands run under the hood")
 	}
 	readFlag := func(cmd *cobra.Command) configdomain.Verbose {
 		value, err := cmd.Flags().GetBool(verboseLong)

--- a/src/cli/flags/version.go
+++ b/src/cli/flags/version.go
@@ -2,5 +2,5 @@ package flags
 
 // type-safe access to the version CLI argument
 func Version() (AddFunc, ReadBoolFlagFunc) {
-	return Bool("version", "V", "Display the version number", FlagTypeNonPersistent)
+	return Bool("version", "V", "display the version number", FlagTypeNonPersistent)
 }

--- a/src/cmd/rename_branch.go
+++ b/src/cmd/rename_branch.go
@@ -45,7 +45,8 @@ When run on a perennial branch:
 
 func renameBranchCommand() *cobra.Command {
 	addVerboseFlag, readVerboseFlag := flags.Verbose()
-	addForceFlag, readForceFlag := flags.Bool("force", "f", "Force rename of perennial branch", flags.FlagTypeNonPersistent)
+	// TODO: extract into flags package
+	addForceFlag, readForceFlag := flags.Bool("force", "f", "force rename of perennial branch", flags.FlagTypeNonPersistent)
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
 	cmd := cobra.Command{
 		Use:   "rename-branch [<old_branch_name>] <new_branch_name>",

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -58,7 +58,7 @@ If your origin server deletes shipped branches, for example GitHub's feature to 
 
 func shipCmd() *cobra.Command {
 	addVerboseFlag, readVerboseFlag := flags.Verbose()
-	addMessageFlag, readMessageFlag := flags.CommitMessage("Specify the commit message for the squash commit")
+	addMessageFlag, readMessageFlag := flags.CommitMessage("specify the commit message for the squash commit")
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
 	cmd := cobra.Command{
 		Use:   shipCommand,


### PR DESCRIPTION
Newer versions of Cobra seem to provide the description of built-in flags in lowercase. The description of our custom flags should match this.