### PR TITLE
Add always-merge ship strategy

### DIFF
--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -32,7 +32,7 @@ Feature: change existing information in Git metadata
       | enable push-new-branches                  | down enter             |
       | disable the push hook                     | down enter             |
       | new-branch-type                           | down enter             |
-      | set ship-strategy to "fast-forward"       | down enter             |
+      | set ship-strategy to "fast-forward"       | down down enter        |
       | disable ship-delete-tracking-branch       | down enter             |
       | save config to Git metadata               | down enter             |
 

--- a/features/ship/always_merge/current_branch/additional_commits/before_undo/offline.feature
+++ b/features/ship/always_merge/current_branch/additional_commits/before_undo/offline.feature
@@ -1,0 +1,38 @@
+Feature: partially undo an offline ship using the always-merge strategy after additional commits to main
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And offline mode is enabled
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+    And I add commit "additional commit" to the "main" branch
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git checkout feature                          |
+    And Git Town prints:
+      """
+      cannot reset branch "main"
+      """
+    And Git Town prints:
+      """
+      it received additional commits in the meantime
+      """
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH  | LOCATION | MESSAGE                |
+      | main    | local    | feature commit         |
+      |         |          | Merge branch 'feature' |
+      |         |          | additional commit      |
+      | feature | origin   | feature commit         |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/additional_commits/before_undo/online.feature
+++ b/features/ship/always_merge/current_branch/additional_commits/before_undo/online.feature
@@ -1,0 +1,29 @@
+Feature: partially undo an online ship using the always-merge strategy after additional commits to the main branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+    And I add commit "additional commit" to the "main" branch
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+      |        | local         | additional commit      |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/additional_commits/on_main/additional_commit_on_main.feature
+++ b/features/ship/always_merge/current_branch/additional_commits/on_main/additional_commit_on_main.feature
@@ -1,0 +1,50 @@
+Feature: can ship not-up-to-date feature branches using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+      | main    | local, origin | main commit    |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push                            |
+      |         | git push origin :feature            |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | main commit            |
+      |        |               | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And the currently checked out commit is "feature commit"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | main commit            |
+      |        |               | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/branch_owner/coworker_branch.feature
+++ b/features/ship/always_merge/current_branch/branch_owner/coworker_branch.feature
@@ -1,0 +1,42 @@
+Feature: ship a coworker's feature branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE         | AUTHOR                          |
+      | feature | local, origin | coworker commit | coworker <coworker@example.com> |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push                            |
+      |         | git push origin :feature            |
+      |         | git branch -D feature               |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                | AUTHOR                          |
+      | main   | local, origin | coworker commit        | coworker <coworker@example.com> |
+      |        |               | Merge branch 'feature' | user <email@example.com>        |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                        |
+      | main   | git branch feature {{ sha 'coworker commit' }} |
+      |        | git push -u origin feature                     |
+      |        | git checkout feature                           |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | coworker commit        |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/branch_owner/multiple_authors.feature
+++ b/features/ship/always_merge/current_branch/branch_owner/multiple_authors.feature
@@ -1,0 +1,40 @@
+Feature: ship a coworker's feature branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE            | AUTHOR                            |
+      | feature | local, origin | developer commit 1 | developer <developer@example.com> |
+      |         |               | developer commit 2 | developer <developer@example.com> |
+      |         |               | coworker commit    | coworker <coworker@example.com>   |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                | AUTHOR                            |
+      | main   | local, origin | developer commit 1     | developer <developer@example.com> |
+      |        |               | developer commit 2     | developer <developer@example.com> |
+      |        |               | coworker commit        | coworker <coworker@example.com>   |
+      |        |               | Merge branch 'feature' | user <email@example.com>          |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                        |
+      | main   | git branch feature {{ sha 'coworker commit' }} |
+      |        | git push -u origin feature                     |
+      |        | git checkout feature                           |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | developer commit 1     |
+      |        |               | developer commit 2     |
+      |        |               | coworker commit        |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/branch_types/contribution.feature
+++ b/features/ship/always_merge/current_branch/branch_types/contribution.feature
@@ -1,0 +1,32 @@
+Feature: cannot ship contribution branches
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME         | TYPE         | PARENT | LOCATIONS     |
+      | contribution | contribution | main   | local, origin |
+    And the current branch is "contribution"
+    And the commits
+      | BRANCH       | LOCATION      | MESSAGE             |
+      | contribution | local, origin | contribution commit |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH       | COMMAND                  |
+      | contribution | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      cannot ship contribution branches
+      """
+    And the current branch is still "contribution"
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And the current branch is still "contribution"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/branch_types/hotfix.feature
+++ b/features/ship/always_merge/current_branch/branch_types/hotfix.feature
@@ -1,0 +1,47 @@
+Feature: ship hotfixes
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME       | TYPE      | PARENT     | LOCATIONS     |
+      | production | perennial |            | local, origin |
+      | hotfix     | feature   | production | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE       |
+      | hotfix | local, origin | hotfix commit |
+    And the current branch is "hotfix"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH     | COMMAND                            |
+      | hotfix     | git fetch --prune --tags           |
+      |            | git checkout production            |
+      | production | git merge --no-ff --edit -- hotfix |
+      |            | git push                           |
+      |            | git push origin :hotfix            |
+      |            | git branch -D hotfix               |
+    And the current branch is now "production"
+    And the branches are now
+      | REPOSITORY    | BRANCHES         |
+      | local, origin | main, production |
+    And these commits exist now
+      | BRANCH     | LOCATION      | MESSAGE                               |
+      | production | local, origin | hotfix commit                         |
+      |            |               | Merge branch 'hotfix' into production |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH     | COMMAND                                     |
+      | production | git branch hotfix {{ sha 'hotfix commit' }} |
+      |            | git push -u origin hotfix                   |
+      |            | git checkout hotfix                         |
+    And the current branch is now "hotfix"
+    And these commits exist now
+      | BRANCH     | LOCATION      | MESSAGE                               |
+      | production | local, origin | hotfix commit                         |
+      |            |               | Merge branch 'hotfix' into production |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/branch_types/observed.feature
+++ b/features/ship/always_merge/current_branch/branch_types/observed.feature
@@ -1,0 +1,32 @@
+Feature: cannot ship observed branches using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME     | TYPE     | LOCATIONS     |
+      | observed | observed | local, origin |
+    And the commits
+      | BRANCH   | LOCATION      | MESSAGE         |
+      | observed | local, origin | observed commit |
+    And the current branch is "observed"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH   | COMMAND                  |
+      | observed | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      cannot ship observed branches
+      """
+    And the current branch is still "observed"
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And the current branch is still "observed"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/branch_types/parked.feature
+++ b/features/ship/always_merge/current_branch/branch_types/parked.feature
@@ -1,0 +1,47 @@
+Feature: shipping a parked branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME   | TYPE   | PARENT | LOCATIONS     |
+      | parked | parked | main   | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE       |
+      | parked | local, origin | parked commit |
+    And the current branch is "parked"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                            |
+      | parked | git fetch --prune --tags           |
+      |        | git checkout main                  |
+      | main   | git merge --no-ff --edit -- parked |
+      |        | git push                           |
+      |        | git push origin :parked            |
+      |        | git branch -D parked               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, origin | parked commit         |
+      |        |               | Merge branch 'parked' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                     |
+      | main   | git branch parked {{ sha 'parked commit' }} |
+      |        | git push -u origin parked                   |
+      |        | git checkout parked                         |
+    And the current branch is now "parked"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, origin | parked commit         |
+      |        |               | Merge branch 'parked' |
+    And the initial branches and lineage exist now
+    And branch "parked" is now parked

