### PR TITLE
Remove TODO

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -361,7 +361,6 @@ func (self *Commands) FirstCommitMessageInBranch(runner gitdomain.Querier, branc
 	return Some(gitdomain.CommitMessage(message)), nil
 }
 
-// TODO: remove this method and replace usages with BranchInfos.FirstLocalBranch
 func (self *Commands) FirstExistingBranch(runner gitdomain.Runner, branches ...gitdomain.LocalBranchName) Option[gitdomain.LocalBranchName] {
 	for _, branch := range branches {
 		if self.BranchExists(runner, branch) {


### PR DESCRIPTION
This TODO is no longer valid. Branches might get removed at runtime, for example when their tracking branch is gone. Or if the branch gets shipped. Or in the future when two branches get merged. We cannot use the initial branches snapshot as an authoritative source of information about whether a branch exists locally or not.