### PR TITLE
Simplify branch logic

### DIFF
--- a/features/park/give_existing_branch/multiple_branches.feature
+++ b/features/park/give_existing_branch/multiple_branches.feature
@@ -22,7 +22,6 @@ Feature: parking multiple other branches
     And branch "observed" is now parked
     And there are now no observed branches
     And branch "prototype" is now parked
-    And branch "prototype" is still prototype
     And the current branch is still "main"
 
   Scenario: undo

--- a/features/prototype/give_existing_branch/multiple_branches.feature
+++ b/features/prototype/give_existing_branch/multiple_branches.feature
@@ -40,6 +40,6 @@ Feature: prototype multiple other branches
     And there are now no prototype branches
     And branch "contribution" is now a contribution branch
     And branch "observed" is now observed
-    And branch "parked" is still parked
+    And branch "parked" is now parked
     And the current branch is still "main"
     And the initial branches and lineage exist now

--- a/features/prototype/give_existing_branch/multiple_branches.feature
+++ b/features/prototype/give_existing_branch/multiple_branches.feature
@@ -32,7 +32,6 @@ Feature: prototype multiple other branches
       branch "parked" is now a prototype branch
       """
     And branch "parked" is now prototype
-    And branch "parked" is still parked
     And the current branch is still "main"
 
   Scenario: undo

--- a/features/prototype/give_existing_branch/parked.feature
+++ b/features/prototype/give_existing_branch/parked.feature
@@ -15,7 +15,6 @@ Feature: prototype another parked branch
       branch "parked" is now a prototype branch
       """
     And the prototype branches are now "parked"
-    And the parked branches are still "parked"
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/prototype/give_no_branch/on_parked_branch.feature
+++ b/features/prototype/give_no_branch/on_parked_branch.feature
@@ -21,5 +21,5 @@ Feature: prototype the current parked branch
     When I run "git-town undo"
     Then Git Town runs no commands
     And the current branch is still "parked"
-    And branch "parked" is still parked
+    And branch "parked" is now parked
     And there are now no prototype branches

