### PR TITLE
Add `Git Town runs no commands` for `nothing to undo` scenarios

### DIFF
--- a/features/shared/double_undo.feature
+++ b/features/shared/double_undo.feature
@@ -9,7 +9,8 @@ Feature: no double undo
     And I run "git-town delete"
     And I run "git-town undo"
     When I run "git-town undo"
-    Then Git Town prints:
+    Then Git Town runs no commands
+    And Git Town prints:
       """
       nothing to undo
       """

--- a/features/ship/squash_merge/current_branch/commit_message/default.feature
+++ b/features/ship/squash_merge/current_branch/commit_message/default.feature
@@ -31,7 +31,8 @@ Feature: must provide a commit message
 
   Scenario: undo
     When I run "git-town undo"
-    Then Git Town prints:
+    Then Git Town runs no commands
+    And Git Town prints:
       """
       nothing to undo
       """

--- a/features/ship/squash_merge/current_branch/commit_message/empty.feature
+++ b/features/ship/squash_merge/current_branch/commit_message/empty.feature
@@ -32,7 +32,8 @@ Feature: abort the ship by empty commit message
 
   Scenario: undo
     When I run "git-town undo"
-    Then Git Town prints:
+    Then Git Town runs no commands
+    And Git Town prints:
       """
       nothing to undo
       """

--- a/features/ship/squash_merge/current_branch/merge_conflicts/feature_vs_main.feature
+++ b/features/ship/squash_merge/current_branch/merge_conflicts/feature_vs_main.feature
@@ -34,11 +34,11 @@ Feature: handle conflicts between the shipped branch and the main branch
 
   Scenario: undo
     When I run "git-town undo"
-    Then Git Town prints:
+    Then Git Town runs no commands
+    And Git Town prints:
       """
       nothing to undo
       """
-    And Git Town runs no commands
     And the current branch is still "feature"
     And no merge is in progress
     And the initial commits exist now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/disabled.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/disabled.feature
@@ -39,8 +39,8 @@ Feature: push-hook setting set to "false"
 
   Scenario: undo
     When I run "git-town undo"
-    Then Git Town prints:
+    Then Git Town runs no commands
+    And Git Town prints:
       """
       nothing to undo
       """
-    And Git Town runs no commands

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/enabled.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/push_hook/enabled.feature
@@ -39,8 +39,8 @@ Feature: push-hook setting set to "true"
 
   Scenario: undo
     When I run "git-town undo"
-    Then Git Town prints:
+    Then Git Town runs no commands
+    And Git Town prints:
       """
       nothing to undo
       """
-    And Git Town runs no commands


### PR DESCRIPTION
And order then consistently [`commands check`, `message check`]. Commands check is more important.

```
    Then Git Town runs no commands
    And Git Town prints:
       """
       nothing to undo
       """
```