### PR TITLE
Fix flags Read*Func comments

### DIFF
--- a/internal/cli/flags/all.go
+++ b/internal/cli/flags/all.go
@@ -19,5 +19,5 @@ func All(desc string) (AddFunc, ReadAllFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadAllFlagFunc is the type signature for the function that reads the "all" flag from the args to the given Cobra command.
 type ReadAllFlagFunc func(*cobra.Command) (configdomain.AllBranches, error)

--- a/internal/cli/flags/beam.go
+++ b/internal/cli/flags/beam.go
@@ -19,5 +19,5 @@ func Beam() (AddFunc, ReadBeamFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadBeamFlagFunc is the type signature for the function that reads the "beam" flag from the args to the given Cobra command.
 type ReadBeamFlagFunc func(*cobra.Command) (configdomain.Beam, error)

--- a/internal/cli/flags/detached.go
+++ b/internal/cli/flags/detached.go
@@ -19,5 +19,5 @@ func Detached() (AddFunc, ReadDetachedFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the detached flag from the args to the given Cobra command
+// ReadDetachedFlagFunc is the type signature for the function that reads the "detached" flag from the args to the given Cobra command.
 type ReadDetachedFlagFunc func(*cobra.Command) (configdomain.Detached, error)

--- a/internal/cli/flags/display_types.go
+++ b/internal/cli/flags/display_types.go
@@ -19,5 +19,5 @@ func Displaytypes() (AddFunc, ReadDisplayTypesFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the display-types flag from the args to the given Cobra command
+// ReadDisplayTypesFlagFunc is the type signature for the function that reads the "display-types" flag from the args to the given Cobra command.
 type ReadDisplayTypesFlagFunc func(*cobra.Command) (configdomain.DisplayTypes, error)

--- a/internal/cli/flags/dryrun.go
+++ b/internal/cli/flags/dryrun.go
@@ -19,5 +19,5 @@ func DryRun() (AddFunc, ReadDryRunFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadDryRunFlagFunc is the type signature for the function that reads the "dry-run" flag from the args to the given Cobra command.
 type ReadDryRunFlagFunc func(*cobra.Command) (configdomain.DryRun, error)

--- a/internal/cli/flags/force.go
+++ b/internal/cli/flags/force.go
@@ -19,5 +19,5 @@ func Force(desc string) (AddFunc, ReadForceFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the force flag from the args to the given Cobra command
+// ReadForceFlagFunc is the type signature for the function that reads the "force" flag from the args to the given Cobra command.
 type ReadForceFlagFunc func(*cobra.Command) (configdomain.Force, error)

--- a/internal/cli/flags/no_push.go
+++ b/internal/cli/flags/no_push.go
@@ -19,5 +19,5 @@ func NoPush() (AddFunc, ReadNoPushFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadNoPushFlagFunc is the type signature for the function that reads the "no-push" flag from the args to the given Cobra command.
 type ReadNoPushFlagFunc func(*cobra.Command) (configdomain.PushBranches, error)

--- a/internal/cli/flags/pending.go
+++ b/internal/cli/flags/pending.go
@@ -22,5 +22,5 @@ func Pending() (AddFunc, ReadPendingFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the pending flag from the args to the given Cobra command
+// ReadPendingFlagFunc is the type signature for the function that reads the "pending" flag from the args to the given Cobra command.
 type ReadPendingFlagFunc func(*cobra.Command) (configdomain.Pending, error)

--- a/internal/cli/flags/proposal_body_file.go
+++ b/internal/cli/flags/proposal_body_file.go
@@ -22,5 +22,5 @@ func ProposalBodyFile() (AddFunc, ReadProposalBodyFileFlagFunc) {
 	return addFlag, readFlag
 }
 
-// reads gitdomain.ProposalBodyFile from the CLI args
+// ReadProposalBodyFileFlagFunc reads gitdomain.ProposalBodyFile from the CLI args.
 type ReadProposalBodyFileFlagFunc func(*cobra.Command) (gitdomain.ProposalBodyFile, error)

--- a/internal/cli/flags/propose.go
+++ b/internal/cli/flags/propose.go
@@ -19,5 +19,5 @@ func Propose() (AddFunc, ReadProposeFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadProposeFlagFunc is the type signature for the function that reads the "propose" flag from the args to the given Cobra command.
 type ReadProposeFlagFunc func(*cobra.Command) (configdomain.Propose, error)

--- a/internal/cli/flags/prototype.go
+++ b/internal/cli/flags/prototype.go
@@ -19,5 +19,5 @@ func Prototype() (AddFunc, ReadPrototypeFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadPrototypeFlagFunc is the type signature for the function that reads the "prototype" flag from the args to the given Cobra command.
 type ReadPrototypeFlagFunc func(*cobra.Command) (configdomain.Prototype, error)

--- a/internal/cli/flags/ship_into_nonperennial_parent.go
+++ b/internal/cli/flags/ship_into_nonperennial_parent.go
@@ -19,5 +19,5 @@ func ShipIntoNonPerennialParent() (AddFunc, ReadShipIntoNonPerennialParentFlagFu
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadShipIntoNonPerennialParentFlagFunc is the type signature for the function that reads the "to-parent" flag from the args to the given Cobra command.
 type ReadShipIntoNonPerennialParentFlagFunc func(*cobra.Command) (configdomain.ShipIntoNonperennialParent, error)

--- a/internal/cli/flags/ship_strategy.go
+++ b/internal/cli/flags/ship_strategy.go
@@ -31,5 +31,5 @@ func ShipStrategy() (AddFunc, ReadShipStrategyFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadShipStrategyFunc is the type signature for the function that reads the ship "strategy" flag from the args to the given Cobra command.
 type ReadShipStrategyFunc func(*cobra.Command) (Option[configdomain.ShipStrategy], error)

--- a/internal/cli/flags/stack.go
+++ b/internal/cli/flags/stack.go
@@ -19,5 +19,5 @@ func Stack(description string) (AddFunc, ReadStackFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the dry-run flag from the args to the given Cobra command
+// ReadStackFlagFunc is the type signature for the function that reads the "stack" flag from the args to the given Cobra command.
 type ReadStackFlagFunc func(*cobra.Command) (configdomain.FullStack, error)

--- a/internal/cli/flags/type.go
+++ b/internal/cli/flags/type.go
@@ -56,5 +56,5 @@ func SplitBranchTypeNames(text string) []string {
 	return result
 }
 
-// the type signature for the function that reads the "type" flag from the args to the given Cobra command
+// ReadTypeFlagFunc is the type signature for the function that reads the "type" flag from the args to the given Cobra command.
 type ReadTypeFlagFunc func(*cobra.Command) ([]configdomain.BranchType, error)

--- a/internal/cli/flags/verbose.go
+++ b/internal/cli/flags/verbose.go
@@ -22,5 +22,5 @@ func Verbose() (AddFunc, ReadVerboseFlagFunc) {
 	return addFlag, readFlag
 }
 
-// the type signature for the function that reads the verbose flag from the args to the given Cobra command
+// ReadVerboseFlagFunc is the type signature for the function that reads the "verbose" flag from the args to the given Cobra command.
 type ReadVerboseFlagFunc func(*cobra.Command) (configdomain.Verbose, error)


### PR DESCRIPTION
- Fix "dry-run" copy&paste.
- Add consistent quotes around flag names to avoid confusion with normal words in the description.
- Add type name prefix as per <https://google.github.io/styleguide/go/decisions#doc-comments>.