### PR TITLE
Update headings in command docs

### DIFF
--- a/website/src/commands/append.md
+++ b/website/src/commands/append.md
@@ -14,7 +14,7 @@ happens on top of the current state of the repository. If the workspace contains
 uncommitted changes, `git town append` does not perform this sync to let you
 commit your open changes first and then sync manually.
 
-### Positional argument
+## Positional argument
 
 When given a non-existing branch name, `git town append` creates a new feature
 branch with the main branch as its parent.
@@ -38,28 +38,30 @@ main
 *   feature-2
 ```
 
-### --prototype / -p
+## Options
+
+#### `-p`<br>`--prototype`
 
 Adding the `--prototype` aka `-p` switch creates a
 [prototype branch](../branch-types.md#prototype-branches).
 
-### --detached / -d
+#### `-d`<br>`--detached`
 
 The `--detached` aka `-d` flag does not pull updates from the main or perennial
 branch. This allows you to build out your branch stack and decide when to pull
 in changes from other developers.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.
 
-### Configuration
+## Configuration
 
 If [push-new-branches](../preferences/push-new-branches.md) is set,
 `git town append` also creates the tracking branch for the new feature branch.

--- a/website/src/commands/branch.md
+++ b/website/src/commands/branch.md
@@ -9,7 +9,9 @@ The _branch_ command is Git Town's equivalent of the
 branch hierarchy, and the types of all branches except for main and feature
 branches.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/completions.md
+++ b/website/src/commands/completions.md
@@ -8,12 +8,14 @@ The _completions_ command outputs shell scripts that enable auto-completion for
 Git Town in Bash, Zsh, Fish, or PowerShell. When set up, typing
 `git-town <tab key>` in your terminal will auto-complete subcommands.
 
-## --no-descriptions
+## Options
+
+#### `--no-descriptions`
 
 The `--no-descriptions` flag outputs shorter completions without descriptions of
 arguments.
 
-## bash
+### Bash
 
 To load autocompletion for Bash, run this command:
 
@@ -23,7 +25,7 @@ source <(git-town completions bash)
 
 To load completions for each session, add the above line to your `.bashrc`.
 
-## fish
+### Fish
 
 To load autocompletions for Fish, run this command:
 
@@ -34,7 +36,7 @@ git-town completions fish | source
 To load completions for each session, add the above line to your
 `~/.config/fish/config.fish`.
 
-## powershell
+### PowerShell
 
 To install autocompletions for Powershell, run this command:
 
@@ -45,7 +47,7 @@ git-town completions powershell | Out-String | Invoke-Expression
 To load completions for each session, add the above line to your PowerShell
 profile.
 
-## zsh
+### Zsh
 
 To load autocompletions for Zsh, run this command:
 

--- a/website/src/commands/compress.md
+++ b/website/src/commands/compress.md
@@ -39,7 +39,9 @@ $ git log --pretty=format:'%s'
 commit 1
 ```
 
-### --message / -m &lt;text&gt;
+## Options
+
+#### `-m <text>`<br>`--message <text>`
 
 By default the now compressed commit uses the commit message of the first commit
 in the branch. You can provide a custom commit message for the squashed commit
@@ -71,7 +73,7 @@ compressed commit
 The new `compressed commit` now contains the changes from the old `commit 1`,
 `commit 2`, and `commit 3`.
 
-### --stack / -s
+#### `-s`<br>`--stack`
 
 To compress all branches in a [branch stack](../stacked-changes.md) provide the
 `--stack` aka `-s` switch.
@@ -118,12 +120,12 @@ changes from the old `commit 1a`, `commit 1b`, and `commit 1c`. The new
 `commit 2a` contains the changes made in `branch 2`, i.e. the changes from the
 old `commit 2a`, `commit 2b`, and `commit 2c`.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/config-get-parent.md
+++ b/website/src/commands/config-get-parent.md
@@ -7,7 +7,9 @@ git town config get-parent [<branch-name>] [-v | --verbose]
 The _config get-parent_ command outputs the parent branch of the current or
 given branch.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/config-remove.md
