### PR TITLE
Split the commit-open-changes opcode into two atomic opcodes

### DIFF
--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -242,8 +242,8 @@ func killLocalBranch(prog, finalUndoProgram Mutable[program.Program], data killD
 	if localBranchToKill, hasLocalBranchToKill := data.branchToKillInfo.LocalName.Get(); hasLocalBranchToKill {
 		if data.initialBranch == localBranchToKill {
 			if data.hasOpenChanges {
+				prog.Value.Add(&opcodes.StageOpenChanges{})
 				prog.Value.Add(&opcodes.CommitOpenChanges{
-					AddAll:  true,
 					Message: "Committing WIP for git town undo",
 				})
 				// update the registered initial SHA for this branch so that undo restores the just committed changes

--- a/internal/sync/sync_feature_branch.go
+++ b/internal/sync/sync_feature_branch.go
@@ -50,7 +50,7 @@ func syncFeatureBranchCompressProgram(args syncFeatureBranchProgramArgs) {
 	args.program.Value.Add(&opcodes.MergeParent{CurrentBranch: args.localName, ParentActiveInOtherWorktree: args.parentOtherWorktree})
 	if firstCommitMessage, branchHasCommits := args.firstCommitMessage.Get(); branchHasCommits {
 		args.program.Value.Add(&opcodes.ResetCurrentBranchToParent{CurrentBranch: args.localName})
-		args.program.Value.Add(&opcodes.CommitOpenChanges{AddAll: false, Message: firstCommitMessage})
+		args.program.Value.Add(&opcodes.CommitOpenChanges{Message: firstCommitMessage})
 	}
 	if hasTrackingBranch && args.offline.IsFalse() {
 		args.program.Value.Add(&opcodes.ForcePushCurrentBranch{ForceIfIncludes: false})

--- a/internal/undo/undo_finished_program.go
+++ b/internal/undo/undo_finished_program.go
@@ -18,10 +18,8 @@ func CreateUndoForFinishedProgram(args CreateUndoProgramArgs) program.Program {
 	if !args.RunState.IsFinished() && args.HasOpenChanges {
 		// Open changes in the middle of an unfinished command will be undone as well.
 		// To achieve this, we commit them here so that they are gone when the branch is reset to the original SHA.
-		result.Value.Add(&opcodes.CommitOpenChanges{
-			AddAll:  true,
-			Message: "Committing WIP for git town undo",
-		})
+		result.Value.Add(&opcodes.StageOpenChanges{})
+		result.Value.Add(&opcodes.CommitOpenChanges{Message: "Committing WIP for git town undo"})
 	}
 	if endBranchesSnapshot, hasEndBranchesSnapshot := args.RunState.EndBranchesSnapshot.Get(); hasEndBranchesSnapshot {
 		result.Value.AddProgram(undobranches.DetermineUndoBranchesProgram(args.RunState.BeginBranchesSnapshot, endBranchesSnapshot, args.RunState.UndoablePerennialCommits, args.Config, args.RunState.TouchedBranches))

--- a/internal/vm/opcodes/commit_open_changes.go
+++ b/internal/vm/opcodes/commit_open_changes.go
@@ -8,7 +8,6 @@ import (
 // CommitOpenChanges commits all open changes as a new commit.
 // It does not ask the user for a commit message, but chooses one automatically.
 type CommitOpenChanges struct {
-	AddAll                  bool
 	Message                 gitdomain.CommitMessage
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
@@ -18,11 +17,5 @@ func (self *CommitOpenChanges) CreateContinueProgram() []shared.Opcode {
 }
 
 func (self *CommitOpenChanges) Run(args shared.RunArgs) error {
-	if self.AddAll {
-		err := args.Git.StageFiles(args.Frontend, "-A")
-		if err != nil {
-			return err
-		}
-	}
 	return args.Git.CommitStagedChanges(args.Frontend, self.Message)
 }

--- a/internal/vm/opcodes/core.go
+++ b/internal/vm/opcodes/core.go
@@ -105,6 +105,7 @@ func Types() []shared.Opcode {
 		&SetParent{},
 		&SetParentIfBranchExists{},
 		&SkipCurrentBranch{},
+		&StageOpenChanges{},
 		&StashOpenChanges{},
 		&SquashMerge{},
 		&UndoLastCommit{},

--- a/internal/vm/opcodes/stage_open_changes.go
+++ b/internal/vm/opcodes/stage_open_changes.go
@@ -1,8 +1,6 @@
 package opcodes
 
-import (
-	"github.com/git-town/git-town/v15/internal/vm/shared"
-)
+import "github.com/git-town/git-town/v15/internal/vm/shared"
 
 // CommitOpenChanges commits all open changes as a new commit.
 // It does not ask the user for a commit message, but chooses one automatically.

--- a/internal/vm/opcodes/stage_open_changes.go
+++ b/internal/vm/opcodes/stage_open_changes.go
@@ -1,0 +1,19 @@
+package opcodes
+
+import (
+	"github.com/git-town/git-town/v15/internal/vm/shared"
+)
+
+// CommitOpenChanges commits all open changes as a new commit.
+// It does not ask the user for a commit message, but chooses one automatically.
+type StageOpenChanges struct {
+	undeclaredOpcodeMethods `exhaustruct:"optional"`
+}
+
+func (self *StageOpenChanges) CreateContinueProgram() []shared.Opcode {
+	return []shared.Opcode{self}
+}
+
+func (self *StageOpenChanges) Run(args shared.RunArgs) error {
+	return args.Git.StageFiles(args.Frontend, "-A")
+}

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -58,7 +58,7 @@ func TestLoadSave(t *testing.T) {
 					Parent: gitdomain.NewLocalBranchName("parent"),
 				},
 				&opcodes.Checkout{Branch: gitdomain.NewLocalBranchName("branch")},
-				&opcodes.CommitOpenChanges{AddAll: true, Message: "my message"},
+				&opcodes.CommitOpenChanges{Message: "my message"},
 				&opcodes.ConnectorMergeProposal{
 					Branch:          gitdomain.NewLocalBranchName("branch"),
 					CommitMessage:   Some(gitdomain.CommitMessage("commit message")),
@@ -172,6 +172,7 @@ func TestLoadSave(t *testing.T) {
 					CommitMessage: Some(gitdomain.CommitMessage("commit message")),
 					Parent:        gitdomain.NewLocalBranchName("parent"),
 				},
+				&opcodes.StageOpenChanges{},
 				&opcodes.StashOpenChanges{},
 				&opcodes.UpdateProposalTarget{
 					ProposalNumber: 123,
@@ -259,7 +260,6 @@ func TestLoadSave(t *testing.T) {
     },
     {
       "data": {
-        "AddAll": true,
         "Message": "my message"
       },
       "type": "CommitOpenChanges"
@@ -509,6 +509,10 @@ func TestLoadSave(t *testing.T) {
         "Parent": "parent"
       },
       "type": "SquashMerge"
+    },
+    {
+      "data": {},
+      "type": "StageOpenChanges"
     },
     {
       "data": {},


### PR DESCRIPTION
The CommitOpenChanges opcode does two operations: staging and committing. If committing fails, and Git Town repeats this opcode, then staging will fail because it already ran. This also simplifies the opcode implementation and reduces configuration data.

part of #3629