### PR TITLE
Loosen type restrictions

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -344,7 +344,7 @@ func (self *Commands) FetchUpstream(runner gitdomain.Runner, branch gitdomain.Lo
 }
 
 // provides the commit message of the first commit in the branch with the given name
-func (self *Commands) FirstCommitMessageInBranch(runner gitdomain.Querier, branch, mainBranch gitdomain.LocalBranchName) (Option[gitdomain.CommitMessage], error) {
+func (self *Commands) FirstCommitMessageInBranch(runner gitdomain.Querier, branch, mainBranch gitdomain.BranchName) (Option[gitdomain.CommitMessage], error) {
 	output, err := runner.QueryTrim("git", "log", fmt.Sprintf("%s..%s", mainBranch, branch), "--format=%h")
 	if err != nil {
 		return None[gitdomain.CommitMessage](), err

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -202,7 +202,7 @@ func TestBackendCommands(t *testing.T) {
 				FileName: "file",
 				Message:  "my commit message",
 			})
-			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, main)
+			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch.BranchName(), main.BranchName())
 			must.NoError(t, err)
 			want := Some(gitdomain.CommitMessage("my commit message"))
 			must.Eq(t, want, have)
@@ -228,7 +228,7 @@ func TestBackendCommands(t *testing.T) {
 				FileName: "file_3",
 				Message:  "commit message 3",
 			})
-			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch, main)
+			have, err := repo.FirstCommitMessageInBranch(repo.TestRunner, branch.BranchName(), main.BranchName())
 			must.NoError(t, err)
 			want := Some(gitdomain.CommitMessage("commit message 1"))
 			must.Eq(t, want, have)

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -955,7 +955,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		branchToShip := gitdomain.NewLocalBranchName(branchName)
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
-		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip, "main")
+		commitMessage, err := originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip.BranchName(), "main")
 		asserts.NoError(err)
 		if commitMessage.IsNone() {
 			panic("branch to ship contains no commits")


### PR DESCRIPTION
When determining the first commit in a branch, the main branch doesn't need to be local.