### PR TITLE
Remove pointless error message

### DIFF
--- a/internal/cli/flags/all.go
+++ b/internal/cli/flags/all.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func All() (AddFunc, ReadAllFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.SyncAllBranches {
 		value, err := cmd.Flags().GetBool(allLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), allLong))
+			panic(err)
 		}
 		return configdomain.SyncAllBranches(value)
 	}

--- a/internal/cli/flags/commit_message.go
+++ b/internal/cli/flags/commit_message.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/git/gitdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	. "github.com/git-town/git-town/v15/pkg/prelude"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +19,7 @@ func CommitMessage(desc string) (AddFunc, ReadCommitMessageFlagFunc) {
 	readFlag := func(cmd *cobra.Command) Option[gitdomain.CommitMessage] {
 		value, err := cmd.Flags().GetString(commitMessageLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), commitMessageLong))
+			panic(err)
 		}
 		if value == "" {
 			return None[gitdomain.CommitMessage]()

--- a/internal/cli/flags/dryrun.go
+++ b/internal/cli/flags/dryrun.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func DryRun() (AddFunc, ReadDryRunFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.DryRun {
 		value, err := cmd.Flags().GetBool(dryRunLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), dryRunLong))
+			panic(err)
 		}
 		return configdomain.DryRun(value)
 	}

--- a/internal/cli/flags/force.go
+++ b/internal/cli/flags/force.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func Force(desc string) (AddFunc, ReadForceFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.Force {
 		value, err := cmd.Flags().GetBool(forceLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), forceLong))
+			panic(err)
 		}
 		return configdomain.Force(value)
 	}

--- a/internal/cli/flags/no_push.go
+++ b/internal/cli/flags/no_push.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func NoPush() (AddFunc, ReadNoPushFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.PushBranches {
 		value, err := cmd.Flags().GetBool(noPushLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), noPushLong))
+			panic(err)
 		}
 		return configdomain.PushBranches(!value)
 	}

--- a/internal/cli/flags/proposal_body.go
+++ b/internal/cli/flags/proposal_body.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/git/gitdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +18,7 @@ func ProposalBody() (AddFunc, ReadProposalBodyFlagFunc) {
 	readFlag := func(cmd *cobra.Command) gitdomain.ProposalBody {
 		value, err := cmd.Flags().GetString(bodyLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), commitMessageLong))
+			panic(err)
 		}
 		return gitdomain.ProposalBody(value)
 	}

--- a/internal/cli/flags/proposal_body_file.go
+++ b/internal/cli/flags/proposal_body_file.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/git/gitdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +18,7 @@ func ProposalBodyFile() (AddFunc, ReadProposalBodyFileFlagFunc) {
 	readFlag := func(cmd *cobra.Command) gitdomain.ProposalBodyFile {
 		value, err := cmd.Flags().GetString(bodyFileLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), commitMessageLong))
+			panic(err)
 		}
 		return gitdomain.ProposalBodyFile(value)
 	}

--- a/internal/cli/flags/proposal_title.go
+++ b/internal/cli/flags/proposal_title.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/git/gitdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +18,7 @@ func ProposalTitle() (AddFunc, ReadProposalTitleFlagFunc) {
 	readFlag := func(cmd *cobra.Command) gitdomain.ProposalTitle {
 		value, err := cmd.Flags().GetString(titleLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), commitMessageLong))
+			panic(err)
 		}
 		return gitdomain.ProposalTitle(value)
 	}

--- a/internal/cli/flags/prototype.go
+++ b/internal/cli/flags/prototype.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func Prototype() (AddFunc, ReadPrototypeFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.Prototype {
 		value, err := cmd.Flags().GetBool(prototypeLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), prototypeLong))
+			panic(err)
 		}
 		return configdomain.Prototype(value)
 	}

--- a/internal/cli/flags/ship_into_nonperennial_parent.go
+++ b/internal/cli/flags/ship_into_nonperennial_parent.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func ShipIntoNonPerennialParent() (AddFunc, ReadShipIntoNonPerennialParentFlagFu
 	readFlag := func(cmd *cobra.Command) configdomain.ShipIntoNonperennialParent {
 		value, err := cmd.Flags().GetBool(shipIntoNonPerennialParentLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), shipIntoNonPerennialParentLong))
+			panic(err)
 		}
 		return configdomain.ShipIntoNonperennialParent(value)
 	}

--- a/internal/cli/flags/stack.go
+++ b/internal/cli/flags/stack.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func Stack(description string) (AddFunc, ReadStackFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.FullStack {
 		value, err := cmd.Flags().GetBool(stackLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), stackLong))
+			panic(err)
 		}
 		return configdomain.FullStack(value)
 	}

--- a/internal/cli/flags/switch_merge.go
+++ b/internal/cli/flags/switch_merge.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +15,7 @@ func SwitchMerge() (AddFunc, ReadMergeFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.SwitchUsingMerge {
 		value, err := cmd.Flags().GetBool(mergeLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), mergeLong))
+			panic(err)
 		}
 		return configdomain.SwitchUsingMerge(value)
 	}

--- a/internal/cli/flags/verbose.go
+++ b/internal/cli/flags/verbose.go
@@ -1,10 +1,7 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/git-town/git-town/v15/internal/config/configdomain"
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +18,7 @@ func Verbose() (AddFunc, ReadVerboseFlagFunc) {
 	readFlag := func(cmd *cobra.Command) configdomain.Verbose {
 		value, err := cmd.Flags().GetBool(verboseLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), verboseLong))
+			panic(err)
 		}
 		return configdomain.Verbose(value)
 	}

--- a/internal/cli/flags/version.go
+++ b/internal/cli/flags/version.go
@@ -1,9 +1,6 @@
 package flags
 
 import (
-	"fmt"
-
-	"github.com/git-town/git-town/v15/internal/messages"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +13,7 @@ func Version() (AddFunc, ReadBoolFlagFunc) {
 	readFlag := func(cmd *cobra.Command) bool {
 		value, err := cmd.Flags().GetBool(versionLong)
 		if err != nil {
-			panic(fmt.Sprintf(messages.FlagStringDoesntExist, cmd.Name(), versionLong))
+			panic(err)
 		}
 		return value
 	}

--- a/internal/messages/en.go
+++ b/internal/messages/en.go
@@ -76,7 +76,6 @@ const (
 	FileReadProblem                   = "cannot read file %q: %w"
 	FileStatProblem                   = "cannot check file %q: %w"
 	FileWriteProblem                  = "cannot write file %q: %w"
-	FlagStringDoesntExist             = "command %q does not have a string %q flag"
 	GiteaToken                        = "Gitea token: %s\n"
 	GitAnotherProcessIsRunningRetry   = "another git process seems to be running in this repository, retrying in 1 sec ..."
 	GitHubEnterpriseInitializeError   = "cannot initialize GitHub Enterprise client: %s"


### PR DESCRIPTION
Not being able to attach flags to Cobra commands is an error that will get caught in E2E tests, we don't need a pretty user-facing message here.