### PR TITLE
Squash-ship in E2E tests

### DIFF
--- a/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
+++ b/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
@@ -11,7 +11,6 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       | parent | local, origin | parent commit | parent_file | parent content |
       | child  | local, origin | child commit  | child_file  | child content  |
     And origin ships the "parent" branch
-    # And inspect the repo
     And the current branch is "child"
     When I run "git-town append new"
 
@@ -43,6 +42,15 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       | BRANCH | PARENT |
       | child  | main   |
       | new    | child  |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | main   | local, origin | parent commit                  |
+      | child  | local, origin | child commit                   |
+      |        |               | parent commit                  |
+      |        |               | Merge branch 'main' into child |
+      | new    | local         | child commit                   |
+      |        |               | parent commit                  |
+      |        |               | Merge branch 'main' into child |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
+++ b/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
@@ -7,9 +7,9 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       | parent | feature | main   | local, origin |
       | child  | feature | parent |               |
     And the commits
-      | BRANCH | LOCATION      | MESSAGE       | FILE NAME   | FILE CONTENT   |
-      | parent | local, origin | parent commit | parent_file | parent content |
-      | child  | local, origin | child commit  | child_file  | child content  |
+      | BRANCH | LOCATION      | MESSAGE       |
+      | parent | local, origin | parent commit |
+      | child  | local, origin | child commit  |
     And origin ships the "parent" branch
     And the current branch is "child"
     When I run "git-town append new"

--- a/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
+++ b/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
@@ -11,45 +11,25 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       | parent | local, origin | parent commit | parent_file | parent content |
       | child  | local, origin | child commit  | child_file  | child content  |
     And origin ships the "parent" branch
-    And inspect the repo
+    # And inspect the repo
     And the current branch is "child"
-    When I run "git-town append new -v"
+    When I run "git-town append new"
 
