### PR TITLE
Fix typo "observed or observed"

### DIFF
--- a/website/src/preferences/observed-branches.md
+++ b/website/src/preferences/observed-branches.md
@@ -10,7 +10,7 @@ To change which branches are observed branches in your local repo, use the
 
 The [Git Town configuration file](../configuration-file.md) does not define
 team-wide observed branches because one developer's feature branch is another
-developer's observed or observed branch.
+developer's contribution or observed branch.
 
 ## view configured observed branches
 


### PR DESCRIPTION
This PR fixes a typo on the ["observed-branches" page](https://www.git-town.com/preferences/observed-branches):

> The [Git Town configuration file](https://www.git-town.com/configuration-file) does not define team-wide observed branches because one developer's feature branch is another developer's observed or observed branch.

This appears to have been copied from the ["contribution-branches" page](https://www.git-town.com/preferences/contribution-branches):

> The [Git Town configuration file](https://www.git-town.com/configuration-file) does not define team-wide contribution branches because one developer's feature branch is another developer's contribution or observed branch.