### PR TITLE
fix(commands.go/Version/Regex): handle patch being alphanumeric

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -772,7 +772,7 @@ func (self *Commands) UndoLastCommit(runner gitdomain.Runner) error {
 
 // Version indicates whether the needed Git version is installed.
 func (self *Commands) Version(querier gitdomain.Querier) (Version, error) {
-	versionRegexp := regexp.MustCompile(`git version (\d+).(\d+).(\d+)`)
+	versionRegexp := regexp.MustCompile(`git version (\d+).(\d+).(\w+)`)
 	output, err := querier.QueryTrim("git", "version")
 	if err != nil {
 		return EmptyVersion(), fmt.Errorf(messages.GitVersionProblem, err)


### PR DESCRIPTION

Fixes the error message

```
Error: 'git version' returned unexpected output: "git version 2.47.GIT".
Please open an issue and supply the output of running 'git version'
```

If one uses Git's development branches, the version number is controlled by https://github.com/git/git/commits/master/GIT-VERSION-GEN file.

For development versions, the Git versioning can often be

MAJOR.MINOR.GIT

example 2.47.GIT

This however breaks with the current regex which assumes that PATCH starts with a numeric value at least.
