### PR TITLE
Extract branch-specific key logic

### DIFF
--- a/internal/config/configdomain/branch_specific_key.go
+++ b/internal/config/configdomain/branch_specific_key.go
@@ -1,0 +1,19 @@
+package configdomain
+
+import "strings"
+
+// a Git config key that contains a branch specific value
+type BranchSpecificKey struct {
+	Key
+}
+
+// provides the name of the child branch encoded in this LineageKey
+func (self BranchSpecificKey) BranchName() string {
+	return strings.TrimSuffix(strings.TrimPrefix(self.String(), BranchSpecificKeyPrefix), LineageKeySuffix)
+}
+
+const BranchSpecificKeyPrefix = "git-town-branch."
+
+func isBranchSpecificKey(key string) bool {
+	return strings.HasPrefix(key, BranchSpecificKeyPrefix)
+}

--- a/internal/config/configdomain/branch_specific_key.go
+++ b/internal/config/configdomain/branch_specific_key.go
@@ -1,6 +1,10 @@
 package configdomain
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/git-town/git-town/v17/internal/git/gitdomain"
+)
 
 // a Git config key that contains a branch specific value
 type BranchSpecificKey struct {
@@ -8,8 +12,9 @@ type BranchSpecificKey struct {
 }
 
 // provides the name of the child branch encoded in this LineageKey
-func (self BranchSpecificKey) BranchName() string {
-	return strings.TrimSuffix(strings.TrimPrefix(self.String(), BranchSpecificKeyPrefix), LineageKeySuffix)
+func (self BranchSpecificKey) BranchName() gitdomain.LocalBranchName {
+	text := strings.TrimSuffix(strings.TrimPrefix(self.String(), BranchSpecificKeyPrefix), LineageKeySuffix)
+	return gitdomain.NewLocalBranchName(text)
 }
 
 const BranchSpecificKeyPrefix = "git-town-branch."

--- a/internal/config/configdomain/branch_specific_key_test.go
+++ b/internal/config/configdomain/branch_specific_key_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestBranchSpecificKey(t *testing.T) {
-
 	t.Run("BranchName", func(t *testing.T) {
 		t.Parallel()
 		key := configdomain.BranchSpecificKey{

--- a/internal/config/configdomain/branch_specific_key_test.go
+++ b/internal/config/configdomain/branch_specific_key_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestBranchSpecificKey(t *testing.T) {
+	t.Parallel()
 	t.Run("BranchName", func(t *testing.T) {
 		t.Parallel()
 		key := configdomain.BranchSpecificKey{

--- a/internal/config/configdomain/branch_specific_key_test.go
+++ b/internal/config/configdomain/branch_specific_key_test.go
@@ -9,11 +9,13 @@ import (
 
 func TestBranchSpecificKey(t *testing.T) {
 
-	t.Run("ChildName", func(t *testing.T) {
+	t.Run("BranchName", func(t *testing.T) {
 		t.Parallel()
-		key := configdomain.NewLineageKey("git-town-branch.foo.parent")
+		key := configdomain.BranchSpecificKey{
+			Key: configdomain.Key("git-town-branch.my-branch.parent"),
+		}
 		have := key.BranchName()
-		want := "foo"
+		want := "my-branch"
 		must.EqOp(t, want, have)
 	})
 }

--- a/internal/config/configdomain/branch_specific_key_test.go
+++ b/internal/config/configdomain/branch_specific_key_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestBranchSpecificKey(t *testing.T) {
 	t.Parallel()
+
 	t.Run("BranchName", func(t *testing.T) {
 		t.Parallel()
 		key := configdomain.BranchSpecificKey{

--- a/internal/config/configdomain/branch_specific_key_test.go
+++ b/internal/config/configdomain/branch_specific_key_test.go
@@ -1,0 +1,19 @@
+package configdomain_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
+	"github.com/shoenig/test/must"
+)
+
+func TestBranchSpecificKey(t *testing.T) {
+
+	t.Run("ChildName", func(t *testing.T) {
+		t.Parallel()
+		key := configdomain.NewLineageKey("git-town-branch.foo.parent")
+		have := key.BranchName()
+		want := "foo"
+		must.EqOp(t, want, have)
+	})
+}

--- a/internal/config/configdomain/branch_specific_key_test.go
+++ b/internal/config/configdomain/branch_specific_key_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v17/internal/config/configdomain"
+	"github.com/git-town/git-town/v17/internal/git/gitdomain"
 	"github.com/shoenig/test/must"
 )
 
@@ -15,7 +16,7 @@ func TestBranchSpecificKey(t *testing.T) {
 			Key: configdomain.Key("git-town-branch.my-branch.parent"),
 		}
 		have := key.BranchName()
-		want := "my-branch"
+		want := gitdomain.LocalBranchName("my-branch")
 		must.EqOp(t, want, have)
 	})
 }

--- a/internal/config/configdomain/key.go
+++ b/internal/config/configdomain/key.go
@@ -152,7 +152,7 @@ var keys = []Key{ //nolint:gochecknoglobals
 }
 
 func NewParentKey(branch gitdomain.LocalBranchName) Key {
-	return Key(LineageKeyPrefix + branch + LineageKeySuffix)
+	return Key(BranchSpecificKeyPrefix + branch + LineageKeySuffix)
 }
 
 func ParseKey(name string) Option[Key] {

--- a/internal/config/configdomain/lineage.go
+++ b/internal/config/configdomain/lineage.go
@@ -33,7 +33,7 @@ func NewLineage() Lineage {
 func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, removeLocalConfigValue removeLocalConfigValueFunc) (Lineage, error) {
 	result := NewLineage()
 	for key, value := range snapshot.LineageEntries() {
-		childName := key.ChildName()
+		childName := key.BranchName()
 		if childName == "" {
 			// empty lineage entries are invalid --> delete it
 			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))

--- a/internal/config/configdomain/lineage.go
+++ b/internal/config/configdomain/lineage.go
@@ -33,14 +33,13 @@ func NewLineage() Lineage {
 func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, removeLocalConfigValue removeLocalConfigValueFunc) (Lineage, error) {
 	result := NewLineage()
 	for key, value := range snapshot.LineageEntries() {
-		childName := key.BranchName()
-		if childName == "" {
+		child := key.BranchName()
+		if child == "" {
 			// empty lineage entries are invalid --> delete it
 			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))
 			_ = removeLocalConfigValue(key.Key)
 			continue
 		}
-		child := childName
 		value = strings.TrimSpace(value)
 		if value == "" {
 			// empty lineage entries are invalid --> delete it
@@ -48,8 +47,8 @@ func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, remove
 			_ = removeLocalConfigValue(key.Key)
 			continue
 		}
-		if updateOutdated && childName.String() == value {
-			fmt.Println(colors.Cyan().Styled(fmt.Sprintf(messages.ConfigLineageParentIsChild, childName)))
+		if updateOutdated && child.String() == value {
+			fmt.Println(colors.Cyan().Styled(fmt.Sprintf(messages.ConfigLineageParentIsChild, child)))
 			_ = removeLocalConfigValue(NewParentKey(child))
 		}
 		parent := gitdomain.NewLocalBranchName(value)

--- a/internal/config/configdomain/lineage.go
+++ b/internal/config/configdomain/lineage.go
@@ -40,7 +40,7 @@ func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, remove
 			_ = removeLocalConfigValue(key.Key)
 			continue
 		}
-		child := gitdomain.NewLocalBranchName(childName)
+		child := childName
 		value = strings.TrimSpace(value)
 		if value == "" {
 			// empty lineage entries are invalid --> delete it
@@ -48,7 +48,7 @@ func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, remove
 			_ = removeLocalConfigValue(key.Key)
 			continue
 		}
-		if updateOutdated && childName == value {
+		if updateOutdated && childName.String() == value {
 			fmt.Println(colors.Cyan().Styled(fmt.Sprintf(messages.ConfigLineageParentIsChild, childName)))
 			_ = removeLocalConfigValue(NewParentKey(child))
 		}

--- a/internal/config/configdomain/lineage_key.go
+++ b/internal/config/configdomain/lineage_key.go
@@ -8,12 +8,14 @@ import (
 
 // a Key that contains a lineage entry
 type LineageKey struct {
-	Key
+	BranchSpecificKey
 }
 
 func NewLineageKey(key Key) LineageKey {
 	return LineageKey{
-		Key: key,
+		BranchSpecificKey: BranchSpecificKey{
+			Key: key,
+		},
 	}
 }
 
@@ -25,17 +27,9 @@ func ParseLineageKey(key Key) Option[LineageKey] {
 	return None[LineageKey]()
 }
 
-// provides the name of the child branch encoded in this LineageKey
-func (self LineageKey) ChildName() string {
-	return strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(self.String(), LineageKeyPrefix), LineageKeySuffix))
-}
-
-const (
-	LineageKeyPrefix = "git-town-branch."
-	LineageKeySuffix = ".parent"
-)
+const LineageKeySuffix = ".parent"
 
 // indicates whether the given key value is for a LineageKey
 func isLineageKey(key string) bool {
-	return strings.HasPrefix(key, LineageKeyPrefix) && strings.HasSuffix(key, LineageKeySuffix)
+	return isBranchSpecificKey(key) && strings.HasSuffix(key, LineageKeySuffix)
 }

--- a/internal/config/configdomain/lineage_key_test.go
+++ b/internal/config/configdomain/lineage_key_test.go
@@ -11,18 +11,6 @@ import (
 func TestLineageKey(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ChildName", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("valid lineage key", func(t *testing.T) {
-			t.Parallel()
-			key := configdomain.NewLineageKey("git-town-branch.foo.parent")
-			have := key.ChildName()
-			want := "foo"
-			must.EqOp(t, want, have)
-		})
-	})
-
 	t.Run("ParseLineageKey", func(t *testing.T) {
 		t.Parallel()
 		tests := map[string]Option[configdomain.LineageKey]{


### PR DESCRIPTION
part of #4373 

Extracts branch-specific logic into a dedicated `BranchSpecificKey` type. This is needed for the upcoming custom branch type override keys, which will also be branch specific.