### PR TITLE
Add `the uncommitted file still exists` checks to undo scenarios

### DIFF
--- a/features/ship/fast_forward/supplied_branch/branch_types/main_branch.feature
+++ b/features/ship/fast_forward/supplied_branch/branch_types/main_branch.feature
@@ -29,3 +29,4 @@ Feature: does not ship the main branch using the fast-forward strategy
       nothing to undo
       """
     And the current branch is still "feature"
+    And the uncommitted file still exists

--- a/features/ship/fast_forward/supplied_branch/happy_path.feature
+++ b/features/ship/fast_forward/supplied_branch/happy_path.feature
@@ -49,6 +49,7 @@ Feature: ship the supplied feature branch
       |        | git push -u origin feature                    |
       |        | git stash pop                                 |
     And the current branch is now "other"
+    And the uncommitted file still exists
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |
       | main   | local, origin | feature commit |

--- a/features/ship/fast_forward/supplied_branch/in_subfolder.feature
+++ b/features/ship/fast_forward/supplied_branch/in_subfolder.feature
@@ -48,6 +48,7 @@ Feature: ship the supplied feature branch from a subfolder using the fast-forwar
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git stash pop                                 |
     And the current branch is now "other"
+    And the uncommitted file still exists
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |
       | main   | local, origin | feature commit |

--- a/features/ship/fast_forward/supplied_branch/tracking_branch/without.feature
+++ b/features/ship/fast_forward/supplied_branch/tracking_branch/without.feature
@@ -47,6 +47,7 @@ Feature: ship the supplied local feature branch
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git stash pop                                 |
     And the current branch is now "other"
+    And the uncommitted file still exists
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |
       | main   | local, origin | feature commit |

--- a/features/ship/squash_merge/supplied_branch/branch_types/main_branch.feature
+++ b/features/ship/squash_merge/supplied_branch/branch_types/main_branch.feature
@@ -29,3 +29,4 @@ Feature: does not ship the main branch
       nothing to undo
       """
     And the current branch is still "feature"
+    And the uncommitted file still exists

--- a/features/ship/squash_merge/supplied_branch/tracking_branch/without.feature
+++ b/features/ship/squash_merge/supplied_branch/tracking_branch/without.feature
@@ -52,6 +52,7 @@ Feature: ship the supplied feature branch without a tracking branch
       |        | git checkout other                            |
       | other  | git stash pop                                 |
     And the current branch is now "other"
+    And the uncommitted file still exists
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE               |
       | main    | local, origin | feature done          |


### PR DESCRIPTION
If an uncommitted file is created, we may as well test that it isn't lost during undo.