### PR TITLE
Add an optional message parameter to MergeNoFastForward

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -526,8 +526,14 @@ func (self *Commands) MergeFastForward(runner gitdomain.Runner, branch gitdomain
 }
 
 // MergeNoFastForward merges branch into the current branch and always creates a merge commit.
-func (self *Commands) MergeNoFastForward(runner gitdomain.Runner, branch gitdomain.LocalBranchName) error {
-	return runner.Run("git", "merge", "--no-ff", branch.String())
+func (self *Commands) MergeNoFastForward(runner gitdomain.Runner, message Option[gitdomain.CommitMessage], branch gitdomain.LocalBranchName) error {
+	gitArgs := []string{"merge", "--no-ff"}
+	if messageContent, has := message.Get(); has {
+		gitArgs = append(gitArgs, "-m", messageContent.String())
+	}
+	// Add branch name as the last argument.
+	gitArgs = append(gitArgs, "--", branch.String())
+	return runner.Run("git", gitArgs...)
 }
 
 // NavigateToDir changes into the root directory of the current repository.


### PR DESCRIPTION
- Unlike MergeFastForward where there are no additional commits created, MergeNoFastForward creates a merge commit and we can specify a custom commit message. Since `git town ship` supports `--message` flag it is a good UX to support custom commit messages.
- SquashMerge doesn't have a commit message parameter because it doesn't create a commit by itself, instead it adds all the files from other commits into the stage area, and a commit is created explicitly with `Commit(...)` later.

See #4381.