-  @debug @this
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                                        |
-      |        | git version                                    |
-      |        | git rev-parse --show-toplevel                  |
-      |        | git config -lz --includes --global             |
-      |        | git config -lz --includes --local              |
-      |        | git status --long --ignore-submodules          |
-      |        | git remote                                     |
-      |        | git rev-parse --abbrev-ref HEAD                |
-      | child  | git fetch --prune --tags                       |
-      | <none> | git stash list                                 |
-      |        | git branch -vva --sort=refname                 |
-      |        | git rev-parse --verify --abbrev-ref @{-1}      |
-      | child  | git checkout main                              |
-      | main   | git rebase origin/main                         |
-      | <none> | git rev-list --left-right main...origin/main   |
-      | main   | git checkout parent                            |
-      | parent | git merge --no-edit --ff main                  |
-      | <none> | git diff main..parent                          |
-      | parent | git checkout child                             |
-      | child  | git merge --no-edit --ff origin/child          |
-      |        | git merge --no-edit --ff parent                |
-      | <none> | git rev-list --left-right child...origin/child |
-      | child  | git push                                       |
-      | <none> | git show-ref --verify --quiet refs/heads/child |
-      | child  | git checkout -b new                            |
-      | <none> | git show-ref --verify --quiet refs/heads/child |
-      |        | git config git-town-branch.new.parent child    |
-      |        | git show-ref --verify --quiet refs/heads/child |
-      |        | git branch -vva --sort=refname                 |
-      |        | git config -lz --includes --global             |
-      |        | git config -lz --includes --local              |
-      |        | git stash list                                 |
+      | BRANCH | COMMAND                               |
+      | child  | git fetch --prune --tags              |
+      |        | git checkout main                     |
+      | main   | git rebase origin/main                |
+      |        | git checkout parent                   |
+      | parent | git merge --no-edit --ff main         |
+      |        | git checkout main                     |
+      | main   | git branch -D parent                  |
+      |        | git checkout child                    |
+      | child  | git merge --no-edit --ff origin/child |
+      |        | git merge --no-edit --ff main         |
+      |        | git push                              |
+      |        | git checkout -b new                   |
     And it prints:
       """
       deleted branch "parent"
@@ -67,14 +47,14 @@ Feature: append a branch to a branch whose parent was shipped on the remote
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                                         |
-      | new    | git checkout child                              |
-      | child  | git reset --hard {{ sha 'child commit' }}       |
-      |        | git push --force-with-lease --force-if-includes |
-      |        | git checkout main                               |
-      | main   | git reset --hard {{ sha 'initial commit' }}     |
-      |        | git branch parent {{ sha 'parent commit' }}     |
-      |        | git checkout child                              |
-      | child  | git branch -D new                               |
+      | BRANCH | COMMAND                                                |
+      | new    | git checkout child                                     |
+      | child  | git reset --hard {{ sha 'child commit' }}              |
+      |        | git push --force-with-lease --force-if-includes        |
+      |        | git checkout main                                      |
+      | main   | git reset --hard {{ sha 'initial commit' }}            |
+      |        | git branch parent {{ sha-before-run 'parent commit' }} |
+      |        | git checkout child                                     |
+      | child  | git branch -D new                                      |
     And the current branch is still "child"
     And the initial branches and lineage exist

--- a/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
+++ b/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
@@ -11,24 +11,45 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       | parent | local, origin | parent commit |
       | child  | local, origin | child commit  |
     And origin ships the "parent" branch
+    And inspect the repo
     And the current branch is "child"
-    When I run "git-town append new"
+    When I run "git-town append new -v"
 
+  @debug @this
   Scenario: result
     Then it runs the commands
-      | BRANCH | COMMAND                               |
-      | child  | git fetch --prune --tags              |
-      |        | git checkout main                     |
-      | main   | git rebase origin/main                |
-      |        | git checkout parent                   |
-      | parent | git merge --no-edit --ff main         |
-      |        | git checkout main                     |
-      | main   | git branch -D parent                  |
-      |        | git checkout child                    |
-      | child  | git merge --no-edit --ff origin/child |
-      |        | git merge --no-edit --ff main         |
-      |        | git push                              |
-      |        | git checkout -b new                   |
+      | BRANCH | COMMAND                                        |
+      |        | git version                                    |
+      |        | git rev-parse --show-toplevel                  |
+      |        | git config -lz --includes --global             |
+      |        | git config -lz --includes --local              |
+      |        | git status --long --ignore-submodules          |
+      |        | git remote                                     |
+      |        | git rev-parse --abbrev-ref HEAD                |
+      | child  | git fetch --prune --tags                       |
+      | <none> | git stash list                                 |
+      |        | git branch -vva --sort=refname                 |
+      |        | git rev-parse --verify --abbrev-ref @{-1}      |
+      | child  | git checkout main                              |
+      | main   | git rebase origin/main                         |
+      | <none> | git rev-list --left-right main...origin/main   |
+      | main   | git checkout parent                            |
+      | parent | git merge --no-edit --ff main                  |
+      | <none> | git diff main..parent                          |
+      | parent | git checkout child                             |
+      | child  | git merge --no-edit --ff origin/child          |
+      |        | git merge --no-edit --ff parent                |
+      | <none> | git rev-list --left-right child...origin/child |
+      | child  | git push                                       |
+      | <none> | git show-ref --verify --quiet refs/heads/child |
+      | child  | git checkout -b new                            |
+      | <none> | git show-ref --verify --quiet refs/heads/child |
+      |        | git config git-town-branch.new.parent child    |
+      |        | git show-ref --verify --quiet refs/heads/child |
+      |        | git branch -vva --sort=refname                 |
+      |        | git config -lz --includes --global             |
+      |        | git config -lz --includes --local              |
+      |        | git stash list                                 |
     And it prints:
       """
       deleted branch "parent"

--- a/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
+++ b/features/append/on_feature_branch/clean_workspace/parent_deleted.feature
@@ -7,9 +7,9 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       | parent | feature | main   | local, origin |
       | child  | feature | parent |               |
     And the commits
-      | BRANCH | LOCATION      | MESSAGE       |
-      | parent | local, origin | parent commit |
-      | child  | local, origin | child commit  |
+      | BRANCH | LOCATION      | MESSAGE       | FILE NAME   | FILE CONTENT   |
+      | parent | local, origin | parent commit | parent_file | parent content |
+      | child  | local, origin | child commit  | child_file  | child content  |
     And origin ships the "parent" branch
     And inspect the repo
     And the current branch is "child"

