### PR TITLE
Improve method to determine files changed by commits

### DIFF
--- a/features/sync/all_branches/merge_sync_strategy/stack/conflicting_changes.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/conflicting_changes.feature
@@ -56,16 +56,16 @@ Feature: sync a stack that makes conflicting changes
     And the current branch is now "alpha"
     And no merge is in progress
     And these commits exist now
-      | BRANCH | LOCATION      | MESSAGE                        | FILE NAME | FILE CONTENT  |
-      | main   | local, origin | main commit                    | file      | main content  |
-      | alpha  | local, origin | alpha commit                   | file      | alpha content |
-      |        |               | main commit                    | file      | main content  |
-      |        |               | Merge branch 'main' into alpha |           |               |
-      | beta   | local, origin | beta commit                    | file      | beta content  |
-      |        |               | alpha commit                   | file      | alpha content |
-      |        |               | main commit                    | file      | main content  |
-      |        |               | Merge branch 'main' into alpha |           |               |
-      |        |               | Merge branch 'alpha' into beta |           |               |
+      | BRANCH | LOCATION      | MESSAGE                        | FILE NAME | FILE CONTENT           |
+      | main   | local, origin | main commit                    | file      | main content           |
+      | alpha  | local, origin | alpha commit                   | file      | alpha content          |
+      |        |               | main commit                    | file      | main content           |
+      |        |               | Merge branch 'main' into alpha | file      | resolved alpha content |
+      | beta   | local, origin | beta commit                    | file      | beta content           |
+      |        |               | alpha commit                   | file      | alpha content          |
+      |        |               | main commit                    | file      | main content           |
+      |        |               | Merge branch 'main' into alpha | file      | resolved alpha content |
+      |        |               | Merge branch 'alpha' into beta | file      | resolved beta content  |
     When I run "git-town undo"
     Then it runs the commands
       | BRANCH | COMMAND                                               |

--- a/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
+++ b/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
@@ -56,10 +56,10 @@ Feature: compatibility between different sync-feature-strategy settings
       |         | git push                      |
     And all branches are now synchronized
     And these commits exist now
-      | BRANCH  | LOCATION                | MESSAGE                                                    | FILE NAME | FILE CONTENT     |
-      | feature | local, coworker, origin | my first commit                                            | file.txt  | my content       |
-      |         | coworker, origin        | coworker first commit                                      | file.txt  | coworker content |
-      |         |                         | Merge remote-tracking branch 'origin/feature' into feature |           |                  |
+      | BRANCH  | LOCATION                | MESSAGE                                                    | FILE NAME | FILE CONTENT            |
+      | feature | local, coworker, origin | my first commit                                            | file.txt  | my content              |
+      |         | coworker, origin        | coworker first commit                                      | file.txt  | coworker content        |
+      |         |                         | Merge remote-tracking branch 'origin/feature' into feature | file.txt  | my and coworker content |
     And the coworkers workspace now contains file "file.txt" with content "my and coworker content"
 
     # I add a conflicting commit locally and then sync
@@ -91,5 +91,5 @@ Feature: compatibility between different sync-feature-strategy settings
       | BRANCH  | LOCATION                | MESSAGE                                                    | FILE NAME | FILE CONTENT                |
       | feature | local, coworker, origin | coworker first commit                                      | file.txt  | coworker content            |
       |         |                         | my first commit                                            | file.txt  | my content                  |
-      |         |                         | Merge remote-tracking branch 'origin/feature' into feature |           |                             |
+      |         |                         | Merge remote-tracking branch 'origin/feature' into feature | file.txt  | my and coworker content     |
       |         | local, origin           | my second commit                                           | file.txt  | my new and coworker content |

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -274,7 +274,7 @@ func (self *TestCommands) FilesInBranches(mainBranch gitdomain.LocalBranchName) 
 
 // FilesInCommit provides the names of the files that the commit with the given SHA changes.
 func (self *TestCommands) FilesInCommit(sha gitdomain.SHA) []string {
-	output := self.MustQuery("git", "diff-tree", "--no-commit-id", "--name-only", "-r", sha.String())
+	output := self.MustQuery("git", "show", "--name-only", "--pretty=format:", sha.String())
 	return strings.Split(output, "\n")
 }
 

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -224,13 +224,19 @@ func TestTestCommands(t *testing.T) {
 	t.Run("FilesInCommit", func(t *testing.T) {
 		t.Parallel()
 		runtime := testruntime.Create(t)
+		runtime.CreateCommit(git.Commit{
+			Branch:    "initial",
+			FileName:  "initial_file",
+			Locations: []git.Location{git.LocationLocal},
+			Message:   "initial file commit",
+		})
 		runtime.CreateFile("f1.txt", "one")
 		runtime.CreateFile("f2.txt", "two")
 		runtime.StageFiles("f1.txt", "f2.txt")
 		runtime.CommitStagedChanges("stuff")
 		commits := runtime.Commits([]string{}, gitdomain.NewLocalBranchName("initial"))
-		must.Len(t, 1, commits)
-		fileNames := runtime.FilesInCommit(commits[0].SHA)
+		must.Len(t, 2, commits)
+		fileNames := runtime.FilesInCommit(commits[1].SHA)
 		must.Eq(t, []string{"f1.txt", "f2.txt"}, fileNames)
 	})
 


### PR DESCRIPTION
ChatGPT found a better way to do this. Now we can verify the file contents in merge commits!