### PR TITLE
Always sync parent before tracking branch

### DIFF
--- a/features/append/on_feature_branch/clean_workspace/create_prototype_branches/enabled.feature
+++ b/features/append/on_feature_branch/clean_workspace/create_prototype_branches/enabled.feature
@@ -12,6 +12,7 @@ Feature: auto-creating a prototype branch when appending
     And Git Town setting "create-prototype-branches" is "true"
     When I run "git-town append new"
 
+  # @this
   Scenario: result
     Then it runs the commands
       | BRANCH   | COMMAND                                  |

--- a/features/append/on_feature_branch/clean_workspace/create_prototype_branches/enabled.feature
+++ b/features/append/on_feature_branch/clean_workspace/create_prototype_branches/enabled.feature
@@ -12,7 +12,6 @@ Feature: auto-creating a prototype branch when appending
     And Git Town setting "create-prototype-branches" is "true"
     When I run "git-town append new"
 
-  # @this
   Scenario: result
     Then it runs the commands
       | BRANCH   | COMMAND                                  |
@@ -20,8 +19,8 @@ Feature: auto-creating a prototype branch when appending
       |          | git checkout main                        |
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff origin/existing |
-      |          | git merge --no-edit --ff main            |
+      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"
     And branch "new" is now prototype

--- a/features/append/on_feature_branch/clean_workspace/deleted_branches/parent.feature
+++ b/features/append/on_feature_branch/clean_workspace/deleted_branches/parent.feature
@@ -22,8 +22,8 @@ Feature: append a branch to a branch whose parent was shipped on the remote
       | main   | git rebase origin/main --no-update-refs |
       |        | git branch -D parent                    |
       |        | git checkout child                      |
-      | child  | git merge --no-edit --ff origin/child   |
-      |        | git merge --no-edit --ff main           |
+      | child  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/child   |
       |        | git push                                |
       |        | git checkout -b new                     |
     And it prints:

--- a/features/append/on_feature_branch/clean_workspace/detached/enabled.feature
+++ b/features/append/on_feature_branch/clean_workspace/detached/enabled.feature
@@ -15,8 +15,8 @@ Feature: append a new feature branch to an existing feature branch in detached m
     Then it runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git merge --no-edit --ff origin/existing |
       |          | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"
     And the initial commits exist now

--- a/features/append/on_feature_branch/clean_workspace/dry_run/enabled.feature
+++ b/features/append/on_feature_branch/clean_workspace/dry_run/enabled.feature
@@ -18,8 +18,8 @@ Feature: dry run appending a new feature branch to an existing feature branch
       |          | git checkout main                        |
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff origin/existing |
-      |          | git merge --no-edit --ff main            |
+      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is still "existing"
     And the initial commits exist now

--- a/features/append/on_feature_branch/clean_workspace/happy_path.feature
+++ b/features/append/on_feature_branch/clean_workspace/happy_path.feature
@@ -19,8 +19,8 @@ Feature: append a new feature branch to an existing feature branch
       |          | git checkout main                        |
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff origin/existing |
-      |          | git merge --no-edit --ff main            |
+      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"
     And the initial commits exist now

--- a/features/append/on_feature_branch/clean_workspace/offline/enabled.feature
+++ b/features/append/on_feature_branch/clean_workspace/offline/enabled.feature
@@ -18,8 +18,8 @@ Feature: append in offline mode
       | existing | git checkout main                        |
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff origin/existing |
-      |          | git merge --no-edit --ff main            |
+      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"
     And the initial commits exist now

--- a/features/append/on_feature_branch/clean_workspace/sync_strategy/compress.feature
+++ b/features/append/on_feature_branch/clean_workspace/sync_strategy/compress.feature
@@ -22,10 +22,10 @@ Feature: append a new feature branch in a clean workspace using the "compress" s
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout existing                    |
       | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff origin/existing |
       |          | git reset --soft main                    |
       |          | git commit -m "existing commit 1"        |
       |          | git push --force-with-lease              |
-      |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"
     And these commits exist now

--- a/features/append/on_feature_branch/clean_workspace/sync_strategy/compress.feature
+++ b/features/append/on_feature_branch/clean_workspace/sync_strategy/compress.feature
@@ -21,11 +21,11 @@ Feature: append a new feature branch in a clean workspace using the "compress" s
       |          | git checkout main                        |
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff origin/existing |
-      |          | git merge --no-edit --ff main            |
+      | existing | git merge --no-edit --ff main            |
       |          | git reset --soft main                    |
       |          | git commit -m "existing commit 1"        |
       |          | git push --force-with-lease              |
+      |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"
     And these commits exist now

--- a/features/append/on_feature_branch/clean_workspace/verbose/enabled.feature
+++ b/features/append/on_feature_branch/clean_workspace/verbose/enabled.feature
@@ -31,8 +31,8 @@ Feature: display all executed Git commands
       | main     | frontend | git rebase origin/main --no-update-refs              |
       |          | backend  | git rev-list --left-right main...origin/main         |
       | main     | frontend | git checkout existing                                |
-      | existing | frontend | git merge --no-edit --ff origin/existing             |
-      |          | frontend | git merge --no-edit --ff main                        |
+      | existing | frontend | git merge --no-edit --ff main                        |
+      |          | frontend | git merge --no-edit --ff origin/existing             |
       |          | backend  | git rev-list --left-right existing...origin/existing |
       |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
       | existing | frontend | git checkout -b new                                  |

--- a/features/append/on_feature_branch/clean_workspace/worktree/previous_branch_in_other_worktree.feature
+++ b/features/append/on_feature_branch/clean_workspace/worktree/previous_branch_in_other_worktree.feature
@@ -17,8 +17,8 @@ Feature: append a branch when the previous branch is active in another worktree
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout current                    |
-      | current | git merge --no-edit --ff origin/current |
-      |         | git merge --no-edit --ff main           |
+      | current | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/current |
       |         | git checkout -b new                     |
     And the current branch is now "new"
     And the previous Git branch is now "current"

--- a/features/prepend/clean_workspace/branch_shipped.feature
+++ b/features/prepend/clean_workspace/branch_shipped.feature
@@ -21,8 +21,8 @@ Feature: prepend a branch to a branch that was shipped at the remote
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout parent                     |
-      | parent | git merge --no-edit --ff origin/parent  |
-      |        | git merge --no-edit --ff main           |
+      | parent | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/parent  |
       |        | git push                                |
       |        | git branch -D child                     |
       |        | git checkout -b new                     |

--- a/features/prepend/clean_workspace/create_prototype_branches/enabled.feature
+++ b/features/prepend/clean_workspace/create_prototype_branches/enabled.feature
@@ -19,8 +19,8 @@ Feature: auto-create prototype branches when prepending
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b parent main             |
     And the current branch is now "parent"
     And branch "parent" is now prototype

--- a/features/prepend/clean_workspace/detached/enabled.feature
+++ b/features/prepend/clean_workspace/detached/enabled.feature
@@ -15,8 +15,8 @@ Feature: prepend a branch to a feature branch in detached mode
     Then it runs the commands
       | BRANCH | COMMAND                             |
       | old    | git fetch --prune --tags            |
-      |        | git merge --no-edit --ff origin/old |
       |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
       |        | git checkout -b parent main         |
     And the current branch is now "parent"
     And these commits exist now

--- a/features/prepend/clean_workspace/dry_run/enabled.feature
+++ b/features/prepend/clean_workspace/dry_run/enabled.feature
@@ -18,8 +18,8 @@ Feature: dry-run prepending a branch to a feature branch
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b parent main             |
     And the current branch is still "old"
     And the initial commits exist now

--- a/features/prepend/clean_workspace/happy_path.feature
+++ b/features/prepend/clean_workspace/happy_path.feature
@@ -19,8 +19,8 @@ Feature: prepend a branch to a feature branch
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b parent main             |
     And the current branch is now "parent"
     And these commits exist now

--- a/features/prepend/clean_workspace/offline/enabled.feature
+++ b/features/prepend/clean_workspace/offline/enabled.feature
@@ -18,8 +18,8 @@ Feature: offline mode
       | old    | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b new main                |
     And the current branch is now "new"
     And these commits exist now

--- a/features/prepend/clean_workspace/prototype/enabled.feature
+++ b/features/prepend/clean_workspace/prototype/enabled.feature
@@ -19,8 +19,8 @@ Feature: prepend a prototype branch to a feature branch
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b parent main             |
     And the current branch is now "parent"
     And branch "parent" is now prototype

--- a/features/prepend/clean_workspace/push_hook/disabled.feature
+++ b/features/prepend/clean_workspace/push_hook/disabled.feature
@@ -20,8 +20,8 @@ Feature: auto-push new branches
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b new main                |
       | new    | git push --no-verify -u origin new      |
     And the current branch is now "new"

--- a/features/prepend/clean_workspace/push_hook/enabled.feature
+++ b/features/prepend/clean_workspace/push_hook/enabled.feature
@@ -20,8 +20,8 @@ Feature: auto-push new branches
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b new main                |
       | new    | git push -u origin new                  |
     And the current branch is now "new"

--- a/features/prepend/clean_workspace/push_new_branches/push_new_branches.feature
+++ b/features/prepend/clean_workspace/push_new_branches/push_new_branches.feature
@@ -19,8 +19,8 @@ Feature: auto-push new branches
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b new main                |
       | new    | git push -u origin new                  |
     And the current branch is now "new"

--- a/features/prepend/clean_workspace/sync_strategy/compress.feature
+++ b/features/prepend/clean_workspace/sync_strategy/compress.feature
@@ -16,6 +16,7 @@ Feature: prepend a branch to a feature branch in a clean workspace using the "co
     And wait 1 second to ensure new Git timestamps
     When I run "git-town prepend branch-1a"
 
+  @this
   Scenario: result
     Then it runs the commands
       | BRANCH   | COMMAND                                  |

--- a/features/prepend/clean_workspace/sync_strategy/compress.feature
+++ b/features/prepend/clean_workspace/sync_strategy/compress.feature
@@ -24,16 +24,16 @@ Feature: prepend a branch to a feature branch in a clean workspace using the "co
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout branch-1                    |
       | branch-1 | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff origin/branch-1 |
       |          | git reset --soft main                    |
       |          | git commit -m "branch-1 commit"          |
       |          | git push --force-with-lease              |