--- a/features/sync/all_branches/merge_sync_strategy/multiple_shipped_branches.feature
+++ b/features/sync/all_branches/merge_sync_strategy/multiple_shipped_branches.feature
@@ -55,13 +55,13 @@ Feature: multiple shipped branches
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                                           |
-      | feature-3 | git reset --hard {{ sha 'feature-3 commit' }}     |
-      |           | git push --force-with-lease --force-if-includes   |
-      |           | git checkout main                                 |
-      | main      | git reset --hard {{ sha 'initial commit' }}       |
-      |           | git branch feature-1 {{ sha 'feature-1 commit' }} |
-      |           | git branch feature-2 {{ sha 'feature-2 commit' }} |
-      |           | git checkout feature-3                            |
+      | BRANCH    | COMMAND                                                      |
+      | feature-3 | git reset --hard {{ sha 'feature-3 commit' }}                |
+      |           | git push --force-with-lease --force-if-includes              |
+      |           | git checkout main                                            |
+      | main      | git reset --hard {{ sha 'initial commit' }}                  |
+      |           | git branch feature-1 {{ sha-before-run 'feature-1 commit' }} |
+      |           | git branch feature-2 {{ sha-before-run 'feature-2 commit' }} |
+      |           | git checkout feature-3                                       |
     And the current branch is still "feature-3"
     And the initial branches and lineage exist

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/stacked_changes/ancestors_shipped.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/stacked_changes/ancestors_shipped.feature
@@ -54,13 +54,13 @@ Feature: shipped parent branches in a stacked change
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                                           |
-      | feature-3 | git reset --hard {{ sha 'feature-3 commit' }}     |
-      |           | git push --force-with-lease --force-if-includes   |
-      |           | git checkout main                                 |
-      | main      | git reset --hard {{ sha 'initial commit' }}       |
-      |           | git branch feature-1 {{ sha 'feature-1 commit' }} |
-      |           | git branch feature-2 {{ sha 'feature-2 commit' }} |
-      |           | git checkout feature-3                            |
+      | BRANCH    | COMMAND                                                      |
+      | feature-3 | git reset --hard {{ sha 'feature-3 commit' }}                |
+      |           | git push --force-with-lease --force-if-includes              |
+      |           | git checkout main                                            |
+      | main      | git reset --hard {{ sha 'initial commit' }}                  |
+      |           | git branch feature-1 {{ sha-before-run 'feature-1 commit' }} |
+      |           | git branch feature-2 {{ sha-before-run 'feature-2 commit' }} |
+      |           | git checkout feature-3                                       |
     And the current branch is still "feature-3"
     And the initial branches and lineage exist

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/stacked_changes/parent_shipped.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/stacked_changes/parent_shipped.feature
@@ -43,12 +43,12 @@ Feature: syncing a branch whose parent was shipped
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                                         |
-      | child  | git reset --hard {{ sha 'child commit' }}       |
-      |        | git push --force-with-lease --force-if-includes |
-      |        | git checkout main                               |
-      | main   | git reset --hard {{ sha 'initial commit' }}     |
-      |        | git branch parent {{ sha 'parent commit' }}     |
-      |        | git checkout child                              |
+      | BRANCH | COMMAND                                                |
+      | child  | git reset --hard {{ sha 'child commit' }}              |
+      |        | git push --force-with-lease --force-if-includes        |
+      |        | git checkout main                                      |
+      | main   | git reset --hard {{ sha 'initial commit' }}            |
+      |        | git branch parent {{ sha-before-run 'parent commit' }} |
+      |        | git checkout child                                     |
     And the current branch is still "child"
     And the initial branches and lineage exist

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/unshipped_local_changes.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/unshipped_local_changes.feature
@@ -36,13 +36,14 @@ Feature: sync a branch with unshipped local changes whose tracking branch was de
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                                     |
-      | shipped | git add -A                                  |
-      |         | git stash                                   |
-      |         | git checkout main                           |
-      | main    | git reset --hard {{ sha 'initial commit' }} |
-      |         | git checkout shipped                        |
-      | shipped | git stash pop                               |
+      | BRANCH  | COMMAND                                                  |
+      | shipped | git add -A                                               |
+      |         | git stash                                                |
+      |         | git checkout main                                        |
+      | main    | git reset --hard {{ sha 'initial commit' }}              |
+      |         | git checkout shipped                                     |
+      | shipped | git reset --hard {{ sha-before-run 'unshipped commit' }} |
+      |         | git stash pop                                            |
     And the current branch is now "shipped"
     And the uncommitted file still exists
     And these commits exist now

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/stacked_changes/ancestors_shipped.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/stacked_changes/ancestors_shipped.feature
@@ -54,13 +54,13 @@ Feature: shipped parent branches in a stacked change
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH    | COMMAND                                           |
-      | feature-3 | git reset --hard {{ sha 'feature-3 commit' }}     |
-      |           | git push --force-with-lease --force-if-includes   |
-      |           | git checkout main                                 |
-      | main      | git reset --hard {{ sha 'initial commit' }}       |
-      |           | git branch feature-1 {{ sha 'feature-1 commit' }} |
-      |           | git branch feature-2 {{ sha 'feature-2 commit' }} |
-      |           | git checkout feature-3                            |
+      | BRANCH    | COMMAND                                                      |
+      | feature-3 | git reset --hard {{ sha 'feature-3 commit' }}                |
+      |           | git push --force-with-lease --force-if-includes              |
+      |           | git checkout main                                            |
+      | main      | git reset --hard {{ sha 'initial commit' }}                  |
+      |           | git branch feature-1 {{ sha-before-run 'feature-1 commit' }} |
+      |           | git branch feature-2 {{ sha-before-run 'feature-2 commit' }} |
+      |           | git checkout feature-3                                       |
     And the current branch is still "feature-3"
     And the initial branches and lineage exist

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/stacked_changes/parent_shipped.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/stacked_changes/parent_shipped.feature
@@ -43,12 +43,12 @@ Feature: syncing a branch whose parent was shipped
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH | COMMAND                                         |
-      | child  | git reset --hard {{ sha 'child commit' }}       |
-      |        | git push --force-with-lease --force-if-includes |
-      |        | git checkout main                               |
-      | main   | git reset --hard {{ sha 'initial commit' }}     |
-      |        | git branch parent {{ sha 'parent commit' }}     |
-      |        | git checkout child                              |
+      | BRANCH | COMMAND                                                |
+      | child  | git reset --hard {{ sha 'child commit' }}              |
+      |        | git push --force-with-lease --force-if-includes        |
+      |        | git checkout main                                      |
+      | main   | git reset --hard {{ sha 'initial commit' }}            |
+      |        | git branch parent {{ sha-before-run 'parent commit' }} |
+      |        | git checkout child                                     |
     And the current branch is still "child"
     And the initial branches and lineage exist

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/unmerged_local_commits.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/unmerged_local_commits.feature
@@ -37,13 +37,14 @@ Feature: sync a branch with unshipped local changes whose tracking branch was de
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                                     |
-      | shipped | git add -A                                  |
-      |         | git stash                                   |
-      |         | git checkout main                           |
-      | main    | git reset --hard {{ sha 'initial commit' }} |
-      |         | git checkout shipped                        |
-      | shipped | git stash pop                               |
+      | BRANCH  | COMMAND                                       |
+      | shipped | git add -A                                    |
+      |         | git stash                                     |
+      |         | git checkout main                             |
+      | main    | git reset --hard {{ sha 'initial commit' }}   |
+      |         | git checkout shipped                          |
+      | shipped | git reset --hard {{ sha 'unshipped commit' }} |
+      |         | git stash pop                                 |
     And the current branch is now "shipped"
     And the uncommitted file still exists
     And these commits exist now

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -343,6 +343,24 @@ func (self *Commands) FetchUpstream(runner gitdomain.Runner, branch gitdomain.Lo
 	return runner.Run("git", "fetch", gitdomain.RemoteUpstream.String(), branch.String())
 }
 
