### PR TITLE
Sort flag definitions alphabetically

### DIFF
--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -35,10 +35,10 @@ Syncs the current branch, forks a new feature branch with the given name off the
 See "sync" for information regarding upstream remotes.`
 
 func appendCmd() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	addDetachedFlag, readDetachedFlag := flags.Detached()
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
 	addPrototypeFlag, readPrototypeFlag := flags.Prototype()
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:     "append <branch>",
 		GroupID: "lineage",

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -43,10 +43,10 @@ You can provide a custom commit message with the -m switch.
 `
 
 func compressCmd() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
 	addMessageFlag, readMessageFlag := flags.CommitMessage("customize the commit message")
 	addStackFlag, readStackFlag := flags.Stack("Compress the entire stack")
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:   compressCommand,
 		Args:  cobra.NoArgs,
@@ -57,9 +57,9 @@ func compressCmd() *cobra.Command {
 		},
 	}
 	addDryRunFlag(&cmd)
-	addVerboseFlag(&cmd)
 	addMessageFlag(&cmd)
 	addStackFlag(&cmd)
+	addVerboseFlag(&cmd)
 	return &cmd
 }
 

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -38,9 +38,9 @@ Syncs the main branch, forks a new feature branch with the given name off the ma
 See "sync" for information regarding upstream remotes.`
 
 func hackCmd() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
 	addPrototypeFlag, readPrototypeFlag := flags.Prototype()
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:     "hack <branch>",
 		GroupID: "basic",

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -35,8 +35,8 @@ const killHelp = `
 Deletes the current or provided branch from the local and origin repositories. Does not delete perennial branches nor the main branch.`
 
 func killCommand() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:   "kill [<branch>]",
 		Args:  cobra.MaximumNArgs(1),

--- a/internal/cmd/new_pull_request.go
+++ b/internal/cmd/new_pull_request.go
@@ -12,11 +12,11 @@ import (
 )
 
 func newPullRequestCommand() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
-	addDryRunFlag, readDryRunFlag := flags.DryRun()
-	addTitleFlag, readTitleFlag := flags.ProposalTitle()
 	addBodyFlag, readBodyFlag := flags.ProposalBody()
 	addBodyFileFlag, readBodyFileFlag := flags.ProposalBodyFile()
+	addDryRunFlag, readDryRunFlag := flags.DryRun()
+	addTitleFlag, readTitleFlag := flags.ProposalTitle()
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:     "new-pull-request",
 		GroupID: "basic",
@@ -31,11 +31,11 @@ func newPullRequestCommand() *cobra.Command {
 			return result
 		},
 	}
-	addDryRunFlag(&cmd)
-	addVerboseFlag(&cmd)
-	addTitleFlag(&cmd)
 	addBodyFlag(&cmd)
 	addBodyFileFlag(&cmd)
+	addDryRunFlag(&cmd)
+	addTitleFlag(&cmd)
+	addVerboseFlag(&cmd)
 	return &cmd
 }
 

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -37,9 +37,9 @@ Syncs the parent branch, cuts a new feature branch with the given name off the p
 See "sync" for upstream remote options.`
 
 func prependCommand() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
 	addPrototypeFlag, readPrototypeFlag := flags.Prototype()
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:     "prepend <branch>",
 		GroupID: "lineage",

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -41,11 +41,11 @@ The form is pre-populated for the current branch so that the proposal only shows
 Supported only for repositories hosted on GitHub, GitLab, Gitea and Bitbucket. When using self-hosted versions this command needs to be configured with "git config %s <driver>" where driver is "github", "gitlab", "gitea", or "bitbucket". When using SSH identities, this command needs to be configured with "git config %s <hostname>" where hostname matches what is in your ssh config file.`
 
 func proposeCommand() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
-	addDryRunFlag, readDryRunFlag := flags.DryRun()
-	addTitleFlag, readTitleFlag := flags.ProposalTitle()
 	addBodyFlag, readBodyFlag := flags.ProposalBody()
 	addBodyFileFlag, readBodyFileFlag := flags.ProposalBodyFile()
+	addDryRunFlag, readDryRunFlag := flags.DryRun()
+	addTitleFlag, readTitleFlag := flags.ProposalTitle()
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:     proposeCmd,
 		GroupID: "basic",
@@ -56,11 +56,11 @@ func proposeCommand() *cobra.Command {
 			return executePropose(readDryRunFlag(cmd), readVerboseFlag(cmd), readTitleFlag(cmd), readBodyFlag(cmd), readBodyFileFlag(cmd))
 		},
 	}
-	addDryRunFlag(&cmd)
-	addVerboseFlag(&cmd)
-	addTitleFlag(&cmd)
 	addBodyFlag(&cmd)
 	addBodyFileFlag(&cmd)
+	addDryRunFlag(&cmd)
+	addTitleFlag(&cmd)
+	addVerboseFlag(&cmd)
 	return &cmd
 }
 

--- a/internal/cmd/rename_branch.go
+++ b/internal/cmd/rename_branch.go
@@ -48,9 +48,9 @@ When run on a perennial branch:
 - registers the new perennial branch name in the local Git Town configuration`
 
 func renameBranchCommand() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