-      |          | git merge --no-edit --ff origin/branch-1 |
       |          | git checkout branch-2                    |
       | branch-2 | git merge --no-edit --ff branch-1        |
+      |          | git merge --no-edit --ff origin/branch-2 |
       |          | git reset --soft branch-1                |
       |          | git commit -m "branch-2 commit"          |
       |          | git push --force-with-lease              |
-      |          | git merge --no-edit --ff origin/branch-2 |
       |          | git checkout -b branch-1a branch-1       |
     And the current branch is now "branch-1a"
     And the initial commits exist now

--- a/features/prepend/clean_workspace/sync_strategy/compress.feature
+++ b/features/prepend/clean_workspace/sync_strategy/compress.feature
@@ -16,7 +16,6 @@ Feature: prepend a branch to a feature branch in a clean workspace using the "co
     And wait 1 second to ensure new Git timestamps
     When I run "git-town prepend branch-1a"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH   | COMMAND                                  |
@@ -24,17 +23,17 @@ Feature: prepend a branch to a feature branch in a clean workspace using the "co
       |          | git checkout main                        |
       | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout branch-1                    |
-      | branch-1 | git merge --no-edit --ff origin/branch-1 |
-      |          | git merge --no-edit --ff main            |
+      | branch-1 | git merge --no-edit --ff main            |
       |          | git reset --soft main                    |
       |          | git commit -m "branch-1 commit"          |
       |          | git push --force-with-lease              |
+      |          | git merge --no-edit --ff origin/branch-1 |
       |          | git checkout branch-2                    |
-      | branch-2 | git merge --no-edit --ff origin/branch-2 |
-      |          | git merge --no-edit --ff branch-1        |
+      | branch-2 | git merge --no-edit --ff branch-1        |
       |          | git reset --soft branch-1                |
       |          | git commit -m "branch-2 commit"          |
       |          | git push --force-with-lease              |
+      |          | git merge --no-edit --ff origin/branch-2 |
       |          | git checkout -b branch-1a branch-1       |
     And the current branch is now "branch-1a"
     And the initial commits exist now

--- a/features/prepend/clean_workspace/sync_tags/enabled.feature
+++ b/features/prepend/clean_workspace/sync_tags/enabled.feature
@@ -20,8 +20,8 @@ Feature: don't sync tags while prepending
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout old                        |
-      | old    | git merge --no-edit --ff origin/old     |
-      |        | git merge --no-edit --ff main           |
+      | old    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/old     |
       |        | git checkout -b new main                |
     And the initial tags exist now
 

--- a/features/prepend/clean_workspace/verbose/enabled.feature
+++ b/features/prepend/clean_workspace/verbose/enabled.feature
@@ -31,8 +31,8 @@ Feature: display all executed Git commands
       | main   | frontend | git rebase origin/main --no-update-refs       |
       |        | backend  | git rev-list --left-right main...origin/main  |
       | main   | frontend | git checkout old                              |
-      | old    | frontend | git merge --no-edit --ff origin/old           |
-      |        | frontend | git merge --no-edit --ff main                 |
+      | old    | frontend | git merge --no-edit --ff main                 |
+      |        | frontend | git merge --no-edit --ff origin/old           |
       |        | backend  | git rev-list --left-right old...origin/old    |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       | old    | frontend | git checkout -b parent main                   |

--- a/features/propose/features/detached/enabled.feature
+++ b/features/propose/features/detached/enabled.feature
@@ -17,8 +17,8 @@ Feature: GitHub support
       | BRANCH  | COMMAND                                                            |
       | feature | git fetch --prune --tags                                           |
       | <none>  | Looking for proposal online ... ok                                 |
-      | feature | git merge --no-edit --ff origin/feature                            |
-      |         | git merge --no-edit --ff main                                      |
+      | feature | git merge --no-edit --ff main                                      |
+      |         | git merge --no-edit --ff origin/feature                            |
       | <none>  | open https://github.com/git-town/git-town/compare/feature?expand=1 |
     And "open" launches a new proposal with this url in my browser:
       """

--- a/features/propose/features/dry_run/enabled.feature
+++ b/features/propose/features/dry_run/enabled.feature
@@ -31,8 +31,8 @@ Feature: dry-run proposing changes
       | feature | git checkout main                                                  |
       | main    | git rebase origin/main --no-update-refs                            |
       |         | git checkout feature                                               |
-      | feature | git merge --no-edit --ff origin/feature                            |
-      |         | git merge --no-edit --ff main                                      |
+      | feature | git merge --no-edit --ff main                                      |
+      |         | git merge --no-edit --ff origin/feature                            |
       | <none>  | open https://github.com/git-town/git-town/compare/feature?expand=1 |
     And the current branch is still "feature"
     And the initial branches and lineage exist now

--- a/features/propose/features/on_outdated_branch.feature
+++ b/features/propose/features/on_outdated_branch.feature
@@ -33,12 +33,12 @@ Feature: sync before proposing
       | main   | git rebase origin/main --no-update-refs                                   |
       |        | git push                                                                  |
       |        | git checkout parent                                                       |
-      | parent | git merge --no-edit --ff origin/parent                                    |
-      |        | git merge --no-edit --ff main                                             |
+      | parent | git merge --no-edit --ff main                                             |
+      |        | git merge --no-edit --ff origin/parent                                    |
       |        | git push                                                                  |
       |        | git checkout child                                                        |
-      | child  | git merge --no-edit --ff origin/child                                     |
-      |        | git merge --no-edit --ff parent                                           |
+      | child  | git merge --no-edit --ff parent                                           |
+      |        | git merge --no-edit --ff origin/child                                     |
       |        | git push                                                                  |
       |        | git stash pop                                                             |
       | <none> | open https://github.com/git-town/git-town/compare/parent...child?expand=1 |
@@ -53,10 +53,10 @@ Feature: sync before proposing
       | main   | local, origin | origin main commit                                       |
       |        |               | local main commit                                        |
       | child  | local, origin | local child commit                                       |
+      |        |               | Merge branch 'parent' into child                         |
       |        |               | origin child commit                                      |
       |        |               | Merge remote-tracking branch 'origin/child' into child   |
-      |        |               | Merge branch 'parent' into child                         |
       | parent | local, origin | local parent commit                                      |
+      |        |               | Merge branch 'main' into parent                          |
       |        |               | origin parent commit                                     |
       |        |               | Merge remote-tracking branch 'origin/parent' into parent |
-      |        |               | Merge branch 'main' into parent                          |

--- a/features/propose/features/sync_strategy/compress.feature
+++ b/features/propose/features/sync_strategy/compress.feature
@@ -25,8 +25,8 @@ Feature: proposing using the "compress" sync strategy
       | existing | git checkout main                                                   |
       | main     | git rebase origin/main --no-update-refs                             |
       |          | git checkout existing                                               |
-      | existing | git merge --no-edit --ff origin/existing                            |
-      |          | git merge --no-edit --ff main                                       |
+      | existing | git merge --no-edit --ff main                                       |
+      |          | git merge --no-edit --ff origin/existing                            |
       |          | git reset --soft main                                               |
       |          | git commit -m "local existing commit 1"                             |
       |          | git push --force-with-lease                                         |

--- a/features/propose/features/sync_tags/enabled.feature
+++ b/features/propose/features/sync_tags/enabled.feature
@@ -24,8 +24,8 @@ Feature: don't sync tags while proposing
       | feature | git checkout main                                                  |
       | main    | git rebase origin/main --no-update-refs                            |
       |         | git checkout feature                                               |
-      | feature | git merge --no-edit --ff origin/feature                            |
-      |         | git merge --no-edit --ff main                                      |
+      | feature | git merge --no-edit --ff main                                      |
+      |         | git merge --no-edit --ff origin/feature                            |
       | <none>  | open https://github.com/git-town/git-town/compare/feature?expand=1 |
     And the initial tags exist now
 

--- a/features/propose/features/verbose/enabled.feature
+++ b/features/propose/features/verbose/enabled.feature
@@ -30,8 +30,8 @@ Feature: display all executed Git commands
       | main    | frontend | git rebase origin/main --no-update-refs                            |
       |         | backend  | git rev-list --left-right main...origin/main                       |
       | main    | frontend | git checkout feature                                               |
-      | feature | frontend | git merge --no-edit --ff origin/feature                            |
-      |         | frontend | git merge --no-edit --ff main                                      |
+      | feature | frontend | git merge --no-edit --ff main                                      |
+      |         | frontend | git merge --no-edit --ff origin/feature                            |
       |         | backend  | git rev-list --left-right feature...origin/feature                 |
       |         | backend  | git rev-parse --abbrev-ref --symbolic-full-name @{u}               |
       |         | backend  | git show-ref --verify --quiet refs/heads/main                      |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -25,12 +25,11 @@ Feature: handle merge conflicts between feature branch and main branch
       |        | git stash                               |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff origin/alpha   |
-      |        | git merge --no-edit --ff main           |
+      | alpha  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/alpha   |
       |        | git push                                |
       |        | git checkout beta                       |
-      | beta   | git merge --no-edit --ff origin/beta    |
-      |        | git merge --no-edit --ff main           |
+      | beta   | git merge --no-edit --ff main           |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -68,8 +67,8 @@ Feature: handle merge conflicts between feature branch and main branch
       | BRANCH | COMMAND                               |
       | beta   | git merge --abort                     |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git push --tags                       |
@@ -125,10 +124,11 @@ Feature: handle merge conflicts between feature branch and main branch
     Then it runs the commands
       | BRANCH | COMMAND                               |
       | beta   | git commit --no-edit                  |
+      |        | git merge --no-edit --ff origin/beta  |
       |        | git push                              |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git push --tags                       |
@@ -152,7 +152,8 @@ Feature: handle merge conflicts between feature branch and main branch
     And I run "git-town continue"
     Then it runs the commands
       | BRANCH | COMMAND                               |
-      | beta   | git push                              |
+      | beta   | git merge --no-edit --ff origin/beta  |
+      |        | git push                              |
       |        | git checkout gamma                    |
       | gamma  | git merge --no-edit --ff main         |
       |        | git merge --no-edit --ff origin/gamma |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -154,8 +154,8 @@ Feature: handle merge conflicts between feature branch and main branch
       | BRANCH | COMMAND                               |
       | beta   | git push                              |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git push --tags                       |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
@@ -24,7 +24,6 @@ Feature: shipped changes conflict with multiple existing feature branches
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
       | alpha  | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/alpha   |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -43,12 +42,12 @@ Feature: shipped changes conflict with multiple existing feature branches
     Then it runs the commands
       | BRANCH | COMMAND                               |
       | alpha  | git commit --no-edit                  |
+      |        | git merge --no-edit --ff origin/alpha |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git branch -D beta                    |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
     And it prints something like:
       """
       deleted branch "beta"
