### PR TITLE
Additional sync statuses

### DIFF
--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -313,7 +313,7 @@ func validateBranchIsSynced(branchName gitdomain.LocalBranchName, syncStatus git
 	switch syncStatus {
 	case gitdomain.SyncStatusUpToDate, gitdomain.SyncStatusLocalOnly:
 		return nil
-	case gitdomain.SyncStatusNotInSync, gitdomain.SyncStatusDeletedAtRemote, gitdomain.SyncStatusRemoteOnly, gitdomain.SyncStatusOtherWorktree:
+	case gitdomain.SyncStatusNotInSync, gitdomain.SyncStatusAhead, gitdomain.SyncStatusBehind, gitdomain.SyncStatusDeletedAtRemote, gitdomain.SyncStatusRemoteOnly, gitdomain.SyncStatusOtherWorktree:
 		return fmt.Errorf(messages.CompressUnsynced, branchName)
 	}
 	panic("unhandled syncstatus: " + syncStatus.String())

--- a/internal/cmd/ship/core.go
+++ b/internal/cmd/ship/core.go
@@ -163,7 +163,7 @@ func validateSharedData(data sharedShipData, toParent configdomain.ShipIntoNonpe
 	switch data.branchToShip.SyncStatus {
 	case gitdomain.SyncStatusDeletedAtRemote:
 		return fmt.Errorf(messages.ShipBranchDeletedAtRemote, data.branchNameToShip)
-	case gitdomain.SyncStatusNotInSync:
+	case gitdomain.SyncStatusNotInSync, gitdomain.SyncStatusAhead, gitdomain.SyncStatusBehind:
 		return fmt.Errorf(messages.ShipBranchNotInSync, data.branchNameToShip)
 	case gitdomain.SyncStatusOtherWorktree:
 		return fmt.Errorf(messages.ShipBranchIsInOtherWorktree, data.branchNameToShip)

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -207,7 +207,7 @@ func determineSyncData(syncAllBranches configdomain.AllBranches, syncStack confi
 	if hasPreviousBranch {
 		if previousBranchInfo, hasPreviousBranchInfo := branchesSnapshot.Branches.FindByLocalName(previousBranch).Get(); hasPreviousBranchInfo {
 			switch previousBranchInfo.SyncStatus {
-			case gitdomain.SyncStatusLocalOnly, gitdomain.SyncStatusNotInSync, gitdomain.SyncStatusUpToDate:
+			case gitdomain.SyncStatusLocalOnly, gitdomain.SyncStatusNotInSync, gitdomain.SyncStatusAhead, gitdomain.SyncStatusBehind, gitdomain.SyncStatusUpToDate:
 				previousBranchOpt = previousBranchInfo.LocalName
 			case gitdomain.SyncStatusDeletedAtRemote, gitdomain.SyncStatusRemoteOnly, gitdomain.SyncStatusOtherWorktree:
 				previousBranchOpt = None[gitdomain.LocalBranchName]()

--- a/internal/git/gitdomain/sync_status.go
+++ b/internal/git/gitdomain/sync_status.go
@@ -10,8 +10,8 @@ func (self SyncStatus) String() string {
 
 const (
 	SyncStatusUpToDate        SyncStatus = "up to date"                 // the branch exists locally and remotely, the local branch is up to date
-	SyncStatusAhead           SyncStatus = "ahead"                      // the branch exists locally and remotely, the local branch is behind the remote branch
-	SyncStatusBehind          SyncStatus = "behind"                     // the branch exists locally and remotely, the local branch is ahead of the remote branch
+	SyncStatusAhead           SyncStatus = "ahead"                      // the branch exists locally and remotely, the local branch is ahead of the remote branch
+	SyncStatusBehind          SyncStatus = "behind"                     // the branch exists locally and remotely, the local branch is behind the remote branch
 	SyncStatusNotInSync       SyncStatus = "not in sync"                // the branch exists locally and remotely, the local branch has different commits than the remote branch
 	SyncStatusLocalOnly       SyncStatus = "local only"                 // the branch was created locally and hasn't been pushed to the remote yet
 	SyncStatusRemoteOnly      SyncStatus = "remote only"                // the branch exists only at the remote

--- a/internal/git/gitdomain/sync_status.go
+++ b/internal/git/gitdomain/sync_status.go
@@ -10,7 +10,9 @@ func (self SyncStatus) String() string {
 
 const (
 	SyncStatusUpToDate        SyncStatus = "up to date"                 // the branch exists locally and remotely, the local branch is up to date
-	SyncStatusNotInSync       SyncStatus = "not in sync"                // the branch exists locally and remotely, the local branch is behind the remote tracking branch
+	SyncStatusAhead           SyncStatus = "ahead"                      // the branch exists locally and remotely, the local branch is behind the remote branch
+	SyncStatusBehind          SyncStatus = "behind"                     // the branch exists locally and remotely, the local branch is ahead of the remote branch
+	SyncStatusNotInSync       SyncStatus = "not in sync"                // the branch exists locally and remotely, the local branch has different commits than the remote branch
 	SyncStatusLocalOnly       SyncStatus = "local only"                 // the branch was created locally and hasn't been pushed to the remote yet
 	SyncStatusRemoteOnly      SyncStatus = "remote only"                // the branch exists only at the remote
 	SyncStatusDeletedAtRemote SyncStatus = "deleted at remote"          // the branch was deleted on the remote


### PR DESCRIPTION
This PR adds the missing sync statuses of "local branch is ahead of its tracking branch" and "local branch is behind its tracking branch". Previously these were all part of the "not in sync" sync status. Now they are dedicated status for each scenario. This is needed for #3641.