### PR TITLE
Add test for error message with alternative config filename

### DIFF
--- a/features/config/view/invalid_alternative_config_file.feature
+++ b/features/config/view/invalid_alternative_config_file.feature
@@ -1,0 +1,14 @@
+@this
+Feature: print nice error message for invalid alternative config file
+
+  Scenario: Config file with alternative filename and invalid TOML content
+    Given a Git repo with origin
+    And file ".git-town.toml" with content
+      """
+      wrong =
+      """
+    When I run "git-town config"
+    Then Git Town prints the error:
+      """
+      the configuration file ".git-town.toml" does not contain TOML-formatted content
+      """

--- a/features/config/view/invalid_alternative_config_file.feature
+++ b/features/config/view/invalid_alternative_config_file.feature
@@ -1,4 +1,3 @@
-@this
 Feature: print nice error message for invalid alternative config file
 
   Scenario: Config file with alternative filename and invalid TOML content


### PR DESCRIPTION
```
Feature: print nice error message for invalid alternative config file

  Scenario: Config file with alternative filename and invalid TOML content
```