@@ -67,12 +66,13 @@ Feature: shipped changes conflict with multiple existing feature branches
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH | COMMAND              |
-      | gamma  | git commit --no-edit |
-      |        | git push             |
-      |        | git checkout main    |
-      | main   | git push --tags      |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                               |
+      | gamma  | git commit --no-edit                  |
+      |        | git merge --no-edit --ff origin/gamma |
+      |        | git push                              |
+      |        | git checkout main                     |
+      | main   | git push --tags                       |
+      |        | git stash pop                         |
     And the current branch is now "main"
     And the uncommitted file still exists
     And all branches are now synchronized

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
@@ -23,8 +23,8 @@ Feature: shipped changes conflict with multiple existing feature branches
       |        | git stash                               |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff origin/alpha   |
-      |        | git merge --no-edit --ff main           |
+      | alpha  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/alpha   |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -95,7 +95,6 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file | main content       |
       |        | feature3_file    | gamma content      |
 
-  @this
   Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands
@@ -113,6 +112,7 @@ Feature: handle merge conflicts between feature branch and main branch
     Then it runs the commands
       | BRANCH | COMMAND                               |
       | beta   | git commit --no-edit                  |
+      |        | git merge --no-edit --ff origin/beta  |
       |        | git push                              |
       |        | git checkout gamma                    |
       | gamma  | git merge --no-edit --ff main         |
@@ -141,10 +141,11 @@ Feature: handle merge conflicts between feature branch and main branch
     And I run "git-town continue"
     Then it runs the commands
       | BRANCH | COMMAND                               |
-      | beta   | git push                              |
+      | beta   | git merge --no-edit --ff origin/beta  |
+      |        | git push                              |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git push --tags                       |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -26,8 +26,8 @@ Feature: handle merge conflicts between feature branch and main branch
       |        | git stash                               |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff origin/alpha   |
-      |        | git merge --no-edit --ff main           |
+      | alpha  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/alpha   |
       |        | git push                                |
       |        | git checkout beta                       |
       | beta   | git merge --no-edit --ff origin/beta    |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -118,8 +118,8 @@ Feature: handle merge conflicts between feature branch and main branch
       | beta   | git commit --no-edit                  |
       |        | git push                              |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git push --tags                       |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -30,8 +30,7 @@ Feature: handle merge conflicts between feature branch and main branch
       |        | git merge --no-edit --ff origin/alpha   |
       |        | git push                                |
       |        | git checkout beta                       |
-      | beta   | git merge --no-edit --ff origin/beta    |
-      |        | git merge --no-edit --ff main           |
+      | beta   | git merge --no-edit --ff main           |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -54,8 +53,6 @@ Feature: handle merge conflicts between feature branch and main branch
       |        | git checkout alpha                              |
       | alpha  | git reset --hard {{ sha 'alpha commit' }}       |
       |        | git push --force-with-lease --force-if-includes |
-      |        | git checkout beta                               |
-      | beta   | git reset --hard {{ sha 'local beta commit' }}  |
       |        | git checkout main                               |
       | main   | git reset --hard {{ sha 'initial commit' }}     |
       |        | git stash pop                                   |
@@ -68,28 +65,27 @@ Feature: handle merge conflicts between feature branch and main branch
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
-      | BRANCH | COMMAND                                        |
-      | beta   | git merge --abort                              |
-      |        | git reset --hard {{ sha 'local beta commit' }} |
-      |        | git checkout gamma                             |
-      | gamma  | git merge --no-edit --ff origin/gamma          |
-      |        | git merge --no-edit --ff main                  |
-      |        | git push                                       |
-      |        | git checkout main                              |
-      | main   | git push --tags                                |
-      |        | git stash pop                                  |
+      | BRANCH | COMMAND                               |
+      | beta   | git merge --abort                     |
+      |        | git checkout gamma                    |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
+      |        | git push                              |
+      |        | git checkout main                     |
+      | main   | git push --tags                       |
+      |        | git stash pop                         |
     And the current branch is now "main"
     And the uncommitted file still exists
     And no merge is in progress
     And these commits exist now
-      | BRANCH | LOCATION      | MESSAGE                        |
-      | main   | local, origin | main commit                    |
-      | alpha  | local, origin | alpha commit                   |
-      |        |               | Merge branch 'main' into alpha |
-      | beta   | local         | local beta commit              |
-      |        | origin        | origin beta commit             |
-      | gamma  | local, origin | gamma commit                   |
-      |        |               | Merge branch 'main' into gamma |
+      | BRANCH | LOCATION      | MESSAGE                                                |
+      | main   | local, origin | main commit                                            |
+      | alpha  | local, origin | alpha commit                                           |
+      |        |               | Merge branch 'main' into alpha                         |
+      | beta   | local         | local beta commit                                      |
+      |        | origin        | origin beta commit                                     |
+      | gamma  | local, origin | gamma commit                                           |
+      |        |               | Merge remote-tracking branch 'origin/gamma' into gamma |
     And these committed files exist now
       | BRANCH | NAME             | CONTENT            |
       | main   | conflicting_file | main content       |
@@ -99,6 +95,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | gamma  | conflicting_file | main content       |
       |        | feature3_file    | gamma content      |
 
+  @this
   Scenario: continue with unresolved conflict
     When I run "git-town continue"
     Then it runs no commands

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_tracking_branch_conflict.feature
@@ -30,7 +30,8 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       |        | git merge --no-edit --ff origin/alpha   |
       |        | git push                                |
       |        | git checkout beta                       |
-      | beta   | git merge --no-edit --ff origin/beta    |
+      | beta   | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/beta    |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -53,6 +54,8 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       |        | git checkout alpha                              |
       | alpha  | git reset --hard {{ sha 'alpha commit' }}       |
       |        | git push --force-with-lease --force-if-includes |
+      |        | git checkout beta                               |
+      | beta   | git reset --hard {{ sha 'local beta commit' }}  |
       |        | git checkout main                               |
       | main   | git reset --hard {{ sha 'initial commit' }}     |
       |        | git stash pop                                   |
@@ -64,15 +67,16 @@ Feature: handle merge conflicts between feature branches and their tracking bran
   Scenario: skip
     When I run "git-town skip"
     Then it runs the commands
-      | BRANCH | COMMAND                               |
-      | beta   | git merge --abort                     |
-      |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
-      |        | git push                              |
-      |        | git checkout main                     |
-      | main   | git push --tags                       |
-      |        | git stash pop                         |
+      | BRANCH | COMMAND                                        |
+      | beta   | git merge --abort                              |
+      |        | git reset --hard {{ sha 'local beta commit' }} |
+      |        | git checkout gamma                             |
+      | gamma  | git merge --no-edit --ff main                  |
+      |        | git merge --no-edit --ff origin/gamma          |
+      |        | git push                                       |
+      |        | git checkout main                              |
+      | main   | git push --tags                                |
+      |        | git stash pop                                  |
     And the current branch is now "main"
     And the uncommitted file still exists
     And these commits exist now
@@ -110,11 +114,10 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     Then it runs the commands
       | BRANCH | COMMAND                               |
       | beta   | git commit --no-edit                  |
-      |        | git merge --no-edit --ff main         |
       |        | git push                              |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git push --tags                       |
@@ -139,11 +142,10 @@ Feature: handle merge conflicts between feature branches and their tracking bran
     And I run "git-town continue"
     Then it runs the commands
       | BRANCH | COMMAND                               |
-      | beta   | git merge --no-edit --ff main         |
-      |        | git push                              |
+      | beta   | git push                              |
       |        | git checkout gamma                    |
-      | gamma  | git merge --no-edit --ff origin/gamma |
-      |        | git merge --no-edit --ff main         |
+      | gamma  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/gamma |
       |        | git push                              |
       |        | git checkout main                     |
       | main   | git push --tags                       |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_tracking_branch_conflict.feature
@@ -26,8 +26,8 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       |        | git stash                               |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff origin/alpha   |
-      |        | git merge --no-edit --ff main           |
+      | alpha  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/alpha   |
       |        | git push                                |
       |        | git checkout beta                       |
       | beta   | git merge --no-edit --ff origin/beta    |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -61,8 +61,8 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       | main    | git rebase --continue                   |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
       |         | git checkout main                       |
       | main    | git push --tags                         |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -85,8 +85,8 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       | BRANCH  | COMMAND                                 |
       | main    | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
       |         | git checkout main                       |
       | main    | git push --tags                         |

--- a/features/sync/all_branches/merge_sync_strategy/detached.feature
+++ b/features/sync/all_branches/merge_sync_strategy/detached.feature
@@ -33,11 +33,11 @@ Feature: sync all feature branches
     Then it runs the commands
       | BRANCH       | COMMAND                                         |
       | alpha        | git fetch --prune --tags                        |
+      |              | git merge --no-edit --ff main                   |
       |              | git merge --no-edit --ff origin/alpha           |
-      |              | git merge --no-edit --ff main                   |
       |              | git checkout beta                               |
-      | beta         | git merge --no-edit --ff origin/beta            |
-      |              | git merge --no-edit --ff main                   |
+      | beta         | git merge --no-edit --ff main                   |
+      |              | git merge --no-edit --ff origin/beta            |
       |              | git checkout contribution                       |
       | contribution | git rebase origin/contribution --no-update-refs |
       |              | git push                                        |

--- a/features/sync/all_branches/merge_sync_strategy/happy_path.feature
+++ b/features/sync/all_branches/merge_sync_strategy/happy_path.feature
@@ -76,12 +76,10 @@ Feature: sync all feature branches
       |            | git checkout main                               |
       | main       | git rebase origin/main --no-update-refs         |
       |            | git checkout alpha                              |
-      | alpha      | git push --force-with-lease --force-if-includes |
-      |            | git rebase main --no-update-refs                |
+      | alpha      | git rebase main --no-update-refs                |
       |            | git push --force-with-lease --force-if-includes |
       |            | git checkout beta                               |
