### PR TITLE
Setup assistant does not store default-branch-type and feature-regex 

### DIFF
--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -31,7 +31,6 @@ Feature: Accepting all default values leads to a working setup
       | ship-delete-tracking-branch | enter |
       | save config to config file  | enter |
 
-  @this
   Scenario: result
     Then it runs no commands
     And the main branch is still not set

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -31,6 +31,7 @@ Feature: Accepting all default values leads to a working setup
       | ship-delete-tracking-branch | enter |
       | save config to config file  | enter |
 
+  @this
   Scenario: result
     Then it runs no commands
     And the main branch is still not set
@@ -38,6 +39,8 @@ Feature: Accepting all default values leads to a working setup
     And local Git Town setting "create-prototype-branches" still doesn't exist
     And local Git Town setting "main-branch" still doesn't exist
     And local Git Town setting "perennial-branches" still doesn't exist
+    And local Git Town setting "default-branch-type" still doesn't exist
+    And local Git Town setting "feature-regex" still doesn't exist
     And local Git Town setting "hosting-platform" still doesn't exist
     And local Git Town setting "push-new-branches" still doesn't exist
     And local Git Town setting "push-hook" still doesn't exist
@@ -133,15 +136,6 @@ Feature: Accepting all default values leads to a working setup
       #
       # If you are not sure, leave this empty.
       perennial-regex = ""
-
-      # Which type should Git Town assume for branches whose type isn't specified?
-      #
-      # When changing this, you should also set the "feature-regex" setting.
-      default-type = "feature"
-
-      # Branches matching this regular expression are treated as feature branches.
-      # This setting is effective only when used together with the "default-branch-type" setting.
-      feature-regex = ""
 
       [hosting]
 

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -41,7 +41,6 @@ Feature: migrate existing configuration in Git metadata to a config file
       | ship-delete-tracking-branch               | enter |
       | save config to config file                | enter |
 
-  @this
   Scenario: result
     Then it runs no commands
     And the main branch is now not set

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -41,6 +41,7 @@ Feature: migrate existing configuration in Git metadata to a config file
       | ship-delete-tracking-branch               | enter |
       | save config to config file                | enter |
 
+  @this
   Scenario: result
     Then it runs no commands
     And the main branch is now not set
@@ -52,6 +53,8 @@ Feature: migrate existing configuration in Git metadata to a config file
     And local Git Town setting "sync-upstream" now doesn't exist
     And local Git Town setting "sync-tags" now doesn't exist
     And local Git Town setting "perennial-regex" now doesn't exist
+    And local Git Town setting "feature-regex" is still "user-.*"
+    And local Git Town setting "default-branch-type" is still "observed"
     And local Git Town setting "push-new-branches" now doesn't exist
     And local Git Town setting "push-hook" now doesn't exist
     And local Git Town setting "create-prototype-branches" now doesn't exist
@@ -143,15 +146,6 @@ Feature: migrate existing configuration in Git metadata to a config file
       #
       # If you are not sure, leave this empty.
       perennial-regex = "release-.*"
-
-      # Which type should Git Town assume for branches whose type isn't specified?
-      #
-      # When changing this, you should also set the "feature-regex" setting.
-      default-type = "observed"
-
-      # Branches matching this regular expression are treated as feature branches.
-      # This setting is effective only when used together with the "default-branch-type" setting.
-      feature-regex = "user-.*"
 
       [hosting]
 

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -489,5 +489,7 @@ func saveToFile(userInput userInput, config config.UnvalidatedConfig) error {
 	config.RemoveSyncPerennialStrategy()
 	config.RemoveSyncUpstream()
 	config.RemoveSyncTags()
+	err = saveDefaultBranchType(config.Config.Value.DefaultBranchType, userInput.config.DefaultBranchType, config)
+	saveFeatureRegex(config.Config.Value.FeatureRegex, userInput.config.FeatureRegex, config)
 	return nil
 }

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -490,6 +490,8 @@ func saveToFile(userInput userInput, config config.UnvalidatedConfig) error {
 	config.RemoveSyncUpstream()
 	config.RemoveSyncTags()
 	err = saveDefaultBranchType(config.Config.Value.DefaultBranchType, userInput.config.DefaultBranchType, config)
-	saveFeatureRegex(config.Config.Value.FeatureRegex, userInput.config.FeatureRegex, config)
-	return nil
+	if err != nil {
+		return err
+	}
+	return saveFeatureRegex(config.Config.Value.FeatureRegex, userInput.config.FeatureRegex, config)
 }

--- a/internal/config/configfile/save.go
+++ b/internal/config/configfile/save.go
@@ -44,11 +44,7 @@ func RenderTOML(config *configdomain.UnvalidatedConfig) string {
 	result.WriteString(TOMLComment(strings.TrimSpace(dialog.PerennialBranchesHelp)) + "\n")
 	result.WriteString(fmt.Sprintf("perennials = %s\n", RenderPerennialBranches(config.PerennialBranches)) + "\n")
 	result.WriteString(TOMLComment(strings.TrimSpace(dialog.PerennialRegexHelp)) + "\n")
-	result.WriteString(fmt.Sprintf("perennial-regex = %q\n\n", config.PerennialRegex))
-	result.WriteString(TOMLComment(strings.TrimSpace(dialog.DefaultBranchTypeHelp)) + "\n")
-	result.WriteString(fmt.Sprintf("default-type = %q\n\n", config.DefaultBranchType))
-	result.WriteString(TOMLComment(strings.TrimSpace(dialog.FeatureRegexHelp)) + "\n")
-	result.WriteString(fmt.Sprintf("feature-regex = %q\n", config.FeatureRegex))
+	result.WriteString(fmt.Sprintf("perennial-regex = %q\n", config.PerennialRegex))
 	result.WriteString("\n[hosting]\n\n")
 	result.WriteString(TOMLComment(strings.TrimSpace(dialog.HostingPlatformHelp)) + "\n")
 	if platform, has := config.HostingPlatform.Get(); has {

--- a/internal/config/configfile/save_test.go
+++ b/internal/config/configfile/save_test.go
@@ -152,15 +152,6 @@ perennials = ["one", "two"]
 # If you are not sure, leave this empty.
 perennial-regex = ""
 
-# Which type should Git Town assume for branches whose type isn't specified?
-#
-# When changing this, you should also set the "feature-regex" setting.
-default-type = "feature"
-
-# Branches matching this regular expression are treated as feature branches.
-# This setting is effective only when used together with the "default-branch-type" setting.
-feature-regex = ""
-
 [hosting]
 
 # Knowing the type of code hosting platform allows Git Town
@@ -287,15 +278,6 @@ perennials = []
 #
 # If you are not sure, leave this empty.
 perennial-regex = ""
-
-# Which type should Git Town assume for branches whose type isn't specified?
-#
-# When changing this, you should also set the "feature-regex" setting.
-default-type = "feature"
-
-# Branches matching this regular expression are treated as feature branches.
-# This setting is effective only when used together with the "default-branch-type" setting.
-feature-regex = ""
 
 [hosting]
 


### PR DESCRIPTION
These values can be manually added to the config file, but the setup assistant stores them in the Git config because they are specific to each developer.