--- a/features/ship/always_merge/current_branch/branch_types/perennial.feature
+++ b/features/ship/always_merge/current_branch/branch_types/perennial.feature
@@ -1,0 +1,32 @@
+Feature: cannot ship perennial branches using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME      | TYPE      | LOCATIONS     |
+      | perennial | perennial | local, origin |
+    And the commits
+      | BRANCH    | LOCATION      | MESSAGE          |
+      | perennial | local, origin | perennial commit |
+    And the current branch is "perennial"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH    | COMMAND                  |
+      | perennial | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      cannot ship perennial branches
+      """
+    And the current branch is still "perennial"
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And the current branch is still "perennial"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/branch_types/prototype.feature
+++ b/features/ship/always_merge/current_branch/branch_types/prototype.feature
@@ -1,0 +1,48 @@
+@skipWindows
+Feature: shipping a prototype branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME      | TYPE      | PARENT | LOCATIONS     |
+      | prototype | prototype | main   | local, origin |
+    And the commits
+      | BRANCH    | LOCATION      | MESSAGE          |
+      | prototype | local, origin | prototype commit |
+    And the current branch is "prototype"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH    | COMMAND                               |
+      | prototype | git fetch --prune --tags              |
+      |           | git checkout main                     |
+      | main      | git merge --no-ff --edit -- prototype |
+      |           | git push                              |
+      |           | git push origin :prototype            |
+      |           | git branch -D prototype               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                  |
+      | main   | local, origin | prototype commit         |
+      |        |               | Merge branch 'prototype' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                           |
+      | main   | git branch prototype {{ sha 'prototype commit' }} |
+      |        | git push -u origin prototype                      |
+      |        | git checkout prototype                            |
+    And the current branch is now "prototype"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                  |
+      | main   | local, origin | prototype commit         |
+      |        |               | Merge branch 'prototype' |
+    And the initial branches and lineage exist now
+    And branch "prototype" is now prototype

--- a/features/ship/always_merge/current_branch/commit_message/default.feature
+++ b/features/ship/always_merge/current_branch/commit_message/default.feature
@@ -1,0 +1,47 @@
+Feature: default merge message
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the current branch is "feature"
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push                            |
+      |         | git push origin :feature            |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And the currently checked out commit is "feature commit"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/commit_message/empty.feature
+++ b/features/ship/always_merge/current_branch/commit_message/empty.feature
@@ -1,0 +1,41 @@
+@skipWindows
+Feature: abort the ship by empty commit message
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS |
+      | feature | feature | main   | local     |
+    And the current branch is "feature"
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE        |
+      | feature | local    | feature commit |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and enter an empty commit message
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git merge --abort                   |
+      |         | git checkout feature                |
+    And Git Town prints the error:
+      """
+      aborted because merge exited with error
+      """
+    And the current branch is still "feature"
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "feature"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/commit_message/via_flag.feature
+++ b/features/ship/always_merge/current_branch/commit_message/via_flag.feature
@@ -1,0 +1,48 @@
+@smoke
+Feature: ship the current feature branch with a tracking branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the current branch is "feature"
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship -m 'feature done'"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                                        |
+      | feature | git fetch --prune --tags                       |
+      |         | git checkout main                              |
+      | main    | git merge --no-ff -m "feature done" -- feature |
+      |         | git push                                       |
+      |         | git push origin :feature                       |
+      |         | git branch -D feature                          |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE        |
+      | main   | local, origin | feature commit |
+      |        |               | feature done   |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And the currently checked out commit is "feature commit"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE        |
+      | main   | local, origin | feature commit |
+      |        |               | feature done   |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/commit_message/with_double_quotes.feature
+++ b/features/ship/always_merge/current_branch/commit_message/with_double_quotes.feature
@@ -1,0 +1,48 @@
+Feature: commit message with double-quotes
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the current branch is "feature"
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship -m 'with "double quotes"'"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                                                |
+      | feature | git fetch --prune --tags                               |
+      |         | git checkout main                                      |
+      | main    | git merge --no-ff -m "with "double quotes"" -- feature |
+      |         | git push                                               |
+      |         | git push origin :feature                               |
+      |         | git branch -D feature                                  |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And no uncommitted files exist now
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE              |
+      | main   | local, origin | feature commit       |
+      |        |               | with "double quotes" |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And the currently checked out commit is "feature commit"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE              |
+      | main   | local, origin | feature commit       |
+      |        |               | with "double quotes" |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/dry_run.feature
+++ b/features/ship/always_merge/current_branch/dry_run.feature
@@ -1,0 +1,32 @@
+Feature: dry-run shipping via the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship --dry-run"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push origin :feature            |
+      |         | git branch -D feature               |
+    And the current branch is still "feature"
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And the current branch is still "feature"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/empty_branch.feature
+++ b/features/ship/always_merge/current_branch/empty_branch.feature
@@ -1,0 +1,37 @@
+Feature: does not ship an empty branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME  | TYPE    | PARENT | LOCATIONS |
+      | empty | feature | main   | local     |
+    And the commits
+      | BRANCH | LOCATION | MESSAGE      | FILE NAME | FILE CONTENT |
+      | main   | local    | main commit  | same_file | same content |
+      | empty  | local    | empty commit | same_file | same content |
+    And the current branch is "empty"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | empty  | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      the branch "empty" has no shippable changes
+      """
+    And the current branch is still "empty"
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "empty"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/git_history.feature
+++ b/features/ship/always_merge/current_branch/git_history.feature
@@ -1,0 +1,39 @@
+Feature: preserve the previous Git branch when shipping using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME     | TYPE    | PARENT | LOCATIONS |
+      | previous | feature | main   | local     |
+      | current  | feature | main   | local     |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+
+  Scenario: current branch gone
+    Given the commits
+      | BRANCH  | LOCATION |
+      | current | local    |
+    And the current branch is "current" and the previous branch is "previous"
+    When I run "git-town ship" and close the editor
+    Then the current branch is now "main"
+    And the previous Git branch is now "previous"
+
+  Scenario: previous branch gone
+    Given the commits
+      | BRANCH   | LOCATION |
+      | previous | local    |
+    And the current branch is "current" and the previous branch is "previous"
+    When I run "git-town ship previous" and close the editor
+    Then the current branch is still "current"
+    And the previous Git branch is now "main"
+
+  Scenario: both branches exist
+    Given the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS |
+      | feature | feature | main   | local     |
+    And the commits
+      | BRANCH  | LOCATION |
+      | feature | local    |
+    And the current branch is "current" and the previous branch is "previous"
+    When I run "git-town ship feature" and close the editor
+    Then the current branch is still "current"
+    And the previous Git branch is still "previous"