+// provides the commit message of the first commit in the branch with the given name
+func (self *Commands) FirstCommitMessageInBranch(runner gitdomain.Querier, branch, mainBranch gitdomain.LocalBranchName) (Option[gitdomain.CommitMessage], error) {
+	output, err := runner.QueryTrim("git", "log", fmt.Sprintf("%s..%s", mainBranch, branch), "--format=%h")
+	if err != nil {
+		return None[gitdomain.CommitMessage](), err
+	}
+	hashes := stringslice.Lines(output)
+	if len(hashes) == 0 {
+		return None[gitdomain.CommitMessage](), nil
+	}
+	hash := hashes[len(hashes)-1]
+	message, err := runner.QueryTrim("git", "log", "--format=%B", "-n", "1", hash)
+	if err != nil {
+		return None[gitdomain.CommitMessage](), err
+	}
+	return Some(gitdomain.CommitMessage(message)), nil
+}
+
 func (self *Commands) FirstExistingBranch(runner gitdomain.Runner, branches ...gitdomain.LocalBranchName) Option[gitdomain.LocalBranchName] {
 	for _, branch := range branches {
 		if self.BranchExists(runner, branch) {

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -183,7 +183,55 @@ func TestBackendCommands(t *testing.T) {
 
 	t.Run("FirstCommitMessageInBranch", func(t *testing.T) {
 		t.Parallel()
-
+		t.Run("branch is empty", func(t *testing.T) {
+			t.Parallel()
+			repo := testruntime.CreateGitTown(t)
+			branch := gitdomain.NewLocalBranchName("branch")
+			repo.CreateAndCheckoutBranch(repo.TestRunner, branch)
+			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, "main")
+			must.NoError(t, err)
+			must.Eq(t, None[gitdomain.CommitMessage](), have)
+		})
+		t.Run("branch has one commit", func(t *testing.T) {
+			t.Parallel()
+			repo := testruntime.CreateGitTown(t)
+			branch := gitdomain.NewLocalBranchName("branch")
+			main := gitdomain.NewLocalBranchName("main")
+			repo.CreateFeatureBranch(branch, main)
+			repo.CreateCommit(testgit.Commit{
+				Branch:      branch,
+				FileContent: "content",
+				FileName:    "file",
+				Message:     "my commit message",
+			})
+			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, main)
+			must.NoError(t, err)
+			want := Some(gitdomain.CommitMessage("my commit message"))
+			must.Eq(t, want, have)
+		})
+		t.Run("branch has multiple commits", func(t *testing.T) {
+			t.Parallel()
+			repo := testruntime.CreateGitTown(t)
+			branch := gitdomain.NewLocalBranchName("branch")
+			main := gitdomain.NewLocalBranchName("main")
+			repo.CreateFeatureBranch(branch, main)
+			repo.CreateCommit(testgit.Commit{
+				Branch:      branch,
+				FileContent: "content",
+				FileName:    "file_1",
+				Message:     "commit message 1",
+			})
+			repo.CreateCommit(testgit.Commit{
+				Branch:      branch,
+				FileContent: "content",
+				FileName:    "file_2",
+				Message:     "commit message 2",
+			})
+			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, main)
+			must.NoError(t, err)
+			want := Some(gitdomain.CommitMessage("commit message 1"))
+			must.Eq(t, want, have)
+		})
 	})
 
 	t.Run("FirstExistingBranch", func(t *testing.T) {

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -238,6 +238,12 @@ func TestBackendCommands(t *testing.T) {
 			want := Some(gitdomain.CommitMessage("commit message 1"))
 			must.Eq(t, want, have)
 		})
+		t.Run("branch doesn't exist", func(t *testing.T) {
+			t.Parallel()
+			repo := testruntime.CreateGitTown(t)
+			_, err := repo.FirstCommitMessageInBranch(repo.TestRunner, "zonk", "main")
+			must.Error(t, err)
+		})
 	})
 
 	t.Run("FirstExistingBranch", func(t *testing.T) {

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -186,7 +186,7 @@ func TestBackendCommands(t *testing.T) {
 		t.Run("branch is empty", func(t *testing.T) {
 			t.Parallel()
 			repo := testruntime.CreateGitTown(t)
-			repo.CreateAndCheckoutBranch(repo.TestRunner, "branch")
+			must.NoError(t, repo.CreateAndCheckoutBranch(repo.TestRunner, "branch"))
 			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, "branch", "main")
 			must.NoError(t, err)
 			must.Eq(t, None[gitdomain.CommitMessage](), have)

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -181,6 +181,11 @@ func TestBackendCommands(t *testing.T) {
 		must.Eq(t, want, have)
 	})
 
+	t.Run("FirstCommitMessageInBranch", func(t *testing.T) {
+		t.Parallel()
+
+	})
+
 	t.Run("FirstExistingBranch", func(t *testing.T) {
 		t.Parallel()
 		t.Run("first branch matches", func(t *testing.T) {

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -227,6 +227,12 @@ func TestBackendCommands(t *testing.T) {
 				FileName:    "file_2",
 				Message:     "commit message 2",
 			})
+			repo.CreateCommit(testgit.Commit{
+				Branch:      branch,
+				FileContent: "content",
+				FileName:    "file_3",
+				Message:     "commit message 3",
+			})
 			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, main)
 			must.NoError(t, err)
 			want := Some(gitdomain.CommitMessage("commit message 1"))

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -198,10 +198,9 @@ func TestBackendCommands(t *testing.T) {
 			main := gitdomain.NewLocalBranchName("main")
 			repo.CreateFeatureBranch(branch, main)
 			repo.CreateCommit(testgit.Commit{
-				Branch:      branch,
-				FileContent: "content",
-				FileName:    "file",
-				Message:     "my commit message",
+				Branch:   branch,
+				FileName: "file",
+				Message:  "my commit message",
 			})
 			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, main)
 			must.NoError(t, err)
@@ -215,22 +214,19 @@ func TestBackendCommands(t *testing.T) {
 			main := gitdomain.NewLocalBranchName("main")
 			repo.CreateFeatureBranch(branch, main)
 			repo.CreateCommit(testgit.Commit{
-				Branch:      branch,
-				FileContent: "content",
-				FileName:    "file_1",
-				Message:     "commit message 1",
+				Branch:   branch,
+				FileName: "file_1",
+				Message:  "commit message 1",
 			})
 			repo.CreateCommit(testgit.Commit{
-				Branch:      branch,
-				FileContent: "content",
-				FileName:    "file_2",
-				Message:     "commit message 2",
+				Branch:   branch,
+				FileName: "file_2",
+				Message:  "commit message 2",
 			})
 			repo.CreateCommit(testgit.Commit{
-				Branch:      branch,
-				FileContent: "content",
-				FileName:    "file_3",
-				Message:     "commit message 3",
+				Branch:   branch,
+				FileName: "file_3",
+				Message:  "commit message 3",
 			})
 			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, main)
 			must.NoError(t, err)

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -186,9 +186,8 @@ func TestBackendCommands(t *testing.T) {
 		t.Run("branch is empty", func(t *testing.T) {
 			t.Parallel()
 			repo := testruntime.CreateGitTown(t)
-			branch := gitdomain.NewLocalBranchName("branch")
-			repo.CreateAndCheckoutBranch(repo.TestRunner, branch)
-			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, "main")
+			repo.CreateAndCheckoutBranch(repo.TestRunner, "branch")
+			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, "branch", "main")
 			must.NoError(t, err)
 			must.Eq(t, None[gitdomain.CommitMessage](), have)
 		})

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -964,7 +964,8 @@ func defineSteps(sc *godog.ScenarioContext) {
 		err = originRepo.SquashMerge(originRepo.TestRunner, branchToShip)
 		asserts.NoError(err)
 		originRepo.StageFiles("-A")
-		originRepo.Commit(originRepo.TestRunner, commitMessage, "CI <ci@acme.com>")
+		err = originRepo.Commit(originRepo.TestRunner, commitMessage, "CI <ci@acme.com>")
+		asserts.NoError(err)
 		originRepo.RemoveBranch(branchToShip)
 	})
 

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -953,10 +953,14 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^origin ships the "([^"]*)" branch$`, func(ctx context.Context, branchName string) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		branch := gitdomain.NewLocalBranchName(branchName)
+		main := gitdomain.NewLocalBranchName("main")
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
-		originRepo.CheckoutBranch(gitdomain.NewLocalBranchName("main"))
-		err := originRepo.SquashMerge(originRepo.TestRunner, branch)
+		originRepo.CheckoutBranch(main)
+		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branch, main)
 		asserts.NoError(err)
