### PR TITLE
Remove "The best way to change this setting"

### DIFF
--- a/website/src/preferences/bitbucket-app-password.md
+++ b/website/src/preferences/bitbucket-app-password.md
@@ -32,11 +32,6 @@ the left `HTTP access tokens`. You need to enable these permissions:
 - Project read
 - Repository write
 
-## Setup app password
-
-The best way to enter the Bitbucket app password is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 Since your App Password is confidential, you cannot add it to the config file.

--- a/website/src/preferences/bitbucket-username.md
+++ b/website/src/preferences/bitbucket-username.md
@@ -8,9 +8,6 @@ needs your Bitbucket username and an
 Bitbucket Datacenter capabilities are a little more restricted but the process
 is the same as for Bitbucket Cloud.
 
-The best way to enter your Bitbucket username is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 Since usernames are user specific, you cannot add them to the config file.

--- a/website/src/preferences/create-prototype-branches.md
+++ b/website/src/preferences/create-prototype-branches.md
@@ -6,9 +6,6 @@ _This setting is deprecated. Please replace it with the
 The "create-prototype-branches" setting determines whether Git Town creates new
 branches as [prototype branches](../branch-types.md#prototype-branches).
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 To configure the creation of prototype branches in the

--- a/website/src/preferences/gitea-token.md
+++ b/website/src/preferences/gitea-token.md
@@ -10,9 +10,6 @@ permissions:
 
 - read and write the repository
 
-The best way to enter your token is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 Since your API token is confidential, you cannot add it to the config file.

--- a/website/src/preferences/github-token.md
+++ b/website/src/preferences/github-token.md
@@ -7,9 +7,6 @@ a
 with the `repo` scope. You can create one in your
 [account settings](https://github.com/settings/tokens/new).
 
-The best way to enter your token is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 Since your API token is confidential, you cannot add it to the config file.

--- a/website/src/preferences/gitlab-token.md
+++ b/website/src/preferences/gitlab-token.md
@@ -6,9 +6,6 @@ a
 [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 with `api` scope. You can create one in your account settings.
 
-The best way to enter your token is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 Since your API token is confidential, you cannot add it to the config file.

--- a/website/src/preferences/hosting-origin-hostname.md
+++ b/website/src/preferences/hosting-origin-hostname.md
@@ -4,9 +4,6 @@ If you use SSH identities, you can define the hostname of your source code
 repository with this setting. The given value should match the hostname in your
 SSH config file.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 In the [config file](../configuration-file.md) the hosting platform is part of

--- a/website/src/preferences/hosting-platform.md
+++ b/website/src/preferences/hosting-platform.md
@@ -8,9 +8,6 @@ of the [development remote](dev-remote.md). If that's not successful, for
 example when using private instances of code hosting platforms, you can tell Git
 Town through this configuration setting which code hosting platform you use.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## values
 
 You can use one of these values for the hosting platform setting:

--- a/website/src/preferences/main-branch.md
+++ b/website/src/preferences/main-branch.md
@@ -5,10 +5,6 @@ parent branch for new feature branches created with
 [git town hack](../commands/hack.md) and the default branch into which Git Town
 [ships](../commands/ship.md) finished feature branches.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md). Git Town commands also prompt for this
-setting if needed.
-
 ## config file
 
 In the [config file](../configuration-file.md) the main branch is part of the

--- a/website/src/preferences/new-branch-type.md
+++ b/website/src/preferences/new-branch-type.md
@@ -4,9 +4,6 @@ The "new-branch-type" setting defines the [type](../branch-types.md) for new
 branches created using the [git town hack](../commands/hack.md),
 [append](../commands/append.md), or [prepend](../commands/prepend.md) commands.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## values
 
 - `feature` (default)

--- a/website/src/preferences/push-hook.md
+++ b/website/src/preferences/push-hook.md
@@ -8,9 +8,6 @@ When disabled, Git Town pushes using the
 [--no-verify](https://git-scm.com/docs/git-push) option. This omits the
 [pre-push](https://git-scm.com/docs/githooks#_pre_push) hook.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## config file
 
 To configure the push hook in the

--- a/website/src/preferences/ship-delete-tracking-branch.md
+++ b/website/src/preferences/ship-delete-tracking-branch.md
@@ -10,9 +10,6 @@ resulting in an error. To prevent this error, set the
 _ship-delete-tracking-branch_ setting to `false` so that Git Town does not try
 to delete the tracking branch.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## in config file
 
 ```toml

--- a/website/src/preferences/ship-strategy.md
+++ b/website/src/preferences/ship-strategy.md
@@ -47,11 +47,6 @@ feature branch to ship in your local Git repository. While doing so it squashes
 all commits on the feature branch into a single commit and lets you edit the
 commit message.
 
-## change this setting
-
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ### config file
 
 Set the ship-strategy in the [config file](../configuration-file.md):

--- a/website/src/preferences/sync-feature-strategy.md
+++ b/website/src/preferences/sync-feature-strategy.md
@@ -58,11 +58,6 @@ Please be aware that this sync strategy leads to more merge conflicts than the
 "merge" sync strategy when more than one Git user makes commits to the same
 branch.
 
-## change this setting
-
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ### config file
 
 In the [config file](../configuration-file.md) the sync-feature-strategy is part

--- a/website/src/preferences/sync-perennial-strategy.md
+++ b/website/src/preferences/sync-perennial-strategy.md
@@ -9,9 +9,6 @@ When set to `rebase` (the default value), Git Town rebases local perennial
 branches against their tracking branch. When set to `merge`, it merges the
 tracking branch into the local perennial branch.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## in config file
 
 In the [config file](../configuration-file.md) the sync-perennial-strategy is

--- a/website/src/preferences/sync-prototype-strategy.md
+++ b/website/src/preferences/sync-prototype-strategy.md
@@ -10,11 +10,6 @@ their parent and tracking branches. When not set, Git Town uses the
 `sync-prototype-strategy` accepts the same options as
 [sync-feature-strategy](sync-feature-strategy.md#options).
 
-## change this setting
-
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ### config file
 
 In the [config file](../configuration-file.md) the sync-prototype-strategy is

--- a/website/src/preferences/sync-tags.md
+++ b/website/src/preferences/sync-tags.md
@@ -9,9 +9,6 @@ When set to `true` (the default value), `git town sync` also pulls and pushes
 Git tags in addition to branches and commits. When set to `false`,
 `git town sync` does not change Git tags at the local or remote Git repository.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## in config file
 
 In the [config file](../configuration-file.md) the sync-tags setting can be set

--- a/website/src/preferences/sync-upstream.md
+++ b/website/src/preferences/sync-upstream.md
@@ -11,9 +11,6 @@ When set to `true` (the default value), `git town sync` also updates the local
 `upstream` remote. When set to `false`, `git town sync` does not pull in updates
 from upstream even if that remote exists.
 
-The best way to change this setting is via the
-[setup assistant](../configuration.md).
-
 ## in config file
 
 In the [config file](../configuration-file.md) the sync-upstream setting can be


### PR DESCRIPTION
This PR removes all lines that say "The best way to change this setting is via the setup assistant" in the preferences documentation.

I disagree that the best way to change settings is via the setup assistant. When I want to update a setting, I don't want my config file rewritten with all the defaults explicitly stated and my comments removed.

Probably the best way to create a config file is using the setup assistant, but not to update one.

I will wait for review to merge this PR since others may disagree.