--- a/features/ship/always_merge/current_branch/in_subfolder.feature
+++ b/features/ship/always_merge/current_branch/in_subfolder.feature
@@ -1,0 +1,46 @@
+Feature: ship the current feature branch from a subfolder on the shipped branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        | FILE NAME               |
+      | feature | local, origin | feature commit | new_folder/feature_file |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship -m 'feature done'" in the "new_folder" folder
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                                        |
+      | feature | git fetch --prune --tags                       |
+      |         | git checkout main                              |
+      | main    | git merge --no-ff -m "feature done" -- feature |
+      |         | git push                                       |
+      |         | git push origin :feature                       |
+      |         | git branch -D feature                          |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE        |
+      | main   | local, origin | feature commit |
+      |        |               | feature done   |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE        |
+      | main   | local, origin | feature commit |
+      |        |               | feature done   |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/offline/offline.feature
+++ b/features/ship/always_merge/current_branch/offline/offline.feature
@@ -1,0 +1,39 @@
+Feature: offline mode
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And offline mode is enabled
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And these commits exist now
+      | BRANCH  | LOCATION | MESSAGE                |
+      | main    | local    | feature commit         |
+      |         |          | Merge branch 'feature' |
+      | feature | origin   | feature commit         |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git reset --hard {{ sha 'initial commit' }}   |
+      |        | git branch feature {{ sha 'feature commit' }} |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/ship_delete_tracking_branch/disabled.feature
+++ b/features/ship/always_merge/current_branch/ship_delete_tracking_branch/disabled.feature
@@ -1,0 +1,50 @@
+Feature: ship-delete-tracking-branch disabled when using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-delete-tracking-branch" is "false"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+    And origin deletes the "feature" branch
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push                            |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And these branches exist now
+      | REPOSITORY | BRANCHES      |
+      | local      | main, feature |
+      | origin     | main          |
+    And the initial lineage exists now

--- a/features/ship/always_merge/current_branch/stack/parent_branch.feature
+++ b/features/ship/always_merge/current_branch/stack/parent_branch.feature
@@ -1,0 +1,53 @@
+Feature: ship a parent branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME   | TYPE    | PARENT | LOCATIONS     |
+      | parent | feature | main   | local, origin |
+      | child  | feature | parent | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE       |
+      | parent | local, origin | parent commit |
+      | child  | local, origin | child commit  |
+    And the current branch is "parent"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                            |
+      | parent | git fetch --prune --tags           |
+      |        | git checkout main                  |
+      | main   | git merge --no-ff --edit -- parent |
+      |        | git push                           |
+      |        | git push origin :parent            |
+      |        | git branch -D parent               |
+    And Git Town prints:
+      """
+      branch "child" is now a child of "main"
+      """
+    And the current branch is now "main"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, origin | parent commit         |
+      |        |               | Merge branch 'parent' |
+      | child  | local, origin | child commit          |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | child  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                     |
+      | main   | git branch parent {{ sha 'parent commit' }} |
+      |        | git push -u origin parent                   |
+      |        | git checkout parent                         |
+    And the current branch is now "parent"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, origin | parent commit         |
+      |        |               | Merge branch 'parent' |
+      | child  | local, origin | child commit          |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/to_parent/disabled.feature
+++ b/features/ship/always_merge/current_branch/to_parent/disabled.feature
@@ -1,0 +1,41 @@
+Feature: does not ship a child branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME  | TYPE    | PARENT | LOCATIONS     |
+      | alpha | feature | main   | local, origin |
+      | beta  | feature | alpha  | local, origin |
+      | gamma | feature | beta   | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, origin | alpha commit |
+      | beta   | local, origin | beta commit  |
+      | gamma  | local, origin | gamma commit |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    And the current branch is "gamma"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | gamma  | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      shipping this branch would ship "alpha" and "beta" as well,
+      please ship "alpha" first
+      """
+    And the current branch is still "gamma"
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "gamma"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/to_parent/enabled.feature
+++ b/features/ship/always_merge/current_branch/to_parent/enabled.feature
@@ -1,0 +1,58 @@
+Feature: allowing shipping into a feature branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME  | TYPE    | PARENT | LOCATIONS     |
+      | alpha | feature | main   | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE | FILE NAME | FILE CONTENT |
+      | alpha  | local, origin | alpha 1 | alpha_1   | alpha 1      |
+      |        |               | alpha 2 | alpha_2   | alpha 2      |
+    And the branches
+      | NAME | TYPE    | PARENT | LOCATIONS     |
+      | beta | feature | alpha  | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE | FILE NAME | FILE CONTENT |
+      | beta   | local, origin | beta 1  | beta_1    | beta 1       |
+      |        |               | beta 2  | beta_2    | beta 2       |
+    And the current branch is "beta"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship --to-parent" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                          |
+      | beta   | git fetch --prune --tags         |
+      |        | git checkout alpha               |
+      | alpha  | git merge --no-ff --edit -- beta |
+      |        | git push                         |
+      |        | git push origin :beta            |
+      |        | git branch -D beta               |
+    And the current branch is now "alpha"
+    And the branches are now
+      | REPOSITORY    | BRANCHES    |
+      | local, origin | main, alpha |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                        |
+      | alpha  | local, origin | alpha 1                        |
+      |        |               | alpha 2                        |
+      |        |               | beta 1                         |
+      |        |               | beta 2                         |
+      |        |               | Merge branch 'beta' into alpha |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | alpha  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                         |
+      | alpha  | git reset --hard {{ sha 'alpha 2' }}            |
+      |        | git push --force-with-lease --force-if-includes |
+      |        | git branch beta {{ sha 'beta 2' }}              |
+      |        | git push -u origin beta                         |
+      |        | git checkout beta                               |
+    And the current branch is now "beta"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/tracking_branch/deleted.feature
+++ b/features/ship/always_merge/current_branch/tracking_branch/deleted.feature
@@ -1,0 +1,28 @@
+Feature: shipping a branch whose tracking branch is deleted using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    And origin deletes the "feature" branch
+    When I run "git-town ship" and enter "feature done" for the commit message
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                  |
+      | feature | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      branch "feature" was deleted at the remote
+      """
+    And the current branch is still "feature"
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands

