### PR TITLE
Make MustKnowParent more solid

### DIFF
--- a/internal/cli/dialog/lineage.go
+++ b/internal/cli/dialog/lineage.go
@@ -14,7 +14,8 @@ func Lineage(args LineageArgs) (additionalLineage configdomain.Lineage, addition
 	branchesToVerify := args.BranchesToVerify
 	for i := 0; i < len(branchesToVerify); i++ {
 		branchToVerify := branchesToVerify[i]
-		if !args.Config.MustKnowParent(branchToVerify) {
+		branchType, hasBranchType := args.BranchesAndTypes[branchToVerify]
+		if hasBranchType && !branchType.MustKnowParent() {
 			continue
 		}
 		if parent, hasParent := args.Config.Lineage.Parent(branchToVerify).Get(); hasParent {
@@ -46,6 +47,7 @@ func Lineage(args LineageArgs) (additionalLineage configdomain.Lineage, addition
 }
 
 type LineageArgs struct {
+	BranchesAndTypes configdomain.BranchesAndTypes
 	BranchesToVerify gitdomain.LocalBranchNames
 	Config           configdomain.UnvalidatedConfig
 	DefaultChoice    gitdomain.LocalBranchName

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -157,8 +157,10 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo execute.Op
 	if !hasInitialBranch {
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)
 	}
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{initialBranch},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -164,8 +164,10 @@ func determineCompressBranchesData(repo execute.OpenRepoResult, dryRun configdom
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{initialBranch},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/continue.go
+++ b/internal/cmd/continue.go
@@ -110,8 +110,10 @@ func determineContinueData(repo execute.OpenRepoResult, verbose configdomain.Ver
 		return data, exit, err
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/diff_parent.go
+++ b/internal/cmd/diff_parent.go
@@ -107,12 +107,13 @@ func determineDiffParentData(args []string, repo execute.OpenRepoResult, verbose
 			return data, false, fmt.Errorf(messages.BranchDoesntExist, branch)
 		}
 	}
-	branchesToDiff := gitdomain.LocalBranchNames{branch}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
-		BranchesToValidate: branchesToDiff,
+		BranchesToValidate: gitdomain.LocalBranchNames{branch},
 		DialogTestInputs:   dialogTestInputs,
 		Frontend:           repo.Frontend,
 		Git:                repo.Git,

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -204,8 +204,10 @@ func determineHackData(args []string, repo execute.OpenRepoResult, dryRun config
 			branchesToValidate = targetBranches
 		}
 	}
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: branchesToValidate,
 		DialogTestInputs:   dialogTestInputs,
@@ -222,7 +224,7 @@ func determineHackData(args []string, repo execute.OpenRepoResult, dryRun config
 	if !shouldCreateBranch {
 		data = Right[appendFeatureData, convertToFeatureData](convertToFeatureData{
 			config:         validatedConfig,
-			targetBranches: configdomain.NewBranchesAndTypes(branchesToValidate, validatedConfig.Config),
+			targetBranches: validatedConfig.Config.BranchesAndTypes(branchesToValidate),
 		})
 		return data, false, nil
 	}

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -152,8 +152,10 @@ func determineKillData(args []string, repo execute.OpenRepoResult, dryRun config
 		return data, exit, fmt.Errorf(messages.KillBranchOtherWorktree, branchNameToKill)
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -161,8 +161,10 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, dryRun con
 	if !hasInitialBranch {
 		return data, false, errors.New(messages.CurrentBranchCannotDetermine)
 	}
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{initialBranch},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -174,8 +174,10 @@ func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRu
 		return data, false, errors.New(messages.CurrentBranchCannotDetermine)
 	}
 	branchToPropose := initialBranch
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{initialBranch},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/rename_branch.go
+++ b/internal/cmd/rename_branch.go
@@ -169,8 +169,10 @@ func determineRenameBranchData(args []string, force configdomain.Force, repo exe
 		return data, false, fmt.Errorf(messages.BranchDoesntExist, oldBranchName)
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{oldBranchName},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -150,8 +150,10 @@ func determineSetParentData(repo execute.OpenRepoResult, verbose configdomain.Ve
 		return data, exit, err
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: localBranches,
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/ship/shared.go
+++ b/internal/cmd/ship/shared.go
@@ -80,8 +80,10 @@ func determineSharedShipData(args []string, repo execute.OpenRepoResult, dryRun 
 		return data, false, fmt.Errorf(messages.BranchDoesntExist, branchNameToShip)
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{branchNameToShip},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/skip.go
+++ b/internal/cmd/skip.go
@@ -84,8 +84,10 @@ func executeSkip(verbose configdomain.Verbose) error {
 		}
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: localBranches,
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/switch.go
+++ b/internal/cmd/switch.go
@@ -114,8 +114,10 @@ func determineSwitchData(repo execute.OpenRepoResult, verbose configdomain.Verbo
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: localBranches,
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -212,8 +212,10 @@ func determineSyncData(syncAllBranches configdomain.SyncAllBranches, syncStack c
 		return data, false, errors.New(messages.CurrentBranchCannotDetermine)
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{initialBranch},
 		DialogTestInputs:   dialogTestInputs,
@@ -236,8 +238,10 @@ func determineSyncData(syncAllBranches configdomain.SyncAllBranches, syncStack c
 	default:
 		branchNamesToSync = gitdomain.LocalBranchNames{initialBranch}
 	}
+	branchesAndTypes = repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err = validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: branchNamesToSync,
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/cmd/undo.go
+++ b/internal/cmd/undo.go
@@ -117,8 +117,10 @@ func determineUndoData(repo execute.OpenRepoResult, verbose configdomain.Verbose
 		return data, false, err
 	}
 	localBranches := branchesSnapshot.Branches.LocalBranches().Names()
+	branchesAndTypes := repo.UnvalidatedConfig.Config.Value.BranchesAndTypes(branchesSnapshot.Branches.LocalBranches().Names())
 	validatedConfig, exit, err := validate.Config(validate.ConfigArgs{
 		Backend:            repo.Backend,
+		BranchesAndTypes:   branchesAndTypes,
 		BranchesSnapshot:   branchesSnapshot,
 		BranchesToValidate: gitdomain.LocalBranchNames{},
 		DialogTestInputs:   dialogTestInputs,

--- a/internal/config/configdomain/branch_type.go
+++ b/internal/config/configdomain/branch_type.go
@@ -40,6 +40,16 @@ func ParseBranchType(text string) (Option[BranchType], error) {
 	return None[BranchType](), fmt.Errorf("unknown branch type: %q", text)
 }
 
+func (self BranchType) MustKnowParent() bool {
+	switch self {
+	case BranchTypeMainBranch, BranchTypePerennialBranch, BranchTypeContributionBranch, BranchTypeObservedBranch:
+		return false
+	case BranchTypeFeatureBranch, BranchTypeParkedBranch, BranchTypePrototypeBranch:
+		return true
+	}
+	panic("unhandled branch type" + self.String())
+}
+
 // ShouldPush indicates whether a branch with this type should push its local commit to origin.
 func (self BranchType) ShouldPush(isInitialBranch bool) bool {
 	switch self {
@@ -50,7 +60,7 @@ func (self BranchType) ShouldPush(isInitialBranch bool) bool {
 	case BranchTypeParkedBranch:
 		return isInitialBranch
 	}
-	panic("unhandled branch type")
+	panic("unhandled branch type" + self.String())
 }
 
 func (self BranchType) String() string {

--- a/internal/config/configdomain/branches_and_types.go
+++ b/internal/config/configdomain/branches_and_types.go
@@ -9,14 +9,6 @@ import (
 
 type BranchesAndTypes map[gitdomain.LocalBranchName]BranchType
 
-func NewBranchesAndTypes(branches gitdomain.LocalBranchNames, config ValidatedConfig) BranchesAndTypes {
-	result := make(BranchesAndTypes, len(branches))
-	for _, branch := range branches {
-		result[branch] = config.BranchType(branch)
-	}
-	return result
-}
-
 func (self *BranchesAndTypes) Add(branch gitdomain.LocalBranchName, fullConfig UnvalidatedConfig) {
 	(*self)[branch] = fullConfig.BranchType(branch)
 }

--- a/internal/config/configdomain/unvalidated_config.go
+++ b/internal/config/configdomain/unvalidated_config.go
@@ -58,6 +58,14 @@ func (self *UnvalidatedConfig) BranchType(branch gitdomain.LocalBranchName) Bran
 	return BranchTypeFeatureBranch
 }
 
+func (self *UnvalidatedConfig) BranchesAndTypes(branches gitdomain.LocalBranchNames) BranchesAndTypes {
+	result := make(BranchesAndTypes, len(branches))
+	for _, branch := range branches {
+		result[branch] = self.BranchType(branch)
+	}
+	return result
+}
+
 // ContainsLineage indicates whether this configuration contains any lineage entries.
 func (self *UnvalidatedConfig) ContainsLineage() bool {
 	return self.Lineage.Len() > 0
@@ -113,10 +121,6 @@ func (self *UnvalidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {
 		return append(gitdomain.LocalBranchNames{mainBranch}, self.PerennialBranches...)
 	}
 	return self.PerennialBranches
-}
-
-func (self *UnvalidatedConfig) MustKnowParent(branch gitdomain.LocalBranchName) bool {
-	return !self.IsMainBranch(branch) && !self.IsPerennialBranch(branch) && !self.IsContributionBranch(branch) && !self.IsObservedBranch(branch)
 }
 
 func (self *UnvalidatedConfig) NoPushHook() NoPushHook {

--- a/internal/config/configdomain/validated_config.go
+++ b/internal/config/configdomain/validated_config.go
@@ -33,6 +33,14 @@ func (self *ValidatedConfig) BranchType(branch gitdomain.LocalBranchName) Branch
 	return BranchTypeFeatureBranch
 }
 
+func (self *ValidatedConfig) BranchesAndTypes(branches gitdomain.LocalBranchNames) BranchesAndTypes {
+	result := make(BranchesAndTypes, len(branches))
+	for _, branch := range branches {
+		result[branch] = self.BranchType(branch)
+	}
+	return result
+}
+
 // IsMainBranch indicates whether the branch with the given name
 // is the main branch of the repository.
 func (self *ValidatedConfig) IsMainBranch(branch gitdomain.LocalBranchName) bool {

--- a/internal/validate/config.go
+++ b/internal/validate/config.go
@@ -32,6 +32,7 @@ func Config(args ConfigArgs) (config.ValidatedConfig, bool, error) {
 			return config.EmptyValidatedConfig(), aborted, err
 		}
 		mainBranch = validatedMain
+		args.BranchesAndTypes[validatedMain] = configdomain.BranchTypeMainBranch
 		if err = args.Unvalidated.SetMainBranch(validatedMain); err != nil {
 			return config.EmptyValidatedConfig(), false, err
 		}
@@ -45,6 +46,7 @@ func Config(args ConfigArgs) (config.ValidatedConfig, bool, error) {
 
 	// enter and save missing parent branches
 	additionalLineage, additionalPerennials, exit, err := dialog.Lineage(dialog.LineageArgs{
+		BranchesAndTypes: args.BranchesAndTypes,
 		BranchesToVerify: args.BranchesToValidate,
 		Config:           args.Unvalidated.Config.Get(),
 		DefaultChoice:    mainBranch,
@@ -83,6 +85,7 @@ func Config(args ConfigArgs) (config.ValidatedConfig, bool, error) {
 
 type ConfigArgs struct {
 	Backend            gitdomain.RunnerQuerier
+	BranchesAndTypes   configdomain.BranchesAndTypes
 	BranchesSnapshot   gitdomain.BranchesSnapshot
 	BranchesToValidate gitdomain.LocalBranchNames
 	DialogTestInputs   components.TestInputs


### PR DESCRIPTION
Previously this function determined the branch type and then based on that branch type whether the lineage needs to know the parent. In the future determining the branch types becomes more involved. So this PR separates determining the branch type from using those branch types.