### PR TITLE
Add MergeNoFastForward

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -525,6 +525,11 @@ func (self *Commands) MergeFastForward(runner gitdomain.Runner, branch gitdomain
 	return runner.Run("git", "merge", "--ff-only", branch.String())
 }
 
+// MergeNoFastForward merges branch into the current branch and always creates a merge commit.
+func (self *Commands) MergeNoFastForward(runner gitdomain.Runner, branch gitdomain.LocalBranchName) error {
+	return runner.Run("git", "merge", "--no-ff", branch.String())
+}
+
 // NavigateToDir changes into the root directory of the current repository.
 func (self *Commands) NavigateToDir(dir gitdomain.RepoRootDir) error {
 	return os.Chdir(dir.String())

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -17,6 +17,7 @@ import (
 func TestBackendCommands(t *testing.T) {
 	t.Parallel()
 	initial := gitdomain.NewLocalBranchName("initial")
+	// Keep tests sorted.
 
 	t.Run("BranchAuthors", func(t *testing.T) {
 		t.Parallel()
@@ -464,6 +465,52 @@ func TestBackendCommands(t *testing.T) {
 			have := git.LastBranchInRef(give)
 			must.EqOp(t, want, have)
 		}
+	})
+
+	t.Run("MergeFastForward", func(t *testing.T) {
+		t.Parallel()
+		branch := gitdomain.NewLocalBranchName("branch")
+		runtime := testruntime.Create(t)
+		runtime.CreateBranch(branch, initial.BranchName())
+		runtime.CreateCommit(testgit.Commit{
+			Branch:      branch,
+			FileContent: "file1",
+			FileName:    "file1",
+			Message:     "first commit",
+		})
+		runtime.CheckoutBranch(initial) // CreateCommit checks out `branch`, go back to `initial`.
+
+		err := runtime.MergeFastForward(runtime.TestRunner, branch)
+		must.NoError(t, err)
+
+		commits, err := runtime.Commands.CommitsInPerennialBranch(runtime) // Current branch.
+		must.NoError(t, err)
+		haveMessages := commits.Messages()
+		wantMessages := gitdomain.NewCommitMessages("first commit", "initial commit")
+		must.Eq(t, wantMessages, haveMessages)
+	})
+
+	t.Run("MergeNoFastForward", func(t *testing.T) {
+		t.Parallel()
+		branch := gitdomain.NewLocalBranchName("branch")
+		runtime := testruntime.Create(t)
+		runtime.CreateBranch(branch, initial.BranchName())
+		runtime.CreateCommit(testgit.Commit{
+			Branch:      branch,
+			FileContent: "file1",
+			FileName:    "file1",
+			Message:     "first commit",
+		})
+		runtime.CheckoutBranch(initial) // CreateCommit checks out `branch`, go back to `initial`.
+
+		err := runtime.MergeNoFastForward(runtime.TestRunner, branch)
+		must.NoError(t, err)
+
+		commits, err := runtime.Commands.CommitsInPerennialBranch(runtime) // Current branch.
+		must.NoError(t, err)
+		haveMessages := commits.Messages()
+		wantMessages := gitdomain.NewCommitMessages("Merge branch 'branch' into initial", "initial commit", "first commit")
+		must.Eq(t, wantMessages, haveMessages)
 	})
 
 	t.Run("NewUnmergedStage", func(t *testing.T) {


### PR DESCRIPTION
Add unit tests for both MergeFastForward and MergeNoFastForward.

Add unit tests for both MergeFastForward and MergeNoFastForward.
Commands.CommitsInPerennialBranch is used because NewCommitMessages is
more convenient for testing than the test_commands's CommitsInBranch.

Commands.CommitsInBranch(branch, None) ignores the branch name as it
is just a wrapper around CommitsInPerennialBranch if the parent is
None, so it is more readable to just call the CommitsInPerennialBranch
directly.

See #4381.