### PR TITLE
Print the Git Town version when in verbose mode

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/git-town/git-town/v15/internal/cli/flags"
 	"github.com/git-town/git-town/v15/internal/cmd/cmdhelpers"
+	"github.com/git-town/git-town/v15/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +49,7 @@ func rootCmd() cobra.Command {
 
 func executeRoot(cmd *cobra.Command, showVersion bool) error {
 	if showVersion {
-		fmt.Println("Git Town 15.1.0")
+		fmt.Println("Git Town " + config.GitTownVersion)
 		return nil
 	}
 	return cmd.Help()

--- a/internal/config/version.go
+++ b/internal/config/version.go
@@ -1,0 +1,4 @@
+package config
+
+// the current Git Town version
+const GitTownVersion = "15.1.0"

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -2,6 +2,7 @@ package execute
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/git-town/git-town/v15/internal/config"
@@ -22,6 +23,9 @@ import (
 
 func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	commandsCounter := NewMutable(new(gohacks.Counter))
+	if args.Verbose {
+		fmt.Println("Git Town " + config.GitTownVersion)
+	}
 	backendRunner := subshell.BackendRunner{
 		Dir:             None[string](),
 		CommandsCounter: commandsCounter,


### PR DESCRIPTION
This makes verbose mode print all information needed to debug problems.