### PR TITLE
Compose LineageKey out of Key

### DIFF
--- a/internal/config/configdomain/lineage.go
+++ b/internal/config/configdomain/lineage.go
@@ -37,7 +37,7 @@ func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, remove
 		if childName == "" {
 			// empty lineage entries are invalid --> delete it
 			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))
-			_ = removeLocalConfigValue(key.Key())
+			_ = removeLocalConfigValue(key.Key)
 			continue
 		}
 		child := gitdomain.NewLocalBranchName(childName)
@@ -45,7 +45,7 @@ func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, remove
 		if value == "" {
 			// empty lineage entries are invalid --> delete it
 			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))
-			_ = removeLocalConfigValue(key.Key())
+			_ = removeLocalConfigValue(key.Key)
 			continue
 		}
 		if updateOutdated && childName == value {

--- a/internal/config/configdomain/lineage_key.go
+++ b/internal/config/configdomain/lineage_key.go
@@ -20,9 +20,7 @@ func NewLineageKey(key Key) LineageKey {
 // CheckLineage indicates using the returned option whether this key is a lineage key.
 func ParseLineageKey(key Key) Option[LineageKey] {
 	if isLineageKey(key.String()) {
-		return Some(LineageKey{
-			Key: key,
-		})
+		return Some(NewLineageKey(key))
 	}
 	return None[LineageKey]()
 }

--- a/internal/config/configdomain/lineage_key.go
+++ b/internal/config/configdomain/lineage_key.go
@@ -7,12 +7,22 @@ import (
 )
 
 // a Key that contains a lineage entry
-type LineageKey Key
+type LineageKey struct {
+	Key
+}
+
+func NewLineageKey(key Key) LineageKey {
+	return LineageKey{
+		Key: key,
+	}
+}
 
 // CheckLineage indicates using the returned option whether this key is a lineage key.
-func NewLineageKey(key Key) Option[LineageKey] {
+func ParseLineageKey(key Key) Option[LineageKey] {
 	if isLineageKey(key.String()) {
-		return Some(LineageKey(key))
+		return Some(LineageKey{
+			Key: key,
+		})
 	}
 	return None[LineageKey]()
 }
@@ -20,15 +30,6 @@ func NewLineageKey(key Key) Option[LineageKey] {
 // provides the name of the child branch encoded in this LineageKey
 func (self LineageKey) ChildName() string {
 	return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(self.String(), LineageKeyPrefix), LineageKeySuffix))
-}
-
-// converts this LineageKey into a generic Key
-func (self LineageKey) Key() Key {
-	return Key(self)
-}
-
-func (self LineageKey) String() string {
-	return string(self)
 }
 
 const (

--- a/internal/config/configdomain/lineage_key_test.go
+++ b/internal/config/configdomain/lineage_key_test.go
@@ -16,23 +16,23 @@ func TestLineageKey(t *testing.T) {
 
 		t.Run("valid lineage key", func(t *testing.T) {
 			t.Parallel()
-			key := configdomain.LineageKey("git-town-branch.foo.parent")
+			key := configdomain.NewLineageKey("git-town-branch.foo.parent")
 			have := key.ChildName()
 			want := "foo"
 			must.EqOp(t, want, have)
 		})
 	})
 
-	t.Run("NewLineageKey", func(t *testing.T) {
+	t.Run("ParseLineageKey", func(t *testing.T) {
 		t.Parallel()
 		tests := map[string]Option[configdomain.LineageKey]{
-			"git-town-branch.branch.parent": Some(configdomain.LineageKey("git-town-branch.branch.parent")), // valid lineage key
-			"git-town-branch..parent":       Some(configdomain.LineageKey("git-town-branch..parent")),       // empty lineage key
-			"git-town.push-hook":            None[configdomain.LineageKey](),                                // not a lineage key
+			"git-town-branch.branch.parent": Some(configdomain.NewLineageKey("git-town-branch.branch.parent")), // valid lineage key
+			"git-town-branch..parent":       Some(configdomain.NewLineageKey("git-town-branch..parent")),       // empty lineage key
+			"git-town.push-hook":            None[configdomain.LineageKey](),                                   // not a lineage key
 		}
 		for give, want := range tests {
 			key := configdomain.Key(give)
-			have := configdomain.NewLineageKey(key)
+			have := configdomain.ParseLineageKey(key)
 			must.Eq(t, want, have)
 		}
 	})

--- a/internal/config/configdomain/single_snapshot.go
+++ b/internal/config/configdomain/single_snapshot.go
@@ -27,7 +27,7 @@ func (self SingleSnapshot) Aliases() Aliases {
 func (self SingleSnapshot) LineageEntries() map[LineageKey]string {
 	result := map[LineageKey]string{}
 	for key, value := range self {
-		if lineageKey, isLineageKey := NewLineageKey(key).Get(); isLineageKey {
+		if lineageKey, isLineageKey := ParseLineageKey(key).Get(); isLineageKey {
 			result[lineageKey] = value
 		}
 	}


### PR DESCRIPTION
The existing code models `LineageKey` as a simple type override. This PR changes this to a struct that embeds a `Key` field. The advantage is a reduction of redundant boilerplate code. `LineageKey` does not need to re-implement methods that `Key` already defines. Examples: `.String()` and `.Key()`.