--- a/features/ship/always_merge/current_branch/tracking_branch/in_sync.feature
+++ b/features/ship/always_merge/current_branch/tracking_branch/in_sync.feature
@@ -1,0 +1,46 @@
+Feature: ship an omni-branch via the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push                            |
+      |         | git push origin :feature            |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                                  |
+      | main   | git branch feature {{ sha-before-run 'feature commit' }} |
+      |        | git push -u origin feature                               |
+      |        | git checkout feature                                     |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/tracking_branch/local_repo.feature
+++ b/features/ship/always_merge/current_branch/tracking_branch/local_repo.feature
@@ -1,0 +1,40 @@
+Feature: ship a feature branch in a local repo using the always-merge strategy
+
+  Background:
+    Given a local Git repo
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS |
+      | feature | feature | main   | local     |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE        |
+      | feature | local    | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY | BRANCHES |
+      | local      | main     |
+    And these commits exist now
+      | BRANCH | LOCATION | MESSAGE                |
+      | main   | local    | feature commit         |
+      |        |          | Merge branch 'feature' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git reset --hard {{ sha 'initial commit' }}   |
+      |        | git branch feature {{ sha 'feature commit' }} |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/tracking_branch/out_of_sync.feature
+++ b/features/ship/always_merge/current_branch/tracking_branch/out_of_sync.feature
@@ -1,0 +1,31 @@
+Feature: does not ship out-of-sync branches
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE                |
+      | feature | local    | unsynced local commit  |
+      |         | origin   | unsynced origin commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                  |
+      | feature | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      branch "feature" is not in sync
+      """
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And the current branch is still "feature"
+    And no merge is in progress
+    And the initial commits exist now
+    And the initial lineage exists now

--- a/features/ship/always_merge/current_branch/tracking_branch/without.feature
+++ b/features/ship/always_merge/current_branch/tracking_branch/without.feature
@@ -1,0 +1,44 @@
+Feature: ship a local feature branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS |
+      | feature | feature | main   | local     |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE        |
+      | feature | local    | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push                            |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/current_branch/uncommitted_changes.feature
+++ b/features/ship/always_merge/current_branch/uncommitted_changes.feature
@@ -1,0 +1,28 @@
+Feature: does not ship uncommitted changes using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    And an uncommitted file
+    When I run "git-town ship"
+
+  Scenario: result
+    Then Git Town runs no commands
+    And Git Town prints the error:
+      """
+      you have uncommitted changes. Did you mean to commit them before shipping?
+      """
+    And the uncommitted file still exists
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the uncommitted file still exists

--- a/features/ship/always_merge/current_branch/unconfigured.feature
+++ b/features/ship/always_merge/current_branch/unconfigured.feature
@@ -1,0 +1,15 @@
+@messyoutput
+Feature: ask for missing configuration information
+
+  Scenario: unconfigured
+    Given a Git repo with origin
+    And Git Town is not configured
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and enter into the dialog:
+      | DIALOG      | KEYS  |
+      | main branch | enter |
+    And the main branch is now "main"
+    And Git Town prints the error:
+      """
+      cannot ship the main branch
+      """

--- a/features/ship/always_merge/current_branch/verbose.feature
+++ b/features/ship/always_merge/current_branch/verbose.feature
@@ -1,0 +1,73 @@
+Feature: display all executed Git commands when using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship --verbose" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | TYPE     | COMMAND                                           |
+      |         | backend  | git version                                       |
+      |         | backend  | git rev-parse --show-toplevel                     |
+      |         | backend  | git config -lz --includes --global                |
+      |         | backend  | git config -lz --includes --local                 |
+      |         | backend  | git status --long --ignore-submodules             |
+      |         | backend  | git remote                                        |
+      |         | backend  | git branch --show-current                         |
+      | feature | frontend | git fetch --prune --tags                          |
+      |         | backend  | git stash list                                    |
+      |         | backend  | git branch -vva --sort=refname                    |
+      |         | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
+      |         | backend  | git remote get-url origin                         |
+      |         | backend  | git shortlog -s -n -e main..feature               |
+      |         | backend  | git diff main..feature                            |
+      | feature | frontend | git checkout main                                 |
+      | main    | frontend | git merge --no-ff --edit -- feature               |
+      |         | backend  | git rev-list --left-right main...origin/main      |
+      | main    | frontend | git push                                          |
+      |         | backend  | git config --unset git-town-branch.feature.parent |
+      | main    | frontend | git push origin :feature                          |
+      |         | frontend | git branch -D feature                             |
+      |         | backend  | git branch -vva --sort=refname                    |
+      |         | backend  | git config -lz --includes --global                |
+      |         | backend  | git config -lz --includes --local                 |
+      |         | backend  | git stash list                                    |
+    And Git Town prints:
+      """
+      Ran 25 shell commands.
+      """
+    And the current branch is now "main"
+
+  Scenario: undo
+    Given I ran "git-town ship -m done"
+    When I run "git-town undo --verbose"
+    Then Git Town runs the commands
+      | BRANCH | TYPE     | COMMAND                                        |
+      |        | backend  | git version                                    |
+      |        | backend  | git rev-parse --show-toplevel                  |
+      |        | backend  | git config -lz --includes --global             |
+      |        | backend  | git config -lz --includes --local              |
+      |        | backend  | git status --long --ignore-submodules          |
+      |        | backend  | git stash list                                 |
+      |        | backend  | git branch -vva --sort=refname                 |
+      |        | backend  | git remote get-url origin                      |
+      |        | backend  | git rev-parse --verify --abbrev-ref @{-1}      |
+      |        | backend  | git remote get-url origin                      |
+      | main   | frontend | git branch feature {{ sha 'feature commit' }}  |
+      |        | frontend | git push -u origin feature                     |
+      |        | backend  | git show-ref --quiet refs/heads/feature        |
+      | main   | frontend | git checkout feature                           |
+      |        | backend  | git config git-town-branch.feature.parent main |
+    And Git Town prints:
+      """
+      Ran 15 shell commands.
+      """
+    And the current branch is now "feature"

--- a/features/ship/always_merge/current_branch/worktree/previous_branch_in_other_worktree.feature
+++ b/features/ship/always_merge/current_branch/worktree/previous_branch_in_other_worktree.feature
@@ -1,0 +1,34 @@
+Feature: ship while the previous branch is active in another worktree
+
+  Background:
+    Given a local Git repo
+    And the branches
+      | NAME     | TYPE    | PARENT | LOCATIONS |
+      | current  | feature | main   | local     |
+      | previous | feature | main   | local     |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE        |
+      | current | local    | current commit |
+    And the current branch is "current" and the previous branch is "previous"
+    And branch "previous" is active in another worktree
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | current | git checkout main                   |
+      | main    | git merge --no-ff --edit -- current |
+      |         | git branch -D current               |
+    And the current branch is now "main"
+    And the previous Git branch is now "main"
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git reset --hard {{ sha 'initial commit' }}   |
+      |        | git branch current {{ sha 'current commit' }} |
+      |        | git checkout current                          |
+    And the current branch is now "current"
+    And the previous Git branch is now "main"

--- a/features/ship/always_merge/supplied_branch/branch_types/main_branch.feature
+++ b/features/ship/always_merge/supplied_branch/branch_types/main_branch.feature
@@ -1,0 +1,32 @@
+Feature: does not ship the main branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the current branch is "feature"
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship main"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                  |
+      | feature | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      cannot ship the main branch
+      """
+    And the current branch is still "feature"
+    And the uncommitted file still exists
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "feature"
+    And the uncommitted file still exists

