### PR TITLE
Remove all unnecessary nil

### DIFF
--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -79,7 +79,7 @@ func executeConfigSetup(verbose configdomain.Verbose) error {
 		FinalMessages:         repo.FinalMessages,
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
-		TouchedBranches:       []gitdomain.BranchName(nil),
+		TouchedBranches:       []gitdomain.BranchName{},
 		Verbose:               verbose,
 	})
 }

--- a/internal/cmd/offline.go
+++ b/internal/cmd/offline.go
@@ -68,7 +68,7 @@ func executeOffline(args []string, verbose configdomain.Verbose) error {
 		FinalMessages:         repo.FinalMessages,
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
-		TouchedBranches:       []gitdomain.BranchName(nil),
+		TouchedBranches:       []gitdomain.BranchName{},
 		Verbose:               verbose,
 	})
 }

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -39,7 +39,7 @@ func (self *Commands) AbortRebase(runner gitdomain.Runner) error {
 func (self *Commands) BranchAuthors(querier gitdomain.Querier, branch, parent gitdomain.LocalBranchName) ([]gitdomain.Author, error) {
 	output, err := querier.QueryTrim("git", "shortlog", "-s", "-n", "-e", parent.String()+".."+branch.String())
 	if err != nil {
-		return []gitdomain.Author(nil), err
+		return []gitdomain.Author{}, err
 	}
 	lines := stringslice.Lines(output)
 	result := make([]gitdomain.Author, len(lines))

--- a/internal/gohacks/slice/find_many_test.go
+++ b/internal/gohacks/slice/find_many_test.go
@@ -30,7 +30,7 @@ func TestFindMany(t *testing.T) {
 
 	t.Run("haystack is empty", func(t *testing.T) {
 		t.Parallel()
-		haystack := []string(nil)
+		haystack := []string{}
 		needles := []string{"one", "two"}
 		have := slice.FindMany(haystack, needles)
 		must.Len(t, 0, have)
@@ -39,7 +39,7 @@ func TestFindMany(t *testing.T) {
 	t.Run("no needles given", func(t *testing.T) {
 		t.Parallel()
 		haystack := []string{"one", "two", "three"}
-		needles := []string(nil)
+		needles := []string{}
 		have := slice.FindMany(haystack, needles)
 		must.Len(t, 0, have)
 	})

--- a/internal/gohacks/slice/first_element_or_test.go
+++ b/internal/gohacks/slice/first_element_or_test.go
@@ -20,7 +20,7 @@ func TestFirstElementOr(t *testing.T) {
 
 	t.Run("list is empty", func(t *testing.T) {
 		t.Parallel()
-		list := []string(nil)
+		list := []string{}
 		have := slice.FirstElementOr(list, "other")
 		want := "other"
 		must.EqOp(t, want, have)

--- a/internal/gohacks/slice/get_all_test.go
+++ b/internal/gohacks/slice/get_all_test.go
@@ -36,7 +36,7 @@ func TestGetAll(t *testing.T) {
 
 	t.Run("empty list", func(t *testing.T) {
 		t.Parallel()
-		give := []Option[int](nil)
+		give := []Option[int]{}
 		have := slice.GetAll(give)
 		must.Len(t, 0, have)
 	})

--- a/internal/gohacks/slice/hoist_test.go
+++ b/internal/gohacks/slice/hoist_test.go
@@ -29,7 +29,7 @@ func TestHoist(t *testing.T) {
 
 	t.Run("empty list", func(t *testing.T) {
 		t.Parallel()
-		list := []string(nil)
+		list := []string{}
 		have := slice.Hoist(list, "initial")
 		must.Len(t, 0, have)
 	})

--- a/internal/gohacks/slice/remove_test.go
+++ b/internal/gohacks/slice/remove_test.go
@@ -29,7 +29,7 @@ func TestRemove(t *testing.T) {
 
 	t.Run("empty slice", func(t *testing.T) {
 		t.Parallel()
-		list := []string(nil)
+		list := []string{}
 		have := slice.Remove(list, "foo")
 		must.Len(t, 0, have)
 	})

--- a/internal/gohacks/slice/truncate_last_test.go
+++ b/internal/gohacks/slice/truncate_last_test.go
@@ -13,7 +13,7 @@ func TestTruncateLast(t *testing.T) {
 
 	t.Run("list contains no elements", func(t *testing.T) {
 		t.Parallel()
-		list := []int(nil)
+		list := []int{}
 		have := slice.TruncateLast(list)
 		must.Len(t, 0, have)
 	})

--- a/internal/gohacks/stringslice/collector.go
+++ b/internal/gohacks/stringslice/collector.go
@@ -21,7 +21,7 @@ func (self Collector) Add(text string) {
 // Result provides all accumulated string instances.
 func (self Collector) Result() []string {
 	if self.data == nil {
-		return []string(nil)
+		return []string{}
 	}
 	return *self.data
 }

--- a/internal/gohacks/stringslice/connect_test.go
+++ b/internal/gohacks/stringslice/connect_test.go
@@ -14,7 +14,7 @@ func TestConnect(t *testing.T) {
 		want string
 	}{
 		{
-			give: []string(nil),
+			give: []string{},
 			want: "",
 		},
 		{

--- a/internal/gohacks/stringslice/longest_test.go
+++ b/internal/gohacks/stringslice/longest_test.go
@@ -22,7 +22,7 @@ func TestLongest(t *testing.T) {
 			want: 0,
 		},
 		{
-			give: []string(nil),
+			give: []string{},
 			want: 0,
 		},
 	}

--- a/internal/hosting/gitea/connector.go
+++ b/internal/hosting/gitea/connector.go
@@ -154,7 +154,7 @@ func (self Connector) UpdateProposalHead(number int, _ gitdomain.LocalBranchName
 }
 
 func FilterPullRequests(pullRequests []*gitea.PullRequest, branch, target gitdomain.LocalBranchName) []*gitea.PullRequest {
-	result := []*gitea.PullRequest(nil)
+	result := []*gitea.PullRequest{}
 	for _, pullRequest := range pullRequests {
 		if pullRequest.Head.Name == branch.String() && pullRequest.Base.Name == target.String() {
 			result = append(result, pullRequest)
@@ -164,7 +164,7 @@ func FilterPullRequests(pullRequests []*gitea.PullRequest, branch, target gitdom
 }
 
 func FilterPullRequests2(pullRequests []*gitea.PullRequest, branch gitdomain.LocalBranchName) []*gitea.PullRequest {
-	result := []*gitea.PullRequest(nil)
+	result := []*gitea.PullRequest{}
 	for _, pullRequest := range pullRequests {
 		if pullRequest.Head.Name == branch.String() {
 			result = append(result, pullRequest)

--- a/internal/undo/undobranches/branch_changes_test.go
+++ b/internal/undo/undobranches/branch_changes_test.go
@@ -80,7 +80,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.CheckoutIfNeeded{Branch: gitdomain.NewLocalBranchName("main")},
@@ -140,7 +140,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.BranchCreate{
@@ -234,7 +234,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.CheckoutIfNeeded{Branch: gitdomain.NewLocalBranchName("feature-branch")},
@@ -329,7 +329,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.BranchTrackingDelete{
@@ -418,7 +418,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.BranchLocalDelete{Branch: gitdomain.NewLocalBranchName("perennial-branch")},
@@ -491,7 +491,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.BranchLocalDelete{Branch: gitdomain.NewLocalBranchName("perennial-branch")},
@@ -589,7 +589,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.CheckoutIfNeeded{Branch: gitdomain.NewLocalBranchName("feature-branch")},
@@ -725,7 +725,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			// It doesn't reset the remote perennial branch since those are assumed to be protected against force-pushes
@@ -1067,7 +1067,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			// It doesn't revert the perennial branch because it cannot force-push the changes to the remote branch.
@@ -1168,7 +1168,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.CheckoutIfNeeded{Branch: gitdomain.NewLocalBranchName("feature-branch")},
@@ -1269,7 +1269,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			// It doesn't revert the remote perennial branch because it cannot force-push the changes to it.
@@ -1358,7 +1358,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			&opcodes.BranchCreate{
@@ -1449,7 +1449,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrDefault(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			// don't re-create the tracking branch for the perennial branch
@@ -1535,7 +1535,7 @@ func TestChanges(t *testing.T) {
 			BeginBranch:              before.Active.GetOrPanic(),
 			Config:                   config,
 			EndBranch:                after.Active.GetOrPanic(),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		})
 		wantProgram := program.Program{
 			// No changes should happen here since all changes were syncs on perennial branches.

--- a/internal/undo/undoconfig/config_test.go
+++ b/internal/undo/undoconfig/config_test.go
@@ -68,14 +68,14 @@ func TestConfigUndo(t *testing.T) {
 		haveDiff := undoconfig.NewConfigDiffs(before, after)
 		wantDiff := undoconfig.ConfigDiffs{
 			Global: undoconfig.ConfigDiff{
-				Added: []configdomain.Key(nil),
+				Added: []configdomain.Key{},
 				Removed: map[configdomain.Key]string{
 					configdomain.KeySyncPerennialStrategy: "1",
 				},
 				Changed: map[configdomain.Key]undodomain.Change[string]{},
 			},
 			Local: undoconfig.ConfigDiff{
-				Added:   []configdomain.Key(nil),
+				Added:   []configdomain.Key{},
 				Removed: map[configdomain.Key]string{},
 				Changed: map[configdomain.Key]undodomain.Change[string]{},
 			},
@@ -108,7 +108,7 @@ func TestConfigUndo(t *testing.T) {
 		haveDiff := undoconfig.NewConfigDiffs(before, after)
 		wantDiff := undoconfig.ConfigDiffs{
 			Global: undoconfig.ConfigDiff{
-				Added:   []configdomain.Key(nil),
+				Added:   []configdomain.Key{},
 				Removed: map[configdomain.Key]string{},
 				Changed: map[configdomain.Key]undodomain.Change[string]{
 					configdomain.KeyOffline: {
@@ -118,7 +118,7 @@ func TestConfigUndo(t *testing.T) {
 				},
 			},
 			Local: undoconfig.ConfigDiff{
-				Added:   []configdomain.Key(nil),
+				Added:   []configdomain.Key{},
 				Removed: map[configdomain.Key]string{},
 				Changed: map[configdomain.Key]undodomain.Change[string]{},
 			},
@@ -188,12 +188,12 @@ func TestConfigUndo(t *testing.T) {
 		haveDiff := undoconfig.NewConfigDiffs(before, after)
 		wantDiff := undoconfig.ConfigDiffs{
 			Global: undoconfig.ConfigDiff{
-				Added:   []configdomain.Key(nil),
+				Added:   []configdomain.Key{},
 				Removed: map[configdomain.Key]string{},
 				Changed: map[configdomain.Key]undodomain.Change[string]{},
 			},
 			Local: undoconfig.ConfigDiff{
-				Added: []configdomain.Key(nil),
+				Added: []configdomain.Key{},
 				Removed: map[configdomain.Key]string{
 					configdomain.KeySyncPerennialStrategy: "1",
 				},
@@ -228,12 +228,12 @@ func TestConfigUndo(t *testing.T) {
 		haveDiff := undoconfig.NewConfigDiffs(before, after)
 		wantDiff := undoconfig.ConfigDiffs{
 			Global: undoconfig.ConfigDiff{
-				Added:   []configdomain.Key(nil),
+				Added:   []configdomain.Key{},
 				Removed: map[configdomain.Key]string{},
 				Changed: map[configdomain.Key]undodomain.Change[string]{},
 			},
 			Local: undoconfig.ConfigDiff{
-				Added:   []configdomain.Key(nil),
+				Added:   []configdomain.Key{},
 				Removed: map[configdomain.Key]string{},
 				Changed: map[configdomain.Key]undodomain.Change[string]{
 					configdomain.KeyOffline: {
@@ -339,7 +339,7 @@ func TestConfigUndo(t *testing.T) {
 
 func emptyConfigDiff() undoconfig.ConfigDiff {
 	return undoconfig.ConfigDiff{
-		Added:   []configdomain.Key(nil),
+		Added:   []configdomain.Key{},
 		Changed: map[configdomain.Key]undodomain.Change[string]{},
 		Removed: map[configdomain.Key]string{},
 	}

--- a/internal/undo/undoconfig/diff.go
+++ b/internal/undo/undoconfig/diff.go
@@ -8,7 +8,7 @@ import (
 // SingleCacheDiff provides a diff of the two given SingleCache instances.
 func SingleCacheDiff(before, after configdomain.SingleSnapshot) ConfigDiff {
 	result := ConfigDiff{
-		Added:   nil,
+		Added:   []configdomain.Key{},
 		Changed: map[configdomain.Key]undodomain.Change[string]{},
 		Removed: map[configdomain.Key]string{},
 	}

--- a/internal/vm/opcodes/connector_proposal_merge.go
+++ b/internal/vm/opcodes/connector_proposal_merge.go
@@ -26,7 +26,7 @@ func (self *ConnectorProposalMerge) AbortProgram() []shared.Opcode {
 	if self.enteredEmptyCommitMessage {
 		return []shared.Opcode{&ChangesDiscard{}}
 	}
-	return []shared.Opcode(nil)
+	return []shared.Opcode{}
 }
 
 func (self *ConnectorProposalMerge) AutomaticUndoError() error {

--- a/internal/vm/opcodes/core.go
+++ b/internal/vm/opcodes/core.go
@@ -13,7 +13,7 @@ import (
 type undeclaredOpcodeMethods struct{}
 
 func (self *undeclaredOpcodeMethods) AbortProgram() []shared.Opcode {
-	return []shared.Opcode(nil)
+	return []shared.Opcode{}
 }
 
 func (self *undeclaredOpcodeMethods) AutomaticUndoError() error {
@@ -21,7 +21,7 @@ func (self *undeclaredOpcodeMethods) AutomaticUndoError() error {
 }
 
 func (self *undeclaredOpcodeMethods) ContinueProgram() []shared.Opcode {
-	return []shared.Opcode(nil)
+	return []shared.Opcode{}
 }
 
 func (self *undeclaredOpcodeMethods) Run(_ shared.RunArgs) error {
@@ -33,7 +33,7 @@ func (self *undeclaredOpcodeMethods) ShouldUndoOnError() bool {
 }
 
 func (self *undeclaredOpcodeMethods) UndoExternalChangesProgram() []shared.Opcode {
-	return []shared.Opcode(nil)
+	return []shared.Opcode{}
 }
 
 func Lookup(opcodeType string) shared.Opcode { //nolint:ireturn

--- a/internal/vm/runstate/runstate_test.go
+++ b/internal/vm/runstate/runstate_test.go
@@ -59,7 +59,7 @@ func TestRunState(t *testing.T) {
 			BeginBranchesSnapshot:    gitdomain.EmptyBranchesSnapshot(),
 			BeginConfigSnapshot:      undoconfig.EmptyConfigSnapshot(),
 			BeginStashSize:           0,
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 			TouchedBranches:          []gitdomain.BranchName{"branch-1", "branch-2"},
 		}
 		encoded, err := json.MarshalIndent(runState, "", "  ")
@@ -124,7 +124,7 @@ func TestRunState(t *testing.T) {
     "branch-2"
   ],
   "UndoAPIProgram": [],
-  "UndoablePerennialCommits": null,
+  "UndoablePerennialCommits": [],
   "UnfinishedDetails": null
 }`[1:]
 		must.EqOp(t, want, string(encoded))

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -135,7 +135,7 @@ func TestLoadSave(t *testing.T) {
 				EndBranch: gitdomain.NewLocalBranchName("end-branch"),
 				EndTime:   time.Time{},
 			}),
-			UndoablePerennialCommits: []gitdomain.SHA(nil),
+			UndoablePerennialCommits: []gitdomain.SHA{},
 		}
 
 		wantJSON := `
@@ -675,7 +675,7 @@ func TestLoadSave(t *testing.T) {
     "branch-2"
   ],
   "UndoAPIProgram": [],
-  "UndoablePerennialCommits": null,
+  "UndoablePerennialCommits": [],
   "UnfinishedDetails": {
     "CanSkip": true,
     "EndBranch": "end-branch",

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -215,7 +215,7 @@ func TestTestCommands(t *testing.T) {
 			FileName:    "hello.txt",
 			Message:     "commit",
 		})
-		commits := runtime.CommitsInBranch(gitdomain.NewLocalBranchName("initial"), []string(nil))
+		commits := runtime.CommitsInBranch(gitdomain.NewLocalBranchName("initial"), []string{})
 		must.Len(t, 1, commits)
 		content := runtime.FileContentInCommit(commits[0].SHA.Location(), "hello.txt")
 		must.EqOp(t, "hello world", content)
@@ -228,7 +228,7 @@ func TestTestCommands(t *testing.T) {
 		runtime.CreateFile("f2.txt", "two")
 		runtime.StageFiles("f1.txt", "f2.txt")
 		runtime.CommitStagedChanges("stuff")
-		commits := runtime.Commits([]string(nil), gitdomain.NewLocalBranchName("initial"))
+		commits := runtime.Commits([]string{}, gitdomain.NewLocalBranchName("initial"))
 		must.Len(t, 1, commits)
 		fileNames := runtime.FilesInCommit(commits[0].SHA)
 		must.Eq(t, []string{"f1.txt", "f2.txt"}, fileNames)

--- a/tools/stats_release/connector/comment_reactions.go
+++ b/tools/stats_release/connector/comment_reactions.go
@@ -10,7 +10,7 @@ import (
 
 func (gh Connector) CommentReactions(comment github.IssueComment) []*github.Reaction {
 	if *comment.Reactions.TotalCount == 0 {
-		return []*github.Reaction(nil)
+		return []*github.Reaction{}
 	}
 	fmt.Printf("loading reactions to comment #%d ", comment.GetID())
 	var result []*github.Reaction


### PR DESCRIPTION
Nil is the billion dollar mistake, even in Go. Let's not use it at all in this codebase, except for the built-in error handling. Optionality is handled better by the `Option` type.

This improves readability and correctness because some values now serialize to empty collections rather than `null`.

This causes a few more allocations, but they are extremely fast, and the allocated objects are usually short-lived.