### PR TITLE
Buffer compiling the regular expressions

### DIFF
--- a/internal/cli/dialog/perennial_regex.go
+++ b/internal/cli/dialog/perennial_regex.go
@@ -29,6 +29,10 @@ func PerennialRegex(oldValue Option[configdomain.PerennialRegex], inputs compone
 		TestInput:     inputs,
 		Title:         perennialRegexTitle,
 	})
+	if err != nil {
+		return None[configdomain.PerennialRegex](), false, err
+	}
 	fmt.Printf(messages.PerennialRegex, components.FormattedSelection(value, aborted))
-	return configdomain.ParsePerennialRegex(value), aborted, err
+	perennialRegex, err := configdomain.ParsePerennialRegex(value)
+	return perennialRegex, aborted, err
 }

--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -73,6 +73,8 @@ func NewPartialConfigFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, 
 	ec.Check(err)
 	lineage, err := NewLineageFromSnapshot(snapshot, updateOutdated, removeLocalConfigValue)
 	ec.Check(err)
+	perennialRegex, err := ParsePerennialRegex(snapshot[KeyPerennialRegex])
+	ec.Check(err)
 	return PartialConfig{
 		Aliases:                  aliases,
 		ContributionBranches:     gitdomain.ParseLocalBranchNames(snapshot[KeyContributionBranches]),
@@ -90,7 +92,7 @@ func NewPartialConfigFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, 
 		Offline:                  offline,
 		ParkedBranches:           gitdomain.ParseLocalBranchNames(snapshot[KeyParkedBranches]),
 		PerennialBranches:        gitdomain.ParseLocalBranchNames(snapshot[KeyPerennialBranches]),
-		PerennialRegex:           ParsePerennialRegex(snapshot[KeyPerennialRegex]),
+		PerennialRegex:           perennialRegex,
 		PrototypeBranches:        gitdomain.ParseLocalBranchNames(snapshot[KeyPrototypeBranches]),
 		PushHook:                 pushHook,
 		PushNewBranches:          pushNewBranches,

--- a/internal/config/configdomain/perennial_regex.go
+++ b/internal/config/configdomain/perennial_regex.go
@@ -1,10 +1,8 @@
 package configdomain
 
 import (
-	"fmt"
 	"regexp"
 
-	"github.com/git-town/git-town/v16/internal/cli/colors"
 	"github.com/git-town/git-town/v16/internal/git/gitdomain"
 	. "github.com/git-town/git-town/v16/pkg/prelude"
 )
@@ -15,27 +13,22 @@ type PerennialRegex struct {
 	text  string
 }
 
-// MatchesBranch indicates whether the given branch matches this PerennialRegex.
-func (self PerennialRegex) MatchesBranch(branch gitdomain.LocalBranchName) bool {
-	if self.text == "" {
-		return false
-	}
-	re, err := regexp.Compile(self.text)
-	if err != nil {
-		fmt.Println(colors.Red().Styled(fmt.Sprintf("Error in perennial regex %q: %s", self, err.Error())))
-		return false
-	}
-	return re.MatchString(branch.String())
-}
-
-func (self PerennialRegex) String() string {
-	return self.text
-}
-
 func ParsePerennialRegex(value string) (Option[PerennialRegex], error) {
 	if value == "" {
 		return None[PerennialRegex](), nil
 	}
 	re, err := regexp.Compile(value)
 	return Some(PerennialRegex{regex: re, text: value}), err
+}
+
+// MatchesBranch indicates whether the given branch matches this PerennialRegex.
+func (self PerennialRegex) MatchesBranch(branch gitdomain.LocalBranchName) bool {
+	if self.text == "" {
+		return false
+	}
+	return self.regex.MatchString(branch.String())
+}
+
+func (self PerennialRegex) String() string {
+	return self.text
 }

--- a/internal/config/configdomain/perennial_regex.go
+++ b/internal/config/configdomain/perennial_regex.go
@@ -15,9 +15,6 @@ type PerennialRegex struct {
 
 // MatchesBranch indicates whether the given branch matches this PerennialRegex.
 func (self PerennialRegex) MatchesBranch(branch gitdomain.LocalBranchName) bool {
-	if self.text == "" {
-		return false
-	}
 	return self.regex.MatchString(branch.String())
 }
 

--- a/internal/config/configdomain/perennial_regex.go
+++ b/internal/config/configdomain/perennial_regex.go
@@ -13,14 +13,6 @@ type PerennialRegex struct {
 	text  string
 }
 
-func ParsePerennialRegex(value string) (Option[PerennialRegex], error) {
-	if value == "" {
-		return None[PerennialRegex](), nil
-	}
-	re, err := regexp.Compile(value)
-	return Some(PerennialRegex{regex: re, text: value}), err
-}
-
 // MatchesBranch indicates whether the given branch matches this PerennialRegex.
 func (self PerennialRegex) MatchesBranch(branch gitdomain.LocalBranchName) bool {
 	if self.text == "" {
@@ -31,4 +23,12 @@ func (self PerennialRegex) MatchesBranch(branch gitdomain.LocalBranchName) bool 
 
 func (self PerennialRegex) String() string {
 	return self.text
+}
+
+func ParsePerennialRegex(value string) (Option[PerennialRegex], error) {
+	if value == "" {
+		return None[PerennialRegex](), nil
+	}
+	re, err := regexp.Compile(value)
+	return Some(PerennialRegex{regex: re, text: value}), err
 }

--- a/internal/config/configdomain/perennial_regex.go
+++ b/internal/config/configdomain/perennial_regex.go
@@ -11,7 +11,7 @@ import (
 
 // PerennialRegex contains the "branches.perennial-regex" setting.
 type PerennialRegex struct {
-	regex Option[*regexp.Regexp]
+	cache Option[*regexp.Regexp]
 	text  string
 }
 
@@ -29,10 +29,10 @@ func (self PerennialRegex) MatchesBranch(branch gitdomain.LocalBranchName) bool 
 }
 
 func (self PerennialRegex) Regex() *regexp.Regexp {
-	if self.regex.IsNone() {
-		self.regex = Some(regexp.MustCompile(self.text))
+	if self.cache.IsNone() {
+		self.cache = Some(regexp.MustCompile(self.text))
 	}
-	return self.regex.GetOrPanic()
+	return self.cache.GetOrPanic()
 }
 
 func (self PerennialRegex) String() string {
@@ -44,7 +44,7 @@ func ParsePerennialRegex(value string) Option[PerennialRegex] {
 		return None[PerennialRegex]()
 	}
 	return Some(PerennialRegex{
-		regex: None[*regexp.Regexp](),
+		cache: None[*regexp.Regexp](),
 		text:  value,
 	})
 }

--- a/internal/config/configdomain/perennial_regex.go
+++ b/internal/config/configdomain/perennial_regex.go
@@ -11,7 +11,7 @@ import (
 
 // PerennialRegex contains the "branches.perennial-regex" setting.
 type PerennialRegex struct {
-	cache Option[*regexp.Regexp]
+	regex *regexp.Regexp
 	text  string
 }
 
@@ -28,23 +28,14 @@ func (self PerennialRegex) MatchesBranch(branch gitdomain.LocalBranchName) bool 
 	return re.MatchString(branch.String())
 }
 
-func (self PerennialRegex) Regex() *regexp.Regexp {
-	if self.cache.IsNone() {
-		self.cache = Some(regexp.MustCompile(self.text))
-	}
-	return self.cache.GetOrPanic()
-}
-
 func (self PerennialRegex) String() string {
 	return self.text
 }
 
-func ParsePerennialRegex(value string) Option[PerennialRegex] {
+func ParsePerennialRegex(value string) (Option[PerennialRegex], error) {
 	if value == "" {
-		return None[PerennialRegex]()
+		return None[PerennialRegex](), nil
 	}
-	return Some(PerennialRegex{
-		cache: None[*regexp.Regexp](),
-		text:  value,
-	})
+	re, err := regexp.Compile(value)
+	return Some(PerennialRegex{regex: re, text: value}), err
 }

--- a/internal/config/configdomain/perennial_regex_test.go
+++ b/internal/config/configdomain/perennial_regex_test.go
@@ -13,7 +13,9 @@ func TestPerennialRegex(t *testing.T) {
 
 	t.Run("only characters, no wildcards matches all branch names that contain that phrase", func(t *testing.T) {
 		t.Parallel()
-		perennialRegex := configdomain.ParsePerennialRegex("release").GetOrPanic()
+		perennialRegexOpt, err := configdomain.ParsePerennialRegex("release")
+		must.NoError(t, err)
+		perennialRegex := perennialRegexOpt.GetOrPanic()
 		tests := map[string]bool{
 			"":                false,
 			"release":         true,
@@ -29,7 +31,9 @@ func TestPerennialRegex(t *testing.T) {
 
 	t.Run("with wildcards", func(t *testing.T) {
 		t.Parallel()
-		perennialRegex := configdomain.ParsePerennialRegex("release-.*").GetOrPanic()
+		perennialRegexOpt, err := configdomain.ParsePerennialRegex("release-.*")
+		must.NoError(t, err)
+		perennialRegex := perennialRegexOpt.GetOrPanic()
 		tests := map[string]bool{
 			"":                false,
 			"release":         false,

--- a/internal/config/configdomain/perennial_regex_test.go
+++ b/internal/config/configdomain/perennial_regex_test.go
@@ -11,16 +11,9 @@ import (
 func TestPerennialRegex(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty regex matches nothing", func(t *testing.T) {
-		t.Parallel()
-		perennialRegex := configdomain.PerennialRegex("")
-		must.False(t, perennialRegex.MatchesBranch(""))
-		must.False(t, perennialRegex.MatchesBranch("foo"))
-	})
-
 	t.Run("only characters, no wildcards matches all branch names that contain that phrase", func(t *testing.T) {
 		t.Parallel()
-		perennialRegex := configdomain.PerennialRegex("release")
+		perennialRegex := configdomain.ParsePerennialRegex("release").GetOrPanic()
 		tests := map[string]bool{
 			"":                false,
 			"release":         true,
@@ -36,7 +29,7 @@ func TestPerennialRegex(t *testing.T) {
 
 	t.Run("with wildcards", func(t *testing.T) {
 		t.Parallel()
-		perennialRegex := configdomain.PerennialRegex("release-.*")
+		perennialRegex := configdomain.ParsePerennialRegex("release-.*").GetOrPanic()
 		tests := map[string]bool{
 			"":                false,
 			"release":         false,

--- a/internal/config/configdomain/validated_config_test.go
+++ b/internal/config/configdomain/validated_config_test.go
@@ -52,10 +52,12 @@ func TestValidatedConfig(t *testing.T) {
 
 	t.Run("IsPerennialBranch", func(t *testing.T) {
 		t.Parallel()
+		perennialRegexOpt, err := configdomain.ParsePerennialRegex("release-.*")
+		must.NoError(t, err)
 		config := configdomain.UnvalidatedConfig{
 			MainBranch:        Some(gitdomain.NewLocalBranchName("main")),
 			PerennialBranches: gitdomain.NewLocalBranchNames("peren1", "peren2"),
-			PerennialRegex:    configdomain.ParsePerennialRegex("release-.*"),
+			PerennialRegex:    perennialRegexOpt,
 		}
 		tests := map[string]bool{
 			"main":      false,

--- a/internal/config/configfile/load.go
+++ b/internal/config/configfile/load.go
@@ -49,7 +49,10 @@ func Validate(data Data) (configdomain.PartialConfig, error) {
 		}
 		result.PerennialBranches = gitdomain.NewLocalBranchNames(data.Branches.Perennials...)
 		if data.Branches.PerennialRegex != nil {
-			result.PerennialRegex = configdomain.ParsePerennialRegex(*data.Branches.PerennialRegex)
+			result.PerennialRegex, err = configdomain.ParsePerennialRegex(*data.Branches.PerennialRegex)
+			if err != nil {
+				return result, err
+			}
 		}
 	}
 	if data.Hosting != nil {

--- a/internal/config/validated_config_test.go
+++ b/internal/config/validated_config_test.go
@@ -87,6 +87,8 @@ func TestValidatedConfig(t *testing.T) {
 		perennial1 := gitdomain.NewLocalBranchName("perennial-1")
 		perennial2 := gitdomain.NewLocalBranchName("perennial-2")
 		prototype := gitdomain.NewLocalBranchName("prototype")
+		perennialRegexOpt, err := configdomain.ParsePerennialRegex("peren*")
+		must.NoError(t, err)
 		config := configdomain.ValidatedConfig{
 			MainBranch: gitdomain.NewLocalBranchName("main"),
 			UnvalidatedConfig: &configdomain.UnvalidatedConfig{
@@ -94,7 +96,7 @@ func TestValidatedConfig(t *testing.T) {
 				ObservedBranches:     gitdomain.LocalBranchNames{observed},
 				ParkedBranches:       gitdomain.LocalBranchNames{parked},
 				PerennialBranches:    gitdomain.LocalBranchNames{perennial1},
-				PerennialRegex:       configdomain.ParsePerennialRegex("peren*"),
+				PerennialRegex:       perennialRegexOpt,
 				PrototypeBranches:    gitdomain.LocalBranchNames{prototype},
 			},
 		}


### PR DESCRIPTION
Checking branches is done repeatedly, and compiling a regex is slow. So we buffer them.