### PR TITLE
Add configdomain.UseMessage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ deadcode: tools/rta@${RTA_VERSION}
 		| grep -v 'Create$$' \
 		| grep -v CreateFile \
 		| grep -v CreateGitTown \
+		| grep -v EditDefaultMessage \
 		| grep -v EmptyConfigSnapshot \
 		| grep -v FileExists \
 		| grep -v FileHasContent \
@@ -152,6 +153,8 @@ deadcode: tools/rta@${RTA_VERSION}
 		| grep -v pkg/prelude/ptr.go \
 		| grep -v Paniced \
 		| grep -v Set.Add \
+		| grep -v UseCustomMessageOr \
+		| grep -v UseDefaultMessage \
 		|| true
 	@tput sgr0 || true
 

--- a/internal/config/configdomain/use_message.go
+++ b/internal/config/configdomain/use_message.go
@@ -1,0 +1,98 @@
+package configdomain
+
+import (
+	"github.com/git-town/git-town/v17/internal/git/gitdomain"
+	. "github.com/git-town/git-town/v17/pkg/prelude"
+)
+
+// UseMessage indicates how to set commit message.
+// The following variants are supported:
+// - EditDefaultMessage
+// - UseCustomMessage(CommitMessage)
+// - UseDefaultMessage
+//
+// See `--message`, `--edit` and `--no-edit` flags in `git commit` and `git merge`.
+type UseMessage struct {
+	customMessage      Option[gitdomain.CommitMessage]
+	editDefaultMessage bool
+}
+
+// EditDefaultMessage indicates that the default message should be edited.
+func EditDefaultMessage() UseMessage {
+	return UseMessage{
+		customMessage:      None[gitdomain.CommitMessage](),
+		editDefaultMessage: true,
+	}
+}
+
+// UseCustomMessage indicates that the custom message should be used as is without opening an editor.
+func UseCustomMessage(message gitdomain.CommitMessage) UseMessage {
+	return UseMessage{
+		customMessage:      Some(message),
+		editDefaultMessage: false, // This value is unused.
+	}
+}
+
+// UseCustomMessageOr returns UseCustomMessage(message) if message is Some, or other.
+func UseCustomMessageOr(message Option[gitdomain.CommitMessage], other UseMessage) UseMessage {
+	if m, has := message.Get(); has {
+		return UseCustomMessage(m)
+	}
+	return other
+}
+
+// UseDefaultMessage indicates that the default message should be used as is without opening an editor.
+func UseDefaultMessage() UseMessage {
+	return UseMessage{
+		customMessage:      None[gitdomain.CommitMessage](),
+		editDefaultMessage: false,
+	}
+}
+
+// UseMessageWithFallbackToDefault returns UseMessage based on an optional message and fallbackToDefault.
+// - If message is Some(...) then this is equivalent to UseCustomMessage(...).
+// - If message is None and fallbackToDefault then this is equivalent to UseDefaultMessage().
+// - If message is None and !fallbackToDefault then this is equivalent to EditDefaultMessage().
+func UseMessageWithFallbackToDefault(message Option[gitdomain.CommitMessage], fallbackToDefault bool) UseMessage {
+	return UseMessage{
+		customMessage:      message,
+		editDefaultMessage: !fallbackToDefault,
+	}
+}
+
+// GetCustomMessage returns a copy of the custom message and IsCustomMessage().
+func (self *UseMessage) GetCustomMessage() (gitdomain.CommitMessage, bool) {
+	// editDefaultMessage is irrelevant when a custom message is set.
+	return self.customMessage.Get()
+}
+
+// GetCustomMessageOrPanic returns a copy of the custom message if IsCustomMessage() or panics.
+func (self *UseMessage) GetCustomMessageOrPanic() gitdomain.CommitMessage {
+	// editDefaultMessage is irrelevant when a custom message is set.
+	if message, is := self.customMessage.Get(); is {
+		return message
+	}
+	panic("UseMessage is not UseCustomMessage")
+}
+
+// IsCustomMessage indicates that the custom message should be used as is without opening an editor.
+func (self *UseMessage) IsCustomMessage() bool {
+	// editDefaultMessage is irrelevant when a custom message is set.
+	return self.customMessage.IsSome()
+}
+
+// IsEditDefault indicates that the default message should be edited.
+func (self *UseMessage) IsEditDefault() bool {
+	if self.customMessage.IsSome() {
+		return false
+	}
+	return self.editDefaultMessage
+}
+
+// IsUseDefault indicates that the default message should be used as is without opening an editor.
+func (self *UseMessage) IsUseDefault() bool {
+	if self.customMessage.IsSome() {
+		return false
+	}
+	return !self.editDefaultMessage
+}

