### PR TITLE
Fix spelling error "pererennial"

### DIFF
--- a/website/src/SUMMARY.md
+++ b/website/src/SUMMARY.md
@@ -55,7 +55,7 @@
   - [parent](preferences/parent.md)
   - [parked-branches](preferences/parked-branches.md)
   - [perennial-branches](preferences/perennial-branches.md)
-  - [pererennial-regex](preferences/perennial-regex.md)
+  - [perennial-regex](preferences/perennial-regex.md)
   - [prototype-branches](preferences/prototype-branches.md)
   - [push-hook](preferences/push-hook.md)
   - [push-new-branches](preferences/push-new-branches.md)

--- a/website/src/preferences/perennial-regex.md
+++ b/website/src/preferences/perennial-regex.md
@@ -1,4 +1,4 @@
-# pererennial-regex
+# perennial-regex
 
 All branches matching this regular expression are considered
 [perennial branches](perennial-branches.md).


### PR DESCRIPTION
This PR fixes a spelling error on the website where "perennial-regex" is spelled "pererennial-regex".