### PR TITLE
Make assumption about previous branch clear in E2E test

### DIFF
--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/stacked_changes/parent_deleted_grandchild_conflicts.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/stacked_changes/parent_deleted_grandchild_conflicts.feature
@@ -6,12 +6,12 @@ Feature: a grandchild branch has conflicts while its parent was deleted remotely
       | NAME       | TYPE    | PARENT | LOCATIONS     |
       | child      | feature | main   | local, origin |
       | grandchild | feature | child  | local, origin |
-    And the current branch is "child"
     And the commits
       | BRANCH     | LOCATION | MESSAGE                       | FILE NAME        | FILE CONTENT       |
       | main       | local    | conflicting main commit       | conflicting_file | main content       |
       | grandchild | local    | conflicting grandchild commit | conflicting_file | grandchild content |
     And origin deletes the "child" branch
+    And the current branch is "child" and the previous branch is "grandchild"
     When I run "git-town sync --all"
 
   Scenario: result

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/stacked_changes/parent_deleted_grandchild_conflict.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/stacked_changes/parent_deleted_grandchild_conflict.feature
@@ -6,13 +6,13 @@ Feature: a grandchild branch has conflicts while its parent was deleted remotely
       | NAME       | TYPE    | PARENT | LOCATIONS     |
       | child      | feature | main   | local, origin |
       | grandchild | feature | child  | local, origin |
-    And Git Town setting "sync-feature-strategy" is "rebase"
-    And the current branch is "child"
     And the commits
       | BRANCH     | LOCATION | MESSAGE                       | FILE NAME        | FILE CONTENT       |
       | main       | local    | conflicting main commit       | conflicting_file | main content       |
       | grandchild | local    | conflicting grandchild commit | conflicting_file | grandchild content |
+    And Git Town setting "sync-feature-strategy" is "rebase"
     And origin deletes the "child" branch
+    And the current branch is "child" and the previous branch is "grandchild"
     When I run "git-town sync --all"
 
   Scenario: result


### PR DESCRIPTION
The E2E tests used a previous branch set as a side effect of branch setup. This PR makes this assumption explicit. This allows reordering E2E test steps.