### PR TITLE
Rename GitConfig to GitConfigAccess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ deadcode: tools/rta@${RTA_VERSION}
 	                                                           | grep -v NewLineageWith \
 	                                                           | grep -v NewSHAs \
 	                                                           | grep -v NewSet \
+																														 | grep -v pkg/prelude/ptr.go \
 	                                                           | grep -v Paniced \
 	                                                           | grep -v Set.Add \
 	                                                           || true

--- a/internal/cmd/config/remove.go
+++ b/internal/cmd/config/remove.go
@@ -45,7 +45,7 @@ func executeRemoveConfig(verbose configdomain.Verbose) error {
 	if err != nil {
 		return err
 	}
-	err = repo.UnvalidatedConfig.NormalConfig.GitConfig.RemoveLocalGitConfiguration(repo.UnvalidatedConfig.NormalConfig.Lineage)
+	err = repo.UnvalidatedConfig.NormalConfig.GitConfigAccess.RemoveLocalGitConfiguration(repo.UnvalidatedConfig.NormalConfig.Lineage)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/config/root.go
+++ b/internal/cmd/config/root.go
@@ -57,7 +57,6 @@ func executeDisplayConfig(verbose configdomain.Verbose) error {
 
 func printConfig(config config.UnvalidatedConfig) {
 	fmt.Println()
-	// TODO: organize these entries exactly like the config file is organized
 	print.Header("Branches")
 	print.Entry("contribution branches", format.StringsSetting((config.NormalConfig.ContributionBranches.Join(", "))))
 	print.Entry("contribution regex", format.OptionalStringerSetting((config.NormalConfig.ContributionRegex)))

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -259,7 +259,7 @@ func loadSetupData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (d
 		dialogInputs:  dialogTestInputs,
 		hasConfigFile: repo.UnvalidatedConfig.NormalConfig.ConfigFile.IsSome(),
 		localBranches: branchesSnapshot.Branches,
-		userInput:     defaultUserInput(repo.UnvalidatedConfig.NormalConfig.GitConfig, repo.UnvalidatedConfig.NormalConfig.GitVersion),
+		userInput:     defaultUserInput(repo.UnvalidatedConfig.NormalConfig.GitConfigAccess, repo.UnvalidatedConfig.NormalConfig.GitVersion),
 	}, exit, err
 }
 

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -21,7 +21,7 @@ type NormalConfig struct {
 	configdomain.NormalConfigData
 	ConfigFile      Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
 	DryRun          configdomain.DryRun                // whether to only print the Git commands but not execute them
-	GitConfigAccess gitconfig.Access                   // access to the Git configuration settings // TODO: rename to GitConfigAccess
+	GitConfigAccess gitconfig.Access                   // access to the Git configuration settings
 	GitVersion      git.Version                        // version of the installed Git executable
 	GlobalGitConfig configdomain.PartialConfig         // content of the global Git configuration
 	LocalGitConfig  configdomain.PartialConfig         // content of the local Git configuration

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -21,7 +21,7 @@ type NormalConfig struct {
 	configdomain.NormalConfigData
 	ConfigFile      Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
 	DryRun          configdomain.DryRun                // whether to only print the Git commands but not execute them
-	GitConfig       gitconfig.Access                   // access to the Git configuration settings // TODO: rename to GitConfigAccess
+	GitConfigAccess gitconfig.Access                   // access to the Git configuration settings // TODO: rename to GitConfigAccess
 	GitVersion      git.Version                        // version of the installed Git executable
 	GlobalGitConfig configdomain.PartialConfig         // content of the global Git configuration
 	LocalGitConfig  configdomain.PartialConfig         // content of the local Git configuration
@@ -64,14 +64,14 @@ func (self *NormalConfig) CleanupBranchFromLineage(branch gitdomain.LocalBranchN
 	for _, child := range children {
 		if hasParent {
 			self.Lineage = self.Lineage.Set(child, parent)
-			_ = self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(child), parent.String())
+			_ = self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(child), parent.String())
 		} else {
 			self.Lineage = self.Lineage.RemoveBranch(child)
-			_ = self.GitConfig.RemoveConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(parent))
+			_ = self.GitConfigAccess.RemoveConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(parent))
 		}
 	}
 	self.Lineage = self.Lineage.RemoveBranch(branch)
-	_ = self.GitConfig.RemoveConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(branch))
+	_ = self.GitConfigAccess.RemoveConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(branch))
 }
 
 // OriginURL provides the URL for the "origin" remote.
