### PR TITLE
git town continue: do not ask for lineage information

### DIFF
--- a/features/sync/current_branch/feature_branch/missing_lineage_for_unrelated_branches.feature
+++ b/features/sync/current_branch/feature_branch/missing_lineage_for_unrelated_branches.feature
@@ -1,0 +1,39 @@
+Feature: do not ask for lineage of branches that don't need to get synced
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME      | TYPE    | PARENT | LOCATIONS     |
+      | feature-1 | feature | main   | local, origin |
+      | feature-2 | (none)  | main   | local, origin |
+    And the current branch is "feature-1"
+    And the commits
+      | BRANCH    | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
+      | feature-1 | local    | conflicting local commit  | conflicting_file | local content  |
+      |           | origin   | conflicting origin commit | conflicting_file | origin content |
+    When I run "git-town sync"
+
+  Scenario: result
+    Then it runs the commands
+      | BRANCH    | COMMAND                                   |
+      | feature-1 | git fetch --prune --tags                  |
+      |           | git checkout main                         |
+      | main      | git rebase origin/main                    |
+      |           | git checkout feature-1                    |
+      | feature-1 | git merge --no-edit --ff origin/feature-1 |
+    And it prints the error:
+      """
+      CONFLICT (add/add): Merge conflict in conflicting_file
+      """
+    And the current branch is still "feature-1"
+    And a merge is now in progress
+
+  Scenario: resolve and continue
+    When I resolve the conflict in "conflicting_file"
+    And I run "git-town continue"
+    Then it runs the commands
+      | BRANCH    | COMMAND                       |
+      | feature-1 | git commit --no-edit          |
+      |           | git merge --no-edit --ff main |
+      |           | git push                      |
+    And all branches are now synchronized

--- a/src/cmd/continue.go
+++ b/src/cmd/continue.go
@@ -113,7 +113,7 @@ func determineContinueData(repo execute.OpenRepoResult, verbose configdomain.Ver
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
 		BranchesSnapshot:   branchesSnapshot,
-		BranchesToValidate: localBranches,
+		BranchesToValidate: gitdomain.LocalBranchNames{},
 		DialogTestInputs:   dialogTestInputs,
 		Frontend:           repo.Frontend,
 		Git:                repo.Git,


### PR DESCRIPTION
resolves #3725 

`git town continue` does not need to ask for the lineage of any branch since it already has a program to execute.