### PR TITLE
Improve GitHub Actions job names

### DIFF
--- a/.github/workflows/cuke.yml
+++ b/.github/workflows/cuke.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  run:
+  godog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  run:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  run:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  run:
+  smoke:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Sometimes, GitHub Actions displays the jobs that were run against a commit without displaying their workflow names.

For example, here's what I see after clicking "View details" in a merged PR:

<img width="842" alt="The message at the top of the screenshot says that a commit was merged. Below that is a list of the checks that were run on the commit. All 4 checks are just labeled 'run'." src="https://github.com/user-attachments/assets/5cf88d25-3e7b-4e02-9031-44d2243ce4b8" />

Updating the job names in the workflows will make it possible to tell which check belongs to which workflow.