### PR TITLE
Make resetting the runstate robust

### DIFF
--- a/internal/cmd/status/reset.go
+++ b/internal/cmd/status/reset.go
@@ -3,10 +3,7 @@ package status
 import (
 	"fmt"
 
-	"github.com/git-town/git-town/v16/internal/cli/flags"
 	"github.com/git-town/git-town/v16/internal/cmd/cmdhelpers"
-	"github.com/git-town/git-town/v16/internal/config/configdomain"
-	"github.com/git-town/git-town/v16/internal/execute"
 	"github.com/git-town/git-town/v16/internal/messages"
 	"github.com/git-town/git-town/v16/internal/vm/statefile"
 	"github.com/spf13/cobra"
@@ -15,37 +12,20 @@ import (
 const statusResetDesc = "Resets the current suspended Git Town command"
 
 func resetRunstateCommand() *cobra.Command {
-	addVerboseFlag, readVerboseFlag := flags.Verbose()
 	cmd := cobra.Command{
 		Use:   "reset",
 		Args:  cobra.NoArgs,
 		Short: statusResetDesc,
 		Long:  cmdhelpers.Long(statusResetDesc),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			verbose, err := readVerboseFlag(cmd)
-			if err != nil {
-				return err
-			}
-			return executeStatusReset(verbose)
+			return executeStatusReset()
 		},
 	}
-	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeStatusReset(verbose configdomain.Verbose) error {
-	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
-		PrintBranchNames: true,
-		PrintCommands:    true,
-		ValidateGitRepo:  true,
-		ValidateIsOnline: false,
-		Verbose:          verbose,
-	})
-	if err != nil {
-		return err
-	}
-	err = statefile.Delete(repo.RootDir)
+func executeStatusReset() error {
+	err := statefile.Delete(".")
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/status/reset.go
+++ b/internal/cmd/status/reset.go
@@ -17,7 +17,7 @@ func resetRunstateCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: statusResetDesc,
 		Long:  cmdhelpers.Long(statusResetDesc),
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return executeStatusReset()
 		},
 	}


### PR DESCRIPTION
Resetting the runstate can fail if the runstate contains invalid information. This PR makes the `runstate reset` delete the runstate without loading it first.