### PR TITLE
Fix broken links in install.md

### DIFF
--- a/website/src/install.md
+++ b/website/src/install.md
@@ -33,8 +33,8 @@ You can install Git Town on Windows using:
 
 If you use the Windows Subsystem for Linux, please install
 [wsl-open](https://www.npmjs.com/package/wsl-open) to allow the commands
-[git town repo](https://git-town.com/commands/repo.md) and
-[git town propose](https://git-town.com/commands/propose.md) to open a browser
+[git town repo](https://www.git-town.com/commands/repo) and
+[git town propose](https://www.git-town.com/commands/propose) to open a browser
 window for you.
 
 ## Linux
@@ -82,7 +82,7 @@ matching binaries from the GitHub release.
 ## manual installation
 
 ```
-curl https://git-town.com/install.sh | sh
+curl https://www.git-town.com/install.sh | sh
 ```
 
 For a fully custom installation,


### PR DESCRIPTION
This Pull Request updates outdated links in the Git Town documentation.

- Updated URLs for the `repo` and `propose` commands to point to the correct pages on [git-town.com](https://www.git-town.com/).

- The error when running the install command without `www.`. See screenshot below

![image](https://github.com/user-attachments/assets/bcf983e6-504b-4b0a-b9d4-cf13105b763b)
