### PR TITLE
Always retry failed opcodes unless the opcode says otherwise

### DIFF
--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -59,7 +59,6 @@ Feature: conflicts between uncommitted changes and the main branch
       you must resolve the conflicts before continuing
       """
 
-  @this
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -59,6 +59,7 @@ Feature: conflicts between uncommitted changes and the main branch
       you must resolve the conflicts before continuing
       """
 
+  @this
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor

--- a/internal/vm/interpreter/full/errored.go
+++ b/internal/vm/interpreter/full/errored.go
@@ -42,7 +42,11 @@ func errored(failedOpcode shared.Opcode, runErr error, args ExecuteArgs) error {
 	if failedOpcode.ShouldAutomaticallyUndoOnError() {
 		return autoUndo(failedOpcode, runErr, args)
 	}
-	args.RunState.RunProgram.Prepend(failedOpcode.CreateContinueProgram()...)
+	continueProgram := failedOpcode.CreateContinueProgram()
+	if len(continueProgram) == 0 {
+		continueProgram = []shared.Opcode{failedOpcode}
+	}
+	args.RunState.RunProgram.Prepend(continueProgram...)
 	err = args.RunState.MarkAsUnfinished(args.Git, args.Backend)
 	if err != nil {
 		return err

--- a/internal/vm/opcodes/commit_open_changes.go
+++ b/internal/vm/opcodes/commit_open_changes.go
@@ -12,10 +12,6 @@ type CommitOpenChanges struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *CommitOpenChanges) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *CommitOpenChanges) Run(args shared.RunArgs) error {
 	return args.Git.CommitStagedChanges(args.Frontend, self.Message)
 }

--- a/internal/vm/opcodes/connector_merge_proposal.go
+++ b/internal/vm/opcodes/connector_merge_proposal.go
@@ -19,6 +19,7 @@ type ConnectorMergeProposal struct {
 	ProposalNumber            int
 	enteredEmptyCommitMessage bool
 	mergeError                error
+	undeclaredOpcodeMethods   `exhaustruct:"optional"`
 }
 
 func (self *ConnectorMergeProposal) CreateAbortProgram() []shared.Opcode {
@@ -33,10 +34,6 @@ func (self *ConnectorMergeProposal) CreateAutomaticUndoError() error {
 		return errors.New(messages.ShipAbortedMergeError)
 	}
 	return self.mergeError
-}
-
-func (self *ConnectorMergeProposal) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
 }
 
 func (self *ConnectorMergeProposal) Run(args shared.RunArgs) error {

--- a/internal/vm/opcodes/continue_merge.go
+++ b/internal/vm/opcodes/continue_merge.go
@@ -8,10 +8,6 @@ type ContinueMerge struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *ContinueMerge) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *ContinueMerge) Run(args shared.RunArgs) error {
 	if args.Git.HasMergeInProgress(args.Backend) {
 		return args.Git.CommitNoEdit(args.Frontend)

--- a/internal/vm/opcodes/continue_rebase.go
+++ b/internal/vm/opcodes/continue_rebase.go
@@ -14,10 +14,6 @@ func (self *ContinueRebase) CreateAbortProgram() []shared.Opcode {
 	}
 }
 
-func (self *ContinueRebase) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *ContinueRebase) Run(args shared.RunArgs) error {
 	repoStatus, err := args.Git.RepoStatus(args.Backend)
 	if err != nil {

--- a/internal/vm/opcodes/create_and_checkout_branch_existing_parent.go
+++ b/internal/vm/opcodes/create_and_checkout_branch_existing_parent.go
@@ -12,10 +12,6 @@ type CreateAndCheckoutBranchExistingParent struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *CreateAndCheckoutBranchExistingParent) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *CreateAndCheckoutBranchExistingParent) Run(args shared.RunArgs) error {
 	currentBranch, err := args.Git.CurrentBranch(args.Backend)
 	if err != nil {

--- a/internal/vm/opcodes/create_proposal.go
+++ b/internal/vm/opcodes/create_proposal.go
@@ -19,10 +19,6 @@ type CreateProposal struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *CreateProposal) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *CreateProposal) Run(args shared.RunArgs) error {
 	parentBranch, hasParentBranch := args.Config.Config.Lineage.Parent(self.Branch).Get()
 	if !hasParentBranch {

--- a/internal/vm/opcodes/create_tracking_branch.go
+++ b/internal/vm/opcodes/create_tracking_branch.go
@@ -12,10 +12,6 @@ type CreateTrackingBranch struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *CreateTrackingBranch) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *CreateTrackingBranch) Run(args shared.RunArgs) error {
 	return args.Git.CreateTrackingBranch(args.Frontend, self.Branch, gitdomain.RemoteOrigin, args.Config.Config.NoPushHook())
 }

--- a/internal/vm/opcodes/push_current_branch.go
+++ b/internal/vm/opcodes/push_current_branch.go
@@ -11,10 +11,6 @@ type PushCurrentBranch struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *PushCurrentBranch) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *PushCurrentBranch) Run(args shared.RunArgs) error {
 	shouldPush, err := args.Git.ShouldPushBranch(args.Backend, self.CurrentBranch)
 	if err != nil {

--- a/internal/vm/opcodes/stage_open_changes.go
+++ b/internal/vm/opcodes/stage_open_changes.go
@@ -8,10 +8,6 @@ type StageOpenChanges struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *StageOpenChanges) CreateContinueProgram() []shared.Opcode {
-	return []shared.Opcode{self}
-}
-
 func (self *StageOpenChanges) Run(args shared.RunArgs) error {
 	return args.Git.StageFiles(args.Frontend, "-A")
 }


### PR DESCRIPTION
Currently opcodes need to indicate whether they want to be retried when they fail. This only works assuming that the opcodes who don't indicate this cannot fail. In reality, all opcodes can fail, for example when a concurrent Git process suddenly starts running.

This PR changes the interpreter engine at the heart of Git Town to always retry failed opcodes.