### PR TITLE
Run govulncheck only on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ lint: tools/node_modules tools/rta@${RTA_VERSION}  # lints the main codebase con
 	(cd tools/lint_steps && go build && ./lint_steps)
 	${CURDIR}/tools/node_modules/.bin/gherkin-lint
 	tools/rta actionlint
-	tools/rta govulncheck ./...
 	tools/rta staticcheck ./...
 	tools/ensure_no_files_with_dashes.sh
 	tools/rta shfmt -f . | grep -v 'tools/node_modules' | grep -v '^vendor/' | xargs tools/rta --optional shellcheck
@@ -65,6 +64,7 @@ lint: tools/node_modules tools/rta@${RTA_VERSION}  # lints the main codebase con
 	tools/rta golangci-lint run
 
 lint-all: lint tools/rta@${RTA_VERSION}  # runs all linters
+	tools/rta govulncheck ./...
 	@echo lint tools/format_self
 	@(cd tools/format_self && ../rta golangci-lint run)
 	@echo lint tools/format_unittests


### PR DESCRIPTION
- dependencies don't change that often
- this linter takes a while
- it's better to keep the dev linter fast