### PR TITLE
Improve logging of loaded Git configuration

### DIFF
--- a/internal/subshell/backend_runner.go
+++ b/internal/subshell/backend_runner.go
@@ -73,7 +73,7 @@ func (self BackendRunner) execute(executable string, args ...string) (string, er
 		time.Sleep(concurrentGitRetryDelay)
 	}
 	if self.Verbose && len(outputBytes) > 0 {
-		os.Stdout.Write(bytes.ReplaceAll(outputBytes, []byte{0x00}, []byte{'\n'}))
+		os.Stdout.Write(bytes.ReplaceAll(outputBytes, []byte{0x00}, []byte{'\n', '\n'}))
 	}
 	return outputText, err
 }

--- a/internal/subshell/backend_runner.go
+++ b/internal/subshell/backend_runner.go
@@ -1,6 +1,7 @@
 package subshell
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -72,7 +73,7 @@ func (self BackendRunner) execute(executable string, args ...string) (string, er
 		time.Sleep(concurrentGitRetryDelay)
 	}
 	if self.Verbose && len(outputBytes) > 0 {
-		os.Stdout.Write(outputBytes)
+		os.Stdout.Write(bytes.ReplaceAll(outputBytes, []byte{0x00}, []byte{'\n'}))
 	}
 	return outputText, err
 }


### PR DESCRIPTION
The configuration loads as zero-terminated strings to handle newlines in Git aliases correctly. This causes poor readability in output, like this:

```
key1
value1key2
value2key3
value3
```

This PR changes the way data loaded in the background is logged to this format:

```
key1
value1

key2
value2
```

This affects only logging. Loaded data is parsed in the original format.