### PR TITLE
Remove unnecessary type aliases

### DIFF
--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -43,7 +43,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 		Verbose:         args.Verbose,
 	}
 	gitCommands := git.Commands{
-		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
+		CurrentBranchCache: &cache.WithPrevious[gitdomain.LocalBranchName]{},
 		RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 	}
 	gitVersion, err := gitCommands.Version(backendRunner)

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -44,7 +44,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	}
 	gitCommands := git.Commands{
 		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
-		RemotesCache:       &cache.Remotes{},
+		RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 	}
 	gitVersion, err := gitCommands.Version(backendRunner)
 	if err != nil {

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -20,8 +20,8 @@ import (
 // They don't change the user's repo, execute instantaneously, and Git Town needs to know their output.
 // They are invisible to the end user unless the "verbose" option is set.
 type Commands struct {
-	CurrentBranchCache *cache.LocalBranchWithPrevious // caches the currently checked out Git branch
-	RemotesCache       *cache.Remotes                 // caches Git remotes
+	CurrentBranchCache *cache.LocalBranchWithPrevious  // caches the currently checked out Git branch
+	RemotesCache       *cache.Cache[gitdomain.Remotes] // caches Git remotes
 }
 
 // AbortMerge cancels a currently ongoing Git merge operation.

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -20,8 +20,8 @@ import (
 // They don't change the user's repo, execute instantaneously, and Git Town needs to know their output.
 // They are invisible to the end user unless the "verbose" option is set.
 type Commands struct {
-	CurrentBranchCache *cache.LocalBranchWithPrevious  // caches the currently checked out Git branch
-	RemotesCache       *cache.Cache[gitdomain.Remotes] // caches Git remotes
+	CurrentBranchCache *cache.WithPrevious[gitdomain.LocalBranchName] // caches the currently checked out Git branch
+	RemotesCache       *cache.Cache[gitdomain.Remotes]                // caches Git remotes
 }
 
 // AbortMerge cancels a currently ongoing Git merge operation.

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -1050,7 +1050,7 @@ func TestBackendCommands(t *testing.T) {
 			}
 			cmds := git.Commands{
 				CurrentBranchCache: &cache.LocalBranchWithPrevious{},
-				RemotesCache:       &cache.Remotes{},
+				RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 			}
 			have := cmds.RootDirectory(runner)
 			must.True(t, have.IsNone())

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -1049,7 +1049,7 @@ func TestBackendCommands(t *testing.T) {
 				CommandsCounter: NewMutable(new(gohacks.Counter)),
 			}
 			cmds := git.Commands{
-				CurrentBranchCache: &cache.LocalBranchWithPrevious{},
+				CurrentBranchCache: &cache.WithPrevious[gitdomain.LocalBranchName]{},
 				RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 			}
 			have := cmds.RootDirectory(runner)

--- a/internal/gohacks/cache/cache_test.go
+++ b/internal/gohacks/cache/cache_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStringSliceCache(t *testing.T) {
 	t.Parallel()
-	ssc := cache.Strings{}
+	ssc := cache.Cache[[]string]{}
 	must.False(t, ssc.Initialized())
 	ssc.Set(&[]string{"foo"})
 	must.True(t, ssc.Initialized())

--- a/internal/gohacks/cache/core.go
+++ b/internal/gohacks/cache/core.go
@@ -11,6 +11,3 @@ type RemoteBranch = Cache[gitdomain.RemoteBranchName]
 
 // Remotes is a cache for domain.Remotes variables.
 type Remotes = Cache[gitdomain.Remotes]
-
-// Strings is a cache for string variables.
-type Strings = Cache[[]string]

--- a/internal/gohacks/cache/core.go
+++ b/internal/gohacks/cache/core.go
@@ -10,4 +10,4 @@ type LocalBranchWithPrevious = WithPrevious[gitdomain.LocalBranchName]
 type RemoteBranch = Cache[gitdomain.RemoteBranchName]
 
 // Remotes is a cache for domain.Remotes variables.
-type Remotes = Cache[gitdomain.Remotes]
+// type Remotes = Cache[gitdomain.Remotes]

--- a/internal/gohacks/cache/core.go
+++ b/internal/gohacks/cache/core.go
@@ -8,6 +8,3 @@ type LocalBranchWithPrevious = WithPrevious[gitdomain.LocalBranchName]
 
 // RemoteBranch is a cache for gitdomain.RemoteBranchName variables.
 type RemoteBranch = Cache[gitdomain.RemoteBranchName]
-
-// Remotes is a cache for domain.Remotes variables.
-// type Remotes = Cache[gitdomain.Remotes]

--- a/internal/gohacks/cache/core.go
+++ b/internal/gohacks/cache/core.go
@@ -5,6 +5,3 @@ import "github.com/git-town/git-town/v17/internal/git/gitdomain"
 
 // LocalBranch is a cache for gitdomain.LocalBranchName variables.
 type LocalBranchWithPrevious = WithPrevious[gitdomain.LocalBranchName]
-
-// RemoteBranch is a cache for gitdomain.RemoteBranchName variables.
-type RemoteBranch = Cache[gitdomain.RemoteBranchName]

--- a/internal/gohacks/cache/core.go
+++ b/internal/gohacks/cache/core.go
@@ -1,7 +1,2 @@
 // Package cache provides infrastructure to cache things in memory.
 package cache
-
-import "github.com/git-town/git-town/v17/internal/git/gitdomain"
-
-// LocalBranch is a cache for gitdomain.LocalBranchName variables.
-type LocalBranchWithPrevious = WithPrevious[gitdomain.LocalBranchName]

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -69,7 +69,7 @@ func (self *Fixture) AddSecondWorktree(branch gitdomain.LocalBranchName) {
 		WorkingDir:       workTreePath,
 	}
 	gitCommands := git.Commands{
-		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
+		CurrentBranchCache: &cache.WithPrevious[gitdomain.LocalBranchName]{},
 		RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 	}
 	self.SecondWorktree = MutableSome(&commands.TestCommands{

--- a/test/fixture/fixture.go
+++ b/test/fixture/fixture.go
@@ -70,7 +70,7 @@ func (self *Fixture) AddSecondWorktree(branch gitdomain.LocalBranchName) {
 	}
 	gitCommands := git.Commands{
 		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
-		RemotesCache:       &cache.Remotes{},
+		RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 	}
 	self.SecondWorktree = MutableSome(&commands.TestCommands{
 		TestRunner: &runner,

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -89,7 +89,7 @@ func New(workingDir, homeDir, binDir string) commands.TestCommands {
 		WorkingDir:       workingDir,
 	}
 	gitCommands := git.Commands{
-		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
+		CurrentBranchCache: &cache.WithPrevious[gitdomain.LocalBranchName]{},
 		RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 	}
 	unvalidatedConfig := config.NewUnvalidatedConfig(config.NewUnvalidatedConfigArgs{

--- a/test/testruntime/test_runtime.go
+++ b/test/testruntime/test_runtime.go
@@ -90,7 +90,7 @@ func New(workingDir, homeDir, binDir string) commands.TestCommands {
 	}
 	gitCommands := git.Commands{
 		CurrentBranchCache: &cache.LocalBranchWithPrevious{},
-		RemotesCache:       &cache.Remotes{},
+		RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 	}
 	unvalidatedConfig := config.NewUnvalidatedConfig(config.NewUnvalidatedConfigArgs{
 		Access: gitconfig.Access{


### PR DESCRIPTION
These type aliases were helpful when developing the caching architecture, but they reduce readability now and come across as unnecessary cleverness. Better to inline them.