### PR TITLE
Update dprint plugin versions

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -6,7 +6,7 @@
   "includes": ["**/*.{json,md}"],
   "excludes": ["CHANGELOG.md", "vendor/**", "tools/node_modules/**", "website/book/**"],
   "plugins": [
-    "https://plugins.dprint.dev/json-0.14.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.12.0.wasm"
+    "https://plugins.dprint.dev/json-0.19.4.wasm",
+    "https://plugins.dprint.dev/markdown-0.17.8.wasm"
   ]
 }


### PR DESCRIPTION
Dprint uses two types of versions:

1. the version of the main `dprint` executable
2. the version of the WASM-based plugins

This PR updates (2).