--- a/features/ship/always_merge/supplied_branch/branch_types/perennial.feature
+++ b/features/ship/always_merge/supplied_branch/branch_types/perennial.feature
@@ -1,0 +1,32 @@
+Feature: does not ship perennial branches using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME       | TYPE      | PARENT | LOCATIONS     |
+      | production | perennial |        | local, origin |
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship production"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      cannot ship perennial branches
+      """
+    And the current branch is still "main"
+    And the uncommitted file still exists
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "main"
+    And no lineage exists now

--- a/features/ship/always_merge/supplied_branch/empty_branch.feature
+++ b/features/ship/always_merge/supplied_branch/empty_branch.feature
@@ -1,0 +1,44 @@
+Feature: does not ship empty feature branches using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME  | TYPE    | PARENT | LOCATIONS |
+      | empty | feature | main   | local     |
+      | other | feature | main   | local     |
+    And the commits
+      | BRANCH | LOCATION | MESSAGE        | FILE NAME   | FILE CONTENT   |
+      | main   | local    | main commit    | common_file | common content |
+      | empty  | local    | feature commit | common_file | common content |
+    And the current branch is "other"
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship empty"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | other  | git fetch --prune --tags |
+      |        | git add -A               |
+      |        | git stash                |
+      |        | git stash pop            |
+    And Git Town prints the error:
+      """
+      the branch "empty" has no shippable changes
+      """
+    And the current branch is still "other"
+    And the uncommitted file still exists
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "other"
+    And the uncommitted file still exists
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/happy_path.feature
+++ b/features/ship/always_merge/supplied_branch/happy_path.feature
@@ -1,0 +1,58 @@
+Feature: ship the supplied feature branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+      | other   | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        |
+      | feature | local, origin | feature commit | conflicting_file |
+    And the current branch is "other"
+    And an uncommitted file with name "conflicting_file" and content "conflicting content"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                             |
+      | other  | git fetch --prune --tags            |
+      |        | git add -A                          |
+      |        | git stash                           |
+      |        | git checkout main                   |
+      | main   | git merge --no-ff --edit -- feature |
+      |        | git push                            |
+      |        | git push origin :feature            |
+      |        | git checkout other                  |
+      | other  | git branch -D feature               |
+      |        | git stash pop                       |
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And the branches are now
+      | REPOSITORY    | BRANCHES    |
+      | local, origin | main, other |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | other  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | other  | git add -A                                    |
+      |        | git stash                                     |
+      |        | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git stash pop                                 |
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/in_subfolder.feature
+++ b/features/ship/always_merge/supplied_branch/in_subfolder.feature
@@ -1,0 +1,57 @@
+Feature: ship the supplied feature branch from a subfolder using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS |
+      | feature | feature | main   | local     |
+      | other   | feature | main   | local     |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE        |
+      | feature | local    | feature commit |
+    And the current branch is "other"
+    And an uncommitted file with name "new_folder/other_feature_file" and content "other feature content"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship -m 'feature done' feature" in the "new_folder" folder
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                        |
+      | other  | git fetch --prune --tags                       |
+      |        | git add -A                                     |
+      |        | git stash                                      |
+      |        | git checkout main                              |
+      | main   | git merge --no-ff -m "feature done" -- feature |
+      |        | git push                                       |
+      |        | git checkout other                             |
+      | other  | git branch -D feature                          |
+      |        | git stash pop                                  |
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And the branches are now
+      | REPOSITORY | BRANCHES    |
+      | local      | main, other |
+      | origin     | main        |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE        |
+      | main   | local, origin | feature commit |
+      |        |               | feature done   |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | other  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | other  | git add -A                                    |
+      |        | git stash                                     |
+      |        | git branch feature {{ sha 'feature commit' }} |
+      |        | git stash pop                                 |
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE        |
+      | main   | local, origin | feature commit |
+      |        |               | feature done   |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/lineage/child_branch.feature
+++ b/features/ship/always_merge/supplied_branch/lineage/child_branch.feature
@@ -1,0 +1,41 @@
+Feature: does not ship a child branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME  | TYPE    | PARENT | LOCATIONS     |
+      | alpha | feature | main   | local, origin |
+      | beta  | feature | alpha  | local, origin |
+      | gamma | feature | beta   | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE      |
+      | alpha  | local, origin | alpha commit |
+      | beta   | local, origin | beta commit  |
+      | gamma  | local, origin | gamma commit |
+    And the current branch is "alpha"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship gamma"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | alpha  | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      shipping this branch would ship "alpha" and "beta" as well,
+      please ship "alpha" first
+      """
+    And the current branch is now "alpha"
+    And the initial commits exist now
+    And the initial lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "alpha"
+    And the initial commits exist now
+    And the initial lineage exists now

