### PR TITLE
Use typograher's quotes in rendered HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@ Big shoutout to @LogvinovLeon, @alexw10, @charlierudolph, @cjol, @ericcao52, @ke
 
 - Full integration of proposals ([#2745](https://github.com/git-town/git-town/issues/2745)):
   - Git Town now updates all affected pull requests when you rename, prepend, or remove a branch or change its parent.
-  - If the parent of a branch is unknown but there's an open PR, Git Town will now grab the PR’s base branch as the parent.
+  - If the parent of a branch is unknown but there's an open PR, Git Town will now grab the PR's base branch as the parent.
   - `git town undo` now also reverts any changes made to pull requests ([#4049](https://github.com/git-town/git-town/issues/4049)).
 - Full integration with the Bitbucket Cloud API ([#973](https://github.com/git-town/git-town/issues/973)) and the gitea API ([#4044](https://github.com/git-town/git-town/pull/4044)).
 - `git town rename-branch` now maintains the Git configuration and reflog for renamed branches ([#4023](https://github.com/git-town/git-town/issues/4023)).

--- a/internal/hosting/hostingdomain/connector.go
+++ b/internal/hosting/hostingdomain/connector.go
@@ -10,7 +10,7 @@ import (
 // Individual implementations exist to talk to specific hosting platforms.
 // Functions that might or might not be supported by a connector are implemented as higher-level functions,
 // i.e. they return an option of the function to call.
-// A `None“ value implies that the respective functionality isn't supported by this connector implementation.
+// A `None` value implies that the respective functionality isn't supported by this connector implementation.
 type Connector interface {
 	// DefaultProposalMessage provides the text that the form for creating new proposals
 	// on the respective hosting platform is prepopulated with.

--- a/website/book.toml
+++ b/website/book.toml
@@ -11,3 +11,4 @@ git-repository-url = "https://github.com/git-town/git-town"
 edit-url-template = "https://github.com/git-town/git-town/edit/main/website/{path}"
 site-url = "https://www.git-town.com/"
 no-section-label = true
+smart-punctuation = true

--- a/website/src/questions.md
+++ b/website/src/questions.md
@@ -2,7 +2,7 @@
 
 ### Does Git Town enforce any specific conventions for branches or commits?
 
-No, Git Town doesn’t impose any rules for branch or commit naming. It works with
+No, Git Town doesn't impose any rules for branch or commit naming. It works with
 a wide range of Git branching strategies and workflows. If you find it doesn't
 mesh with your specific setup,
 [reach out to us](https://github.com/git-town/git-town/issues/new).
@@ -19,8 +19,8 @@ you commit directly to the main branch!
 ### How is Git Town different from the [git-flow](https://github.com/nvie/gitflow) tool?
 
 `git-flow` is a specialized Git extension designed around providing opinionated
-support for the Git Flow branching model. It doesn’t help with keeping your
-branches or team in sync. Git Town, on the other hand, doesn’t mind which
+support for the Git Flow branching model. It doesn't help with keeping your
+branches or team in sync. Git Town, on the other hand, doesn't mind which
 branching model you use&mdash;it focuses on syncing your team's work and keeping
 your repo tidy by cleaning up old branches. You can use Git Town alongside
 `git-flow` if that fits your workflow.

--- a/website/src/stacked-changes.md
+++ b/website/src/stacked-changes.md
@@ -142,7 +142,7 @@ it merges branch 1 into branch 2 and branch 2 into branch 3.
 
 ## Shipping the refactor
 
-We got the approval for the refactor from step 1. Let’s ship it!
+We got the approval for the refactor from step 1. Let's ship it!
 
 ```
 git town ship 1-refactor
@@ -186,7 +186,7 @@ We can now add the new feature on top of the code base we prepared:
 git town append 4-add-feature
 ```
 
-Let’s stop here and review what we have done.
+Let's stop here and review what we have done.
 
 - Each change happens in its own feature branch.
 - Our feature branches build on top of each other and see changes in their


### PR DESCRIPTION
Enable the `smart-punctuation` option in mdBook. This option automatically converts straight quotes to curly quotes when rendering the website.

This PR also replaces the handful of curly quotes in the Markdown files with straight quotes to be consistent.

**Before:**
![Screenshot of the Git Town website with straight quotes](https://github.com/user-attachments/assets/98948f18-95a5-4122-bd43-0dd93f6ee450#gh-light-mode-only)![Screenshot of the Git Town website with straight quotes](https://github.com/user-attachments/assets/27642d04-59cf-4bda-8bbb-685d97cbd234#gh-dark-mode-only)

**After:**
![Screenshot of the Git Town website with curly quotes](https://github.com/user-attachments/assets/cd421cbf-4345-4a9e-a6e2-ba41d1a73483#gh-light-mode-only)![Screenshot of the Git Town website with curly quotes](https://github.com/user-attachments/assets/1c7cbc60-e48b-4aee-8955-02090f4b1955#gh-dark-mode-only)
