### PR TITLE
Collect previous branch candidates as options

### DIFF
--- a/features/append/on_feature_branch/clean_workspace/verbose.feature
+++ b/features/append/on_feature_branch/clean_workspace/verbose.feature
@@ -53,23 +53,19 @@ Feature: display all executed Git commands
     Given I ran "git-town append new"
     When I run "git-town undo --verbose"
     Then it runs the commands
-      | BRANCH   | TYPE     | COMMAND                                           |
-      |          | backend  | git version                                       |
-      |          | backend  | git rev-parse --show-toplevel                     |
-      |          | backend  | git config -lz --includes --global                |
-      |          | backend  | git config -lz --includes --local                 |
-      |          | backend  | git status --long --ignore-submodules             |
-      |          | backend  | git stash list                                    |
-      |          | backend  | git branch -vva --sort=refname                    |
-      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
-      |          | backend  | git remote get-url origin                         |
-      | new      | frontend | git checkout existing                             |
-      | existing | frontend | git branch -D new                                 |
-      |          | backend  | git config --unset git-town-branch.new.parent     |
-      |          | backend  | git show-ref --verify --quiet refs/heads/existing |
-      |          | backend  | git checkout existing                             |
-      |          | backend  | git checkout existing                             |
-
+      | BRANCH   | TYPE     | COMMAND                                       |
+      |          | backend  | git version                                   |
+      |          | backend  | git rev-parse --show-toplevel                 |
+      |          | backend  | git config -lz --includes --global            |
+      |          | backend  | git config -lz --includes --local             |
+      |          | backend  | git status --long --ignore-submodules         |
+      |          | backend  | git stash list                                |
+      |          | backend  | git branch -vva --sort=refname                |
+      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
+      |          | backend  | git remote get-url origin                     |
+      | new      | frontend | git checkout existing                         |
+      | existing | frontend | git branch -D new                             |
+      |          | backend  | git config --unset git-town-branch.new.parent |
     And it prints:
       """
       Ran 12 shell commands.

--- a/features/append/on_feature_branch/clean_workspace/verbose.feature
+++ b/features/append/on_feature_branch/clean_workspace/verbose.feature
@@ -53,19 +53,23 @@ Feature: display all executed Git commands
     Given I ran "git-town append new"
     When I run "git-town undo --verbose"
     Then it runs the commands
-      | BRANCH   | TYPE     | COMMAND                                       |
-      |          | backend  | git version                                   |
-      |          | backend  | git rev-parse --show-toplevel                 |
-      |          | backend  | git config -lz --includes --global            |
-      |          | backend  | git config -lz --includes --local             |
-      |          | backend  | git status --long --ignore-submodules         |
-      |          | backend  | git stash list                                |
-      |          | backend  | git branch -vva --sort=refname                |
-      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
-      |          | backend  | git remote get-url origin                     |
-      | new      | frontend | git checkout existing                         |
-      | existing | frontend | git branch -D new                             |
-      |          | backend  | git config --unset git-town-branch.new.parent |
+      | BRANCH   | TYPE     | COMMAND                                           |
+      |          | backend  | git version                                       |
+      |          | backend  | git rev-parse --show-toplevel                     |
+      |          | backend  | git config -lz --includes --global                |
+      |          | backend  | git config -lz --includes --local                 |
+      |          | backend  | git status --long --ignore-submodules             |
+      |          | backend  | git stash list                                    |
+      |          | backend  | git branch -vva --sort=refname                    |
+      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
+      |          | backend  | git remote get-url origin                         |
+      | new      | frontend | git checkout existing                             |
+      | existing | frontend | git branch -D new                                 |
+      |          | backend  | git config --unset git-town-branch.new.parent     |
+      |          | backend  | git show-ref --verify --quiet refs/heads/existing |
+      |          | backend  | git checkout existing                             |
+      |          | backend  | git checkout existing                             |
+
     And it prints:
       """
       Ran 12 shell commands.

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -226,8 +226,7 @@ func appendProgram(data appendFeatureData) program.Program {
 	if data.prototype.IsTrue() || data.config.Config.CreatePrototypeBranches.IsTrue() {
 		prog.Value.Add(&opcodes.AddToPrototypeBranches{Branch: data.targetBranch})
 	}
-	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.initialBranch)}
-	previousBranchCandidates = append(previousBranchCandidates, data.previousBranch)
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.initialBranch), data.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.dryRun,
 		RunInGitRoot:             true,

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -226,10 +226,8 @@ func appendProgram(data appendFeatureData) program.Program {
 	if data.prototype.IsTrue() || data.config.Config.CreatePrototypeBranches.IsTrue() {
 		prog.Value.Add(&opcodes.AddToPrototypeBranches{Branch: data.targetBranch})
 	}
-	previousBranchCandidates := gitdomain.LocalBranchNames{data.initialBranch}
-	if previousBranch, hasPreviousBranch := data.previousBranch.Get(); hasPreviousBranch {
-		previousBranchCandidates = append(previousBranchCandidates, previousBranch)
-	}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.initialBranch)}
+	previousBranchCandidates = append(previousBranchCandidates, data.previousBranch)
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.dryRun,
 		RunInGitRoot:             true,