--- a/features/ship/always_merge/supplied_branch/lineage/parent_branch.feature
+++ b/features/ship/always_merge/supplied_branch/lineage/parent_branch.feature
@@ -1,0 +1,53 @@
+Feature: ship a parent branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME   | TYPE    | PARENT | LOCATIONS     |
+      | parent | feature | main   | local, origin |
+      | child  | feature | parent | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE       |
+      | parent | local, origin | parent commit |
+      | child  | local, origin | child commit  |
+    And the current branch is "child"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship parent" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                            |
+      | child  | git fetch --prune --tags           |
+      |        | git checkout main                  |
+      | main   | git merge --no-ff --edit -- parent |
+      |        | git push                           |
+      |        | git push origin :parent            |
+      |        | git checkout child                 |
+      | child  | git branch -D parent               |
+    And Git Town prints:
+      """
+      branch "child" is now a child of "main"
+      """
+    And the current branch is now "child"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, origin | parent commit         |
+      |        |               | Merge branch 'parent' |
+      | child  | local, origin | child commit          |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | child  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                     |
+      | child  | git branch parent {{ sha 'parent commit' }} |
+      |        | git push -u origin parent                   |
+    And the current branch is now "child"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE               |
+      | main   | local, origin | parent commit         |
+      |        |               | Merge branch 'parent' |
+      | child  | local, origin | child commit          |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/merge_conflict/feature_and_main.feature
+++ b/features/ship/always_merge/supplied_branch/merge_conflict/feature_and_main.feature
@@ -1,0 +1,52 @@
+Feature: handle conflicts between the supplied feature branch and the main branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS |
+      | feature | feature | main   | local     |
+      | other   | feature | main   | local     |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE                    | FILE NAME        | FILE CONTENT    |
+      | main    | local    | conflicting main commit    | conflicting_file | main content    |
+      | feature | local    | conflicting feature commit | conflicting_file | feature content |
+    And the current branch is "other"
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    And I run "git-town ship feature" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                             |
+      | other  | git fetch --prune --tags            |
+      |        | git add -A                          |
+      |        | git stash                           |
+      |        | git checkout main                   |
+      | main   | git merge --no-ff --edit -- feature |
+      |        | git merge --abort                   |
+      |        | git checkout other                  |
+      | other  | git stash pop                       |
+    And Git Town prints the error:
+      """
+      CONFLICT (add/add): Merge conflict in conflicting_file
+      """
+    And Git Town prints the error:
+      """
+      aborted because merge exited with error
+      """
+    And the current branch is still "other"
+    And the uncommitted file still exists
+    And no merge is in progress
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And no merge is in progress
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/non_existing_branch.feature
+++ b/features/ship/always_merge/supplied_branch/non_existing_branch.feature
@@ -1,0 +1,28 @@
+Feature: does not ship a non-existing branch
+
+  Background:
+    Given a Git repo with origin
+    And the current branch is "main"
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship non-existing-branch"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      there is no branch "non-existing-branch"
+      """
+    And the current branch is now "main"
+    And the uncommitted file still exists
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "main"

--- a/features/ship/always_merge/supplied_branch/on_supplied_branch.feature
+++ b/features/ship/always_merge/supplied_branch/on_supplied_branch.feature
@@ -1,0 +1,46 @@
+Feature: ship the current feature branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And the current branch is "feature"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                             |
+      | feature | git fetch --prune --tags            |
+      |         | git checkout main                   |
+      | main    | git merge --no-ff --edit -- feature |
+      |         | git push                            |
+      |         | git push origin :feature            |
+      |         | git branch -D feature               |
+    And the current branch is now "main"
+    And the branches are now
+      | REPOSITORY    | BRANCHES |
+      | local, origin | main     |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And no lineage exists now
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | main   | git branch feature {{ sha 'feature commit' }} |
+      |        | git push -u origin feature                    |
+      |        | git checkout feature                          |
+    And the current branch is now "feature"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/ship_delete_tracking_branch/disabled.feature
+++ b/features/ship/always_merge/supplied_branch/ship_delete_tracking_branch/disabled.feature
@@ -1,0 +1,56 @@
+Feature: skip deleting the remote branch when shipping another branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+      | other   | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+      | other   | local         | other commit   |
+    And the current branch is "other"
+    And Git setting "git-town.ship-delete-tracking-branch" is "false"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature" and close the editor
+    And origin deletes the "feature" branch
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                             |
+      | other  | git fetch --prune --tags            |
+      |        | git checkout main                   |
+      | main   | git merge --no-ff --edit -- feature |
+      |        | git push                            |
+      |        | git checkout other                  |
+      | other  | git branch -D feature               |
+    And the current branch is now "other"
+    And the branches are now
+      | REPOSITORY    | BRANCHES    |
+      | local, origin | main, other |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+      | other  | local         | other commit           |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | other  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | other  | git branch feature {{ sha 'feature commit' }} |
+    And the current branch is now "other"
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+      | other  | local         | other commit           |
+    And these branches exist now
+      | REPOSITORY | BRANCHES             |
+      | local      | main, feature, other |
+      | origin     | main, other          |
+    And the initial lineage exists now

--- a/features/ship/always_merge/supplied_branch/tracking_branch/deleted.feature
+++ b/features/ship/always_merge/supplied_branch/tracking_branch/deleted.feature
@@ -1,0 +1,28 @@
+Feature: branch was deleted at the remote
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+      | other   | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        |
+      | feature | local, origin | feature commit | conflicting_file |
+    And the current branch is "other"
+    And origin deletes the "feature" branch
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | other  | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      branch "feature" was deleted at the remote
+      """
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands

