### PR TITLE
Add MockCommitMessage test

### DIFF
--- a/test/subshell/test_runner_test.go
+++ b/test/subshell/test_runner_test.go
@@ -32,6 +32,20 @@ func TestMockingRunner(t *testing.T) {
 		must.EqOp(t, "foo called with: bar", res)
 	})
 
+	t.Run("MockCommitMessage", func(t *testing.T) {
+		t.Parallel()
+		runner := subshell.TestRunner{
+			WorkingDir: t.TempDir(),
+			HomeDir:    t.TempDir(),
+			BinDir:     filepath.Join(t.TempDir(), "bin"),
+		}
+
+		runner.MockCommitMessage("test commit message")
+
+		res := runner.MustQuery("bash", "-c", "$GIT_EDITOR output; cat output")
+		must.Eq(t, "test commit message", res)
+	})
+
 	t.Run("Run", func(t *testing.T) {
 		t.Parallel()
 		runner := subshell.TestRunner{


### PR DESCRIPTION
While debugging confusing [`git merge
--edit`](https://github.com/git/git/blob/306ab352f4e98f6809ce52fc4e5d63fb947d0635/builtin/merge.c#L1082-L1106) behaviour I wasn't sure if `MockCommitMessage` works properly, so let's add a test.