@@ -99,15 +99,15 @@ func (self *NormalConfig) RemoteURLString(remote gitdomain.Remote) Option[string
 	if remoteOverride.IsSome() {
 		return remoteOverride
 	}
-	return self.GitConfig.RemoteURL(remote)
+	return self.GitConfigAccess.RemoteURL(remote)
 }
 
 func (self *NormalConfig) RemoveCreatePrototypeBranches() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyDeprecatedCreatePrototypeBranches)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyDeprecatedCreatePrototypeBranches)
 }
 
 func (self *NormalConfig) RemoveFeatureRegex() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyFeatureRegex)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyFeatureRegex)
 }
 
 // RemoveFromContributionBranches removes the given branch as a perennial branch.
@@ -141,19 +141,19 @@ func (self *NormalConfig) RemoveFromPrototypeBranches(branch gitdomain.LocalBran
 }
 
 func (self *NormalConfig) RemoveNewBranchType() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyNewBranchType)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyNewBranchType)
 }
 
 // RemoveParent removes the parent branch entry for the given branch from the Git configuration.
 func (self *NormalConfig) RemoveParent(branch gitdomain.LocalBranchName) {
 	self.LocalGitConfig.Lineage = self.LocalGitConfig.Lineage.RemoveBranch(branch)
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.NewParentKey(branch))
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.NewParentKey(branch))
 }
 
 func (self *NormalConfig) RemovePerennialAncestors(finalMessages stringslice.Collector) {
 	for _, perennialBranch := range self.PerennialBranches {
 		if self.Lineage.Parent(perennialBranch).IsSome() {
-			_ = self.GitConfig.RemoveLocalConfigValue(configdomain.NewParentKey(perennialBranch))
+			_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.NewParentKey(perennialBranch))
 			self.Lineage = self.Lineage.RemoveBranch(perennialBranch)
 			finalMessages.Add(fmt.Sprintf(messages.PerennialBranchRemovedParentEntry, perennialBranch))
 		}
@@ -161,83 +161,83 @@ func (self *NormalConfig) RemovePerennialAncestors(finalMessages stringslice.Col
 }
 
 func (self *NormalConfig) RemovePerennialBranches() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyPerennialBranches)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyPerennialBranches)
 }
 
 func (self *NormalConfig) RemovePerennialRegex() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyPerennialRegex)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyPerennialRegex)
 }
 
 func (self *NormalConfig) RemovePushHook() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyPushHook)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyPushHook)
 }
 
 func (self *NormalConfig) RemovePushNewBranches() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyPushNewBranches)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyPushNewBranches)
 }
 
 func (self *NormalConfig) RemoveShipDeleteTrackingBranch() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyShipDeleteTrackingBranch)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyShipDeleteTrackingBranch)
 }
 
 func (self *NormalConfig) RemoveShipStrategy() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeyShipStrategy)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyShipStrategy)
 }
 
 func (self *NormalConfig) RemoveSyncFeatureStrategy() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeySyncFeatureStrategy)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeySyncFeatureStrategy)
 }
 
 func (self *NormalConfig) RemoveSyncPerennialStrategy() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeySyncPerennialStrategy)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeySyncPerennialStrategy)
 }
 
 func (self *NormalConfig) RemoveSyncPrototypeStrategy() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeySyncPrototypeStrategy)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeySyncPrototypeStrategy)
 }
 
 func (self *NormalConfig) RemoveSyncTags() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeySyncTags)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeySyncTags)
 }
 
 func (self *NormalConfig) RemoveSyncUpstream() {
-	_ = self.GitConfig.RemoveLocalConfigValue(configdomain.KeySyncUpstream)
+	_ = self.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeySyncUpstream)
 }
 
 // SetObservedBranches marks the given branches as observed branches.
 func (self *NormalConfig) SetContributionBranches(branches gitdomain.LocalBranchNames) error {
 	self.ContributionBranches = branches
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyContributionBranches, branches.Join(" "))
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyContributionBranches, branches.Join(" "))
 }
 
 // SetDefaultBranchTypeLocally updates the locally configured default branch type.
 func (self *NormalConfig) SetDefaultBranchTypeLocally(value configdomain.BranchType) error {
 	self.DefaultBranchType = value
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyDefaultBranchType, value.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyDefaultBranchType, value.String())
 }
 
 // SetFeatureRegexLocally updates the locally configured feature regex.
 func (self *NormalConfig) SetFeatureRegexLocally(value configdomain.FeatureRegex) error {
 	self.FeatureRegex = Some(value)
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyFeatureRegex, value.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyFeatureRegex, value.String())
 }
 
 // SetContributionBranches marks the given branches as contribution branches.
 func (self *NormalConfig) SetNewBranchType(value configdomain.BranchType) error {
 	self.NewBranchType = value
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyNewBranchType, value.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyNewBranchType, value.String())
 }
 
 // SetContributionBranches marks the given branches as contribution branches.
 func (self *NormalConfig) SetObservedBranches(branches gitdomain.LocalBranchNames) error {
 	self.ObservedBranches = branches
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyObservedBranches, branches.Join(" "))
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyObservedBranches, branches.Join(" "))
 }
 
 // SetOffline updates whether Git Town is in offline mode.
 func (self *NormalConfig) SetOffline(value configdomain.Offline) error {
 	self.Offline = value
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeGlobal, configdomain.KeyOffline, value.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeGlobal, configdomain.KeyOffline, value.String())
 }
 
 // SetParent marks the given branch as the direct parent of the other given branch
