### PR TITLE
Fix Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
   base = "website/"
   publish = "book/"
-  command = "make install"
+  command = "make build"
   ignore = "/bin/false"


### PR DESCRIPTION
Netlify uses the Makefile in the `website` directory. This one still uses `make build`.