### PR TITLE
Apply verbosity to all E2E test repos

### DIFF
--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -105,6 +105,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		fixture := fixtureFactory.CreateFixture(scenarioName)
 		if helpers.HasTag(scenarioTags, "@debug") {
 			fixture.DevRepo.GetOrPanic().Verbose = true
+			fixture.OriginRepo.GetOrPanic().Verbose = true
 		}
 		state := ScenarioState{
 			fixture:              fixture,

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -96,6 +96,7 @@ func (self *Fixture) AddSubmoduleRepo() {
 func (self *Fixture) AddUpstream() {
 	devRepo := self.DevRepo.GetOrPanic()
 	upstreamRepo := testruntime.Clone(devRepo.TestRunner, filepath.Join(self.Dir, gitdomain.RemoteUpstream.String()))
+	upstreamRepo.TestRunner.Verbose = devRepo.Verbose
 	self.UpstreamRepo = SomeP(&upstreamRepo)
 	devRepo.AddRemote(gitdomain.RemoteUpstream, upstreamRepo.WorkingDir)
 }


### PR DESCRIPTION
Currently in E2E tests only the "dev" repo gets switch to verbose. This change applies the verbosity setting to all test repos.