-      | beta       | git push --force-with-lease --force-if-includes |
-      |            | git rebase main --no-update-refs                |
+      | beta       | git rebase main --no-update-refs                |
       |            | git push --force-with-lease --force-if-includes |
       |            | git checkout observed                           |
       | observed   | git rebase origin/observed --no-update-refs     |

--- a/features/sync/all_branches/merge_sync_strategy/happy_path.feature
+++ b/features/sync/all_branches/merge_sync_strategy/happy_path.feature
@@ -33,12 +33,12 @@ Feature: sync all feature branches
       |            | git checkout main                             |
       | main       | git rebase origin/main --no-update-refs       |
       |            | git checkout alpha                            |
-      | alpha      | git merge --no-edit --ff origin/alpha         |
-      |            | git merge --no-edit --ff main                 |
+      | alpha      | git merge --no-edit --ff main                 |
+      |            | git merge --no-edit --ff origin/alpha         |
       |            | git push                                      |
       |            | git checkout beta                             |
-      | beta       | git merge --no-edit --ff origin/beta          |
-      |            | git merge --no-edit --ff main                 |
+      | beta       | git merge --no-edit --ff main                 |
+      |            | git merge --no-edit --ff origin/beta          |
       |            | git push                                      |
       |            | git checkout observed                         |
       | observed   | git rebase origin/observed --no-update-refs   |

--- a/features/sync/all_branches/merge_sync_strategy/happy_path.feature
+++ b/features/sync/all_branches/merge_sync_strategy/happy_path.feature
@@ -76,10 +76,12 @@ Feature: sync all feature branches
       |            | git checkout main                               |
       | main       | git rebase origin/main --no-update-refs         |
       |            | git checkout alpha                              |
-      | alpha      | git rebase main --no-update-refs                |
+      | alpha      | git push --force-with-lease --force-if-includes |
+      |            | git rebase main --no-update-refs                |
       |            | git push --force-with-lease --force-if-includes |
       |            | git checkout beta                               |
-      | beta       | git rebase main --no-update-refs                |
+      | beta       | git push --force-with-lease --force-if-includes |
+      |            | git rebase main --no-update-refs                |
       |            | git push --force-with-lease --force-if-includes |
       |            | git checkout observed                           |
       | observed   | git rebase origin/observed --no-update-refs     |

--- a/features/sync/all_branches/merge_sync_strategy/multiple_shipped_branches.feature
+++ b/features/sync/all_branches/merge_sync_strategy/multiple_shipped_branches.feature
@@ -26,8 +26,8 @@ Feature: multiple shipped branches
       |           | git branch -D feature-1                   |
       |           | git branch -D feature-2                   |
       |           | git checkout feature-3                    |
-      | feature-3 | git merge --no-edit --ff origin/feature-3 |
-      |           | git merge --no-edit --ff main             |
+      | feature-3 | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff origin/feature-3 |
       |           | git push                                  |
       |           | git push --tags                           |
     And it prints:

--- a/features/sync/all_branches/merge_sync_strategy/remote_only_branches.feature
+++ b/features/sync/all_branches/merge_sync_strategy/remote_only_branches.feature
@@ -20,8 +20,8 @@ Feature: does not sync branches that exist only on remotes
       | main   | git fetch --prune --tags                |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout mine                       |
-      | mine   | git merge --no-edit --ff origin/mine    |
-      |        | git merge --no-edit --ff main           |
+      | mine   | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/mine    |
       |        | git push                                |
       |        | git checkout main                       |
       | main   | git push --tags                         |

--- a/features/sync/all_branches/merge_sync_strategy/stack/already_synced.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/already_synced.feature
@@ -42,17 +42,17 @@ Feature: sync a stack making independent changes
       |        | git stash                               |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff origin/alpha   |
-      |        | git merge --no-edit --ff main           |
+      | alpha  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/alpha   |
       |        | git checkout beta                       |
-      | beta   | git merge --no-edit --ff origin/beta    |
-      |        | git merge --no-edit --ff alpha          |
+      | beta   | git merge --no-edit --ff alpha          |
+      |        | git merge --no-edit --ff origin/beta    |
       |        | git checkout gamma                      |
-      | gamma  | git merge --no-edit --ff origin/gamma   |
-      |        | git merge --no-edit --ff beta           |
+      | gamma  | git merge --no-edit --ff beta           |
+      |        | git merge --no-edit --ff origin/gamma   |
       |        | git checkout delta                      |
-      | delta  | git merge --no-edit --ff origin/delta   |
-      |        | git merge --no-edit --ff gamma          |
+      | delta  | git merge --no-edit --ff gamma          |
+      |        | git merge --no-edit --ff origin/delta   |
       |        | git checkout main                       |
       | main   | git push --tags                         |
       |        | git stash pop                           |