+		err = originRepo.SquashMerge(originRepo.TestRunner, branch)
+		asserts.NoError(err)
+		originRepo.Commit(originRepo.TestRunner, commitMessage, "ci@acme.com")
 		originRepo.RemoveBranch(branch)
 	})
 

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -954,11 +954,10 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^origin ships the "([^"]*)" branch$`, func(ctx context.Context, branchName string) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		branchToShip := gitdomain.NewLocalBranchName(branchName)
-		mainBranch := gitdomain.NewLocalBranchName("main")
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
-		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip, mainBranch)
+		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip, "main")
 		asserts.NoError(err)
-		originRepo.CheckoutBranch(mainBranch)
+		originRepo.CheckoutBranch("main")
 		err = originRepo.SquashMerge(originRepo.TestRunner, branchToShip)
 		asserts.NoError(err)
 		originRepo.StageFiles("-A")

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -958,12 +958,11 @@ func defineSteps(sc *godog.ScenarioContext) {
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
 		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip, mainBranch)
 		asserts.NoError(err)
-		fmt.Println("1111111111111111111111111", originRepo.TestRunner.Verbose)
 		originRepo.CheckoutBranch(mainBranch)
 		err = originRepo.SquashMerge(originRepo.TestRunner, branchToShip)
 		asserts.NoError(err)
 		originRepo.StageFiles("-A")
