### PR TITLE
Consistently use un-aliased forms in documentation

### DIFF
--- a/website/src/commands/prepend.md
+++ b/website/src/commands/prepend.md
@@ -58,5 +58,5 @@ run of `git town sync` will create the remote tracking branch.
 
 If the configuration setting
 [create-prototype-branches](../preferences/create-prototype-branches.md) is set,
-`git prepend` always creates a
+`git town prepend` always creates a
 [prototype branch](../branch-types.md#prototype-branches).


### PR DESCRIPTION
This makes the documentation easier to understand for people new to Git Town, and separates the Git Town commands from Git commands.

This PR fixes one example missed in #4052.