### PR TITLE
Simplify error output

### DIFF
--- a/internal/cli/print/logger.go
+++ b/internal/cli/print/logger.go
@@ -10,7 +10,7 @@ import (
 type Logger struct{}
 
 func (l Logger) Failed(failure string) {
-	l.Log(colors.BoldRed().Styled(fmt.Sprintf("FAILED: %v\n", failure)))
+	l.Log(colors.BoldRed().Styled(fmt.Sprintf("%v\n", failure)))
 }
 
 func (l Logger) Log(text string) {


### PR DESCRIPTION
No need to print FAILED, the red color and the error text indicate it's an error.