### PR TITLE
Trim only the trailing newline of E2E test output

### DIFF
--- a/test/subshell/test_runner.go
+++ b/test/subshell/test_runner.go
@@ -268,7 +268,7 @@ func (self *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string)
 	if opts.IgnoreOutput {
 		return "", exitCode, err
 	}
-	return strings.TrimSpace(outputBuf.String()), exitCode, err
+	return strings.TrimRight(outputBuf.String(), "\n"), exitCode, err
 }
 
 // Run runs the given command with the given arguments.


### PR DESCRIPTION
After 642 end-to-end tests we finally have one that requires the beginning whitespace to be there!