--- a/features/sync/all_branches/merge_sync_strategy/stack/conflicting_changes.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/conflicting_changes.feature
@@ -22,8 +22,7 @@ Feature: sync a stack that makes conflicting changes
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff origin/alpha   |
-      |        | git merge --no-edit --ff main           |
+      | alpha  | git merge --no-edit --ff main           |
     And the current branch is now "alpha"
     And it prints the error:
       """
@@ -32,12 +31,12 @@ Feature: sync a stack that makes conflicting changes
     When I resolve the conflict in "file" with "resolved alpha content"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH | COMMAND                              |
-      | alpha  | git commit --no-edit                 |
-      |        | git push                             |
-      |        | git checkout beta                    |
-      | beta   | git merge --no-edit --ff origin/beta |
-      |        | git merge --no-edit --ff alpha       |
+      | BRANCH | COMMAND                               |
+      | alpha  | git commit --no-edit                  |
+      |        | git merge --no-edit --ff origin/alpha |
+      |        | git push                              |
+      |        | git checkout beta                     |
+      | beta   | git merge --no-edit --ff alpha        |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in file
@@ -47,12 +46,13 @@ Feature: sync a stack that makes conflicting changes
     When I resolve the conflict in "file" with "resolved beta content"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH | COMMAND              |
-      | beta   | git commit --no-edit |
-      |        | git push             |
-      |        | git checkout alpha   |
-      | alpha  | git push --tags      |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                              |
+      | beta   | git commit --no-edit                 |
+      |        | git merge --no-edit --ff origin/beta |
+      |        | git push                             |
+      |        | git checkout alpha                   |
+      | alpha  | git push --tags                      |
+      |        | git stash pop                        |
     And the current branch is now "alpha"
     And no merge is in progress
     And these commits exist now

--- a/features/sync/all_branches/merge_sync_strategy/stack/two_stacks.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/two_stacks.feature
@@ -62,29 +62,29 @@ Feature: sync a workspace with two independent stacks
       |        | git stash                               |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout first                      |
-      | first  | git merge --no-edit --ff origin/first   |
-      |        | git merge --no-edit --ff main           |
+      | first  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/first   |
       |        | git checkout second                     |
-      | second | git merge --no-edit --ff origin/second  |
-      |        | git merge --no-edit --ff first          |
+      | second | git merge --no-edit --ff first          |
+      |        | git merge --no-edit --ff origin/second  |
       |        | git checkout third                      |
-      | third  | git merge --no-edit --ff origin/third   |
-      |        | git merge --no-edit --ff second         |
+      | third  | git merge --no-edit --ff second         |
+      |        | git merge --no-edit --ff origin/third   |
       |        | git checkout fourth                     |
-      | fourth | git merge --no-edit --ff origin/fourth  |
-      |        | git merge --no-edit --ff third          |
+      | fourth | git merge --no-edit --ff third          |
+      |        | git merge --no-edit --ff origin/fourth  |
       |        | git checkout one                        |
-      | one    | git merge --no-edit --ff origin/one     |
-      |        | git merge --no-edit --ff main           |
+      | one    | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/one     |
       |        | git checkout two                        |
-      | two    | git merge --no-edit --ff origin/two     |
-      |        | git merge --no-edit --ff one            |
+      | two    | git merge --no-edit --ff one            |
+      |        | git merge --no-edit --ff origin/two     |
       |        | git checkout three                      |
-      | three  | git merge --no-edit --ff origin/three   |
-      |        | git merge --no-edit --ff two            |
+      | three  | git merge --no-edit --ff two            |
+      |        | git merge --no-edit --ff origin/three   |
       |        | git checkout four                       |
-      | four   | git merge --no-edit --ff origin/four    |
-      |        | git merge --no-edit --ff three          |
+      | four   | git merge --no-edit --ff three          |
+      |        | git merge --no-edit --ff origin/four    |
       |        | git checkout main                       |
       | main   | git push --tags                         |
       |        | git stash pop                           |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/detached/enabled.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/detached/enabled.feature
@@ -24,14 +24,14 @@ Feature: detached sync a grandchild feature branch using the "compress" strategy
       | BRANCH | COMMAND                               |
       | beta   | git fetch --prune --tags              |
       |        | git checkout alpha                    |
-      | alpha  | git merge --no-edit --ff origin/alpha |
-      |        | git merge --no-edit --ff main         |
+      | alpha  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/alpha |
       |        | git reset --soft main                 |
       |        | git commit -m "local alpha commit"    |
       |        | git push --force-with-lease           |
       |        | git checkout beta                     |
-      | beta   | git merge --no-edit --ff origin/beta  |
-      |        | git merge --no-edit --ff alpha        |
+      | beta   | git merge --no-edit --ff alpha        |
+      |        | git merge --no-edit --ff origin/beta  |
       |        | git reset --soft alpha                |
       |        | git commit -m "local beta commit"     |
       |        | git push --force-with-lease           |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/happy_path.feature
@@ -32,8 +32,8 @@ Feature: one person making a series of commits and syncs in between
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -54,8 +54,8 @@ Feature: one person making a series of commits and syncs in between
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -76,8 +76,8 @@ Feature: one person making a series of commits and syncs in between
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/offline/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/offline/happy_path.feature
@@ -24,8 +24,8 @@ Feature: sync the current feature branch using the "compress" strategy in offlin
       | feature | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "local feature commit 1"  |
     And the current branch is still "feature"

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
@@ -24,7 +24,8 @@ Feature: handle conflicts between the current feature branch and its tracking br
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -66,7 +67,6 @@ Feature: handle conflicts between the current feature branch and its tracking br
     Then it runs the commands
       | BRANCH  | COMMAND                                  |
       | feature | git commit --no-edit                     |
-      |         | git merge --no-edit --ff main            |
       |         | git reset --soft main                    |
       |         | git commit -m "conflicting local commit" |
       |         | git push --force-with-lease              |
@@ -85,8 +85,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And I run "git-town continue"
     Then it runs the commands
       | BRANCH  | COMMAND                                  |
-      | feature | git merge --no-edit --ff main            |
-      |         | git reset --soft main                    |
+      | feature | git reset --soft main                    |
       |         | git commit -m "conflicting local commit" |
       |         | git push --force-with-lease              |
       |         | git stash pop                            |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
@@ -26,8 +26,7 @@ Feature: while syncing using the "compress" strategy, handle conflicts between t
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -45,10 +44,9 @@ Feature: while syncing using the "compress" strategy, handle conflicts between t
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                                                 |
-      | feature | git merge --abort                                       |
-      |         | git reset --hard {{ sha 'conflicting feature commit' }} |
-      |         | git stash pop                                           |
+      | BRANCH  | COMMAND           |
+      | feature | git merge --abort |
+      |         | git stash pop     |
     And the current branch is still "feature"
     And the uncommitted file still exists
     And no rebase is in progress
@@ -75,6 +73,7 @@ Feature: while syncing using the "compress" strategy, handle conflicts between t
     Then it runs the commands
       | BRANCH  | COMMAND                                    |
       | feature | git commit --no-edit                       |
+      |         | git merge --no-edit --ff origin/feature    |
       |         | git reset --soft main                      |
       |         | git commit -m "conflicting feature commit" |
       |         | git push --force-with-lease                |
@@ -95,7 +94,8 @@ Feature: while syncing using the "compress" strategy, handle conflicts between t
     And I run "git-town continue"
     Then it runs the commands
       | BRANCH  | COMMAND                                    |
-      | feature | git reset --soft main                      |
+      | feature | git merge --no-edit --ff origin/feature    |
+      |         | git reset --soft main                      |
       |         | git commit -m "conflicting feature commit" |
       |         | git push --force-with-lease                |
       |         | git stash pop                              |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/happy_path.feature
@@ -23,8 +23,8 @@ Feature: sync the current omni feature branch using the "compress" sync-feature 
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "local feature commit"    |
       |         | git push --force-with-lease             |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -15,6 +15,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And an uncommitted file
     When I run "git-town sync"
 
+  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                                 |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -15,7 +15,6 @@ Feature: handle conflicts between the current feature branch and the main branch
     And an uncommitted file
     When I run "git-town sync"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                                 |
@@ -26,8 +25,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -73,6 +71,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     Then it runs the commands
       | BRANCH  | COMMAND                                    |
       | feature | git commit --no-edit                       |
+      |         | git merge --no-edit --ff origin/feature    |
       |         | git reset --soft main                      |
       |         | git commit -m "conflicting feature commit" |
       |         | git push --force-with-lease                |
@@ -92,6 +91,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     Then it runs the commands
       | BRANCH  | COMMAND                                    |
       | feature | git commit --no-edit                       |
+      |         | git merge --no-edit --ff origin/feature    |
       |         | git reset --soft main                      |
       |         | git commit -m "conflicting feature commit" |
       |         | git push --force-with-lease                |
@@ -111,7 +111,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     And I run "git-town continue"
     Then it runs the commands
       | BRANCH  | COMMAND                                    |
-      | feature | git reset --soft main                      |
+      | feature | git merge --no-edit --ff origin/feature    |
+      |         | git reset --soft main                      |
       |         | git commit -m "conflicting feature commit" |
       |         | git push --force-with-lease                |
       |         | git stash pop                              |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/happy_path.feature
@@ -24,16 +24,16 @@ Feature: sync the current feature branch without a tracking branch using the "co
       |         | git push                                |
       |         | git checkout feature                    |
       | feature | git merge --no-edit --ff main           |
-      |         | git reset --soft main                   |
-      |         | git commit -m "local feature commit 1"  |
       |         | git push -u origin feature              |
     And all branches are now synchronized
     And the current branch is still "feature"
     And these commits exist now
-      | BRANCH  | LOCATION      | MESSAGE                |
-      | main    | local, origin | origin main commit     |
-      |         |               | local main commit      |
-      | feature | local, origin | local feature commit 1 |
+      | BRANCH  | LOCATION      | MESSAGE                          |
+      | main    | local, origin | origin main commit               |
+      |         |               | local main commit                |
+      | feature | local, origin | local feature commit 1           |
+      |         |               | local feature commit 2           |
+      |         |               | Merge branch 'main' into feature |
     And the branches are now
       | REPOSITORY    | BRANCHES      |
       | local, origin | main, feature |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_parallel.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_parallel.feature
@@ -39,8 +39,8 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "my first commit"         |
       |         | git push --force-with-lease             |
@@ -61,7 +61,8 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -71,7 +72,6 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
     Then it runs the commands
       | BRANCH  | COMMAND                               |
       | feature | git commit --no-edit                  |
-      |         | git merge --no-edit --ff main         |
       |         | git reset --soft main                 |
       |         | git commit -m "coworker first commit" |
       |         | git push --force-with-lease           |
@@ -93,7 +93,8 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -103,7 +104,6 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
     Then it runs the commands
       | BRANCH  | COMMAND                         |
       | feature | git commit --no-edit            |
-      |         | git merge --no-edit --ff main   |
       |         | git reset --soft main           |
       |         | git commit -m "my first commit" |
       |         | git push --force-with-lease     |
@@ -125,7 +125,8 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -135,7 +136,6 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
     Then it runs the commands
       | BRANCH  | COMMAND                               |
       | feature | git commit --no-edit                  |
-      |         | git merge --no-edit --ff main         |
       |         | git reset --soft main                 |
       |         | git commit -m "coworker first commit" |
       |         | git push --force-with-lease           |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_serial.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_serial.feature
@@ -38,8 +38,8 @@ Feature: two people make alternating conflicting changes to the same branch usin
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -57,8 +57,8 @@ Feature: two people make alternating conflicting changes to the same branch usin
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And these commits exist now
       | BRANCH  | LOCATION                | MESSAGE     | FILE NAME        | FILE CONTENT |
       | feature | local, coworker, origin | the feature | conflicting_file | my content 1 |
@@ -74,8 +74,8 @@ Feature: two people make alternating conflicting changes to the same branch usin
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -94,7 +94,8 @@ Feature: two people make alternating conflicting changes to the same branch usin
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -102,12 +103,11 @@ Feature: two people make alternating conflicting changes to the same branch usin
     When I resolve the conflict in "conflicting_file" with "my content 1 and coworker content 1"
     And I run "git town continue" and close the editor
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git commit --no-edit          |
-      |         | git merge --no-edit --ff main |
-      |         | git reset --soft main         |
-      |         | git commit -m "the feature"   |
-      |         | git push --force-with-lease   |
+      | BRANCH  | COMMAND                     |
+      | feature | git commit --no-edit        |
+      |         | git reset --soft main       |
+      |         | git commit -m "the feature" |
+      |         | git push --force-with-lease |
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE     | FILE NAME        | FILE CONTENT                        |
       | feature | local, origin | the feature | conflicting_file | my content 1 and coworker content 1 |
@@ -124,8 +124,8 @@ Feature: two people make alternating conflicting changes to the same branch usin
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -144,7 +144,8 @@ Feature: two people make alternating conflicting changes to the same branch usin
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -152,12 +153,11 @@ Feature: two people make alternating conflicting changes to the same branch usin
     When the coworker resolves the conflict in "conflicting_file" with "my content 2 and coworker content 1"
     And the coworker runs "git town continue" and closes the editor
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git commit --no-edit          |
-      |         | git merge --no-edit --ff main |
-      |         | git reset --soft main         |
-      |         | git commit -m "the feature"   |
-      |         | git push --force-with-lease   |
+      | BRANCH  | COMMAND                     |
+      | feature | git commit --no-edit        |
+      |         | git reset --soft main       |
+      |         | git commit -m "the feature" |
+      |         | git push --force-with-lease |
     And these commits exist now
       | BRANCH  | LOCATION         | MESSAGE     |
       | feature | local            | the feature |
@@ -174,8 +174,8 @@ Feature: two people make alternating conflicting changes to the same branch usin
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/nonconflicting_changes_serial.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/nonconflicting_changes_serial.feature
@@ -38,8 +38,8 @@ Feature: two people make alternating non-conflicting changes to the same branch 
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -57,8 +57,8 @@ Feature: two people make alternating non-conflicting changes to the same branch 
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And these commits exist now
       | BRANCH  | LOCATION                | MESSAGE     | FILE NAME | FILE CONTENT                         |
       | feature | local, coworker, origin | the feature | file      | my content 1 \n\n coworker content 0 |
@@ -74,8 +74,8 @@ Feature: two people make alternating non-conflicting changes to the same branch 
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -94,7 +94,8 @@ Feature: two people make alternating non-conflicting changes to the same branch 
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in file
@@ -102,12 +103,11 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     When I resolve the conflict in "file" with "my content 1 \n\n coworker content 1"
     And I run "git town continue" and close the editor
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git commit --no-edit          |
-      |         | git merge --no-edit --ff main |
-      |         | git reset --soft main         |
-      |         | git commit -m "the feature"   |
-      |         | git push --force-with-lease   |
+      | BRANCH  | COMMAND                     |
+      | feature | git commit --no-edit        |
+      |         | git reset --soft main       |
+      |         | git commit -m "the feature" |
+      |         | git push --force-with-lease |
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE     | FILE NAME | FILE CONTENT                         |
       | feature | local, origin | the feature | file      | my content 1 \n\n coworker content 1 |
@@ -124,8 +124,8 @@ Feature: two people make alternating non-conflicting changes to the same branch 
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |
@@ -144,7 +144,8 @@ Feature: two people make alternating non-conflicting changes to the same branch 
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in file
@@ -152,12 +153,11 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     When the coworker resolves the conflict in "file" with "my content 2 \n\n coworker content 1"
     And the coworker runs "git town continue" and closes the editor
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git commit --no-edit          |
-      |         | git merge --no-edit --ff main |
-      |         | git reset --soft main         |
-      |         | git commit -m "the feature"   |
-      |         | git push --force-with-lease   |
+      | BRANCH  | COMMAND                     |
+      | feature | git commit --no-edit        |
+      |         | git reset --soft main       |
+      |         | git commit -m "the feature" |
+      |         | git push --force-with-lease |
     And these commits exist now
       | BRANCH  | LOCATION         | MESSAGE     |
       | feature | local            | the feature |
@@ -174,8 +174,8 @@ Feature: two people make alternating non-conflicting changes to the same branch 
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
       |         | git push --force-with-lease             |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/upstream/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/upstream/happy_path.feature
@@ -25,8 +25,8 @@ Feature: "compress" sync with upstream repo
       |         | git rebase upstream/main --no-update-refs |
       |         | git push                                  |
       |         | git checkout feature                      |
-      | feature | git merge --no-edit --ff origin/feature   |
-      |         | git merge --no-edit --ff main             |
+      | feature | git merge --no-edit --ff main             |
+      |         | git merge --no-edit --ff origin/feature   |
       |         | git reset --soft main                     |
       |         | git commit -m "local commit"              |
       |         | git push --force-with-lease               |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -23,8 +23,6 @@ Feature: sync while the previous branch is checked out in another worktree
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout current                    |
       | current | git merge --no-edit --ff main           |
-      |         | git reset --soft main                   |
-      |         | git commit -m "current 1"               |
       |         | git push -u origin current              |
     And the current branch is still "current"
     And the previous Git branch is now "main"
@@ -32,9 +30,8 @@ Feature: sync while the previous branch is checked out in another worktree
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                                |
-      | current | git reset --hard {{ sha 'current 2' }} |
-      |         | git push origin :current               |
+      | BRANCH  | COMMAND                  |
+      | current | git push origin :current |
     And the current branch is now "current"
     And the previous Git branch is now "main"
     And the initial commits exist now

--- a/features/sync/current_branch/feature_branch/create_branch_in_between.feature
+++ b/features/sync/current_branch/feature_branch/create_branch_in_between.feature
@@ -17,7 +17,8 @@ Feature: do not undo branches that were created while resolving conflicts
       |           | git checkout main                         |
       | main      | git rebase origin/main --no-update-refs   |
       |           | git checkout feature-1                    |
-      | feature-1 | git merge --no-edit --ff origin/feature-1 |
+      | feature-1 | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff origin/feature-1 |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -34,9 +35,8 @@ Feature: do not undo branches that were created while resolving conflicts
 
   Scenario: result
     Then it runs the commands
-      | BRANCH    | COMMAND                       |
-      | feature-1 | git merge --no-edit --ff main |
-      |           | git push                      |
+      | BRANCH    | COMMAND  |
+      | feature-1 | git push |
     And no merge is in progress
     And all branches are now synchronized
 

--- a/features/sync/current_branch/feature_branch/fetch_in_between.feature
+++ b/features/sync/current_branch/feature_branch/fetch_in_between.feature
@@ -20,7 +20,8 @@ Feature: do not undo branches that were pulled in through "git fetch" while reso
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -39,10 +40,9 @@ Feature: do not undo branches that were pulled in through "git fetch" while reso
 
   Scenario: result
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git commit --no-edit          |
-      |         | git merge --no-edit --ff main |
-      |         | git push                      |
+      | BRANCH  | COMMAND              |
+      | feature | git commit --no-edit |
+      |         | git push             |
     And no merge is in progress
     And all branches are now synchronized
 

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/default_branch_type/feature_regex_match.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/default_branch_type/feature_regex_match.feature
@@ -25,8 +25,8 @@ Feature: a default branch type is set, the feature-regex matches
       | main      | git rebase origin/main --no-update-refs   |
       |           | git push                                  |
       |           | git checkout my-branch                    |
-      | my-branch | git merge --no-edit --ff origin/my-branch |
-      |           | git merge --no-edit --ff main             |
+      | my-branch | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff origin/my-branch |
       |           | git push                                  |
     And all branches are now synchronized
     And the current branch is still "my-branch"
@@ -35,9 +35,9 @@ Feature: a default branch type is set, the feature-regex matches
       | main      | local, origin | origin main commit                                             |
       |           |               | local main commit                                              |
       | my-branch | local, origin | local my-branch commit                                         |
+      |           |               | Merge branch 'main' into my-branch                             |
       |           |               | origin my-branch commit                                        |
       |           |               | Merge remote-tracking branch 'origin/my-branch' into my-branch |
-      |           |               | Merge branch 'main' into my-branch                             |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/detached/enabled.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/detached/enabled.feature
@@ -23,12 +23,12 @@ Feature: sync the current feature branch with a tracking branch using the "merge
       | BRANCH | COMMAND                               |
       | beta   | git fetch --prune --tags              |
       |        | git checkout alpha                    |
-      | alpha  | git merge --no-edit --ff origin/alpha |
-      |        | git merge --no-edit --ff main         |
+      | alpha  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/alpha |
       |        | git push                              |
       |        | git checkout beta                     |
-      | beta   | git merge --no-edit --ff origin/beta  |
-      |        | git merge --no-edit --ff alpha        |
+      | beta   | git merge --no-edit --ff alpha        |
+      |        | git merge --no-edit --ff origin/beta  |
       |        | git push                              |
     And the current branch is still "beta"
     And these commits exist now
@@ -36,14 +36,14 @@ Feature: sync the current feature branch with a tracking branch using the "merge
       | main   | local         | local main commit                                      |
       |        | origin        | origin main commit                                     |
       | alpha  | local, origin | local alpha commit                                     |
+      |        |               | Merge branch 'main' into alpha                         |
       |        |               | origin alpha commit                                    |
       |        |               | Merge remote-tracking branch 'origin/alpha' into alpha |
-      |        |               | Merge branch 'main' into alpha                         |
       |        | origin        | local main commit                                      |
       | beta   | local, origin | local beta commit                                      |
+      |        |               | Merge branch 'alpha' into beta                         |
       |        |               | origin beta commit                                     |
       |        |               | Merge remote-tracking branch 'origin/beta' into beta   |
-      |        |               | Merge branch 'alpha' into beta                         |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/no_push/detached.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/no_push/detached.feature
@@ -23,24 +23,24 @@ Feature: detached syncing a stacked feature branch using --no-push
       | BRANCH | COMMAND                               |
       | beta   | git fetch --prune --tags              |
       |        | git checkout alpha                    |
-      | alpha  | git merge --no-edit --ff origin/alpha |
-      |        | git merge --no-edit --ff main         |
+      | alpha  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/alpha |
       |        | git checkout beta                     |
-      | beta   | git merge --no-edit --ff origin/beta  |
-      |        | git merge --no-edit --ff alpha        |
+      | beta   | git merge --no-edit --ff alpha        |
+      |        | git merge --no-edit --ff origin/beta  |
     And the current branch is still "beta"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE                                                |
       | main   | local         | local main commit                                      |
       |        | origin        | origin main commit                                     |
       | alpha  | local         | local alpha commit                                     |
+      |        |               | Merge branch 'main' into alpha                         |
       |        | local, origin | origin alpha commit                                    |
       |        | local         | Merge remote-tracking branch 'origin/alpha' into alpha |
-      |        |               | Merge branch 'main' into alpha                         |
       | beta   | local         | local beta commit                                      |
+      |        |               | Merge branch 'alpha' into beta                         |
       |        | local, origin | origin beta commit                                     |
       |        | local         | Merge remote-tracking branch 'origin/beta' into beta   |
-      |        |               | Merge branch 'alpha' into beta                         |
     And the initial branches and lineage exist now
 
   Scenario: undo

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/no_push/stacked_feature_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/no_push/stacked_feature_branch.feature
@@ -25,24 +25,24 @@ Feature: syncing a stacked feature branch using --no-push
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout parent                     |
-      | parent | git merge --no-edit --ff origin/parent  |
-      |        | git merge --no-edit --ff main           |
+      | parent | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/parent  |
       |        | git checkout child                      |
-      | child  | git merge --no-edit --ff origin/child   |
-      |        | git merge --no-edit --ff parent         |
+      | child  | git merge --no-edit --ff parent         |
+      |        | git merge --no-edit --ff origin/child   |
     And the current branch is still "child"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE                                                  |
       | main   | local, origin | origin main commit                                       |
       |        | local         | local main commit                                        |
       | child  | local         | local child commit                                       |
+      |        |               | Merge branch 'parent' into child                         |
       |        | local, origin | origin child commit                                      |
       |        | local         | Merge remote-tracking branch 'origin/child' into child   |
-      |        |               | Merge branch 'parent' into child                         |
       | parent | local         | local parent commit                                      |
+      |        |               | Merge branch 'main' into parent                          |
       |        | local, origin | origin parent commit                                     |
       |        | local         | Merge remote-tracking branch 'origin/parent' into parent |
-      |        |               | Merge branch 'main' into parent                          |
     And the initial branches and lineage exist now
 
   Scenario: undo

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/no_push/top_level_feature_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/no_push/top_level_feature_branch.feature
@@ -21,17 +21,17 @@ Feature: syncing a top-level feature branch using --no-push
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And the current branch is still "feature"
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE                                                    |
       | main    | local, origin | origin main commit                                         |
       |         | local         | local main commit                                          |
       | feature | local         | local feature commit                                       |
+      |         |               | Merge branch 'main' into feature                           |
       |         | local, origin | origin feature commit                                      |
       |         | local         | Merge remote-tracking branch 'origin/feature' into feature |
-      |         |               | Merge branch 'main' into feature                           |
     And the initial branches and lineage exist now
 
   Scenario: undo

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/happy_path.feature
@@ -21,8 +21,8 @@ Feature: offline mode
       | feature | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And the current branch is still "feature"
     And these commits exist now
       | BRANCH  | LOCATION | MESSAGE                          |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/tracking_branch_deleted.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/tracking_branch_deleted.feature
@@ -26,8 +26,8 @@ Feature: sync a branch whose tracking branch was shipped in offline mode
       |           | git checkout main                         |
       | main      | git rebase origin/main --no-update-refs   |
       |           | git checkout feature-1                    |
-      | feature-1 | git merge --no-edit --ff origin/feature-1 |
-      |           | git merge --no-edit --ff main             |
+      | feature-1 | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff origin/feature-1 |
       |           | git stash pop                             |
     And the current branch is still "feature-1"
     And the uncommitted file still exists

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/disabled.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/disabled.feature
@@ -23,8 +23,8 @@ Feature: push-hook setting set to "false"
       | main    | git rebase origin/main --no-update-refs |
       |         | git push --no-verify                    |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push --no-verify                    |
     And all branches are now synchronized
     And the current branch is still "feature"
@@ -33,9 +33,9 @@ Feature: push-hook setting set to "false"
       | main    | local, origin | origin main commit                                         |
       |         |               | local main commit                                          |
       | feature | local, origin | local feature commit                                       |
+      |         |               | Merge branch 'main' into feature                           |
       |         |               | origin feature commit                                      |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |
-      |         |               | Merge branch 'main' into feature                           |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/enabled.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/enabled.feature
@@ -23,8 +23,8 @@ Feature: push-hook setting set to "true"
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And all branches are now synchronized
     And the current branch is still "feature"
@@ -33,9 +33,9 @@ Feature: push-hook setting set to "true"
       | main    | local, origin | origin main commit                                         |
       |         |               | local main commit                                          |
       | feature | local, origin | local feature commit                                       |
+      |         |               | Merge branch 'main' into feature                           |
       |         |               | origin feature commit                                      |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |
-      |         |               | Merge branch 'main' into feature                           |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/happy_path.feature
@@ -24,12 +24,12 @@ Feature: sync inside a folder that doesn't exist on the main branch
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff origin/alpha   |
-      |        | git merge --no-edit --ff main           |
+      | alpha  | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/alpha   |
       |        | git push                                |
       |        | git checkout beta                       |
-      | beta   | git merge --no-edit --ff origin/beta    |
-      |        | git merge --no-edit --ff main           |
+      | beta   | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/beta    |
       |        | git push                                |
       |        | git checkout alpha                      |
       | alpha  | git push --tags                         |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/with_conflict.feature
@@ -25,8 +25,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout current                    |
-      | current | git merge --no-edit --ff origin/current |
-      |         | git merge --no-edit --ff main           |
+      | current | git merge --no-edit --ff main           |
     And the current branch is still "current"
     And the uncommitted file is stashed
     And a merge is now in progress
@@ -62,16 +61,17 @@ Feature: sync inside a folder that doesn't exist on the main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" in the "new_folder" folder
     Then it runs the commands
-      | BRANCH  | COMMAND                               |
-      | current | git commit --no-edit                  |
-      |         | git push                              |
-      |         | git checkout other                    |
-      | other   | git merge --no-edit --ff origin/other |
-      |         | git merge --no-edit --ff main         |
-      |         | git push                              |
-      |         | git checkout current                  |
-      | current | git push --tags                       |
-      |         | git stash pop                         |
+      | BRANCH  | COMMAND                                 |
+      | current | git commit --no-edit                    |
+      |         | git merge --no-edit --ff origin/current |
+      |         | git push                                |
+      |         | git checkout other                      |
+      | other   | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/other   |
+      |         | git push                                |
+      |         | git checkout current                    |
+      | current | git push --tags                         |
+      |         | git stash pop                           |
     And all branches are now synchronized
     And the current branch is still "current"
     And the uncommitted file still exists

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/sync_perennial_strategy/merge.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/sync_perennial_strategy/merge.feature
@@ -23,8 +23,8 @@ Feature: with sync-perennial-strategy set to "merge"
       | main    | git merge --no-edit --ff origin/main    |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And all branches are now synchronized
     And the current branch is still "feature"
@@ -34,9 +34,9 @@ Feature: with sync-perennial-strategy set to "merge"
       |         |               | origin main commit                                         |
       |         |               | Merge remote-tracking branch 'origin/main'                 |
       | feature | local, origin | local feature commit                                       |
+      |         |               | Merge branch 'main' into feature                           |
       |         |               | origin feature commit                                      |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |
-      |         |               | Merge branch 'main' into feature                           |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
@@ -22,7 +22,8 @@ Feature: handle conflicts between the current feature branch and its tracking br
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -78,11 +79,10 @@ Feature: handle conflicts between the current feature branch and its tracking br
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git commit --no-edit          |
-      |         | git merge --no-edit --ff main |
-      |         | git push                      |
-      |         | git stash pop                 |
+      | BRANCH  | COMMAND              |
+      | feature | git commit --no-edit |
+      |         | git push             |
+      |         | git stash pop        |
     And all branches are now synchronized
     And the current branch is still "feature"
     And no merge is in progress
@@ -96,7 +96,6 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git merge --no-edit --ff main |
-      |         | git push                      |
-      |         | git stash pop                 |
+      | BRANCH  | COMMAND       |
+      | feature | git push      |
+      |         | git stash pop |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
@@ -24,8 +24,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -43,10 +42,9 @@ Feature: handle conflicts between the current feature branch and the main branch
   Scenario: undo
     When I run "git-town undo"
     Then it runs the commands
-      | BRANCH  | COMMAND                                                 |
-      | feature | git merge --abort                                       |
-      |         | git reset --hard {{ sha 'conflicting feature commit' }} |
-      |         | git stash pop                                           |
+      | BRANCH  | COMMAND           |
+      | feature | git merge --abort |
+      |         | git stash pop     |
     And the current branch is still "feature"
     And the uncommitted file still exists
     And no merge is in progress
@@ -67,10 +65,9 @@ Feature: handle conflicts between the current feature branch and the main branch
       Handle unfinished command: undo
       """
     And it runs the commands