@@ -247,37 +247,37 @@ func (self *NormalConfig) SetParent(branch, parentBranch gitdomain.LocalBranchNa
 		return nil
 	}
 	self.Lineage = self.Lineage.Set(branch, parentBranch)
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(branch), parentBranch.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.NewParentKey(branch), parentBranch.String())
 }
 
 // SetObservedBranches marks the given branches as perennial branches.
 func (self *NormalConfig) SetParkedBranches(branches gitdomain.LocalBranchNames) error {
 	self.ParkedBranches = branches
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyParkedBranches, branches.Join(" "))
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyParkedBranches, branches.Join(" "))
 }
 
 // SetPerennialBranches marks the given branches as perennial branches.
 func (self *NormalConfig) SetPerennialBranches(branches gitdomain.LocalBranchNames) error {
 	self.PerennialBranches = branches
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPerennialBranches, branches.Join(" "))
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPerennialBranches, branches.Join(" "))
 }
 
 // SetPerennialRegexLocally updates the locally configured perennial regex.
 func (self *NormalConfig) SetPerennialRegexLocally(value configdomain.PerennialRegex) error {
 	self.PerennialRegex = Some(value)
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPerennialRegex, value.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPerennialRegex, value.String())
 }
 
 // SetContributionBranches marks the given branches as contribution branches.
 func (self *NormalConfig) SetPrototypeBranches(branches gitdomain.LocalBranchNames) error {
 	self.PrototypeBranches = branches
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPrototypeBranches, branches.Join(" "))
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPrototypeBranches, branches.Join(" "))
 }
 
 // SetPushHookLocally updates the locally configured push-hook strategy.
 func (self *NormalConfig) SetPushHookLocally(value configdomain.PushHook) error {
 	self.PushHook = value
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPushHook, strconv.FormatBool(bool(value)))
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyPushHook, strconv.FormatBool(bool(value)))
 }
 
 // SetPushNewBranches updates whether the current repository is configured to push