--- a/internal/config/configdomain/use_message_test.go
+++ b/internal/config/configdomain/use_message_test.go
@@ -1,0 +1,150 @@
+package configdomain_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
+	"github.com/git-town/git-town/v17/internal/git/gitdomain"
+	. "github.com/git-town/git-town/v17/pkg/prelude"
+	"github.com/shoenig/test/must"
+)
+
+func TestUseMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EditDefaultMessage", func(t *testing.T) {
+		t.Parallel()
+
+		m := configdomain.EditDefaultMessage()
+
+		// Custom type getters.
+		_, isCustom := m.GetCustomMessage()
+		must.False(t, isCustom)
+		// Type checks.
+		must.False(t, m.IsCustomMessage())
+		must.True(t, m.IsEditDefault())
+		must.False(t, m.IsUseDefault())
+	})
+
+	t.Run("GetCustomMessageOrPanic", func(t *testing.T) {
+		// Arrange.
+		t.Parallel()
+		m := configdomain.EditDefaultMessage()
+
+		// Assert.
+		defer func() {
+			r := recover()
+			must.Eq(t, r, "UseMessage is not UseCustomMessage")
+		}()
+
+		// Act.
+		_ = m.GetCustomMessageOrPanic()
+	})
+
+	t.Run("UseCustomMessage", func(t *testing.T) {
+		t.Parallel()
+		want := gitdomain.CommitMessage("foo")
+
+		m := configdomain.UseCustomMessage(want)
+
+		// Custom type getters.
+		message, isCustom := m.GetCustomMessage()
+		must.True(t, isCustom)
+		must.Eq(t, want, message)
+		must.Eq(t, want, m.GetCustomMessageOrPanic())
+		// Type checks.
+		must.True(t, m.IsCustomMessage())
+		must.False(t, m.IsEditDefault())
+		must.False(t, m.IsUseDefault())
+	})
+
+	t.Run("UseCustomMessageOr", func(t *testing.T) {
+		t.Parallel()
+		t.Run("WithSome", func(t *testing.T) {
+			want := gitdomain.CommitMessage("foo")
+
+			m := configdomain.UseCustomMessageOr(Some(want), configdomain.EditDefaultMessage())
+
+			message, isCustom := m.GetCustomMessage()
+			must.True(t, isCustom)
+			must.Eq(t, want, message)
+		})
+		t.Run("WithNone", func(t *testing.T) {
+			t.Parallel()
+
+			m := configdomain.UseCustomMessageOr(None[gitdomain.CommitMessage](), configdomain.EditDefaultMessage())
+
+			must.True(t, m.IsEditDefault())
+		})
+	})
+
+	t.Run("UseDefaultMessage", func(t *testing.T) {
+		t.Parallel()
+
+		m := configdomain.UseDefaultMessage()
+
+		// Custom type getters.
+		_, isCustom := m.GetCustomMessage()
+		must.False(t, isCustom)
+		// Type checks.
+		must.False(t, m.IsCustomMessage())
+		must.False(t, m.IsEditDefault())
+		must.True(t, m.IsUseDefault())
+	})
+
+	t.Run("UseMessageWithFallbackToDefault", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			desc              string
+			message           Option[gitdomain.CommitMessage]
+			fallbackToDefault bool
+			wantIsCustom      bool
+			wantIsEditDefault bool
+			wantIsUseDefault  bool
+		}{
+			{
+				desc:              "No message, no fallback",
+				message:           None[gitdomain.CommitMessage](),
+				fallbackToDefault: false,
+				wantIsCustom:      false,
+				wantIsEditDefault: true,
+				wantIsUseDefault:  false,
+			}, {
+				desc:              "No message, with fallback",
+				message:           None[gitdomain.CommitMessage](),
+				fallbackToDefault: true,
+				wantIsCustom:      false,
+				wantIsEditDefault: false,
+				wantIsUseDefault:  true,
+			}, {
+				desc:              "With message, no fallback",
+				message:           Some(gitdomain.CommitMessage("foo")),
+				fallbackToDefault: false,
+				wantIsCustom:      true,
+				wantIsEditDefault: false,
+				wantIsUseDefault:  false,
+			}, {
+				desc:              "With message, with fallback",
+				message:           Some(gitdomain.CommitMessage("foo")),
+				fallbackToDefault: true,
+				wantIsCustom:      true,
+				wantIsEditDefault: false,
+				wantIsUseDefault:  false,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				m := configdomain.UseMessageWithFallbackToDefault(tc.message, tc.fallbackToDefault)
+
+				message, isCustom := m.GetCustomMessage()
+				must.Eq(t, tc.wantIsCustom, isCustom)
+				if isCustom {
+					must.Eq(t, tc.message.GetOrPanic(), message)
+					must.Eq(t, tc.message.GetOrPanic(), m.GetCustomMessageOrPanic())
+				}
+				must.Eq(t, tc.wantIsCustom, m.IsCustomMessage())
+				must.Eq(t, tc.wantIsEditDefault, m.IsEditDefault())
+				must.Eq(t, tc.wantIsUseDefault, m.IsUseDefault())
+			})
+		}
+	})
+}