-      | BRANCH  | COMMAND                                                 |
-      | feature | git merge --abort                                       |
-      |         | git reset --hard {{ sha 'conflicting feature commit' }} |
-      |         | git stash pop                                           |
+      | BRANCH  | COMMAND           |
+      | feature | git merge --abort |
+      |         | git stash pop     |
     And the current branch is still "feature"
     And the uncommitted file still exists
     And no merge is in progress
@@ -96,10 +93,11 @@ Feature: handle conflicts between the current feature branch and the main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH  | COMMAND              |
-      | feature | git commit --no-edit |
-      |         | git push             |
-      |         | git stash pop        |
+      | BRANCH  | COMMAND                                 |
+      | feature | git commit --no-edit                    |
+      |         | git merge --no-edit --ff origin/feature |
+      |         | git push                                |
+      |         | git stash pop                           |
     And all branches are now synchronized
     And the current branch is still "feature"
     And no merge is in progress
@@ -115,6 +113,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH  | COMMAND       |
-      | feature | git push      |
-      |         | git stash pop |
+      | BRANCH  | COMMAND                                 |
+      | feature | git merge --no-edit --ff origin/feature |
+      |         | git push                                |
+      |         | git stash pop                           |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/happy_path.feature
@@ -15,6 +15,7 @@ Feature: sync the current feature branch with a tracking branch using the "merge
       |         | origin   | origin feature commit |
     When I run "git-town sync"
 