--- a/features/prototype/give_no_branch/on_parked_branch.feature
+++ b/features/prototype/give_no_branch/on_parked_branch.feature
@@ -16,7 +16,6 @@ Feature: prototype the current parked branch
       """
     And the current branch is still "parked"
     And branch "parked" is now prototype
-    And branch "parked" is still parked
 
   Scenario: undo
     When I run "git-town undo"

--- a/internal/cmd/prototype.go
+++ b/internal/cmd/prototype.go
@@ -114,11 +114,14 @@ func removeNonPrototypeBranchTypes(branches configdomain.BranchesAndTypes, confi
 			if err := config.NormalConfig.RemoveFromObservedBranches(branchName); err != nil {
 				return err
 			}
+		case configdomain.BranchTypeParkedBranch:
+			if err := config.NormalConfig.RemoveFromParkedBranches(branchName); err != nil {
+				return err
+			}
 		case
 			configdomain.BranchTypeFeatureBranch,
 			configdomain.BranchTypePrototypeBranch,
 			configdomain.BranchTypeMainBranch,
-			configdomain.BranchTypeParkedBranch,
 			configdomain.BranchTypePerennialBranch:
 		}
 	}

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -217,7 +217,7 @@ func determineRenameData(args []string, force configdomain.Force, repo execute.O
 		return data, false, errors.New(messages.RenameMainBranch)
 	}
 	if force.IsFalse() {
-		if validatedConfig.NormalConfig.IsPerennialBranch(oldBranchName) {
+		if validatedConfig.BranchType(oldBranchName) == configdomain.BranchTypePerennialBranch {
 			return data, false, fmt.Errorf(messages.RenamePerennialBranchWarning, oldBranchName)
 		}
 	}
@@ -274,7 +274,9 @@ func renameProgram(data renameData, finalMessages stringslice.Collector) program
 		result.Value.Add(&opcodes.CheckoutIfNeeded{Branch: data.newBranch})
 	}
 	if !data.dryRun {
-		if data.config.NormalConfig.IsPerennialBranch(data.initialBranch) {
+		// TODO: renaming a branch should not update the these configuration settings.
+		// Rather, update the upcoming branch type override.
+		if slices.Contains(data.config.NormalConfig.PerennialBranches, data.initialBranch) {
 			result.Value.Add(&opcodes.BranchesPerennialRemove{Branch: oldLocalBranch})
 			result.Value.Add(&opcodes.BranchesPerennialAdd{Branch: data.newBranch})
 		}

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -43,12 +43,6 @@ type NormalConfigData struct {
 }
 
 // TODO: delete
-// ContainsLineage indicates whether this configuration contains any lineage entries.
-func (self *NormalConfigData) ContainsLineage() bool {
-	return self.Lineage.Len() > 0
-}
-
-// TODO: delete
 func (self *NormalConfigData) IsContributionBranch(branch gitdomain.LocalBranchName) bool {
 	if slices.Contains(self.ContributionBranches, branch) {
 		return true

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -42,7 +42,6 @@ type NormalConfigData struct {
 	SyncUpstream             SyncUpstream
 }
 
-// TODO: delete
 func (self *NormalConfigData) IsOnline() bool {
 	return self.Online().IsTrue()
 }

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -43,17 +43,6 @@ type NormalConfigData struct {
 }
 
 // TODO: delete
-func (self *NormalConfigData) IsObservedBranch(branch gitdomain.LocalBranchName) bool {
-	if slices.Contains(self.ObservedBranches, branch) {
-		return true
-	}
-	if regex, has := self.ObservedRegex.Get(); has {
-		return regex.MatchesBranch(branch)
-	}
-	return false
-}
-
-// TODO: delete
 func (self *NormalConfigData) IsOnline() bool {
 	return self.Online().IsTrue()
 }

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -43,17 +43,6 @@ type NormalConfigData struct {
 }
 
 // TODO: delete
-func (self *NormalConfigData) IsContributionBranch(branch gitdomain.LocalBranchName) bool {
-	if slices.Contains(self.ContributionBranches, branch) {
-		return true
-	}
-	if regex, has := self.ContributionRegex.Get(); has {
-		return regex.MatchesBranch(branch)
-	}
-	return false
-}
-
-// TODO: delete
 func (self *NormalConfigData) IsObservedBranch(branch gitdomain.LocalBranchName) bool {
 	if slices.Contains(self.ObservedBranches, branch) {
 		return true

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -46,14 +46,6 @@ func (self *NormalConfigData) IsOnline() bool {
 	return self.Online().IsTrue()
 }
 
-// TODO: delete
-func (self *NormalConfigData) IsPrototypeBranch(branch gitdomain.LocalBranchName) bool {
-	if slices.Contains(self.PrototypeBranches, branch) {
-		return true
-	}
-	return self.DefaultBranchType == BranchTypePrototypeBranch
-}
-
 func (self *NormalConfigData) NoPushHook() NoPushHook {
 	return self.PushHook.Negate()
 }

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -47,22 +47,6 @@ func (self *NormalConfigData) IsOnline() bool {
 }
 
 // TODO: delete
-func (self *NormalConfigData) IsParkedBranch(branch gitdomain.LocalBranchName) bool {
-	return slices.Contains(self.ParkedBranches, branch)
-}
-
-// TODO: delete
-func (self *NormalConfigData) IsPerennialBranch(branch gitdomain.LocalBranchName) bool {
-	if slices.Contains(self.PerennialBranches, branch) {
-		return true
-	}
-	if perennialRegex, has := self.PerennialRegex.Get(); has {
-		return perennialRegex.MatchesBranch(branch)
-	}
-	return false
-}
-
-// TODO: delete
 func (self *NormalConfigData) IsPrototypeBranch(branch gitdomain.LocalBranchName) bool {
 	if slices.Contains(self.PrototypeBranches, branch) {
 		return true

--- a/internal/config/configdomain/normal_config_data_test.go
+++ b/internal/config/configdomain/normal_config_data_test.go
@@ -2,67 +2,8 @@ package configdomain_test
 
 import (
 	"testing"
-
-	"github.com/git-town/git-town/v17/internal/config/configdomain"
-	"github.com/git-town/git-town/v17/internal/git/gitdomain"
-	"github.com/shoenig/test/must"
 )
 
 func TestNormalConfig(t *testing.T) {
 	t.Parallel()
-
-	t.Run("IsPerennialBranch", func(t *testing.T) {
-		t.Parallel()
-		perennialRegexOpt, err := configdomain.ParsePerennialRegex("release-.*")
-		must.NoError(t, err)
-		config := configdomain.NormalConfigData{
-			PerennialBranches: gitdomain.NewLocalBranchNames("peren1", "peren2"),
-			PerennialRegex:    perennialRegexOpt,
-		}
-		tests := map[string]bool{
-			"main":      false,
-			"peren1":    true,
-			"peren2":    true,
-			"peren3":    false,
-			"feature":   false,
-			"release-1": true,
-			"release-2": true,
-			"other":     false,
-		}
-		for give, want := range tests {
-			have := config.IsPerennialBranch(gitdomain.NewLocalBranchName(give))
-			must.Eq(t, want, have)
-		}
-	})
-
-	t.Run("IsPrototypeBranch", func(t *testing.T) {
-		t.Parallel()
-		t.Run("listed as prototype branch", func(t *testing.T) {
-			t.Parallel()
-			config := configdomain.NormalConfigData{
-				PrototypeBranches: gitdomain.NewLocalBranchNames("proto1"),
-				DefaultBranchType: configdomain.BranchTypeFeatureBranch,
-			}
-			have := config.IsPrototypeBranch(gitdomain.NewLocalBranchName("proto1"))
-			must.True(t, have)
-		})
-		t.Run("not listed as prototype branch", func(t *testing.T) {
-			t.Parallel()
-			config := configdomain.NormalConfigData{
-				PrototypeBranches: gitdomain.NewLocalBranchNames("proto1"),
-				DefaultBranchType: configdomain.BranchTypeFeatureBranch,
-			}
-			have := config.IsPrototypeBranch(gitdomain.NewLocalBranchName("proto2"))
-			must.False(t, have)
-		})
-		t.Run("defaultbranch is prototype", func(t *testing.T) {
-			t.Parallel()
-			config := configdomain.NormalConfigData{
-				PrototypeBranches: gitdomain.LocalBranchNames{},
-				DefaultBranchType: configdomain.BranchTypePrototypeBranch,
-			}
-			have := config.IsPrototypeBranch(gitdomain.NewLocalBranchName("any"))
-			must.True(t, have)
-		})
-	})
 }

--- a/internal/config/configdomain/validated_config_data.go
+++ b/internal/config/configdomain/validated_config_data.go
@@ -21,6 +21,7 @@ func (self *ValidatedConfigData) Author() gitdomain.Author {
 	return gitdomain.Author(fmt.Sprintf("%s <%s>", name, email))
 }
 
+// TODO: delete
 // IsMainBranch indicates whether the branch with the given name
 // is the main branch of the repository.
 func (self *ValidatedConfigData) IsMainBranch(branch gitdomain.LocalBranchName) bool {

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -21,7 +21,8 @@ func (self *UnvalidatedConfig) BranchType(branch gitdomain.LocalBranchName) conf
 // IsMainOrPerennialBranch indicates whether the branch with the given name
 // is the main branch or a perennial branch of the repository.
 func (self *UnvalidatedConfig) IsMainOrPerennialBranch(branch gitdomain.LocalBranchName) bool {
-	return self.UnvalidatedConfig.IsMainBranch(branch) || self.NormalConfig.IsPerennialBranch(branch)
+	branchType := self.BranchType(branch)
+	return branchType == configdomain.BranchTypeMainBranch || branchType == configdomain.BranchTypePerennialBranch
 }
 
 func (self *UnvalidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {

--- a/internal/config/validated_config.go
+++ b/internal/config/validated_config.go
@@ -40,7 +40,8 @@ func (self *ValidatedConfig) CleanupLineage(branchInfos gitdomain.BranchInfos, n
 // IsMainOrPerennialBranch indicates whether the branch with the given name
 // is the main branch or a perennial branch of the repository.
 func (self *ValidatedConfig) IsMainOrPerennialBranch(branch gitdomain.LocalBranchName) bool {
-	return self.ValidatedConfigData.IsMainBranch(branch) || self.NormalConfig.IsPerennialBranch(branch)
+	branchType := self.BranchType(branch)
+	return branchType == configdomain.BranchTypeMainBranch || branchType == configdomain.BranchTypePerennialBranch
 }
 
 func (self *ValidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {

--- a/internal/config/validated_config_test.go
+++ b/internal/config/validated_config_test.go
@@ -26,6 +26,7 @@ func TestValidatedConfig(t *testing.T) {
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
 					ContributionBranches: gitdomain.NewLocalBranchNames("contribution"),
+					DefaultBranchType:    configdomain.BranchTypeFeatureBranch,
 					PerennialBranches:    gitdomain.NewLocalBranchNames("perennial-1", "perennial-2"),
 					ObservedBranches:     gitdomain.NewLocalBranchNames("observed"),
 					ParkedBranches:       gitdomain.NewLocalBranchNames("parked"),
@@ -119,6 +120,7 @@ func TestValidatedConfig(t *testing.T) {
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
 					ContributionBranches: gitdomain.LocalBranchNames{contribution},
+					DefaultBranchType:    configdomain.BranchTypeFeatureBranch,
 					ObservedBranches:     gitdomain.LocalBranchNames{observed},
 					ParkedBranches:       gitdomain.LocalBranchNames{parked},
 					PerennialBranches:    gitdomain.LocalBranchNames{perennial1},

--- a/internal/undo/undobranches/branch_changes_test.go
+++ b/internal/undo/undobranches/branch_changes_test.go
@@ -722,6 +722,7 @@ func TestChanges(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          true,
@@ -837,6 +838,7 @@ func TestChanges(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
@@ -1067,6 +1069,7 @@ func TestChanges(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
@@ -1271,6 +1274,7 @@ func TestChanges(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
@@ -1453,6 +1457,7 @@ func TestChanges(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,

--- a/internal/undo/undobranches/categorize_test.go
+++ b/internal/undo/undobranches/categorize_test.go
@@ -57,6 +57,7 @@ func TestCategorize(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-1"),
 				},
 			},
@@ -120,6 +121,7 @@ func TestCategorize(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("dev"),
 				},
 			},
@@ -159,6 +161,7 @@ func TestCategorize(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("dev"),
 				},
 			},
@@ -192,6 +195,7 @@ func TestCategorize(t *testing.T) {
 			},
 			NormalConfig: config.NormalConfig{
 				NormalConfigData: configdomain.NormalConfigData{
+					DefaultBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 				},
 			},

--- a/internal/vm/opcodes/branches_prototype_remove.go
+++ b/internal/vm/opcodes/branches_prototype_remove.go
@@ -3,6 +3,7 @@ package opcodes
 import (
 	"fmt"
 
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
 	"github.com/git-town/git-town/v17/internal/git/gitdomain"
 	"github.com/git-town/git-town/v17/internal/messages"
 	"github.com/git-town/git-town/v17/internal/vm/shared"
@@ -16,7 +17,8 @@ type BranchesPrototypeRemove struct {
 
 func (self *BranchesPrototypeRemove) Run(args shared.RunArgs) error {
 	var err error
-	if args.Config.Value.NormalConfig.IsPrototypeBranch(self.Branch) {
+	branchType := args.Config.Value.BranchType(self.Branch)
+	if branchType == configdomain.BranchTypePrototypeBranch {
 		args.FinalMessages.Add(fmt.Sprintf(messages.PrototypeRemoved, self.Branch))
 		err = args.Config.Value.NormalConfig.RemoveFromPrototypeBranches(self.Branch)
 	}

--- a/test/commands/test_commands_test.go
+++ b/test/commands/test_commands_test.go
@@ -158,6 +158,7 @@ func TestTestCommands(t *testing.T) {
 		runtime := testruntime.CreateGitTown(t)
 		runtime.CreateFeatureBranch("f1", "main")
 		runtime.Config.Reload()
+		// TODO: remove "gitdomain.NewLocalBranchName" for all matches of `gitdomain.NewLocalBranchName("`
 		must.False(t, runtime.Config.IsMainOrPerennialBranch(gitdomain.NewLocalBranchName("f1")))
 		lineageHave := runtime.Config.NormalConfig.Lineage
 		lineageWant := configdomain.NewLineageWith(configdomain.LineageData{
@@ -196,8 +197,8 @@ func TestTestCommands(t *testing.T) {
 		want := gitdomain.NewLocalBranchNames("main", "initial", "p1", "p2")
 		must.Eq(t, want, branches)
 		runtime.Config.Reload()
-		must.True(t, runtime.Config.NormalConfig.IsPerennialBranch(gitdomain.NewLocalBranchName("p1")))
-		must.True(t, runtime.Config.NormalConfig.IsPerennialBranch(gitdomain.NewLocalBranchName("p2")))
+		must.EqOp(t, configdomain.BranchTypePerennialBranch, runtime.Config.BranchType(gitdomain.NewLocalBranchName("p1")))
+		must.EqOp(t, configdomain.BranchTypePerennialBranch, runtime.Config.BranchType(gitdomain.NewLocalBranchName("p2")))
 	})
 
 	t.Run("Fetch", func(t *testing.T) {

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -345,7 +345,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		branch := gitdomain.NewLocalBranchName(name)
-		if !slices.Contains(devRepo.Config.NormalConfig.PrototypeBranches, branch) {
+		if !devRepo.Config.NormalConfig.IsPrototypeBranch(branch) {
 			return fmt.Errorf(
 				"branch %q isn't prototype as expected.\nPrototype branches: %s",
 				branch,

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -328,11 +328,13 @@ func defineSteps(sc *godog.ScenarioContext) {
 		return nil
 	})
 
+	// TODO: replace with a single step implementation that compares against BranchType.String()
 	sc.Step(`^branch "([^"]+)" is (?:now|still) perennial`, func(ctx context.Context, name string) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		branch := gitdomain.NewLocalBranchName(name)
-		if !devRepo.Config.NormalConfig.IsPerennialBranch(branch) {
+		branchType := devRepo.Config.BranchType(branch)
+		if branchType != configdomain.BranchTypePerennialBranch {
 			return fmt.Errorf(
 				"branch %q isn't perennial as expected.\nPerennial branches: %s",
 				branch,
@@ -346,7 +348,8 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		branch := gitdomain.NewLocalBranchName(name)
-		if !devRepo.Config.NormalConfig.IsPrototypeBranch(branch) {
+		branchType := devRepo.Config.BranchType(branch)
+		if branchType != configdomain.BranchTypePrototypeBranch {
 			return fmt.Errorf(
 				"branch %q isn't prototype as expected.\nPrototype branches: %s",
 				branch,

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -278,7 +278,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		branch := gitdomain.NewLocalBranchName(name)
-		if !slices.Contains(devRepo.Config.NormalConfig.ContributionBranches, branch) {
+		if !devRepo.Config.NormalConfig.IsContributionBranch(branch) {
 			return fmt.Errorf(
 				"branch %q isn't contribution as expected.\nContribution branches: %s",
 				branch,

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -278,7 +278,8 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		branch := gitdomain.NewLocalBranchName(name)
-		if !devRepo.Config.NormalConfig.IsContributionBranch(branch) {
+		branchType := devRepo.Config.BranchType(branch)
+		if branchType != configdomain.BranchTypeContributionBranch {
 			return fmt.Errorf(
 				"branch %q isn't contribution as expected.\nContribution branches: %s",
 				branch,

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -963,7 +963,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^no lineage exists now$`, func(ctx context.Context) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		if devRepo.Config.NormalConfig.ContainsLineage() {
+		if devRepo.Config.NormalConfig.Lineage.Len() > 0 {
 			lineage := devRepo.Config.NormalConfig.Lineage
 			return fmt.Errorf("unexpected Git Town lineage information: %+v", lineage)
 		}


### PR DESCRIPTION
The branch logic has grown a number of boilerplate, helper methods, and ravioli code that later turned out to not be necessary. Cleaning this up make the code more readable. 

There is a slight change in behavior: previously, a branch could be both prototype and parked. Now branches always have exactly one type. The old behavior wasn't documented anywhere, so this isn't considered a breaking change.