--- a/internal/cmd/cmdhelpers/wrap.go
+++ b/internal/cmd/cmdhelpers/wrap.go
@@ -27,7 +27,7 @@ func Wrap(program Mutable[program.Program], options WrapOptions) {
 // WrapOptions represents the options given to Wrap.
 type WrapOptions struct {
 	DryRun                   configdomain.DryRun
-	PreviousBranchCandidates gitdomain.LocalBranchNames
+	PreviousBranchCandidates []Option[gitdomain.LocalBranchName]
 	RunInGitRoot             bool
 	StashOpenChanges         bool
 }

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -253,10 +253,7 @@ func compressProgram(data compressBranchesData) program.Program {
 		compressBranchProgram(prog, branchToCompress, data.config.Config.Online(), data.initialBranch)
 	}
 	prog.Value.Add(&opcodes.Checkout{Branch: data.initialBranch.BranchName().LocalName()})
-	previousBranchCandidates := gitdomain.LocalBranchNames{}
-	if previousBranch, hasPreviousBranch := data.previousBranch.Get(); hasPreviousBranch {
-		previousBranchCandidates = append(previousBranchCandidates, previousBranch)
-	}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{data.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.dryRun,
 		RunInGitRoot:             true,

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -168,7 +168,8 @@ func determineKillData(args []string, repo execute.OpenRepoResult, dryRun config
 		return data, exit, err
 	}
 	branchTypeToKill := validatedConfig.Config.BranchType(branchNameToKill)
-	previousBranch, hasPreviousBranch := repo.Git.PreviouslyCheckedOutBranch(repo.Backend).Get()
+	previousBranchOpt := repo.Git.PreviouslyCheckedOutBranch(repo.Backend)
+	previousBranch, hasPreviousBranch := previousBranchOpt.Get()
 	initialBranch, hasInitialBranch := branchesSnapshot.Active.Get()
 	if !hasInitialBranch {
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)
@@ -222,7 +223,7 @@ func killProgram(data killData) (runProgram, finalUndoProgram program.Program) {
 		DryRun:                   data.dryRun,
 		RunInGitRoot:             true,
 		StashOpenChanges:         hasLocalBranchToKill && data.initialBranch != localBranchNameToKill && data.hasOpenChanges,
-		PreviousBranchCandidates: gitdomain.LocalBranchNames{data.previousBranch, data.initialBranch},
+		PreviousBranchCandidates: []Option[gitdomain.LocalBranchName]{Some(data.previousBranch), Some(data.initialBranch)},
 	})
 	return prog.Get(), undoProg.Get()
 }

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -168,8 +168,7 @@ func determineKillData(args []string, repo execute.OpenRepoResult, dryRun config
 		return data, exit, err
 	}
 	branchTypeToKill := validatedConfig.Config.BranchType(branchNameToKill)