-		originRepo.Commit(originRepo.TestRunner, commitMessage, "ci@acme.com")
+		originRepo.Commit(originRepo.TestRunner, commitMessage, "CI <ci@acme.com>")
 		originRepo.RemoveBranch(branchToShip)
 	})
 

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -957,7 +957,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
 		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip, mainBranch)
 		asserts.NoError(err)
-		fmt.Println("1111111111111111111111111", commitMessage)
+		fmt.Println("1111111111111111111111111", originRepo.TestRunner.Verbose)
 		originRepo.CheckoutBranch(mainBranch)
 		err = originRepo.SquashMerge(originRepo.TestRunner, branchToShip)
 		asserts.NoError(err)

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -952,16 +952,18 @@ func defineSteps(sc *godog.ScenarioContext) {
 
 	sc.Step(`^origin ships the "([^"]*)" branch$`, func(ctx context.Context, branchName string) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
-		branch := gitdomain.NewLocalBranchName(branchName)
-		main := gitdomain.NewLocalBranchName("main")
+		branchToShip := gitdomain.NewLocalBranchName(branchName)
+		mainBranch := gitdomain.NewLocalBranchName("main")
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
-		originRepo.CheckoutBranch(main)
-		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branch, main)
+		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip, mainBranch)
 		asserts.NoError(err)
