### PR TITLE
More idiomatic loading of the current branch

### DIFF
--- a/features/compress/current_branch/verbose.feature
+++ b/features/compress/current_branch/verbose.feature
@@ -24,7 +24,7 @@ Feature: compress the commits on a feature branch verbosely
       |         | git rev-parse --verify --abbrev-ref @{-1}          |
       |         | git status --long --ignore-submodules              |
       |         | git remote                                         |
-      |         | git rev-parse --abbrev-ref HEAD                    |
+      |         | git branch --show-current                          |
       | feature | git fetch --prune --tags                           |
       | <none>  | git stash list                                     |
       |         | git branch -vva --sort=refname                     |

--- a/features/config/get_parent/no_arg/verbose.feature
+++ b/features/config/get_parent/no_arg/verbose.feature
@@ -14,7 +14,7 @@ Feature: display the parent of a top-level feature branch
       |        | backend | git rev-parse --show-toplevel      |
       |        | backend | git config -lz --includes --global |
       |        | backend | git config -lz --includes --local  |
-      |        | backend | git rev-parse --abbrev-ref HEAD    |
+      |        | backend | git branch --show-current          |
     And Git Town prints:
       """
       Ran 5 shell commands.

--- a/features/delete/current_branch/features/verbose.feature
+++ b/features/delete/current_branch/features/verbose.feature
@@ -23,7 +23,7 @@ Feature: display all executed Git commands
       |         | backend  | git config -lz --includes --local                 |
       |         | backend  | git status --long --ignore-submodules             |
       |         | backend  | git remote                                        |
-      |         | backend  | git rev-parse --abbrev-ref HEAD                   |
+      |         | backend  | git branch --show-current                         |
       | current | frontend | git fetch --prune --tags                          |
       |         | backend  | git stash list                                    |
       |         | backend  | git branch -vva --sort=refname                    |

--- a/features/rename/features/verbose.feature
+++ b/features/rename/features/verbose.feature
@@ -22,7 +22,7 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git status --long --ignore-submodules         |
       |        | backend  | git remote                                    |
-      |        | backend  | git rev-parse --abbrev-ref HEAD               |
+      |        | backend  | git branch --show-current                     |
       | old    | frontend | git fetch --prune --tags                      |
       |        | backend  | git stash list                                |
       |        | backend  | git branch -vva --sort=refname                |

--- a/features/repo/features/verbose.feature
+++ b/features/repo/features/verbose.feature
@@ -16,7 +16,7 @@ Feature: display all executed Git commands
       |        | backend  | which garcon-url-handler                  |
       |        | backend  | which xdg-open                            |
       |        | backend  | which open                                |
-      |        | backend  | git rev-parse --abbrev-ref HEAD           |
+      |        | backend  | git branch --show-current                 |
       | <none> | frontend | open https://github.com/git-town/git-town |
     And Git Town prints:
       """

--- a/features/ship/fast_forward/current_branch/verbose.feature
+++ b/features/ship/fast_forward/current_branch/verbose.feature
@@ -21,7 +21,7 @@ Feature: display all executed Git commands when using the fast-forward strategy
       |         | backend  | git config -lz --includes --local                 |
       |         | backend  | git status --long --ignore-submodules             |
       |         | backend  | git remote                                        |
-      |         | backend  | git rev-parse --abbrev-ref HEAD                   |
+      |         | backend  | git branch --show-current                         |
       | feature | frontend | git fetch --prune --tags                          |
       |         | backend  | git stash list                                    |
       |         | backend  | git branch -vva --sort=refname                    |

--- a/features/ship/squash_merge/current_branch/verbose/verbose.feature
+++ b/features/ship/squash_merge/current_branch/verbose/verbose.feature
@@ -21,7 +21,7 @@ Feature: display all executed Git commands
       |         | backend  | git config -lz --includes --local                 |
       |         | backend  | git status --long --ignore-submodules             |
       |         | backend  | git remote                                        |
-      |         | backend  | git rev-parse --abbrev-ref HEAD                   |
+      |         | backend  | git branch --show-current                         |
       | feature | frontend | git fetch --prune --tags                          |
       |         | backend  | git stash list                                    |
       |         | backend  | git branch -vva --sort=refname                    |

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -293,8 +293,8 @@ func (self *Commands) CurrentBranchHasTrackingBranch(runner gitdomain.Runner) bo
 // CurrentBranch provides the currently checked out branch.
 func (self *Commands) CurrentBranchUncached(querier gitdomain.Querier) (gitdomain.LocalBranchName, error) {
 	// first try to detect the current branch the normal way
-	output, err := querier.QueryTrim("git", "rev-parse", "--abbrev-ref", "HEAD")
-	if err == nil && output != "HEAD" {
+	output, err := querier.QueryTrim("git", "branch", "--show-current")
+	if err == nil && output != "" {
 		return gitdomain.NewLocalBranchName(output), nil
 	}
 	// here we couldn't detect the current branch the normal way --> assume we are in a rebase and try the rebase way


### PR DESCRIPTION
This is @stephenwade's excellent idea, extracted from #4365. The point of this PR is to test and ship this change separate from the other changes made.