--- a/features/ship/always_merge/supplied_branch/tracking_branch/local_repo.feature
+++ b/features/ship/always_merge/supplied_branch/tracking_branch/local_repo.feature
@@ -1,0 +1,53 @@
+Feature: ship the supplied feature branch in a local repo using the always-merge strategy
+
+  Background:
+    Given a local Git repo
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS |
+      | feature | feature | main   | local     |
+      | other   | feature | main   | local     |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE        | FILE NAME        |
+      | feature | local    | feature commit | conflicting_file |
+    And the current branch is "other"
+    And an uncommitted file with name "conflicting_file" and content "conflicting content"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                             |
+      | other  | git add -A                          |
+      |        | git stash                           |
+      |        | git checkout main                   |
+      | main   | git merge --no-ff --edit -- feature |
+      |        | git checkout other                  |
+      | other  | git branch -D feature               |
+      |        | git stash pop                       |
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And the branches are now
+      | REPOSITORY | BRANCHES    |
+      | local      | main, other |
+    And these commits exist now
+      | BRANCH | LOCATION | MESSAGE                |
+      | main   | local    | feature commit         |
+      |        |          | Merge branch 'feature' |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | other  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | other  | git add -A                                    |
+      |        | git stash                                     |
+      |        | git checkout main                             |
+      | main   | git reset --hard {{ sha 'initial commit' }}   |
+      |        | git branch feature {{ sha 'feature commit' }} |
+      |        | git checkout other                            |
+      | other  | git stash pop                                 |
+    And the current branch is now "other"
+    And the initial commits exist now
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/tracking_branch/out_of_sync.feature
+++ b/features/ship/always_merge/supplied_branch/tracking_branch/out_of_sync.feature
@@ -1,0 +1,36 @@
+Feature: does not ship the given out-of-sync branch using the always-merge strategy
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+      | other   | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE       |
+      | feature | local    | local commit  |
+      |         | origin   | origin commit |
+    And the current branch is "other"
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    And I run "git-town ship feature"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | other  | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      branch "feature" is not in sync
+      """
+    And the current branch is still "other"
+    And the uncommitted file still exists
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And the current branch is still "other"
+    And the uncommitted file still exists
+    And no merge is in progress
+    And the initial commits exist now
+    And the initial lineage exists now

--- a/features/ship/always_merge/supplied_branch/tracking_branch/without.feature
+++ b/features/ship/always_merge/supplied_branch/tracking_branch/without.feature
@@ -1,0 +1,56 @@
+Feature: ship the supplied local feature branch
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local         |
+      | other   | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE        | FILE NAME        |
+      | feature | local    | feature commit | conflicting_file |
+    And the current branch is "other"
+    And an uncommitted file with name "conflicting_file" and content "conflicting content"
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature" and close the editor
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                             |
+      | other  | git fetch --prune --tags            |
+      |        | git add -A                          |
+      |        | git stash                           |
+      |        | git checkout main                   |
+      | main   | git merge --no-ff --edit -- feature |
+      |        | git push                            |
+      |        | git checkout other                  |
+      | other  | git branch -D feature               |
+      |        | git stash pop                       |
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And the branches are now
+      | REPOSITORY    | BRANCHES    |
+      | local, origin | main, other |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And this lineage exists now
+      | BRANCH | PARENT |
+      | other  | main   |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                       |
+      | other  | git add -A                                    |
+      |        | git stash                                     |
+      |        | git branch feature {{ sha 'feature commit' }} |
+      |        | git stash pop                                 |
+    And the current branch is now "other"
+    And the uncommitted file still exists
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE                |
+      | main   | local, origin | feature commit         |
+      |        |               | Merge branch 'feature' |
+    And the initial branches and lineage exist now

--- a/features/ship/always_merge/supplied_branch/uncommitted_changes/on_supplied_branch.feature
+++ b/features/ship/always_merge/supplied_branch/uncommitted_changes/on_supplied_branch.feature
@@ -1,0 +1,31 @@
+Feature: does not ship a branch that has open changes
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the current branch is "feature"
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                  |
+      | feature | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      you have uncommitted changes. Did you mean to commit them before shipping?
+      """
+    And the current branch is still "feature"
+    And the uncommitted file still exists
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "feature"

--- a/features/ship/always_merge/supplied_branch/worktree/branch_is_active_in_another_worktree.feature
+++ b/features/ship/always_merge/supplied_branch/worktree/branch_is_active_in_another_worktree.feature
@@ -1,0 +1,36 @@
+Feature: cannot ship a feature branch that is active in another worktree
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+      | other   | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        | FILE NAME        |
+      | feature | local, origin | feature commit | conflicting_file |
+    And the current branch is "other"
+    And branch "feature" is active in another worktree
+    And an uncommitted file
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    When I run "git-town ship feature"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                  |
+      | other  | git fetch --prune --tags |
+    And Git Town prints the error:
+      """
+      branch "feature" is active in another worktree
+      """
+    And the current branch is still "other"
+    And the uncommitted file still exists
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs no commands
+    And Git Town prints:
+      """
+      nothing to undo
+      """
+    And the current branch is still "other"

--- a/internal/cli/dialog/ship_strategy.go
+++ b/internal/cli/dialog/ship_strategy.go
@@ -17,6 +17,7 @@ Which method should Git Town use to ship feature branches?
 Options:
 
 - api: merge the proposal on your code hosting platform via the code hosting API
+- always-merge: in your local repo, merge the feature branch into its parent by always creating a merge comment (merge --no-ff)
 - fast-forward: in your local repo, fast-forward the parent branch to point to the commits on the feature branch
 - squash-merge: in your local repo, squash-merge the feature branch into its parent branch
 
@@ -31,10 +32,13 @@ func ShipStrategy(existing configdomain.ShipStrategy, inputs components.TestInpu
 			Text: `api: merge the proposal on your code hosting platform via the code hosting API`,
 		},
 		{
+			Data: configdomain.ShipStrategyAlwaysMerge,
+			Text: `always-merge: in your local repo, merge the feature branch into its parent by always creating a merge comment (merge --no-ff)`,
+		},
+		{
 			Data: configdomain.ShipStrategyFastForward,
 			Text: `fast-forward: in your local repo, fast-forward the parent branch to point to the commits on the feature branch`,
 		},
-		// TODO: #4381 - add ShipStrategyAlwaysMerge
 		{
 			Data: configdomain.ShipStrategySquashMerge,
 			Text: `squash-merge: in your local repo, squash-merge the feature branch into its parent branch`,

--- a/internal/cmd/ship/always_merge.go
+++ b/internal/cmd/ship/always_merge.go
@@ -1,0 +1,47 @@
+package ship
+
+import (
+	"github.com/git-town/git-town/v17/internal/cmd/cmdhelpers"
+	"github.com/git-town/git-town/v17/internal/git/gitdomain"
+	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/program"
+	. "github.com/git-town/git-town/v17/pkg/prelude"
+)
+
+func shipProgramAlwaysMerge(prog Mutable[program.Program], sharedData sharedShipData, mergeData shipDataMerge, commitMessage Option[gitdomain.CommitMessage]) {
+	prog.Value.Add(&opcodes.BranchEnsureShippableChanges{Branch: sharedData.branchNameToShip, Parent: sharedData.targetBranchName})
+	if sharedData.initialBranch != sharedData.targetBranchName {
+		prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: sharedData.targetBranchName})
+	}
+	if mergeData.remotes.HasDev(sharedData.config.NormalConfig.DevRemote) && sharedData.config.NormalConfig.IsOnline() {
+		UpdateChildBranchProposalsToGrandParent(prog.Value, sharedData.proposalsOfChildBranches)
+	}
+	prog.Value.Add(&opcodes.MergeAlwaysProgram{Branch: sharedData.branchNameToShip, CommitMessage: commitMessage})
+	if mergeData.remotes.HasDev(sharedData.config.NormalConfig.DevRemote) && sharedData.config.NormalConfig.IsOnline() {
+		prog.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: sharedData.targetBranchName})
+	}
+	if !sharedData.dryRun {
+		prog.Value.Add(&opcodes.LineageParentRemove{Branch: sharedData.branchNameToShip})
+	}
+	if branchToShipRemoteName, hasRemoteName := sharedData.branchToShip.RemoteName.Get(); hasRemoteName {
+		if sharedData.config.NormalConfig.IsOnline() {
+			if sharedData.config.NormalConfig.ShipDeleteTrackingBranch {
+				prog.Value.Add(&opcodes.BranchTrackingDelete{Branch: branchToShipRemoteName})
+			}
+		}
+	}
+	for _, child := range sharedData.childBranches {
+		prog.Value.Add(&opcodes.LineageParentSetToGrandParent{Branch: child})
+	}
+	if !sharedData.isShippingInitialBranch {
+		prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: sharedData.initialBranch})
+	}
+	prog.Value.Add(&opcodes.BranchLocalDelete{Branch: sharedData.branchNameToShip})
+	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{sharedData.previousBranch}
+	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
+		DryRun:                   sharedData.dryRun,
+		RunInGitRoot:             true,
+		StashOpenChanges:         !sharedData.isShippingInitialBranch && sharedData.hasOpenChanges,
+		PreviousBranchCandidates: previousBranchCandidates,
+	})
+}