-		err = originRepo.SquashMerge(originRepo.TestRunner, branch)
+		fmt.Println("1111111111111111111111111", commitMessage)
+		originRepo.CheckoutBranch(mainBranch)
+		err = originRepo.SquashMerge(originRepo.TestRunner, branchToShip)
 		asserts.NoError(err)
+		originRepo.StageFiles("-A")
 		originRepo.Commit(originRepo.TestRunner, commitMessage, "ci@acme.com")
-		originRepo.RemoveBranch(branch)
+		originRepo.RemoveBranch(branchToShip)
 	})
 
 	sc.Step(`^the branch(es)?$`, func(ctx context.Context, plural string, table *godog.Table) {

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -957,6 +957,9 @@ func defineSteps(sc *godog.ScenarioContext) {
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
 		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip, "main")
 		asserts.NoError(err)
+		if commitMessage.IsNone() {
+			panic("branch to ship contains no commits")
+		}
 		originRepo.CheckoutBranch("main")
 		err = originRepo.SquashMerge(originRepo.TestRunner, branchToShip)
 		asserts.NoError(err)

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -954,7 +954,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
 		originRepo.CheckoutBranch(gitdomain.NewLocalBranchName("main"))
-		err := originRepo.MergeBranch(gitdomain.NewLocalBranchName(branch))
+		err := originRepo.SquashMerge(originRepo.TestRunner, gitdomain.NewLocalBranchName(branch))
 		asserts.NoError(err)
 		originRepo.RemoveBranch(gitdomain.NewLocalBranchName(branch))
 	})


### PR DESCRIPTION
Previously when the origin ships a branch in E2E tests it used the "merge" strategy. Which is not idiomatic since Git Town uses the "squash-merge" strategy. E2E tests should reflect that. This PR fixes this problem.