### PR TITLE
feat: reintroduce deprecated "rename-branch" command with a deprecated placeholder

### DIFF
--- a/internal/cmd/core.go
+++ b/internal/cmd/core.go
@@ -30,6 +30,7 @@ func Execute() error {
 	rootCmd.AddCommand(proposeCommand())
 	rootCmd.AddCommand(prependCommand())
 	rootCmd.AddCommand(prototypeCmd())
+	rootCmd.AddCommand(renameBranchCommand())
 	rootCmd.AddCommand(renameCommand())
 	rootCmd.AddCommand(repoCommand())
 	rootCmd.AddCommand(status.RootCommand())

--- a/internal/cmd/rename_branch.go
+++ b/internal/cmd/rename_branch.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/git-town/git-town/v16/internal/cli/flags"
+	"github.com/git-town/git-town/v16/internal/cmd/cmdhelpers"
+	"github.com/git-town/git-town/v16/internal/messages"
+	"github.com/spf13/cobra"
+)
+
+func renameBranchCommand() *cobra.Command {
+	addDryRunFlag, readDryRunFlag := flags.DryRun()
+	addForceFlag, readForceFlag := flags.Force("force rename of perennial branch")
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
+	cmd := cobra.Command{
+		Use:    "rename-branch",
+		Hidden: true,
+		Args:   cobra.RangeArgs(1, 2),
+		Short:  renameDesc,
+		Long:   cmdhelpers.Long(renameDesc, renameHelp),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			printRenameBranchDeprecationNotice()
+			result := executeRename(args, readDryRunFlag(cmd), readForceFlag(cmd), readVerboseFlag(cmd))
+			printRenameBranchDeprecationNotice()
+			return result
+		},
+	}
+	addDryRunFlag(&cmd)
+	addForceFlag(&cmd)
+	addVerboseFlag(&cmd)
+	return &cmd
+}
+
+func printRenameBranchDeprecationNotice() {
+	fmt.Println(messages.RenameBranchDeprecation)
+	time.Sleep(2000 * time.Millisecond)
+}

--- a/internal/messages/en.go
+++ b/internal/messages/en.go
@@ -171,11 +171,15 @@ END OUTPUT FROM 'git branch -vva'
 
 This command has been renamed to "git town propose"
 nd will be removed in future versions of Git Town.`
-	PushHook                       = "Push hook: %s\n"
-	PushNewBranches                = "Push new branches: %s\n"
-	RebaseProblem                  = "cannot determine rebase in progress: %w"
-	RemoteExistsProblem            = "cannot determine if remote %q exists: %w"
-	RemotesProblem                 = "cannot determine remotes: %w"
+	PushHook                = "Push hook: %s\n"
+	PushNewBranches         = "Push new branches: %s\n"
+	RebaseProblem           = "cannot determine rebase in progress: %w"
+	RemoteExistsProblem     = "cannot determine if remote %q exists: %w"
+	RemotesProblem          = "cannot determine remotes: %w"
+	RenameBranchDeprecation = `DEPRECATION NOTICE
+
+	This command has been renamed to "git town rename"
+	and will be removed in future versions of Git Town.`
 	RenameNotInSync                = "%q is not in sync with its tracking branch, please sync the branches before renaming"
 	RenameMainBranch               = "the main branch cannot be renamed"
 	RenamePerennialBranchWarning   = "%q is a perennial branch. Renaming a perennial branch typically requires other updates. If you are sure you want to do this, use '--force'"


### PR DESCRIPTION
Fixes https://github.com/git-town/git-town/issues/4146