+  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                                 |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/happy_path.feature
@@ -15,7 +15,6 @@ Feature: sync the current feature branch with a tracking branch using the "merge
       |         | origin   | origin feature commit |
     When I run "git-town sync"
 
-  @this
   Scenario: result
     Then it runs the commands
       | BRANCH  | COMMAND                                 |
@@ -24,8 +23,8 @@ Feature: sync the current feature branch with a tracking branch using the "merge
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And all branches are now synchronized
     And the current branch is still "feature"
@@ -34,9 +33,9 @@ Feature: sync the current feature branch with a tracking branch using the "merge
       | main    | local, origin | origin main commit                                         |
       |         |               | local main commit                                          |
       | feature | local, origin | local feature commit                                       |
+      |         |               | Merge branch 'main' into feature                           |
       |         |               | origin feature commit                                      |
       |         |               | Merge remote-tracking branch 'origin/feature' into feature |
-      |         |               | Merge branch 'main' into feature                           |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -23,8 +23,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -89,10 +88,11 @@ Feature: handle conflicts between the current feature branch and the main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH  | COMMAND              |
-      | feature | git commit --no-edit |
-      |         | git push             |
-      |         | git stash pop        |
+      | BRANCH  | COMMAND                                 |
+      | feature | git commit --no-edit                    |
+      |         | git merge --no-edit --ff origin/feature |
+      |         | git push                                |
+      |         | git stash pop                           |
     And all branches are now synchronized
     And the current branch is still "feature"
     And no merge is in progress
@@ -106,10 +106,11 @@ Feature: handle conflicts between the current feature branch and the main branch
     When I resolve the conflict in "conflicting_file" with "feature content"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH  | COMMAND              |
-      | feature | git commit --no-edit |
-      |         | git push             |
-      |         | git stash pop        |
+      | BRANCH  | COMMAND                                 |
+      | feature | git commit --no-edit                    |
+      |         | git merge --no-edit --ff origin/feature |
+      |         | git push                                |
+      |         | git stash pop                           |
     And the current branch is still "feature"
     And all branches are now synchronized
     And no merge is in progress
@@ -124,9 +125,10 @@ Feature: handle conflicts between the current feature branch and the main branch
     And I run "git commit --no-edit"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH  | COMMAND       |
-      | feature | git push      |
-      |         | git stash pop |
+      | BRANCH  | COMMAND                                 |
+      | feature | git merge --no-edit --ff origin/feature |
+      |         | git push                                |
+      |         | git stash pop                           |
     And the current branch is still "feature"
     And all branches are now synchronized
     And no merge is in progress

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -82,8 +82,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | main    | git rebase --continue                   |
       |         | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
       |         | git stash pop                           |
     And all branches are now synchronized
@@ -103,8 +103,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | BRANCH  | COMMAND                                 |
       | main    | git push                                |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
       |         | git stash pop                           |
     And all branches are now synchronized

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/two_collaborators/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/two_collaborators/happy_path.feature
@@ -20,8 +20,8 @@ Feature: collaborative feature branch syncing
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE         |
@@ -37,8 +37,8 @@ Feature: collaborative feature branch syncing
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And all branches are now synchronized
     And these commits exist now
@@ -55,8 +55,8 @@ Feature: collaborative feature branch syncing
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
-      |         | git merge --no-edit --ff main           |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And all branches are now synchronized
     And these commits exist now
       | BRANCH  | LOCATION                | MESSAGE                                                    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/upstream/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/upstream/happy_path.feature
@@ -23,8 +23,8 @@ Feature: with upstream repo
       |         | git rebase upstream/main --no-update-refs |
       |         | git push                                  |
       |         | git checkout feature                      |
-      | feature | git merge --no-edit --ff origin/feature   |
-      |         | git merge --no-edit --ff main             |
+      | feature | git merge --no-edit --ff main             |
+      |         | git merge --no-edit --ff origin/feature   |
       |         | git push                                  |
     And all branches are now synchronized
     And the current branch is still "feature"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/feature_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/feature_branch_in_other_worktree.feature
