### PR TITLE
Fix wrong branch name in stacked changes example

### DIFF
--- a/website/src/stacked-changes.md
+++ b/website/src/stacked-changes.md
@@ -106,7 +106,7 @@ The lineage is now:
 ```
 main
  \
-  1-fix-typos
+  1-refactor
    \
     2-rename-foo
      \


### PR DESCRIPTION
Replace `1-fix-typos` with `1-refactor` to match previous commands.