### PR TITLE
Rename UpdateProposalTarget to UpdateProposalBase

### DIFF
--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -235,7 +235,7 @@ func setParentProgram(outcome dialog.ParentOutcome, selectedBranch gitdomain.Loc
 	case dialog.ParentOutcomeSelectedParent:
 		prog.Add(&opcodes.SetParent{Branch: data.initialBranch, Parent: selectedBranch})
 		if data.connector.IsSome() && hasProposal {
-			prog.Add(&opcodes.UpdateProposalTarget{
+			prog.Add(&opcodes.UpdateProposalBase{
 				NewTarget:      selectedBranch,
 				ProposalNumber: proposal.Number,
 			})

--- a/internal/cmd/ship/core.go
+++ b/internal/cmd/ship/core.go
@@ -136,7 +136,7 @@ func executeShip(args []string, message Option[gitdomain.CommitMessage], dryRun 
 
 func UpdateChildBranchProposals(prog *program.Program, proposals []hostingdomain.Proposal, targetBranch gitdomain.LocalBranchName) {
 	for _, childProposal := range proposals {
-		prog.Add(&opcodes.UpdateProposalTarget{
+		prog.Add(&opcodes.UpdateProposalBase{
 			ProposalNumber: childProposal.Number,
 			NewTarget:      targetBranch,
 		})

--- a/internal/hosting/bitbucket/connector.go
+++ b/internal/hosting/bitbucket/connector.go
@@ -65,6 +65,6 @@ func (self Connector) SquashMergeProposal(_ int, _ gitdomain.CommitMessage) erro
 	return errors.New(messages.HostingBitBucketNotImplemented)
 }
 
-func (self Connector) UpdateProposalTarget(_ int, _ gitdomain.LocalBranchName) error {
+func (self Connector) UpdateProposalBase(_ int, _ gitdomain.LocalBranchName) error {
 	return errors.New(messages.HostingBitBucketNotImplemented)
 }

--- a/internal/hosting/gitea/connector.go
+++ b/internal/hosting/gitea/connector.go
@@ -110,7 +110,7 @@ func (self Connector) SquashMergeProposal(number int, message gitdomain.CommitMe
 	return err
 }
 
-func (self Connector) UpdateProposalTarget(_ int, _ gitdomain.LocalBranchName) error {
+func (self Connector) UpdateProposalBase(_ int, _ gitdomain.LocalBranchName) error {
 	// if self.log != nil {
 	// 	self.log(message.HostingGiteaUpdateBasebranchViaAPI, number, target)
 	// }

--- a/internal/hosting/github/connector.go
+++ b/internal/hosting/github/connector.go
@@ -109,7 +109,7 @@ func (self Connector) SquashMergeProposal(number int, message gitdomain.CommitMe
 
 func (self Connector) UpdateProposalBase(number int, target gitdomain.LocalBranchName) error {
 	targetName := target.String()
-	self.log.Start(messages.APIUpdateProposalTarget, colors.BoldGreen().Styled("#"+strconv.Itoa(number)), colors.BoldCyan().Styled(target.String()))
+	self.log.Start(messages.APIUpdateProposalBase, colors.BoldGreen().Styled("#"+strconv.Itoa(number)), colors.BoldCyan().Styled(target.String()))
 	_, _, err := self.client.PullRequests.Edit(context.Background(), self.Organization, self.Repository, number, &github.PullRequest{
 		Base: &github.PullRequestBranch{
 			Ref: &(targetName),

--- a/internal/hosting/github/connector.go
+++ b/internal/hosting/github/connector.go
@@ -107,7 +107,7 @@ func (self Connector) SquashMergeProposal(number int, message gitdomain.CommitMe
 	return err
 }
 
-func (self Connector) UpdateProposalTarget(number int, target gitdomain.LocalBranchName) error {
+func (self Connector) UpdateProposalBase(number int, target gitdomain.LocalBranchName) error {
 	targetName := target.String()
 	self.log.Start(messages.APIUpdateProposalTarget, colors.BoldGreen().Styled("#"+strconv.Itoa(number)), colors.BoldCyan().Styled(target.String()))
 	_, _, err := self.client.PullRequests.Edit(context.Background(), self.Organization, self.Repository, number, &github.PullRequest{

--- a/internal/hosting/gitlab/connector.go
+++ b/internal/hosting/gitlab/connector.go
@@ -84,7 +84,7 @@ func (self Connector) SquashMergeProposal(number int, message gitdomain.CommitMe
 	return nil
 }
 
-func (self Connector) UpdateProposalTarget(number int, target gitdomain.LocalBranchName) error {
+func (self Connector) UpdateProposalBase(number int, target gitdomain.LocalBranchName) error {
 	self.log.Start(messages.HostingGitlabUpdateMRViaAPI, number, target)
 	_, _, err := self.client.MergeRequests.UpdateMergeRequest(self.projectPath(), number, &gitlab.UpdateMergeRequestOptions{
 		TargetBranch: gitlab.Ptr(target.String()),

--- a/internal/hosting/hostingdomain/connector.go
+++ b/internal/hosting/hostingdomain/connector.go
@@ -31,6 +31,6 @@ type Connector interface {
 	// RepositoryURL provides the URL where the current repository can be found online.
 	RepositoryURL() string
 
-	// UpdateProposalTarget updates the target branch of the given proposal.
-	UpdateProposalTarget(number int, target gitdomain.LocalBranchName) error
+	// UpdateProposalBase updates the target branch of the given proposal.
+	UpdateProposalBase(number int, target gitdomain.LocalBranchName) error
 }

--- a/internal/messages/en.go
+++ b/internal/messages/en.go
@@ -6,7 +6,7 @@ const (
 	ArgumentUnknown                   = "unknown argument: %q"
 	APIProposalLookupStart            = "Looking for proposal online ... "
 	APIProposalUpdateStart            = "updating proposal online ... "
-	APIUpdateProposalTarget           = "updating target of proposal %s to %s ... "
+	APIUpdateProposalBase             = "updating base of proposal %s to %s ... "
 	BranchAlreadyExistsLocally        = "there is already a branch %q"
 	BranchAlreadyExistsRemotely       = "there is already a branch %q at the \"origin\" remote"
 	BranchAuthorMultiple              = "\nMultiple people authored the %q branch.\n\n"

--- a/internal/vm/opcodes/core.go
+++ b/internal/vm/opcodes/core.go
@@ -110,6 +110,6 @@ func Types() []shared.Opcode {
 		&StashOpenChanges{},
 		&SquashMerge{},
 		&UndoLastCommit{},
-		&UpdateProposalTarget{},
+		&UpdateProposalBase{},
 	} //exhaustruct:ignore
 }

--- a/internal/vm/opcodes/update_proposal_base.go
+++ b/internal/vm/opcodes/update_proposal_base.go
@@ -9,24 +9,24 @@ import (
 	"github.com/git-town/git-town/v16/internal/vm/shared"
 )
 
-// UpdateProposalTarget updates the target of the proposal with the given number at the code hosting platform.
-type UpdateProposalTarget struct {
+// UpdateProposalBase updates the target of the proposal with the given number at the code hosting platform.
+type UpdateProposalBase struct {
 	NewTarget               gitdomain.LocalBranchName
 	ProposalNumber          int
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *UpdateProposalTarget) CreateAutomaticUndoError() error {
+func (self *UpdateProposalBase) CreateAutomaticUndoError() error {
 	return fmt.Errorf(messages.ProposalTargetBranchUpdateProblem, self.ProposalNumber)
 }
 
-func (self *UpdateProposalTarget) Run(args shared.RunArgs) error {
+func (self *UpdateProposalBase) Run(args shared.RunArgs) error {
 	if connector, hasConnector := args.Connector.Get(); hasConnector {
 		return connector.UpdateProposalBase(self.ProposalNumber, self.NewTarget)
 	}
 	return hostingdomain.UnsupportedServiceError()
 }
 
-func (self *UpdateProposalTarget) ShouldAutomaticallyUndoOnError() bool {
+func (self *UpdateProposalBase) ShouldAutomaticallyUndoOnError() bool {
 	return true
 }

--- a/internal/vm/opcodes/update_proposal_target.go
+++ b/internal/vm/opcodes/update_proposal_target.go
@@ -22,7 +22,7 @@ func (self *UpdateProposalTarget) CreateAutomaticUndoError() error {
 
 func (self *UpdateProposalTarget) Run(args shared.RunArgs) error {
 	if connector, hasConnector := args.Connector.Get(); hasConnector {
-		return connector.UpdateProposalTarget(self.ProposalNumber, self.NewTarget)
+		return connector.UpdateProposalBase(self.ProposalNumber, self.NewTarget)
 	}
 	return hostingdomain.UnsupportedServiceError()
 }

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -175,7 +175,7 @@ func TestLoadSave(t *testing.T) {
 				},
 				&opcodes.StageOpenChanges{},
 				&opcodes.StashOpenChanges{},
-				&opcodes.UpdateProposalTarget{
+				&opcodes.UpdateProposalBase{
 					ProposalNumber: 123,
 					NewTarget:      gitdomain.NewLocalBranchName("new-target"),
 				},
@@ -528,7 +528,7 @@ func TestLoadSave(t *testing.T) {
         "NewTarget": "new-target",
         "ProposalNumber": 123
       },
-      "type": "UpdateProposalTarget"
+      "type": "UpdateProposalBase"
     }
   ],
   "TouchedBranches": [


### PR DESCRIPTION
Let's use the existing terminology from GitHub as the internal domain model of Git Town because it solves the problem and everybody is familiar with it.