--- a/internal/cmd/ship/cmd.go
+++ b/internal/cmd/ship/cmd.go
@@ -114,15 +114,18 @@ func executeShip(args []string, message Option[gitdomain.CommitMessage], dryRun 
 		if err != nil {
 			return err
 		}
+	case configdomain.ShipStrategyAlwaysMerge:
+		mergeData, err := determineMergeData(repo, sharedData.branchNameToShip, sharedData.targetBranchName)
+		if err != nil {
+			return err
+		}
+		shipProgramAlwaysMerge(prog, sharedData, mergeData, message)
 	case configdomain.ShipStrategyFastForward:
 		mergeData, err := determineMergeData(repo, sharedData.branchNameToShip, sharedData.targetBranchName)
 		if err != nil {
 			return err
 		}
 		shipProgramFastForward(prog, sharedData, mergeData)
-	case configdomain.ShipStrategyAlwaysMerge:
-		// TODO: #4381 - add ShipStrategyAlwaysMerge support
-		return errors.New("unimplemented, impossible branch")
 	case configdomain.ShipStrategySquashMerge:
 		squashMergeData, err := determineMergeData(repo, sharedData.branchNameToShip, sharedData.targetBranchName)
 		if err != nil {

--- a/internal/config/configdomain/ship_strategy.go
+++ b/internal/config/configdomain/ship_strategy.go
@@ -10,8 +10,8 @@ import (
 
 const (
 	ShipStrategyAPI         ShipStrategy = "api"          // shipping via the code hosting API
-	ShipStrategyFastForward ShipStrategy = "fast-forward" // shipping by doing a local fast-forward
 	ShipStrategyAlwaysMerge ShipStrategy = "always-merge" // shipping by doing a local merge commit (merge --no-ff)
+	ShipStrategyFastForward ShipStrategy = "fast-forward" // shipping by doing a local fast-forward
 	ShipStrategySquashMerge ShipStrategy = "squash-merge" // shipping by doing a local squash-merge
 )
 
@@ -38,8 +38,8 @@ func ParseShipStrategy(text string) (Option[ShipStrategy], error) {
 func ShipStrategies() []ShipStrategy {
 	return []ShipStrategy{
 		ShipStrategyAPI,
+		ShipStrategyAlwaysMerge,
 		ShipStrategyFastForward,
-		// TODO: #4381 - add ShipStrategyAlwaysMerge
 		ShipStrategySquashMerge,
 	}
 }

--- a/internal/vm/opcodes/merge_always_program.go
+++ b/internal/vm/opcodes/merge_always_program.go
@@ -1,0 +1,41 @@
+package opcodes
+
+import (
+	"errors"
+
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
+	"github.com/git-town/git-town/v17/internal/git/gitdomain"
+	"github.com/git-town/git-town/v17/internal/messages"
+	"github.com/git-town/git-town/v17/internal/vm/shared"
+	. "github.com/git-town/git-town/v17/pkg/prelude"
+)
+
+// MergeAlwaysProgram merges the feature branch into its parent by always creating a merge comment (merge --no-ff).
+type MergeAlwaysProgram struct {
+	Branch        gitdomain.LocalBranchName
+	CommitMessage Option[gitdomain.CommitMessage]
+	undeclaredOpcodeMethods
+}
+
+func (self *MergeAlwaysProgram) AbortProgram() []shared.Opcode {
+	return []shared.Opcode{
+		&MergeAbort{},
+	}
+}
+
+func (self *MergeAlwaysProgram) AutomaticUndoError() error {
+	return errors.New(messages.ShipAbortedMergeError)
+}
+
+func (self *MergeAlwaysProgram) Run(args shared.RunArgs) error {
+	// Reverting parent is intentionally not supported due to potential confusion
+	// caused by reverted merge commit. See
+	// <https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt>
+	// for more information.
+	useMessage := configdomain.UseCustomMessageOr(self.CommitMessage, configdomain.EditDefaultMessage())
+	return args.Git.MergeNoFastForward(args.Frontend, useMessage, self.Branch)
+}
+
+func (self *MergeAlwaysProgram) ShouldUndoOnError() bool {
+	return true
+}

--- a/website/src/preferences/ship-strategy.md
+++ b/website/src/preferences/ship-strategy.md
@@ -17,6 +17,13 @@ You need to configure an API token in the
 `api` is the default value because it does exactly what you normally do
 manually.
 
+### always-merge
+
+The `always-merge` ship strategy creates a merge commit via `git merge --no-ff`.
+
+This strategy allows visually grouping related feature commits together which
+may aid in understanding project history in certain situations.
+
 ### fast-forward
 
 The `fast-forward` ship strategy prevents false merge conflicts when using


### PR DESCRIPTION
Tests are a modified copy of fast-forward tests.

Currently undo only restores the feature branch, similar to fast-forward
strategy. There is no undo support for the parent branch like in
squash-merge.

Undoing merge commits generally should be avoided. Reverting a merge
creates a new revert commit that reverts the data, but the original
commits are still part of the history. As a result any subsequent merge
will skip commits that have been merged, even though their data has been
reverted, unless the user modified the old commits in some way, e.g. by
rebasing or amending them.

While this is unlikely to be a problem in modern workflows where users
often sync their branches, we should err on the side of not doing
something that can lead to confusion potentially far in the future.

See
https://github.com/git/git/blob/master/Documentation/howto/revert-a-faulty-merge.txt
for more information.

See #4381.