### PR TITLE
Misc docs cleanup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,7 @@ issues:
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all
-  # excluded by default patterns execute `golangci-lint run --help`
+  # excluded by default patterns, run `golangci-lint run --help`
   exclude:
     - Using the variable on range scope `(input|expected)` in function literal
   exclude-rules:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ development. Supports mono-repos and stacked changes. Check out
 
 #### Dealing with errors
 
-- [continue](https://www.git-town.com/commands/continue.html) - restart the last
-  Git Town command after having resolved conflicts
-- [skip](https://www.git-town.com/commands/skip.html) - restart the last run Git
+- [continue](https://www.git-town.com/commands/continue.html) - resume the last
+  run Git Town command after having resolved conflicts
+- [skip](https://www.git-town.com/commands/skip.html) - resume the last run Git
   Town command by skipping the current branch
 - [status](https://www.git-town.com/commands/status.html) - displays or resets
   the current suspended Git Town command

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -167,11 +167,11 @@ Git commands that the Git Town test suite runs under the hood, add a tag
 Scenario: my awesome scenario
 ```
 
-To see all Git commands that the test runner and the Git Town command run,
-execute the Git Town command with the `--verbose` option. As an example, if the
-step `When I run "git-town append new"` mysteriously fails, you could change it
-to `When I run "git-town append new -v"`. Also add the tags `@debug @this` to
-see the CLI output on the console.
+To see all Git commands that the test runner and the Git Town command execute,
+run the Git Town command with the `--verbose` option. As an example, if the step
+`When I run "git-town append new"` mysteriously fails, you could change it to
+`When I run "git-town append new -v"`. Also add the tags `@debug @this` to see
+the CLI output on the console.
 
 To get a quick glance of which status the repo is at any point in time, insert
 the step `And display "<command_>"` running whatever command you want to execute

--- a/internal/cmd/continue.go
+++ b/internal/cmd/continue.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const continueDesc = "Restart the last run Git Town command after having resolved conflicts"
+const continueDesc = "Resume the last run Git Town command after having resolved conflicts"
 
 func continueCmd() *cobra.Command {
 	addVerboseFlag, readVerboseFlag := flags.Verbose()

--- a/internal/cmd/skip.go
+++ b/internal/cmd/skip.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const skipDesc = "Restart the last run Git Town command by skipping the current branch"
+const skipDesc = "Resume the last run Git Town command by skipping the current branch"
 
 func skipCmd() *cobra.Command {
 	addVerboseFlag, readVerboseFlag := flags.Verbose()

--- a/website/src/branch-types.md
+++ b/website/src/branch-types.md
@@ -108,9 +108,9 @@ You can compress and ship prototype branches as usual. Parking and unparking a
 prototype branch maintains its prototype status. When you change a prototype
 branch to an observed or contribution branch it loses its prototype status.
 
-To designate any feature branch as a prototype branch, execute
-[git town prototype](commands/prototype.md) on it. To convert a prototype branch
-to a feature branch, use [git town hack](commands/hack.md).
+To designate any feature branch as a prototype branch, run
+[git town prototype](commands/prototype.md). To convert a prototype branch to a
+feature branch, run [git town hack](commands/hack.md).
 
 ## Configuring branch types
 

--- a/website/src/commands/status.md
+++ b/website/src/commands/status.md
@@ -20,5 +20,5 @@ determine the repository state.
 
 ### subcommands
 
-The [reset](status-reset.md) subcommand prints the parent branch of the current
-or given
+The [reset](status-reset.md) subcommand deletes the persisted runstate. This is
+only needed if the runstate is corrupted and causes Git Town to crash.

--- a/website/src/commands/sync.md
+++ b/website/src/commands/sync.md
@@ -43,8 +43,8 @@ developers.
 
 ### --dry-run
 
-The `--dry-run` flag allows to test-drive this command. It prints the Git
-commands that would be run but doesn't execute them.
+Use the `--dry-run` flag to test-drive this command. It prints the Git commands
+that would be run but doesn't execute them.
 
 ### --no-push
 

--- a/website/src/configuration-file.md
+++ b/website/src/configuration-file.md
@@ -1,7 +1,7 @@
 # Git Town Configuration File
 
 Git Town can be configured through a configuration file with named
-**.git-branches.toml**. To create one, execute:
+**.git-branches.toml**. To create one, run:
 
 ```
 git town config setup

--- a/website/src/configuration-file.md
+++ b/website/src/configuration-file.md
@@ -1,6 +1,6 @@
 # Git Town Configuration File
 
-Git Town can be configured through a configuration file with named
+Git Town can be configured through a configuration file named
 **.git-branches.toml** or **.git-town.toml**. To create one, run:
 
 ```

--- a/website/src/configuration.md
+++ b/website/src/configuration.md
@@ -1,8 +1,9 @@
 # Configuration
 
-If your repository already contains a `.git-branches.toml` file, you are good to
-go. If not or something doesn't work, run Git Town's setup assistant. It walks
-you through every configuration option and gives you a chance to adjust it.
+If your repository already contains a `.git-branches.toml` or `.git-town.toml`
+file, you are good to go. If not or something doesn't work, run Git Town's setup
+assistant. It walks you through every configuration option and gives you a
+chance to adjust it.
 
 ```
 git town config setup

--- a/website/src/preferences/offline.md
+++ b/website/src/preferences/offline.md
@@ -12,8 +12,8 @@ This setting applies to all repositories on your local machine.
 
 ## set via CLI
 
-To put Git Town into offline mode, execute the
-[git town offline](../commands/offline.md) command.
+To put Git Town into offline mode, run
+[git town offline](../commands/offline.md).
 
 ## Git metadata
 


### PR DESCRIPTION
@kevgo Let me know if you would prefer I split this up into multiple PRs.

This PR fixes a few things I found while reading the documentation today:

- Consistently use "run" instead of "execute" when telling the user to run a command
- Change "restart" to "resume" when talking about error handling
- Update the description for `--dry-run` in sync.md to match other files
- Fix description of `git town status reset` subcommand in status.md
- Fix grammar in "a configuration file with named" with "a configuration file named" in configuration-file.md
- Add reference to alternative config filename in configuration.md