### PR TITLE
Add "always-merge" strategy (inaccessible to users for now)

### DIFF
--- a/internal/cli/dialog/ship_strategy.go
+++ b/internal/cli/dialog/ship_strategy.go
@@ -34,6 +34,7 @@ func ShipStrategy(existing configdomain.ShipStrategy, inputs components.TestInpu
 			Data: configdomain.ShipStrategyFastForward,
 			Text: `fast-forward: in your local repo, fast-forward the parent branch to point to the commits on the feature branch`,
 		},
+		// TODO: #4381 - add ShipStrategyAlwaysMerge
 		{
 			Data: configdomain.ShipStrategySquashMerge,
 			Text: `squash-merge: in your local repo, squash-merge the feature branch into its parent branch`,

--- a/internal/cmd/ship/core.go
+++ b/internal/cmd/ship/core.go
@@ -121,6 +121,9 @@ func executeShip(args []string, message Option[gitdomain.CommitMessage], dryRun 
 			return err
 		}
 		shipProgramFastForward(prog, sharedData, mergeData)
+	case configdomain.ShipStrategyAlwaysMerge:
+		// TODO: #4381 - add ShipStrategyAlwaysMerge support
+		return errors.New("unimplemented, impossible branch")
 	case configdomain.ShipStrategySquashMerge:
 		squashMergeData, err := determineMergeData(repo, sharedData.branchNameToShip, sharedData.targetBranchName)
 		if err != nil {

--- a/internal/config/configdomain/ship_strategy.go
+++ b/internal/config/configdomain/ship_strategy.go
@@ -11,6 +11,7 @@ import (
 const (
 	ShipStrategyAPI         ShipStrategy = "api"          // shipping via the code hosting API
 	ShipStrategyFastForward ShipStrategy = "fast-forward" // shipping by doing a local fast-forward
+	ShipStrategyAlwaysMerge ShipStrategy = "always-merge" // shipping by doing a local merge commit (merge --no-ff)
 	ShipStrategySquashMerge ShipStrategy = "squash-merge" // shipping by doing a local squash-merge
 )
 
@@ -38,6 +39,7 @@ func ShipStrategies() []ShipStrategy {
 	return []ShipStrategy{
 		ShipStrategyAPI,
 		ShipStrategyFastForward,
+		// TODO: #4381 - add ShipStrategyAlwaysMerge
 		ShipStrategySquashMerge,
 	}
 }


### PR DESCRIPTION
"always-merge" clearly states that this is a merge commit. "always" also
implies that the merge commit is always going to be created.

Alternative names considered:
- "no-fast-forward" is longer than "forced-merge" and relies on users
  knowing the implementation detail of the merge command: --no-ff flag.
  It is reasonable to call the internal operation MergeNoFastForward
  (see #4390) as it clearly resembles `merge --no-ff`, but it shouldn't
  be exposed the same way to the end users. Plus having negative words
  in the name makes it harder to read.
- "no-ff" is inconsistent with "fast-forward" and "squash-merge". Both
  use full words instead of abbreviations.
- "forced-merge" clearly states that this is a merge commit. "forced"
  also implies that the merge commit is always going to be created, but
  it does have a connotation that this isn't a good idea to do so,
  similar to `git push --force`. See
  <https://github.com/git-town/git-town/pull/4404#issuecomment-2560555323>.

See #4381.