### PR TITLE
Temporarily disable smart-punctuation

### DIFF
--- a/website/book.toml
+++ b/website/book.toml
@@ -11,4 +11,3 @@ git-repository-url = "https://github.com/git-town/git-town"
 edit-url-template = "https://github.com/git-town/git-town/edit/main/website/{path}"
 site-url = "https://www.git-town.com/"
 no-section-label = true
-smart-punctuation = true


### PR DESCRIPTION
In #4386, we added the `smart-punctuation` option to our mdBook config. This option automatically converts straight quotes to curly quotes, which we want; but it also converts "--" to "–" in command-line optons, which we don't want.

We should probably use code formatting for command-line options and then turn this setting back on.