-	addForceFlag, readForceFlag := flags.Force("force rename of perennial branch")
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
+	addForceFlag, readForceFlag := flags.Force("force rename of perennial branch")
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:   "rename-branch [<old_branch_name>] <new_branch_name>",
 		Args:  cobra.RangeArgs(1, 2),
@@ -61,8 +61,8 @@ func renameBranchCommand() *cobra.Command {
 		},
 	}
 	addDryRunFlag(&cmd)
-	addVerboseFlag(&cmd)
 	addForceFlag(&cmd)
+	addVerboseFlag(&cmd)
 	return &cmd
 }
 

--- a/internal/cmd/switch.go
+++ b/internal/cmd/switch.go
@@ -27,10 +27,10 @@ const switchDesc = "Display the local branches visually and allows switching bet
 
 func switchCmd() *cobra.Command {
 	addAllFlag, readAllFlag := flags.All("list both remote-tracking and local branches")
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
+	addDisplayTypesFlag, readDisplayTypesFlag := flags.Displaytypes()
 	addMergeFlag, readMergeFlag := flags.SwitchMerge()
 	addTypeFlag, readTypeFlag := flags.BranchType()
-	addDisplayTypesFlag, readDisplayTypesFlag := flags.Displaytypes()
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:     "switch",
 		GroupID: "basic",
@@ -48,8 +48,8 @@ func switchCmd() *cobra.Command {
 	addAllFlag(&cmd)
 	addDisplayTypesFlag(&cmd)
 	addMergeFlag(&cmd)
-	addVerboseFlag(&cmd)
 	addTypeFlag(&cmd)
+	addVerboseFlag(&cmd)
 	return &cmd
 }
 

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -49,12 +49,12 @@ When run on the main branch or a perennial branch:
 If the repository contains an "upstream" remote, syncs the main branch with its upstream counterpart. You can disable this by running "git config %s false".`
 
 func syncCmd() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
+	addAllFlag, readAllFlag := flags.All("sync all local branches")
 	addDetachedFlag, readDetachedFlag := flags.Detached()
 	addDryRunFlag, readDryRunFlag := flags.DryRun()
-	addAllFlag, readAllFlag := flags.All("sync all local branches")
 	addNoPushFlag, readNoPushFlag := flags.NoPush()
 	addStackFlag, readStackFlag := flags.Stack("sync the stack that the current branch belongs to")
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:     syncCommand,
 		GroupID: "basic",
@@ -67,10 +67,10 @@ func syncCmd() *cobra.Command {
 	}
 	addAllFlag(&cmd)
 	addDetachedFlag(&cmd)
-	addVerboseFlag(&cmd)
 	addDryRunFlag(&cmd)
 	addNoPushFlag(&cmd)
 	addStackFlag(&cmd)
+	addVerboseFlag(&cmd)
 	return &cmd
 }
 


### PR DESCRIPTION
We start having quite a few flag definitions in some commands. Time to sort them alphabetically so that it's easier to locate them.