+++ b/website/src/commands/config-remove.md
@@ -7,7 +7,9 @@ git town config remove [-v | --verbose]
 The _config remove_ command removes all Git Town related configuration from the
 current Git repository.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/config-setup.md
+++ b/website/src/commands/config-setup.md
@@ -8,7 +8,9 @@ The _config setup_ command launches Git Town's setup assistant. The setup
 assistant walks you through all configuration options for Git Town and gives you
 a chance to adjust them.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/config.md
+++ b/website/src/commands/config.md
@@ -9,7 +9,7 @@ git town config setup [-v | --verbose]
 
 The _config_ command displays and updates the local Git Town configuration.
 
-### Subcommands
+## Subcommands
 
 Running without a subcommand shows the current Git Town configuration.
 
@@ -19,7 +19,9 @@ Running without a subcommand shows the current Git Town configuration.
   configuration from the current Git repository.
 - The [setup](config-setup.md) subcommand launches Git Town's setup assistant.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/continue.md
+++ b/website/src/commands/continue.md
@@ -10,7 +10,9 @@ Once you have resolved the issue, run the _continue_ command to tell Git Town to
 continue executing the failed command. Git Town will retry the failed operation
 and execute all remaining operations of the original command.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/contribute.md
+++ b/website/src/commands/contribute.md
@@ -19,7 +19,7 @@ To make the current branch a contribution branch:
 git town contribute
 ```
 
-### Positional arguments
+## Positional arguments
 
 When called with positional arguments, this commands makes the branches with the
 given names contribution branches.
@@ -38,7 +38,9 @@ machine) and make it a contribution branch:
 git town contribute somebody-elses-branch
 ```
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/delete.md
+++ b/website/src/commands/delete.md
@@ -11,19 +11,21 @@ deleted branch. It does not remove perennial branches.
 Removes commits of deleted branches from their descendents, unless when using
 the [merge sync strategy](../preferences/sync-feature-strategy.md#merge).
 
-### Positional arguments
+## Positional arguments
 
 When called without arguments, the _delete_ command deletes the feature branch
 you are on, including all uncommitted changes.
 
 When called with a branch name, it deletes the given branch.
 
-### --dry-run
+## Options
+
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/diff-parent.md
+++ b/website/src/commands/diff-parent.md
@@ -7,7 +7,9 @@ git town diff-parent [-v | --verbose]
 The _diff-parent_ command displays the changes made on a feature branch, i.e.
 the diff between the current branch and its parent branch.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/hack.md
+++ b/website/src/commands/hack.md
@@ -14,7 +14,7 @@ state of the repository. If the workspace is not clean (contains uncommitted
 changes), `git town hack` does not perform this sync to let you commit your open
 changes.
 
-### Positional arguments
+## Positional arguments
 
 When given a non-existing branch name, `git town hack` creates a new feature
 branch with the main branch as its parent.
@@ -25,34 +25,36 @@ When given an existing contribution, observed, parked, or prototype branch,
 When given no arguments, `git town hack` converts the current contribution,
 observed, parked, or prototype branch into a feature branch.
 
-### --prototype / -p
+## Options
+
+#### `-p`<br>`--prototype`
 
 Adding the `--prototype` aka `-p` switch creates a
 [prototype branch](../branch-types.md#prototype-branches).
 
-### --detached / -d
+#### `-d`<br>`--detached`
 
 The `--detached` aka `-d` flag does not pull updates from the main or perennial
 branch. This allows you to build out your branch stack and decide when to pull
 in changes from other developers.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.
 
-### upstream remote
+### Upstream remote
 
 If the repository contains a remote called `upstream`, it also syncs the main
 branch with its upstream counterpart. You can control this behavior with the
 [sync-upstream](../preferences/sync-upstream.md) flag.
 
-### configuration
+## Configuration
 
 If [push-new-branches](../preferences/push-new-branches.md) is set,
 `git town hack` creates a remote tracking branch for the new feature branch.

--- a/website/src/commands/merge.md
+++ b/website/src/commands/merge.md
@@ -13,12 +13,14 @@ merged branch will contain two separate commits: one per merged branch. This
 makes it easy to verify that both branches were merged as expected. To
 consolidate these commits, run [git town sync](sync.md).
 
-### --dry-run
+## Options
+
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/observe.md
+++ b/website/src/commands/observe.md
@@ -10,7 +10,7 @@ The _observe_ command makes some of your branches
 To convert an observed branch back into a feature branch, use the
 [hack](hack.md) command.
 
-### Positional arguments
+## Positional arguments
 
 Observe the current branch:
 
@@ -32,7 +32,9 @@ machine) and make it observed:
 git town observe somebody-elses-branch
 ```
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/offline.md
+++ b/website/src/commands/offline.md
@@ -7,7 +7,7 @@ git town offline <status> [-v | --verbose]
 The _offline_ configuration command displays or changes Git Town's offline mode.
 Git Town skips all network operations in offline mode.
 
-### Positional arguments
+## Positional arguments
 
 When called without an argument, the _offline_ command displays the current
 offline status.
@@ -15,7 +15,9 @@ offline status.
 When called with `yes`, `1`, `on`, or `true`, this command enables offline mode.
 When called with `no`, `0`, `off`, or `false`, it disables offline mode.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/park.md
+++ b/website/src/commands/park.md
@@ -24,7 +24,9 @@ Park branches "alpha" and "beta":
 git town park alpha beta
 ```
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/prepend.md
+++ b/website/src/commands/prepend.md
@@ -36,48 +36,50 @@ main
     feature-2
 ```
 
-### --beam / -b
+## Options
+
+#### `-b`<br>`--beam`
 
 Moves ("beams") one or more commits from the current branch to the new parent
 branch that gets created. Lets you select the commits to beam via a visual
 dialog.
 
-### --body &lt;string&gt;
+#### `--body <string>`
 
 Pre-populate the body of the pull request to create with the given text.
 Requires `--propose`.
 
-### --propose
+#### `--propose`
 
 When set, this command proposes the branch it creates.
 
-### --prototype / -p
+#### `-p`<br>`--prototype`
 
 Adding the `--prototype` aka `-p` switch creates a
 [prototype branch](../branch-types.md#prototype-branches).
 
-### --title / -t &lt;text&gt;
+#### `-t <text>`<br>`--title <text>`
 
 Pre-populate the title of the pull request to create with the given text.
 Requires `--propose`.
 
-### --detached / -d
+#### `-d`<br>`--detached`
 
 The `--detached` aka `-d` flag does not pull updates from the main or perennial
 branch. This allows you to build out your branch stack and decide when to pull
 in changes from other developers.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.
 
-### Configuration
+## Configuration
 
 If [push-new-branches](../preferences/push-new-branches.md) is set,
 `git town hack` creates a remote tracking branch for the new feature branch.

--- a/website/src/commands/propose.md
+++ b/website/src/commands/propose.md
@@ -17,38 +17,40 @@ You can create pull requests for repositories hosted on:
 - [GitHub](https://github.com)
 - [GitLab](https://gitlab.com)
 
-### --body / -b &lt;text&gt;
+## Options
+
+#### `-b <text>`<br>`--body <text>`
 
 Pre-populate the body of the pull request with the given text.
 
-### --body-file / -f &lt;path&gt;
+#### `-f <path>`<br>`--body-file <path>`
 
 When called with the `--body-file` aka `-f` flag, it pre-populates the body of
 the pull request with the content of the given file. The filename `-` reads the
 body text from STDIN.
 
-### --title / -t &lt;text&gt;
+#### `-t <text>`<br>`--title <text>`
 
 When called with the `--title <title>` aka `-t` flag, the _propose_ command
 pre-populate the title of the pull request to the given text.
 
-### --detached / -d
+#### `-d`<br>`--detached`
 
 The `--detached` aka `-d` flag does not pull updates from the main or perennial
 branch. This allows you to build out your branch stack and decide when to pull
 in changes from other developers.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.
 
-### Configuration
+## Configuration
 
 You can configure the hosting platform type with the
 [hosting-platform](../preferences/hosting-platform.md) setting.

--- a/website/src/commands/prototype.md
+++ b/website/src/commands/prototype.md
@@ -10,7 +10,7 @@ The _prototype_ command marks some of your branches as
 To convert a prototype branch back into a feature branch, use the
 [hack](hack.md) command.
 
-### Positional arguments
+## Positional arguments
 
 Make the current branch a prototype branch:
 
@@ -24,7 +24,9 @@ Make branches "alpha" and "beta" prototype branches:
 git town prototype alpha beta
 ```
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/rename.md
+++ b/website/src/commands/rename.md
@@ -16,7 +16,7 @@ a proposal, the existing proposal will most likely end up closed and you have to
 create a new proposal that supersedes the old one. If that happens, Git Town
 will notify you. Updating proposals of child branches usually works.
 
-### Positional arguments
+## Positional arguments
 
 When called with only one argument, the _rename_ command renames the current
 branch to the given name.
@@ -24,17 +24,19 @@ branch to the given name.
 When called with two arguments, it renames the branch with the given name to the
 given name.
 
-### --force / -f
+## Options
+
+#### `-f`<br>`--force`
 
 Renaming perennial branches requires confirmation with the `--force` aka `-f`
 flag.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/repo.md
+++ b/website/src/commands/repo.md
@@ -9,7 +9,7 @@ repository in your browser. Git Town can display repositories hosted on
 [GitHub](https://github.com), [GitLab](https://gitlab.com),
 [Gitea](https://gitea.com), and [Bitbucket](https://bitbucket.org).
 
-### Positional arguments
+## Positional arguments
 
 When called without arguments, the _repo_ command shows the repository at the
 [development remote](../preferences/dev-remote.md).
@@ -17,7 +17,7 @@ When called without arguments, the _repo_ command shows the repository at the
 When called with an argument, it shows the repository at the remote with the
 given name.
 
-### Configuration
+## Configuration
 
 Git Town automatically identifies the hosting platform type through the URL of
 the development remote. You can override the type of hosting server with the
@@ -26,7 +26,9 @@ the development remote. You can override the type of hosting server with the
 Set the [hosting-origin-hostname](../preferences/hosting-origin-hostname.md)
 setting to tell Git Town about the hostname when using ssh identities.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/set-parent.md
+++ b/website/src/commands/set-parent.md
@@ -40,7 +40,9 @@ main
 * feature-2
 ```
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/ship.md
+++ b/website/src/commands/ship.md
@@ -18,40 +18,42 @@ exit with an error. When that happens, run [git town sync](sync.md) to get the
 branch in sync, re-test and re-review the updated branch, and then run
 `git town ship` again.
 
-### Positional argument
+## Positional argument
 
 When called without a positional argument, the _ship_ command ships the current
 branch.
 
 When called with a positional argument, it ships the branch with the given name.
 
-### --message / -m &lt;text&gt;
+## Options
+
+#### `-m <text>`<br>`--message <text>`
 
 Similar to `git commit`, the `--message <message>` aka `-m` parameter allows
 specifying the commit message via the CLI.
 
-### --strategy / -s &lt;name&gt;
+#### `-s <name>`<br>`--strategy <name>`
 
 Overrides the configured [ship-strategy](../preferences/ship-strategy.md).
 
-### --to-parent / -p
+#### `-p`<br>`--to-parent`
 
 The _ship_ command ships only direct children of the main branch. To ship a
 child branch, you need to first ship or [delete](delete.md) all its ancestor
 branches. If you really want to ship into a non-perennial branch, you can
 override the protection against that with the `--to-parent` aka `-p` option.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.
 
-### Configuration
+## Configuration
 
 The configured [ship-strategy](../preferences/ship-strategy.md) determines how
 the _ship_ command merges branches. When shipping

--- a/website/src/commands/skip.md
+++ b/website/src/commands/skip.md
@@ -7,7 +7,9 @@ git town skip [-v | --verbose]
 The _skip_ command allows to skip a Git branch with merge conflicts when syncing
 all feature branches.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/status-reset.md
+++ b/website/src/commands/status-reset.md
@@ -7,7 +7,9 @@ git town status reset [-v | --verbose]
 The _status reset_ command deletes the persisted runstate. This is only needed
 if the runstate is corrupted and causes Git Town to crash.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/status.md
+++ b/website/src/commands/status.md
@@ -8,12 +8,14 @@ git town status reset [-v | --verbose]
 The _status_ command indicates whether Git Town has encountered a merge conflict
 and which commands you can run to continue, skip, or undo it.
 
-### Subcommands
+## Subcommands
 
 The [reset](status-reset.md) subcommand deletes the persisted runstate. This is
 only needed if the runstate is corrupted and causes Git Town to crash.
 
-### --pending / -p
+## Options
+
+#### `-p`<br>`--pending`
 
 The `--pending` aka `-p` argument causes this command to output only the name of
 the pending Git Town command if one exists. This allows displaying a reminder to
@@ -21,7 +23,7 @@ run `git town continue` into your shell prompt when you encountered a merge
 conflict earlier. See [Integration](../integration.md#shell-prompt) on how to
 set this up.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/switch.md
+++ b/website/src/commands/switch.md
@@ -12,7 +12,7 @@ regular expression matches.
 `git town switch` reminds you about uncommitted changes in your workspace in
 case you forgot to commit them to the current branch.
 
-### positional arguments
+## Positional arguments
 
 `git town switch` interprets all positional arguments as regular expressions.
 When receiving regular expressions from the user, it displays only the branches
@@ -31,22 +31,24 @@ To display all branches starting with `me-` and the main branch:
 git town switch me- main
 ```
 
-### --all / -a
+## Options
+
+#### `-a`<br>`--all`
 
 The `--all` aka `-a` flag also displays both local and remote branches.
 
-### --display-types / -d
+#### `-d`<br>`--display-types`
 
 When enabled, this command displays the types for all branches except the main
 branch and feature branches.
 
-### --merge / -m
+#### `-m`<br>`--merge`
 
 The `--merge` aka `-m` flag has the same effect as the
 [git checkout -m](https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt--m)
 flag.
 
-### --type / -t &lt;name&gt;
+#### `-t <name>`<br>`--type <name>`
 
 The `--type` aka `-t` flag reduces the list of branches to those that have the
 given type(s). For example, to display only observed branches:
@@ -82,7 +84,7 @@ This can be shortened to:
 git town switch -to+c
 ```
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.

--- a/website/src/commands/sync.md
+++ b/website/src/commands/sync.md
@@ -30,39 +30,41 @@ back to the exact state you repo was in before the sync by running
 If the parent branch is not known, Git Town looks for a pull/merge request for
 this branch and uses its parent branch. Otherwise it prompts you for the parent.
 
-### --all / -a
+## Options
+
+#### `-a`<br>`--all`
 
 By default this command syncs only the current branch. The `--all` aka `-a`
 parameter makes Git Town sync all local branches.
 
-### --no-push
+#### `--no-push`
 
 The `--no-push` argument disables all pushes of local commits to their tracking
 branch.
 
-### --stack / -s
+#### `-s`<br>`--stack`
 
 The `--stack` aka `-s` parameter makes Git Town sync all branches in the stack
 that the current branch belongs to.
 
-### --detached / -d
+#### `-d`<br>`--detached`
 
 The `--detached` aka `-d` flag does not pull updates from the main or perennial
 branch at the root of your branch hierarchy. This allows you to keep your
 branches in sync with each other and decide when to pull in changes from other
 developers.
 
-### --dry-run
+#### `--dry-run`
 
 Use the `--dry-run` flag to test-drive this command. It prints the Git commands
 that would be run but doesn't execute them.
 
-### --verbose / -v
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.
 
-### Configuration
+## Configuration
 
 [sync-perennial-strategy](../preferences/sync-perennial-strategy.md) configures
 whether perennial branches merge their tracking branch or rebase against it.

--- a/website/src/commands/undo.md
+++ b/website/src/commands/undo.md
@@ -8,7 +8,9 @@ The _undo_ command reverts the last fully executed Git Town command. It performs
 the opposite activities that the last command did and leaves your repository in
 the state it was before you ran the problematic command.
 
-### --verbose / -v
+## Options
+
+#### `-v`<br>`--verbose`
 
 The `--verbose` aka `-v` flag prints all Git commands run under the hood to
 determine the repository state.


### PR DESCRIPTION
This PR updates headings in the commands documentation to have consistent levels and to use code formatting.

A follow-up PR will reorganize a few of these files so the heading levels all line up.

Ref: #4429