### PR TITLE
Simplify error handling in test code

### DIFF
--- a/test/fixture/factory.go
+++ b/test/fixture/factory.go
@@ -1,10 +1,10 @@
 package fixture
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 
+	"github.com/git-town/git-town/v17/test/asserts"
 	"github.com/git-town/git-town/v17/test/filesystem"
 	"github.com/git-town/git-town/v17/test/helpers"
 )
@@ -30,14 +30,10 @@ type Factory struct {
 // creates a new FixtureFactory instance
 func CreateFactory() Factory {
 	baseDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		log.Fatalf("cannot create base directory for feature specs: %s", err)
-	}
+	asserts.NoError(err)
 	// Evaluate symlinks as Mac temp dir is symlinked
 	evalBaseDir, err := filepath.EvalSymlinks(baseDir)
-	if err != nil {
-		log.Fatalf("cannot evaluate symlinks of base directory for feature specs: %s", err)
-	}
+	asserts.NoError(err)
 	return Factory{
 		Counter:  helpers.AtomicCounter{},
 		Dir:      evalBaseDir,

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -82,9 +82,7 @@ func (self *Fixture) AddSecondWorktree(branch gitdomain.LocalBranchName) {
 // AddSubmodule adds a submodule repository.
 func (self *Fixture) AddSubmoduleRepo() {
 	err := os.MkdirAll(self.submoduleRepoPath(), 0o744)
-	if err != nil {
-		log.Fatalf("cannot create directory %q: %v", self.submoduleRepoPath(), err)
-	}
+	asserts.NoError(err)
 	submoduleRepo := testruntime.Initialize(self.submoduleRepoPath(), self.Dir, self.binPath())
 	submoduleRepo.MustRun("git", "config", "--global", "protocol.file.allow", "always")
 	self.SubmoduleRepo = MutableSome(&submoduleRepo)

--- a/test/fixture/fresh.go
+++ b/test/fixture/fresh.go
@@ -1,10 +1,10 @@
 package fixture
 
 import (
-	"log"
 	"os"
 
 	. "github.com/git-town/git-town/v17/pkg/prelude"
+	"github.com/git-town/git-town/v17/test/asserts"
 	"github.com/git-town/git-town/v17/test/commands"
 	"github.com/git-town/git-town/v17/test/testruntime"
 )
@@ -23,9 +23,7 @@ func NewFresh(dir string) Fresh {
 	devRepoPath := developerRepoPath(dir)
 	// create the "developer" repo
 	err := os.MkdirAll(devRepoPath, 0o744)
-	if err != nil {
-		log.Fatalf("cannot create directory %q: %v", devRepoPath, err)
-	}
+	asserts.NoError(err)
 	// initialize the repo in the folder
 	devRepo := testruntime.InitializeNoInitialCommit(devRepoPath, dir, binPath)
 	devRepo.RemoveUnnecessaryFiles()

--- a/test/fixture/memoized.go
+++ b/test/fixture/memoized.go
@@ -1,11 +1,11 @@
 package fixture
 
 import (
-	"log"
 	"os"
 
 	"github.com/git-town/git-town/v17/internal/git/gitdomain"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
+	"github.com/git-town/git-town/v17/test/asserts"
 	"github.com/git-town/git-town/v17/test/commands"
 	"github.com/git-town/git-town/v17/test/filesystem"
 	"github.com/git-town/git-town/v17/test/testruntime"
@@ -30,15 +30,11 @@ func NewMemoized(dir string) Memoized {
 	devRepoPath := developerRepoPath(dir)
 	// create the origin repo
 	err := os.MkdirAll(originPath, 0o744)
-	if err != nil {
-		log.Fatalf("cannot create directory %q: %v", originPath, err)
-	}
+	asserts.NoError(err)
 	// initialize the repo in the folder
 	originRepo := testruntime.Initialize(originPath, dir, binPath)
 	err = originRepo.Run("git", "branch", "main", "initial")
-	if err != nil {
-		log.Fatalf("cannot initialize origin directory at %q: %v", originPath, err)
-	}
+	asserts.NoError(err)
 	// clone the "developer" repo
 	devRepo := testruntime.Clone(originRepo.TestRunner, devRepoPath)
 	initializeWorkspace(&devRepo)

--- a/test/subshell/test_runner.go
+++ b/test/subshell/test_runner.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,9 +95,7 @@ else
 	%s "$@"
 fi`
 	gitPath, err := exec.LookPath("git")
-	if err != nil {
-		log.Fatalf("cannot locate the git executable: %v", err)
-	}
+	asserts.NoError(err)
 	content := fmt.Sprintf(mockGit, version, gitPath)
 	self.createMockBinary("git", content)
 }


### PR DESCRIPTION
No need for human-friendly error messages. Exploding with a stack trace is all we need when test code fails since it's easy to debug this.