### PR TITLE
Auto-update outdated config values only for Git aliases

### DIFF
--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -156,7 +156,7 @@ func (self *Access) load(scope configdomain.ConfigScope, updateOutdated bool) (c
 					self.UpdateDeprecatedSetting(scope, configKey, update.After.Key, update.After.Value)
 					configKey = update.After.Key
 					value = update.After.Value
-				} else if isGitTownAlias(value) && value == update.Before.Value {
+				} else if IsGitTownAlias(value) && value == update.Before.Value {
 					self.UpdateDeprecatedCustomSetting(scope, configdomain.Key(key), update.Before.Value, update.After.Value)
 					configKey = update.After.Key
 					value = update.After.Value
@@ -172,6 +172,6 @@ func (self *Access) load(scope configdomain.ConfigScope, updateOutdated bool) (c
 }
 
 // indicates whether the given value of a Git configuration setting contains an alias for a Git Town command
-func isGitTownAlias(value string) bool {
+func IsGitTownAlias(value string) bool {
 	return strings.HasPrefix(value, "town ")
 }

--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -156,7 +156,7 @@ func (self *Access) load(scope configdomain.ConfigScope, updateOutdated bool) (c
 					self.UpdateDeprecatedSetting(scope, configKey, update.After.Key, update.After.Value)
 					configKey = update.After.Key
 					value = update.After.Value
-				} else if value == update.Before.Value {
+				} else if strings.HasPrefix(value, "town ") && value == update.Before.Value {
 					self.UpdateDeprecatedCustomSetting(scope, configdomain.Key(key), update.Before.Value, update.After.Value)
 					configKey = update.After.Key
 					value = update.After.Value

--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -156,7 +156,7 @@ func (self *Access) load(scope configdomain.ConfigScope, updateOutdated bool) (c
 					self.UpdateDeprecatedSetting(scope, configKey, update.After.Key, update.After.Value)
 					configKey = update.After.Key
 					value = update.After.Value
-				} else if strings.HasPrefix(value, "town ") && value == update.Before.Value {
+				} else if isGitTownAlias(value) && value == update.Before.Value {
 					self.UpdateDeprecatedCustomSetting(scope, configdomain.Key(key), update.Before.Value, update.After.Value)
 					configKey = update.After.Key
 					value = update.After.Value
@@ -169,4 +169,9 @@ func (self *Access) load(scope configdomain.ConfigScope, updateOutdated bool) (c
 	}
 	partialConfig, err := configdomain.NewPartialConfigFromSnapshot(snapshot, updateOutdated, self.RemoveLocalConfigValue)
 	return snapshot, partialConfig, err
+}
+
+// indicates whether the given value of a Git configuration setting contains an alias for a Git Town command
+func isGitTownAlias(value string) bool {
+	return strings.HasPrefix(value, "town ")
 }

--- a/internal/config/gitconfig/access_test.go
+++ b/internal/config/gitconfig/access_test.go
@@ -1,0 +1,21 @@
+package gitconfig_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v16/internal/config/gitconfig"
+	"github.com/shoenig/test/must"
+)
+
+func TestIsGitTownAlias(t *testing.T) {
+	t.Parallel()
+	tests := map[string]bool{
+		"town append": true,
+		"town sync":   true,
+		"other":       false,
+	}
+	for give, want := range tests {
+		have := gitconfig.IsGitTownAlias(give)
+		must.EqOp(t, want, have)
+	}
+}


### PR DESCRIPTION
This update mechanism is intended only for Git Town aliases and shouldn't update anything else.
