### PR TITLE
Prepare ParseBranchType for production use

### DIFF
--- a/internal/config/configdomain/branch_type.go
+++ b/internal/config/configdomain/branch_type.go
@@ -1,6 +1,8 @@
 package configdomain
 
 import (
+	"fmt"
+
 	. "github.com/git-town/git-town/v16/pkg/prelude"
 )
 
@@ -16,26 +18,26 @@ const (
 	BranchTypePrototypeBranch
 )
 
-func ParseBranchType(name string) Option[BranchType] {
-	switch name {
+func ParseBranchType(text string) (Option[BranchType], error) {
+	switch text {
 	case "contribution":
-		return Some(BranchTypeContributionBranch)
+		return Some(BranchTypeContributionBranch), nil
 	case "feature":
-		return Some(BranchTypeFeatureBranch)
+		return Some(BranchTypeFeatureBranch), nil
 	case "main":
-		return Some(BranchTypeMainBranch)
+		return Some(BranchTypeMainBranch), nil
 	case "observed":
-		return Some(BranchTypeObservedBranch)
+		return Some(BranchTypeObservedBranch), nil
 	case "parked":
-		return Some(BranchTypeParkedBranch)
+		return Some(BranchTypeParkedBranch), nil
 	case "perennial":
-		return Some(BranchTypePerennialBranch)
+		return Some(BranchTypePerennialBranch), nil
 	case "prototype":
-		return Some(BranchTypePrototypeBranch)
+		return Some(BranchTypePrototypeBranch), nil
 	case "(none)":
-		return None[BranchType]()
+		return None[BranchType](), nil
 	}
-	panic("unknown branch type: " + name)
+	return None[BranchType](), fmt.Errorf("unknown branch type: %q", text)
 }
 
 // ShouldPush indicates whether a branch with this type should push its local commit to origin.

--- a/test/datatable/branch_setup_table.go
+++ b/test/datatable/branch_setup_table.go
@@ -5,6 +5,7 @@ import (
 	"github.com/git-town/git-town/v16/internal/config/configdomain"
 	"github.com/git-town/git-town/v16/internal/git/gitdomain"
 	. "github.com/git-town/git-town/v16/pkg/prelude"
+	"github.com/git-town/git-town/v16/test/asserts"
 	testgit "github.com/git-town/git-town/v16/test/git"
 )
 
@@ -29,7 +30,9 @@ func ParseBranchSetupTable(table *godog.Table) []BranchSetup {
 			case "NAME":
 				name = Some(gitdomain.NewLocalBranchName(cell.Value))
 			case "TYPE":
-				branchType = configdomain.ParseBranchType(cell.Value)
+				var err error
+				branchType, err = configdomain.ParseBranchType(cell.Value)
+				asserts.NoError(err)
 			case "PARENT":
 				if cell.Value != "" {
 					parent = Some(gitdomain.NewLocalBranchName(cell.Value))


### PR DESCRIPTION
ParseBranchType will be use in production code so we need to remove the explodium from it.