### PR TITLE
Drop the stash when continuing stash conflicts

### DIFF
--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -62,7 +62,9 @@ Feature: conflicts between uncommitted changes and the main branch
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
-    Then it runs no commands
+    Then it runs the commands
+      | BRANCH | COMMAND        |
+      | new    | git stash drop |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE            | FILE NAME        | FILE CONTENT |
@@ -80,7 +82,6 @@ Feature: conflicts between uncommitted changes and the main branch
       |          | git stash             |
       |          | git checkout existing |
       | existing | git branch -D new     |
-      |          | git stash pop         |
       |          | git stash pop         |
     And the current branch is now "existing"
     And the initial commits exist

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -320,11 +320,6 @@ func (self *Commands) DeleteTrackingBranch(runner gitdomain.Runner, name gitdoma
 	return runner.Run("git", "push", remote.String(), ":"+localBranchName.String())
 }
 
-// DropStash removes the most recent stash entry
-func (self *Commands) DropStash(runner gitdomain.Runner) error {
-	return runner.Run("git", "stash", "drop")
-}
-
 // DiffParent displays the diff between the given branch and its given parent branch.
 func (self *Commands) DiffParent(runner gitdomain.Runner, branch, parentBranch gitdomain.LocalBranchName) error {
 	return runner.Run("git", "diff", parentBranch.String()+".."+branch.String())
@@ -333,6 +328,11 @@ func (self *Commands) DiffParent(runner gitdomain.Runner, branch, parentBranch g
 // DiscardOpenChanges deletes all uncommitted changes.
 func (self *Commands) DiscardOpenChanges(runner gitdomain.Runner) error {
 	return runner.Run("git", "reset", "--hard")
+}
+
+// DropStash removes the most recent stash entry
+func (self *Commands) DropStash(runner gitdomain.Runner) error {
+	return runner.Run("git", "stash", "drop")
 }
 
 // Fetch retrieves the updates from the origin repo.

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -320,7 +320,7 @@ func (self *Commands) DeleteTrackingBranch(runner gitdomain.Runner, name gitdoma
 	return runner.Run("git", "push", remote.String(), ":"+localBranchName.String())
 }
 
-// DropStash restores stashed-away changes into the workspace.
+// DropStash removes the most recent stash entry
 func (self *Commands) DropStash(runner gitdomain.Runner) error {
 	return runner.Run("git", "stash", "drop")
 }

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -320,6 +320,11 @@ func (self *Commands) DeleteTrackingBranch(runner gitdomain.Runner, name gitdoma
 	return runner.Run("git", "push", remote.String(), ":"+localBranchName.String())
 }
 
+// DropStash restores stashed-away changes into the workspace.
+func (self *Commands) DropStash(runner gitdomain.Runner) error {
+	return runner.Run("git", "stash", "drop")
+}
+
 // DiffParent displays the diff between the given branch and its given parent branch.
 func (self *Commands) DiffParent(runner gitdomain.Runner, branch, parentBranch gitdomain.LocalBranchName) error {
 	return runner.Run("git", "diff", parentBranch.String()+".."+branch.String())

--- a/internal/vm/opcodes/core.go
+++ b/internal/vm/opcodes/core.go
@@ -71,6 +71,7 @@ func Types() []shared.Opcode {
 		&DeleteParentBranch{},
 		&DeleteTrackingBranch{},
 		&DiscardOpenChanges{},
+		&DropStash{},
 		&EndOfBranchProgram{},
 		&EnsureHasShippableChanges{},
 		&FetchUpstream{},

--- a/internal/vm/opcodes/drop_stash.go
+++ b/internal/vm/opcodes/drop_stash.go
@@ -1,0 +1,15 @@
+package opcodes
+
+import (
+	"github.com/git-town/git-town/v15/internal/vm/shared"
+)
+
+// RestoreOpenChanges restores stashed away changes into the workspace.
+type DropStash struct {
+	undeclaredOpcodeMethods `exhaustruct:"optional"`
+}
+
+func (self *DropStash) Run(args shared.RunArgs) error {
+	_ = args.Git.DropStash(args.Frontend)
+	return nil
+}

--- a/internal/vm/opcodes/restore_open_changes.go
+++ b/internal/vm/opcodes/restore_open_changes.go
@@ -12,6 +12,10 @@ type RestoreOpenChanges struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
+func (self *RestoreOpenChanges) CreateContinueProgram() []shared.Opcode {
+	return []shared.Opcode{&DropStash{}}
+}
+
 func (self *RestoreOpenChanges) Run(args shared.RunArgs) error {
 	stashSize, err := args.Git.StashSize(args.Backend)
 	if err != nil {

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -90,6 +90,7 @@ func TestLoadSave(t *testing.T) {
 					Branch: gitdomain.NewRemoteBranchName("origin/branch"),
 				},
 				&opcodes.DiscardOpenChanges{},
+				&opcodes.DropStash{},
 				&opcodes.EndOfBranchProgram{},
 				&opcodes.EnsureHasShippableChanges{
 					Branch: gitdomain.NewLocalBranchName("branch"),
@@ -331,6 +332,10 @@ func TestLoadSave(t *testing.T) {
     {
       "data": {},
       "type": "DiscardOpenChanges"
+    },
+    {
+      "data": {},
+      "type": "DropStash"
     },
     {
       "data": {},


### PR DESCRIPTION
Currently Git Town keep the stashed entry when popping the stash at the end results in conflicts, even if the user runs `git town continue` after resolving the problem. This PR changes the behavior when encountering merge conflicts while restoring the stash to the following:

- if the user chooses to continue after encountering conflicts while unstashing, Git Town assumes the user was able to resolve the merge conflicts. It therefore removes the stash entry
- if the user chooses to undo after encountering conflicts while unstashing, Git Town restores the original situation