@@ -285,45 +285,45 @@ func (self *NormalConfig) SetPushHookLocally(value configdomain.PushHook) error 
 func (self *NormalConfig) SetPushNewBranches(value configdomain.PushNewBranches, scope configdomain.ConfigScope) error {
 	setting := strconv.FormatBool(bool(value))
 	self.PushNewBranches = value
-	return self.GitConfig.SetConfigValue(scope, configdomain.KeyPushNewBranches, setting)
+	return self.GitConfigAccess.SetConfigValue(scope, configdomain.KeyPushNewBranches, setting)
 }
 
 // SetShipDeleteTrackingBranch updates the configured delete-tracking-branch strategy.
 func (self *NormalConfig) SetShipDeleteTrackingBranch(value configdomain.ShipDeleteTrackingBranch, scope configdomain.ConfigScope) error {
 	self.ShipDeleteTrackingBranch = value
-	return self.GitConfig.SetConfigValue(scope, configdomain.KeyShipDeleteTrackingBranch, strconv.FormatBool(value.IsTrue()))
+	return self.GitConfigAccess.SetConfigValue(scope, configdomain.KeyShipDeleteTrackingBranch, strconv.FormatBool(value.IsTrue()))
 }
 
 func (self *NormalConfig) SetShipStrategy(value configdomain.ShipStrategy, scope configdomain.ConfigScope) error {
 	self.ShipStrategy = value
-	return self.GitConfig.SetConfigValue(scope, configdomain.KeyShipStrategy, value.String())
+	return self.GitConfigAccess.SetConfigValue(scope, configdomain.KeyShipStrategy, value.String())
 }
 
 func (self *NormalConfig) SetSyncFeatureStrategy(value configdomain.SyncFeatureStrategy) error {
 	self.SyncFeatureStrategy = value
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncFeatureStrategy, value.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncFeatureStrategy, value.String())
 }
 
 // SetSyncPerennialStrategy updates the configured sync-perennial strategy.
 func (self *NormalConfig) SetSyncPerennialStrategy(strategy configdomain.SyncPerennialStrategy) error {
 	self.SyncPerennialStrategy = strategy
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncPerennialStrategy, strategy.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncPerennialStrategy, strategy.String())
 }
 
 // SetSyncPerennialStrategy updates the configured sync-perennial strategy.
 func (self *NormalConfig) SetSyncPrototypeStrategy(strategy configdomain.SyncPrototypeStrategy) error {
 	self.SyncPrototypeStrategy = strategy
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncPrototypeStrategy, strategy.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncPrototypeStrategy, strategy.String())
 }
 
 // SetSyncPerennialStrategy updates the configured sync-perennial strategy.
 func (self *NormalConfig) SetSyncTags(value configdomain.SyncTags) error {
 	self.SyncTags = value
-	return self.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncTags, value.String())
+	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeySyncTags, value.String())
 }
 
 // SetSyncUpstream updates the configured sync-upstream strategy.
 func (self *NormalConfig) SetSyncUpstream(value configdomain.SyncUpstream, scope configdomain.ConfigScope) error {
 	self.SyncUpstream = value
-	return self.GitConfig.SetConfigValue(scope, configdomain.KeySyncUpstream, strconv.FormatBool(value.IsTrue()))
+	return self.GitConfigAccess.SetConfigValue(scope, configdomain.KeySyncUpstream, strconv.FormatBool(value.IsTrue()))
 }

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -32,14 +32,14 @@ func (self *UnvalidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {
 }
 
 func (self *UnvalidatedConfig) Reload() {
-	_, globalGitConfig, _ := self.NormalConfig.GitConfig.LoadGlobal(false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	_, localGitConfig, _ := self.NormalConfig.GitConfig.LoadLocal(false)   // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	_, globalGitConfig, _ := self.NormalConfig.GitConfigAccess.LoadGlobal(false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	_, localGitConfig, _ := self.NormalConfig.GitConfigAccess.LoadLocal(false)   // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	unvalidatedConfig, normalConfig := NewConfigs(self.NormalConfig.ConfigFile, globalGitConfig, localGitConfig)
 	self.UnvalidatedConfig = unvalidatedConfig
 	self.NormalConfig = NormalConfig{
 		ConfigFile:       self.NormalConfig.ConfigFile,
 		DryRun:           self.NormalConfig.DryRun,
-		GitConfig:        self.NormalConfig.GitConfig,
+		GitConfigAccess:  self.NormalConfig.GitConfigAccess,
 		GitVersion:       self.NormalConfig.GitVersion,
 		GlobalGitConfig:  globalGitConfig,
 		LocalGitConfig:   localGitConfig,
@@ -48,14 +48,14 @@ func (self *UnvalidatedConfig) Reload() {
 }
 
 func (self *UnvalidatedConfig) RemoveMainBranch() {
-	_ = self.NormalConfig.GitConfig.RemoveLocalConfigValue(configdomain.KeyMainBranch)
+	_ = self.NormalConfig.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyMainBranch)
 }
 
 // SetMainBranch marks the given branch as the main branch
 // in the Git Town configuration.
 func (self *UnvalidatedConfig) SetMainBranch(branch gitdomain.LocalBranchName) error {
 	self.UnvalidatedConfig.MainBranch = Some(branch)
-	return self.NormalConfig.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyMainBranch, branch.String())
+	return self.NormalConfig.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyMainBranch, branch.String())
 }
 
 // UnvalidatedBranchesAndTypes provides the types for the given branches.
@@ -74,7 +74,7 @@ func DefaultUnvalidatedConfig(gitAccess gitconfig.Access, gitVersion git.Version
 		NormalConfig: NormalConfig{
 			ConfigFile:       None[configdomain.PartialConfig](),
 			DryRun:           false,
-			GitConfig:        gitAccess,
+			GitConfigAccess:  gitAccess,
 			GitVersion:       gitVersion,
 			GlobalGitConfig:  configdomain.EmptyPartialConfig(),
 			LocalGitConfig:   configdomain.EmptyPartialConfig(),
@@ -112,7 +112,7 @@ func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {
 		NormalConfig: NormalConfig{
 			ConfigFile:       args.ConfigFile,
 			DryRun:           args.DryRun,
-			GitConfig:        args.Access,
+			GitConfigAccess:  args.Access,
 			GitVersion:       args.GitVersion,
 			GlobalGitConfig:  args.GlobalConfig,
 			LocalGitConfig:   args.LocalConfig,

--- a/internal/config/validated_config.go
+++ b/internal/config/validated_config.go
@@ -83,5 +83,5 @@ func (self *ValidatedConfig) RemovePerennials(stack gitdomain.LocalBranchNames) 
 // in the Git Town configuration.
 func (self *ValidatedConfig) SetMainBranch(branch gitdomain.LocalBranchName) error {
 	self.ValidatedConfigData.MainBranch = branch
-	return self.NormalConfig.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyMainBranch, branch.String())
+	return self.NormalConfig.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyMainBranch, branch.String())
 }

--- a/internal/vm/opcodes/config_remove.go
+++ b/internal/vm/opcodes/config_remove.go
@@ -12,5 +12,5 @@ type ConfigRemove struct {
 }
 
 func (self *ConfigRemove) Run(args shared.RunArgs) error {
-	return args.Config.Value.NormalConfig.GitConfig.RemoveConfigValue(self.Scope, self.Key)
+	return args.Config.Value.NormalConfig.GitConfigAccess.RemoveConfigValue(self.Scope, self.Key)
 }

--- a/internal/vm/opcodes/config_set.go
+++ b/internal/vm/opcodes/config_set.go
@@ -13,5 +13,5 @@ type ConfigSet struct {
 }
 
 func (self *ConfigSet) Run(args shared.RunArgs) error {
-	return args.Config.Value.NormalConfig.GitConfig.SetConfigValue(self.Scope, self.Key, self.Value)
+	return args.Config.Value.NormalConfig.GitConfigAccess.SetConfigValue(self.Scope, self.Key, self.Value)
 }

--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -365,7 +365,7 @@ func (self *TestCommands) HasFile(name, content string) string {
 func (self *TestCommands) LineageTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("BRANCH", "PARENT")
-	_, localGitConfig, _ := self.Config.NormalConfig.GitConfig.LoadLocal(false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	_, localGitConfig, _ := self.Config.NormalConfig.GitConfigAccess.LoadLocal(false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	lineage := localGitConfig.Lineage
 	for _, entry := range lineage.Entries() {
 		result.AddRow(entry.Child.String(), entry.Parent.String())
@@ -433,7 +433,7 @@ func (self *TestCommands) RemoveMainBranchConfiguration() {
 
 // RemovePerennialBranchConfiguration removes the configuration entry for the perennial branches.
 func (self *TestCommands) RemovePerennialBranchConfiguration() error {
-	return self.Config.NormalConfig.GitConfig.RemoveLocalConfigValue(configdomain.KeyPerennialBranches)
+	return self.Config.NormalConfig.GitConfigAccess.RemoveLocalConfigValue(configdomain.KeyPerennialBranches)
 }
 
 // RemoveRemote deletes the Git remote with the given name.

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -417,7 +417,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		branchName := gitdomain.NewLocalBranchName(branch)
 		configKey := configdomain.NewParentKey(branchName)
-		return devRepo.Config.NormalConfig.GitConfig.SetConfigValue(configdomain.ConfigScopeLocal, configKey, value)
+		return devRepo.Config.NormalConfig.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configKey, value)
 	})
 
 	sc.Step(`^Git Town prints:$`, func(ctx context.Context, expected *godog.DocString) error {
@@ -575,7 +575,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		key := configdomain.Key("rebase.updateRefs")
-		return devRepo.Config.NormalConfig.GitConfig.SetConfigValue(configdomain.ConfigScopeGlobal, key, value)
+		return devRepo.Config.NormalConfig.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeGlobal, key, value)
 	})
 
 	sc.Step(`^(global |local |)Git Town setting "([^"]+)" is "([^"]+)"$`, func(ctx context.Context, locality, name, value string) error {
@@ -586,7 +586,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 			return fmt.Errorf("unknown config key: %q", name)
 		}
 		scope := configdomain.ParseConfigScope(strings.TrimSpace(locality))
-		return devRepo.Config.NormalConfig.GitConfig.SetConfigValue(scope, key, value)
+		return devRepo.Config.NormalConfig.GitConfigAccess.SetConfigValue(scope, key, value)
 	})
 
 	sc.Step(`^(global |local |)Git Town setting "([^"]+)" is (?:now|still) "([^"]+)"$`, func(ctx context.Context, locality, name, want string) error {


### PR DESCRIPTION
This type is for accessing the Git configuration on disk. It doesn't represent the Git config in memory.