-	previousBranchOpt := repo.Git.PreviouslyCheckedOutBranch(repo.Backend)
-	previousBranch, hasPreviousBranch := previousBranchOpt.Get()
+	previousBranch, hasPreviousBranch := repo.Git.PreviouslyCheckedOutBranch(repo.Backend).Get()
 	initialBranch, hasInitialBranch := branchesSnapshot.Active.Get()
 	if !hasInitialBranch {
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -241,10 +241,7 @@ func prependProgram(data prependData) program.Program {
 	if data.remotes.HasOrigin() && data.config.Config.ShouldPushNewBranches() && data.config.Config.IsOnline() {
 		prog.Value.Add(&opcodes.CreateTrackingBranch{Branch: data.targetBranch})
 	}
-	previousBranchCandidates := gitdomain.LocalBranchNames{}
-	if previousBranch, hasPreviousBranch := data.previousBranch.Get(); hasPreviousBranch {
-		previousBranchCandidates = append(previousBranchCandidates, previousBranch)
-	}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{data.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.dryRun,
 		RunInGitRoot:             true,

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -281,10 +281,7 @@ func proposeProgram(data proposeData) program.Program {
 	if data.branchTypeToPropose == configdomain.BranchTypePrototypeBranch {
 		prog.Value.Add(&opcodes.RemoveFromPrototypeBranches{Branch: data.branchToPropose})
 	}
-	previousBranchCandidates := gitdomain.LocalBranchNames{}
-	if previousBranch, hasPreviousBranch := data.previousBranch.Get(); hasPreviousBranch {
-		previousBranchCandidates = append(previousBranchCandidates, previousBranch)
-	}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{data.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.dryRun,
 		RunInGitRoot:             true,

--- a/internal/cmd/rename_branch.go
+++ b/internal/cmd/rename_branch.go
@@ -262,10 +262,7 @@ func renameBranchProgram(data renameBranchData) program.Program {
 			}
 		}
 		result.Value.Add(&opcodes.DeleteLocalBranch{Branch: oldLocalBranch})
-		previousBranchCandidates := gitdomain.LocalBranchNames{data.newBranch}
-		if previousBranch, hasPrepreviousBranch := data.previousBranch.Get(); hasPrepreviousBranch {
-			previousBranchCandidates = append(gitdomain.LocalBranchNames{previousBranch}, previousBranchCandidates...)
-		}
+		previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.newBranch), data.previousBranch}
 		cmdhelpers.Wrap(result, cmdhelpers.WrapOptions{
 			DryRun:                   data.dryRun,
 			RunInGitRoot:             false,

--- a/internal/cmd/ship/api.go
+++ b/internal/cmd/ship/api.go
@@ -71,10 +71,7 @@ func shipAPIProgram(sharedData sharedShipData, apiData shipDataAPI, commitMessag
 	for _, child := range sharedData.childBranches {
 		prog.Value.Add(&opcodes.ChangeParent{Branch: child, Parent: localTargetBranch})
 	}
-	previousBranchCandidates := gitdomain.LocalBranchNames{}
-	if previousBranch, hasPreviousBranch := sharedData.previousBranch.Get(); hasPreviousBranch {
-		previousBranchCandidates = append(previousBranchCandidates, previousBranch)
-	}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{sharedData.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   sharedData.dryRun,
 		RunInGitRoot:             true,

--- a/internal/cmd/ship/ff.go
+++ b/internal/cmd/ship/ff.go
@@ -39,10 +39,7 @@ func shipProgramFastForward(sharedData sharedShipData, squashMergeData shipDataM
 		prog.Value.Add(&opcodes.Checkout{Branch: sharedData.initialBranch})
 	}
 	prog.Value.Add(&opcodes.DeleteLocalBranch{Branch: sharedData.branchNameToShip})
-	previousBranchCandidates := gitdomain.LocalBranchNames{}
-	if previousBranch, hasPreviousBranch := sharedData.previousBranch.Get(); hasPreviousBranch {
-		previousBranchCandidates = append(previousBranchCandidates, previousBranch)
-	}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{sharedData.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   sharedData.dryRun,
 		RunInGitRoot:             true,

--- a/internal/cmd/ship/squash_merge.go
+++ b/internal/cmd/ship/squash_merge.go
@@ -54,10 +54,7 @@ func shipProgramSquashMerge(sharedData sharedShipData, squashMergeData shipDataM
 		prog.Value.Add(&opcodes.Checkout{Branch: sharedData.initialBranch})
 	}
 	prog.Value.Add(&opcodes.DeleteLocalBranch{Branch: sharedData.branchNameToShip})
-	previousBranchCandidates := gitdomain.LocalBranchNames{}
-	if previousBranch, hasPreviousBranch := sharedData.previousBranch.Get(); hasPreviousBranch {
-		previousBranchCandidates = append(previousBranchCandidates, previousBranch)
-	}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{sharedData.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   sharedData.dryRun,
 		RunInGitRoot:             true,

--- a/internal/gohacks/slice/get_all.go
+++ b/internal/gohacks/slice/get_all.go
@@ -1,0 +1,14 @@
+package slice
+
+import . "github.com/git-town/git-town/v16/pkg/prelude"
+
+// returns a copy of given slice where all options are unwrapped and None options are removed
+func GetAll[T any](slice []Option[T]) []T {
+	result := make([]T, 0, len(slice))
+	for _, elementOpt := range slice {
+		if element, hasElement := elementOpt.Get(); hasElement {
+			result = append(result, element)
+		}
+	}
+	return result
+}

--- a/internal/gohacks/slice/get_all_test.go
+++ b/internal/gohacks/slice/get_all_test.go
@@ -1,0 +1,45 @@
+package slice_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v16/internal/gohacks/slice"
+	. "github.com/git-town/git-town/v16/pkg/prelude"
+	"github.com/shoenig/test/must"
+)
+
+func TestGetAll(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all are Some values", func(t *testing.T) {
+		t.Parallel()
+		give := []Option[int]{Some(1), Some(2), Some(3)}
+		have := slice.GetAll(give)
+		want := []int{1, 2, 3}
+		must.Eq(t, want, have)
+	})
+
+	t.Run("all are None values", func(t *testing.T) {
+		t.Parallel()
+		give := []Option[int]{None[int](), None[int]()}
+		have := slice.GetAll(give)
+		want := []int{}
+		must.Eq(t, want, have)
+	})
+
+	t.Run("mixed values", func(t *testing.T) {
+		t.Parallel()
+		give := []Option[int]{Some(1), None[int](), Some(3)}
+		have := slice.GetAll(give)
+		want := []int{1, 3}
+		must.Eq(t, want, have)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+		give := []Option[int]{}
+		have := slice.GetAll(give)
+		want := []int{}
+		must.Eq(t, want, have)
+	})
+}

--- a/internal/gohacks/slice/remove.go
+++ b/internal/gohacks/slice/remove.go
@@ -1,13 +1,13 @@
 package slice
 
 // Remove provides the given list without the given element.
-func Remove[S ~[]C, C comparable](list S, value C) S { //nolint:ireturn
-	if len(list) == 0 {
-		return list
+func Remove[S ~[]C, C comparable](haystack S, needle C) S { //nolint:ireturn
+	if len(haystack) == 0 {
+		return haystack
 	}
-	result := make([]C, 0, len(list)-1)
-	for _, element := range list {
-		if element != value {
+	result := make([]C, 0, len(haystack)-1)
+	for _, element := range haystack {
+		if element != needle {
 			result = append(result, element)
 		}
 	}

--- a/internal/sync/sync_branches.go
+++ b/internal/sync/sync_branches.go
@@ -14,11 +14,11 @@ func BranchesProgram(args BranchesProgramArgs) {
 		args.BranchProgramArgs.FirstCommitMessage = branchToSync.FirstCommitMessage
 		BranchProgram(branchToSync.BranchInfo, args.BranchProgramArgs)
 	}
-	previousbranchCandidates := gitdomain.LocalBranchNames{}
+	previousbranchCandidates := []Option[gitdomain.LocalBranchName]{args.PreviousBranch}
+	// TODO: make this a list of options
 	finalBranchCandidates := gitdomain.LocalBranchNames{args.InitialBranch}
 	if previousBranch, hasPreviousBranch := args.PreviousBranch.Get(); hasPreviousBranch {
 		finalBranchCandidates = append(finalBranchCandidates, previousBranch)
-		previousbranchCandidates = append(previousbranchCandidates, previousBranch)
 	}
 	args.Program.Value.Add(&opcodes.CheckoutFirstExisting{
 		Branches:   finalBranchCandidates,

--- a/internal/undo/undo_finished_program.go
+++ b/internal/undo/undo_finished_program.go
@@ -31,10 +31,10 @@ func CreateUndoForFinishedProgram(args CreateUndoProgramArgs) program.Program {
 		result.Value.AddProgram(undostash.DetermineUndoStashProgram(args.RunState.BeginStashSize, endStashSize))
 	}
 	result.Value.AddProgram(args.RunState.FinalUndoProgram)
-	previousBranchCandidates := gitdomain.LocalBranchNames{}
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{}
 	if initialBranch, hasInitialBranch := args.RunState.BeginBranchesSnapshot.Active.Get(); hasInitialBranch {
 		result.Value.Add(&opcodes.Checkout{Branch: initialBranch})
-		previousBranchCandidates = append(previousBranchCandidates, initialBranch)
+		previousBranchCandidates = append(previousBranchCandidates, Some(initialBranch))
 	}
 	cmdhelpers.Wrap(result, cmdhelpers.WrapOptions{
 		DryRun:                   args.RunState.DryRun,

--- a/internal/undo/undo_finished_program.go
+++ b/internal/undo/undo_finished_program.go
@@ -31,10 +31,10 @@ func CreateUndoForFinishedProgram(args CreateUndoProgramArgs) program.Program {
 		result.Value.AddProgram(undostash.DetermineUndoStashProgram(args.RunState.BeginStashSize, endStashSize))
 	}
 	result.Value.AddProgram(args.RunState.FinalUndoProgram)
-	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{}
-	if initialBranch, hasInitialBranch := args.RunState.BeginBranchesSnapshot.Active.Get(); hasInitialBranch {
+	initialBranchOpt := args.RunState.BeginBranchesSnapshot.Active
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{initialBranchOpt}
+	if initialBranch, hasInitialBranch := initialBranchOpt.Get(); hasInitialBranch {
 		result.Value.Add(&opcodes.Checkout{Branch: initialBranch})
-		previousBranchCandidates = append(previousBranchCandidates, Some(initialBranch))
 	}
 	cmdhelpers.Wrap(result, cmdhelpers.WrapOptions{
 		DryRun:                   args.RunState.DryRun,

--- a/internal/vm/opcodes/preserve_checkout_history.go
+++ b/internal/vm/opcodes/preserve_checkout_history.go
@@ -21,8 +21,8 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 	currentBranch := args.Git.CurrentBranchCache.Value()
 	actualPreviousBranch := args.Git.CurrentBranchCache.Previous()
 	// remove the current branch from the list of previous branch candidates because the current branch should never also be the previous branch
-	candidateOptsWithoutCurrent := slice.Remove(self.PreviousBranchCandidates, Some(currentBranch))
-	candidatesWithoutCurrent := slice.GetAll(candidateOptsWithoutCurrent)
+	candidates := slice.GetAll(self.PreviousBranchCandidates)
+	candidatesWithoutCurrent := slice.Remove(candidates, currentBranch)
 	expectedPreviousBranch, hasExpectedPreviousBranch := args.Git.FirstExistingBranch(args.Backend, candidatesWithoutCurrent...).Get()
 	if !hasExpectedPreviousBranch || actualPreviousBranch == expectedPreviousBranch {
 		return nil

--- a/internal/vm/opcodes/preserve_checkout_history.go
+++ b/internal/vm/opcodes/preserve_checkout_history.go
@@ -2,12 +2,14 @@ package opcodes
 
 import (
 	"github.com/git-town/git-town/v16/internal/git/gitdomain"
+	"github.com/git-town/git-town/v16/internal/gohacks/slice"
 	"github.com/git-town/git-town/v16/internal/vm/shared"
+	. "github.com/git-town/git-town/v16/pkg/prelude"
 )
 
 // PreserveCheckoutHistory does stuff.
 type PreserveCheckoutHistory struct {
-	PreviousBranchCandidates gitdomain.LocalBranchNames
+	PreviousBranchCandidates []Option[gitdomain.LocalBranchName]
 	undeclaredOpcodeMethods  `exhaustruct:"optional"`
 }
 
@@ -19,7 +21,8 @@ func (self *PreserveCheckoutHistory) Run(args shared.RunArgs) error {
 	currentBranch := args.Git.CurrentBranchCache.Value()
 	actualPreviousBranch := args.Git.CurrentBranchCache.Previous()
 	// remove the current branch from the list of previous branch candidates because the current branch should never also be the previous branch
-	candidatesWithoutCurrent := self.PreviousBranchCandidates.Remove(currentBranch)
+	candidateOptsWithoutCurrent := slice.Remove(self.PreviousBranchCandidates, Some(currentBranch))
+	candidatesWithoutCurrent := slice.GetAll(candidateOptsWithoutCurrent)
 	expectedPreviousBranch, hasExpectedPreviousBranch := args.Git.FirstExistingBranch(args.Backend, candidatesWithoutCurrent...).Get()
 	if !hasExpectedPreviousBranch || actualPreviousBranch == expectedPreviousBranch {
 		return nil

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -106,7 +106,7 @@ func TestLoadSave(t *testing.T) {
 					ParentActiveInOtherWorktree: true,
 				},
 				&opcodes.PreserveCheckoutHistory{
-					PreviousBranchCandidates: gitdomain.NewLocalBranchNames("previous"),
+					PreviousBranchCandidates: []Option[gitdomain.LocalBranchName]{Some(gitdomain.NewLocalBranchName("previous"))},
 				},
 				&opcodes.PullCurrentBranch{},
 				&opcodes.PushCurrentBranch{


### PR DESCRIPTION
A lot of the previous branch candidates are options. Rather than unwrapping them in every command, it's easier to collect all the options and unwrap them when once when used.