### PR TITLE
Add ship-strategy.md to SUMMARY.md

### DIFF
--- a/website/src/SUMMARY.md
+++ b/website/src/SUMMARY.md
@@ -53,6 +53,7 @@
   - [pererennial-branches](preferences/perennial-branches.md)
   - [pererennial-regex](preferences/perennial-regex.md)
   - [ship-delete-tracking-branch](preferences/ship-delete-tracking-branch.md)
+  - [ship-strategy](preferences/ship-strategy.md)
   - [sync-feature-strategy](preferences/sync-feature-strategy.md)
   - [sync-perennial-strategy](preferences/sync-perennial-strategy.md)
   - [sync-prototype-strategy](preferences/sync-prototype-strategy.md)


### PR DESCRIPTION
This will generate the page that currently 404s: https://www.git-town.com/preferences/ship-strategy.html
And fix the links are coming from here: https://www.git-town.com/commands/ship