--- a/internal/vm/opcodes/commit.go
+++ b/internal/vm/opcodes/commit.go
@@ -1,6 +1,7 @@
 package opcodes
 
 import (
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
 	"github.com/git-town/git-town/v17/internal/git/gitdomain"
 	"github.com/git-town/git-town/v17/internal/vm/shared"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -18,5 +19,5 @@ type Commit struct {
 }
 
 func (self *Commit) Run(args shared.RunArgs) error {
-	return args.Git.Commit(args.Frontend, self.Message, self.FallbackToDefaultCommitMessage, self.AuthorOverride)
+	return args.Git.Commit(args.Frontend, configdomain.UseMessageWithFallbackToDefault(self.Message, self.FallbackToDefaultCommitMessage), self.AuthorOverride)
 }

--- a/internal/vm/opcodes/commit_auto_undo.go
+++ b/internal/vm/opcodes/commit_auto_undo.go
@@ -3,6 +3,7 @@ package opcodes
 import (
 	"errors"
 
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
 	"github.com/git-town/git-town/v17/internal/git/gitdomain"
 	"github.com/git-town/git-town/v17/internal/messages"
 	"github.com/git-town/git-town/v17/internal/vm/shared"
@@ -28,7 +29,7 @@ func (self *CommitAutoUndo) AutomaticUndoError() error {
 }
 
 func (self *CommitAutoUndo) Run(args shared.RunArgs) error {
-	return args.Git.Commit(args.Frontend, self.Message, self.FallbackToDefaultCommitMessage, self.AuthorOverride)
+	return args.Git.Commit(args.Frontend, configdomain.UseMessageWithFallbackToDefault(self.Message, self.FallbackToDefaultCommitMessage), self.AuthorOverride)
 }
 
 func (self *CommitAutoUndo) ShouldUndoOnError() bool {

--- a/internal/vm/opcodes/commit_with_message.go
+++ b/internal/vm/opcodes/commit_with_message.go
@@ -1,6 +1,7 @@
 package opcodes
 
 import (
+	"github.com/git-town/git-town/v17/internal/config/configdomain"
 	"github.com/git-town/git-town/v17/internal/git/gitdomain"
 	"github.com/git-town/git-town/v17/internal/vm/shared"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -14,5 +15,5 @@ type CommitWithMessage struct {
 }
 
 func (self *CommitWithMessage) Run(args shared.RunArgs) error {
-	return args.Git.Commit(args.Frontend, Some(self.Message), false, self.AuthorOverride)
+	return args.Git.Commit(args.Frontend, configdomain.UseCustomMessage(self.Message), self.AuthorOverride)
 }

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -935,13 +935,14 @@ func defineSteps(sc *godog.ScenarioContext) {
 		branchToShip := gitdomain.NewLocalBranchName(branchName)
 		originRepo := state.fixture.OriginRepo.GetOrPanic()
 		commitMessage := asserts.NoError1(originRepo.FirstCommitMessageInBranch(originRepo.TestRunner, branchToShip.BranchName(), "main"))
-		if commitMessage.IsNone() {
+		message, hasCommitMessage := commitMessage.Get()
+		if !hasCommitMessage {
 			return errors.New("branch to ship contains no commits")
 		}
 		originRepo.CheckoutBranch("main")
 		asserts.NoError(originRepo.SquashMerge(originRepo.TestRunner, branchToShip))
 		originRepo.StageFiles("-A")
-		asserts.NoError(originRepo.Commit(originRepo.TestRunner, commitMessage, false, gitdomain.NewAuthorOpt("CI <ci@acme.com>")))
+		asserts.NoError(originRepo.Commit(originRepo.TestRunner, configdomain.UseCustomMessage(message), gitdomain.NewAuthorOpt("CI <ci@acme.com>")))
 		originRepo.RemoveBranch(branchToShip)
 		originRepo.CheckoutBranch("initial")
 		return nil
@@ -958,7 +959,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		}
 		originRepo.CreateFile(fileName, fileContent)
 		originRepo.StageFiles("-A")
-		asserts.NoError(originRepo.Commit(originRepo.TestRunner, Some(gitdomain.CommitMessage(commitMessage)), false, gitdomain.NewAuthorOpt("CI <ci@acme.com>")))
+		asserts.NoError(originRepo.Commit(originRepo.TestRunner, configdomain.UseCustomMessage(gitdomain.CommitMessage(commitMessage)), gitdomain.NewAuthorOpt("CI <ci@acme.com>")))
 		originRepo.RemoveBranch(branchToShip)
 		originRepo.CheckoutBranch("initial")
 		return nil
@@ -971,7 +972,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		originRepo.CheckoutBranch("main")
 		asserts.NoError(originRepo.SquashMerge(originRepo.TestRunner, branchToShip))
 		originRepo.StageFiles("-A")
-		asserts.NoError(originRepo.Commit(originRepo.TestRunner, Some(gitdomain.CommitMessage(commitMessage)), false, gitdomain.NewAuthorOpt("CI <ci@acme.com>")))
+		asserts.NoError(originRepo.Commit(originRepo.TestRunner, configdomain.UseCustomMessage(gitdomain.CommitMessage(commitMessage)), gitdomain.NewAuthorOpt("CI <ci@acme.com>")))
 		originRepo.RemoveBranch(branchToShip)
 		originRepo.CheckoutBranch("initial")
 		return nil


### PR DESCRIPTION
UseMessage is a variant type that supports the following options:
- `EditDefaultMessage`
- `UseCustomMessage(CommitMessage)`
- `UseDefaultMessage`

As Go doesn't support algebraic enums we can instead use helper functions `Is<Type>()`. Compared to Go style const enums we lose the linter's exhaustive check, so we have to use a default clause instead.

One of the advantages of this approach is we don't have to think about `useDefaultMessage` value when we explicitly set a custom commit message, e.g. in `test/cucumber/steps.go`. That value would be unused anyway.

Alternatives considered:
1. `configdomain.UseDefaultMessage(bool)`. This name is confusing when used together with a custom message. For example `Commit(message, UseDefaultMessage(true))` is ambiguous whether a default message or a custom message is used.
2. `configdomain.EditCommitMessage(bool)`. This separates default message and editing. But currently we only care about editing default messages, so the caller needs to handle more complexity.
3. `configdomain.EditCommitMessage(int)`. This allows us to declare custom behaviours such as `EditDefaultMessage`, `NoEditDefaultMessage` or even `AlwaysEditMessage`, `EditCustomMessage` if they become necessary. However negative `NoEditDefaultMessage` doesn't read well, and if we just call it `UseDefaultMessage` we go back to (1): `Commit(message, UseDefaultMessage)`: do we use the message or the default message?

Looking at the issue at hand we always care about the combination of the message and default message editing behaviour. We only care about the default message editing if the message itself is None. So it is much simpler to think of these two arguments as if it is a composite type, hence UseMessage.

See https://github.com/git-town/git-town/pull/4443#discussion_r1899236258.