### PR TITLE
MergeNoFastForward: stop relying on default value of --edit in git merge

### DIFF
--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -3,6 +3,7 @@ package git_test
 import (
 	"testing"
 
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
 	"github.com/git-town/git-town/v17/internal/git"
 	"github.com/git-town/git-town/v17/internal/git/gitdomain"
 	"github.com/git-town/git-town/v17/internal/gohacks"
@@ -502,7 +503,7 @@ func TestBackendCommands(t *testing.T) {
 		})
 		runtime.CheckoutBranch(initial) // CreateCommit checks out `branch`, go back to `initial`.
 
-		err := runtime.MergeNoFastForward(runtime.TestRunner, None[gitdomain.CommitMessage](), branch)
+		err := runtime.MergeNoFastForward(runtime.TestRunner, configdomain.UseDefaultMessage(), branch)
 		must.NoError(t, err)
 
 		commits, err := runtime.Commands.CommitsInPerennialBranch(runtime) // Current branch.
@@ -526,7 +527,7 @@ func TestBackendCommands(t *testing.T) {
 		mergeMessage := gitdomain.CommitMessage("merge message")
 		runtime.CheckoutBranch(initial) // CreateCommit checks out `branch`, go back to `initial`.
 
-		err := runtime.MergeNoFastForward(runtime.TestRunner, Some(mergeMessage), branch)
+		err := runtime.MergeNoFastForward(runtime.TestRunner, configdomain.UseCustomMessage(mergeMessage), branch)
 		must.NoError(t, err)
 
 		commits, err := runtime.Commands.CommitsInPerennialBranch(runtime) // Current branch.


### PR DESCRIPTION
`git merge` determines the default value of the `--edit` flag based on whether git runs on a tty. This can be convenient for bare git where it can be used both interactively and non-interactively. However git-town is always interactive but cucumber tests run subcommands without tty. This creates a problem where `git merge` behaves differently in cucumber tests compared to real interactive use, e.g. it doesn't run an editor even though we use `and close the editor` or `and enter "..." for the commit message`, which can be extremely confusing.

Assuming that git-town will always run interactively it is much easier to set an appropriate `--edit` value explicitly:
- If an explicit message is set, we don't need to worry about `--edit`, git will not run an editor regardless of tty.
- If a message is not present and we run the command interactively we should prompt a user to edit the default message, so we use `--edit`.
- If a message is not present and we run the command non-interactively we should accept the default message, so we use `--no-edit`.

The behaviour is controlled by the `useDefaultMessage` parameter named after a similar parameter in `Commands.Commit()`.

See also:
- [default_edit_option in builtin/merge.cc](https://github.com/git/git/blob/306ab352f4e98f6809ce52fc4e5d63fb947d0635/builtin/merge.c#L1082-L1106).
- #4381.