@@ -19,8 +19,8 @@ Feature: Sync a feature branch that is in another worktree than the main branch
     Then it runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git merge --no-edit --ff origin/feature |
       |         | git merge --no-edit --ff origin/main    |
+      |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And the current branch in the other worktree is still "feature"
     And these commits exist now
@@ -28,9 +28,9 @@ Feature: Sync a feature branch that is in another worktree than the main branch
       | main    | local            | local main commit                                          |
       |         | origin           | origin main commit                                         |
       | feature | origin, worktree | local feature commit                                       |
+      |         |                  | Merge remote-tracking branch 'origin/main' into feature    |
       |         |                  | origin feature commit                                      |
       |         |                  | Merge remote-tracking branch 'origin/feature' into feature |
-      |         |                  | Merge remote-tracking branch 'origin/main' into feature    |
       |         | worktree         | origin main commit                                         |
 
   Scenario: undo

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/parent_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/parent_in_other_worktree.feature
@@ -26,8 +26,8 @@ Feature: sync a branch whose parent is active in another worktree
       | main   | git rebase origin/main --no-update-refs |
       |        | git push                                |
       |        | git checkout child                      |
-      | child  | git merge --no-edit --ff origin/child   |
-      |        | git merge --no-edit --ff origin/parent  |
+      | child  | git merge --no-edit --ff origin/parent  |
+      |        | git merge --no-edit --ff origin/child   |
       |        | git push                                |
     And the current branch is still "child"
     And these commits exist now
@@ -35,10 +35,10 @@ Feature: sync a branch whose parent is active in another worktree
       | main   | local, origin, worktree | origin main commit                                      |
       |        |                         | local main commit                                       |
       | child  | local, origin           | local child commit                                      |
-      |        |                         | origin child commit                                     |
-      |        |                         | Merge remote-tracking branch 'origin/child' into child  |
       |        | local                   | origin parent commit                                    |
       |        | local, origin           | Merge remote-tracking branch 'origin/parent' into child |
+      |        |                         | origin child commit                                     |
+      |        |                         | Merge remote-tracking branch 'origin/child' into child  |
       | parent | origin                  | origin parent commit                                    |
       |        | worktree                | local parent commit                                     |
 

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -17,8 +17,8 @@ Feature: sync a branch when the previous branch is active in another worktree
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout current                    |
-      | current | git merge --no-edit --ff origin/current |
-      |         | git merge --no-edit --ff main           |
+      | current | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/current |
     And the current branch is still "current"
     And no commits exist now
 

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/sync_from_linked_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/sync_from_linked_worktree.feature
@@ -26,8 +26,8 @@ Feature: sync a branch whose parent is active in another worktree
       | main   | git rebase origin/main --no-update-refs |
       |        | git push                                |
       |        | git checkout child                      |
-      | child  | git merge --no-edit --ff origin/child   |
-      |        | git merge --no-edit --ff origin/parent  |
+      | child  | git merge --no-edit --ff origin/parent  |
+      |        | git merge --no-edit --ff origin/child   |
       |        | git push                                |
     And the current branch is still "parent"
     And these commits exist now
@@ -35,9 +35,9 @@ Feature: sync a branch whose parent is active in another worktree
       | main   | local, origin, worktree | origin main commit                                      |
       |        |                         | local main commit                                       |
       | child  | origin, worktree        | local child commit                                      |
+      |        |                         | Merge remote-tracking branch 'origin/parent' into child |
       |        |                         | origin child commit                                     |
       |        |                         | Merge remote-tracking branch 'origin/child' into child  |
-      |        |                         | Merge remote-tracking branch 'origin/parent' into child |
       |        | worktree                | origin parent commit                                    |
       | parent | local                   | local parent commit                                     |
       |        | origin                  | origin parent commit                                    |

--- a/features/sync/current_branch/feature_branch/missing_lineage_for_unrelated_branches.feature
+++ b/features/sync/current_branch/feature_branch/missing_lineage_for_unrelated_branches.feature
@@ -20,7 +20,8 @@ Feature: do not ask for lineage of branches that don't need to get synced
       |           | git checkout main                         |
       | main      | git rebase origin/main --no-update-refs   |
       |           | git checkout feature-1                    |
-      | feature-1 | git merge --no-edit --ff origin/feature-1 |
+      | feature-1 | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff origin/feature-1 |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -32,8 +33,7 @@ Feature: do not ask for lineage of branches that don't need to get synced
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                       |
-      | feature-1 | git commit --no-edit          |
-      |           | git merge --no-edit --ff main |
-      |           | git push                      |
+      | BRANCH    | COMMAND              |
+      | feature-1 | git commit --no-edit |
+      |           | git push             |
     And all branches are now synchronized

--- a/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
+++ b/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
@@ -42,7 +42,8 @@ Feature: compatibility between different sync-feature-strategy settings
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff origin/feature |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
     And it prints the error:
       """
       To continue after having resolved conflicts, run "git town continue".
@@ -50,10 +51,9 @@ Feature: compatibility between different sync-feature-strategy settings
     When the coworker resolves the conflict in "file.txt" with "my and coworker content"
     And the coworker runs "git town continue" and closes the editor
     Then it runs the commands
-      | BRANCH  | COMMAND                       |
-      | feature | git commit --no-edit          |
-      |         | git merge --no-edit --ff main |
-      |         | git push                      |
+      | BRANCH  | COMMAND              |
+      | feature | git commit --no-edit |
+      |         | git push             |
     And all branches are now synchronized
     And these commits exist now
       | BRANCH  | LOCATION                | MESSAGE                                                    | FILE NAME | FILE CONTENT            |

--- a/features/sync/current_branch/parked_branch/active.feature
+++ b/features/sync/current_branch/parked_branch/active.feature
@@ -22,8 +22,8 @@ Feature: active parked branches get synced like normal feature branches
       | main   | git rebase origin/main --no-update-refs |
       |        | git push                                |
       |        | git checkout parked                     |
-      | parked | git merge --no-edit --ff origin/parked  |
-      |        | git merge --no-edit --ff main           |
+      | parked | git merge --no-edit --ff main           |
+      |        | git merge --no-edit --ff origin/parked  |
       |        | git push                                |
     And all branches are now synchronized
     And the current branch is still "parked"
@@ -32,9 +32,9 @@ Feature: active parked branches get synced like normal feature branches
       | main   | local, origin | origin main commit                                       |
       |        |               | local main commit                                        |
       | parked | local, origin | local parked commit                                      |
+      |        |               | Merge branch 'main' into parked                          |
       |        |               | origin parked commit                                     |
       |        |               | Merge remote-tracking branch 'origin/parked' into parked |
-      |        |               | Merge branch 'main' into parked                          |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/with/conflict.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/with/conflict.feature
@@ -22,7 +22,8 @@ Feature: handle conflicts between the current prototype branch and its tracking 
       |           | git checkout main                         |
       | main      | git rebase origin/main --no-update-refs   |
       |           | git checkout prototype                    |
-      | prototype | git merge --no-edit --ff origin/prototype |
+      | prototype | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff origin/prototype |
     And it prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file
@@ -62,10 +63,9 @@ Feature: handle conflicts between the current prototype branch and its tracking 
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then it runs the commands
-      | BRANCH    | COMMAND                       |
-      | prototype | git commit --no-edit          |
-      |           | git merge --no-edit --ff main |
-      |           | git stash pop                 |
+      | BRANCH    | COMMAND              |
+      | prototype | git commit --no-edit |
+      |           | git stash pop        |
     And these commits exist now
       | BRANCH    | LOCATION      | MESSAGE                                                        |
       | prototype | local         | conflicting local commit                                       |
@@ -83,10 +83,9 @@ Feature: handle conflicts between the current prototype branch and its tracking 
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"
     Then it runs the commands
-      | BRANCH    | COMMAND                       |
-      | prototype | git commit --no-edit          |
-      |           | git merge --no-edit --ff main |
-      |           | git stash pop                 |
+      | BRANCH    | COMMAND              |
+      | prototype | git commit --no-edit |
+      |           | git stash pop        |
     And these commits exist now
       | BRANCH    | LOCATION      | MESSAGE                                                        |
       | prototype | local         | conflicting local commit                                       |

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/with/happy_path.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/with/happy_path.feature
@@ -22,17 +22,17 @@ Feature: sync the current prototype branch with tracking branch
       | main      | git rebase origin/main --no-update-refs   |
       |           | git push                                  |
       |           | git checkout prototype                    |
-      | prototype | git merge --no-edit --ff origin/prototype |
-      |           | git merge --no-edit --ff main             |
+      | prototype | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff origin/prototype |
     And the current branch is still "prototype"
     And these commits exist now
       | BRANCH    | LOCATION      | MESSAGE                                                        |
       | main      | local, origin | main local commit                                              |
       |           |               | main origin commit                                             |
       | prototype | local         | local commit                                                   |
+      |           |               | Merge branch 'main' into prototype                             |
       |           | local, origin | origin commit                                                  |
       |           | local         | Merge remote-tracking branch 'origin/prototype' into prototype |
-      |           |               | Merge branch 'main' into prototype                             |
 
   Scenario: undo
     When I run "git-town undo"

--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -53,9 +53,9 @@ type featureBranchArgs struct {
 }
 
 func syncFeatureTrackingBranchProgram(syncStrategy configdomain.SyncStrategy, args featureBranchArgs) bool {
-	if args.offline.IsTrue() {
-		return false
-	}
+	// if args.offline.IsTrue() {
+	// 	return false
+	// }
 	trackingBranch, hasTrackingBranch := args.remoteName.Get()
 	if !hasTrackingBranch {
 		return hasTrackingBranch

--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -58,9 +58,6 @@ func syncFeatureParentBranch(syncStrategy configdomain.SyncStrategy, hasTracking
 }
 
 func syncFeatureTrackingBranchProgram(trackingBranch gitdomain.RemoteBranchName, syncStrategy configdomain.SyncStrategy, args featureBranchArgs) {
-	// if args.offline.IsTrue() {
-	// 	return false
-	// }
 	switch syncStrategy {
 	case configdomain.SyncStrategyCompress:
 		args.program.Value.Add(&opcodes.Merge{Branch: trackingBranch.BranchName()})


### PR DESCRIPTION
This PR organizes the somewhat organically grown logic for syncing parent and tracking branches a bit. This is in preparation for #3338.