### PR TITLE
Fix loading persistent runstate file

### DIFF
--- a/internal/vm/opcodes/core.go
+++ b/internal/vm/opcodes/core.go
@@ -96,6 +96,7 @@ func Types() []shared.Opcode {
 		&PushCurrentBranchIfLocal{},
 		&PushCurrentBranchIfNeeded{},
 		&PushTags{},
+		&QueueMessage{},
 		&RebaseBranch{},
 		&RebaseFeatureTrackingBranch{},
 		&RebaseParentIfNeeded{},


### PR DESCRIPTION
The `QueueMessage` opcode should be loadable.