### PR TITLE
Make the new-branch-type config setting optional

### DIFF
--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -31,7 +31,7 @@ Feature: change existing information in Git metadata
       | sync-tags                                 | down enter             |
       | enable push-new-branches                  | down enter             |
       | disable the push hook                     | down enter             |
-      | new-branch-type                           | down enter             |
+      | new-branch-type                           | down down enter        |
       | set ship-strategy to "fast-forward"       | down down enter        |
       | disable ship-delete-tracking-branch       | down enter             |
       | save config to Git metadata               | down enter             |

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -62,7 +62,7 @@ Feature: Accepting all default values leads to a working setup
       perennial-regex = ""
 
       [create]
-      new-branch-type = "feature"
+      new-branch-type = ""
       push-new-branches = false
 
       [hosting]

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -56,7 +56,7 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       perennial-regex = ""
 
       [create]
-      new-branch-type = "feature"
+      new-branch-type = ""
       push-new-branches = false
 
       [hosting]

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -18,7 +18,6 @@ Feature: migrate existing configuration in Git metadata to a config file
     And local Git setting "git-town.sync-perennial-strategy" is "rebase"
     And local Git setting "git-town.sync-upstream" is "true"
     And local Git setting "git-town.sync-tags" is "false"
-    # And inspect the repo
     When I run "git-town config setup" and enter into the dialogs:
       | DESCRIPTION                               | KEYS  |
       | welcome                                   | enter |

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -18,6 +18,7 @@ Feature: migrate existing configuration in Git metadata to a config file
     And local Git setting "git-town.sync-perennial-strategy" is "rebase"
     And local Git setting "git-town.sync-upstream" is "true"
     And local Git setting "git-town.sync-tags" is "false"
+    # And inspect the repo
     When I run "git-town config setup" and enter into the dialogs:
       | DESCRIPTION                               | KEYS  |
       | welcome                                   | enter |
@@ -70,7 +71,7 @@ Feature: migrate existing configuration in Git metadata to a config file
       perennial-regex = "release-.*"
 
       [create]
-      new-branch-type = "parked"
+      new-branch-type = "prototype"
       push-new-branches = false
 
       [hosting]

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -40,7 +40,7 @@ Feature: Configure a different development remote
       perennial-regex = ""
 
       [create]
-      new-branch-type = "feature"
+      new-branch-type = ""
       push-new-branches = false
 
       [hosting]

--- a/features/config/view/alternative_config_file.feature
+++ b/features/config/view/alternative_config_file.feature
@@ -27,7 +27,7 @@ Feature: show the configuration when using an alternative config file
         offline: no
 
       Create:
-        new branch type: feature
+        new branch type: (not set)
         push new branches: no
 
       Hosting:

--- a/features/config/view/happy_path.feature
+++ b/features/config/view/happy_path.feature
@@ -34,7 +34,7 @@ Feature: show the configuration
         offline: no
 
       Create:
-        new branch type: feature
+        new branch type: (not set)
         push new branches: no
 
       Hosting:
@@ -106,7 +106,7 @@ Feature: show the configuration
         offline: no
 
       Create:
-        new branch type: feature
+        new branch type: (not set)
         push new branches: yes
 
       Hosting:
@@ -196,7 +196,7 @@ Feature: show the configuration
         offline: no
 
       Create:
-        new branch type: feature
+        new branch type: (not set)
         push new branches: no
 
       Hosting:
@@ -247,7 +247,7 @@ Feature: show the configuration
         offline: no
 
       Create:
-        new branch type: feature
+        new branch type: (not set)
         push new branches: no
 
       Hosting:
@@ -300,7 +300,7 @@ Feature: show the configuration
         offline: no
 
       Create:
-        new branch type: feature
+        new branch type: (not set)
         push new branches: no
 
       Hosting:

--- a/features/config/view/in_subfolder.feature
+++ b/features/config/view/in_subfolder.feature
@@ -28,7 +28,7 @@ Feature: show the configuration from a subfolder
         offline: no
 
       Create:
-        new branch type: feature
+        new branch type: (not set)
         push new branches: no
 
       Hosting:

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -19,19 +19,6 @@ will have when you run "git town hack", "append", or "prepend".
 Branches for which no branch type is set, and for which no configuration entries match, are considered feature branches.
 More info at https://www.git-town.com/preferences/new-branch-type.
 
-Before setting this, try to configure the branch type using one of these configuration entries:
-
-- contribution-branches
-- contribution-regex
-- default-branch-type
-- feature-regex
-- observed-branches
-- observed-regex
-- parked-branches
-- perennial-branches
-- perennial-regex
-- prototype-branches
-
 `
 )
 

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -45,7 +45,12 @@ func NewBranchType(existingOpt Option[configdomain.BranchType], inputs component
 			Text: "always create perennial branches",
 		},
 	}
-	defaultPos := entries.IndexOf(existingOpt)
+	defaultPos := 0
+	for e, entry := range entries {
+		if entry.Data.Equal(existingOpt) {
+			defaultPos = e
+		}
+	}
 	selection, aborted, err := components.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs)
 	if err != nil || aborted {
 		return None[configdomain.BranchType](), aborted, err

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -41,7 +41,7 @@ func NewBranchType(existingOpt Option[configdomain.BranchType], inputs component
 			Text: "always create prototype branches",
 		},
 		{
-			Data: Some(configdomain.BranchTypePrototypeBranch),
+			Data: Some(configdomain.BranchTypePerennialBranch),
 			Text: "always create perennial branches",
 		},
 	}

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -41,20 +41,12 @@ func NewBranchType(existingOpt Option[configdomain.BranchType], inputs component
 			Data: Some(configdomain.BranchTypePrototypeBranch),
 			Text: "always create prototype branches",
 		},
+		{
+			Data: Some(configdomain.BranchTypePrototypeBranch),
+			Text: "always create perennial branches",
+		},
 	}
-	var defaultPos int
-	if existing, hasExisting := existingOpt.Get(); hasExisting {
-		switch existing {
-		case configdomain.BranchTypeFeatureBranch:
-			defaultPos = 1
-		case configdomain.BranchTypeParkedBranch:
-			defaultPos = 2
-		case configdomain.BranchTypePrototypeBranch:
-			defaultPos = 3
-		}
-	} else {
-		defaultPos = 0
-	}
+	defaultPos := entries.IndexOf(existingOpt)
 	selection, aborted, err := components.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs)
 	if err != nil || aborted {
 		return None[configdomain.BranchType](), aborted, err

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -13,12 +13,24 @@ import (
 const (
 	newBranchTypeTitle = `New branch type`
 	NewBranchTypeHelp  = `
-The "new-branch-type" setting determines which branch type Git Town
-creates when you run "git town hack", "append", or "prepend".
+The "new-branch-type" setting allows you to override the type that new branches
+will have when you run "git town hack", "append", or "prepend".
 
-The default is to create feature branches.
-
+Branches for which no branch type is set, and for which no configuration entries match, are considered feature branches.
 More info at https://www.git-town.com/preferences/new-branch-type.
+
+Before setting this, try to configure the branch type using one of these configuration entries:
+
+- contribution-branches
+- contribution-regex
+- default-branch-type
+- feature-regex
+- observed-branches
+- observed-regex
+- parked-branches
+- perennial-branches
+- perennial-regex
+- prototype-branches
 
 `
 )

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -269,19 +269,21 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector) 
 	if data.prototype.IsTrue() {
 		prog.Value.Add(&opcodes.BranchesPrototypeAdd{Branch: data.targetBranch})
 	} else {
-		switch data.config.NormalConfig.NewBranchType {
-		case configdomain.BranchTypeContributionBranch:
-			prog.Value.Add(&opcodes.BranchesContributionAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypeFeatureBranch:
-		case configdomain.BranchTypeMainBranch:
-		case configdomain.BranchTypeObservedBranch:
-			prog.Value.Add(&opcodes.BranchesObservedAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypeParkedBranch:
-			prog.Value.Add(&opcodes.BranchesParkedAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypePerennialBranch:
-			prog.Value.Add(&opcodes.BranchesPerennialAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypePrototypeBranch:
-			prog.Value.Add(&opcodes.BranchesPrototypeAdd{Branch: data.targetBranch})
+		if newBranchType, hasNewBranchType := data.config.NormalConfig.NewBranchType.Get(); hasNewBranchType {
+			switch newBranchType {
+			case configdomain.BranchTypeContributionBranch:
+				prog.Value.Add(&opcodes.BranchesContributionAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypeFeatureBranch:
+			case configdomain.BranchTypeMainBranch:
+			case configdomain.BranchTypeObservedBranch:
+				prog.Value.Add(&opcodes.BranchesObservedAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypeParkedBranch:
+				prog.Value.Add(&opcodes.BranchesParkedAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypePerennialBranch:
+				prog.Value.Add(&opcodes.BranchesPerennialAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypePrototypeBranch:
+				prog.Value.Add(&opcodes.BranchesPrototypeAdd{Branch: data.targetBranch})
+			}
 		}
 	}
 	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.initialBranch), data.previousBranch}

--- a/internal/cmd/config/root.go
+++ b/internal/cmd/config/root.go
@@ -73,7 +73,7 @@ func printConfig(config config.UnvalidatedConfig) {
 	print.Entry("offline", format.Bool(config.NormalConfig.Offline.IsTrue()))
 	fmt.Println()
 	print.Header("Create")
-	print.Entry("new branch type", format.StringsSetting(config.NormalConfig.NewBranchType.String()))
+	print.Entry("new branch type", format.OptionalStringerSetting(config.NormalConfig.NewBranchType))
 	print.Entry("push new branches", format.Bool(config.NormalConfig.ShouldPushNewBranches()))
 	fmt.Println()
 	print.Header("Hosting")

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -379,10 +379,9 @@ func saveNewBranchType(oldValue, newValue Option[configdomain.BranchType], confi
 	}
 	if value, hasValue := newValue.Get(); hasValue {
 		return config.NormalConfig.SetNewBranchType(value)
-	} else {
-		config.NormalConfig.RemoveNewBranchType()
-		return nil
 	}
+	config.NormalConfig.RemoveNewBranchType()
+	return nil
 }
 
 func saveDefaultBranchType(oldValue, newValue configdomain.BranchType, config config.UnvalidatedConfig) error {

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -373,11 +373,16 @@ func saveBitbucketUsername(oldValue, newValue Option[configdomain.BitbucketUsern
 	return gitCommands.RemoveBitbucketUsername(frontend)
 }
 
-func saveNewBranchType(oldValue, newValue configdomain.BranchType, config config.UnvalidatedConfig) error {
+func saveNewBranchType(oldValue, newValue Option[configdomain.BranchType], config config.UnvalidatedConfig) error {
 	if newValue == oldValue {
 		return nil
 	}
-	return config.NormalConfig.SetNewBranchType(newValue)
+	if value, hasValue := newValue.Get(); hasValue {
+		return config.NormalConfig.SetNewBranchType(value)
+	} else {
+		config.NormalConfig.RemoveNewBranchType()
+		return nil
+	}
 }
 
 func saveDefaultBranchType(oldValue, newValue configdomain.BranchType, config config.UnvalidatedConfig) error {

--- a/internal/cmd/debug/enter_new_branch_type.go
+++ b/internal/cmd/debug/enter_new_branch_type.go
@@ -6,6 +6,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/cli/dialog"
 	"github.com/git-town/git-town/v17/internal/cli/dialog/components"
 	"github.com/git-town/git-town/v17/internal/config/configdomain"
+	. "github.com/git-town/git-town/v17/pkg/prelude"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ func enterNewBranchType() *cobra.Command {
 		Use: "new-branch-type",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := components.LoadTestInputs(os.Environ())
-			_, _, err := dialog.NewBranchType(configdomain.BranchTypeFeatureBranch, dialogTestInputs.Next())
+			_, _, err := dialog.NewBranchType(Some(configdomain.BranchTypePrototypeBranch), dialogTestInputs.Next())
 			return err
 		},
 	}

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -332,19 +332,21 @@ func prependProgram(data prependData, finalMessages stringslice.Collector) progr
 	if data.prototype.IsTrue() {
 		prog.Value.Add(&opcodes.BranchesPrototypeAdd{Branch: data.targetBranch})
 	} else {
-		switch data.config.NormalConfig.NewBranchType {
-		case configdomain.BranchTypePrototypeBranch:
-			prog.Value.Add(&opcodes.BranchesPrototypeAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypeContributionBranch:
-			prog.Value.Add(&opcodes.BranchesContributionAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypeFeatureBranch:
-		case configdomain.BranchTypeMainBranch:
-		case configdomain.BranchTypeObservedBranch:
-			prog.Value.Add(&opcodes.BranchesObservedAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypeParkedBranch:
-			prog.Value.Add(&opcodes.BranchesParkedAdd{Branch: data.targetBranch})
-		case configdomain.BranchTypePerennialBranch:
-			prog.Value.Add(&opcodes.BranchesPerennialAdd{Branch: data.targetBranch})
+		if newBranchType, hasNewBranchType := data.config.NormalConfig.NewBranchType.Get(); hasNewBranchType {
+			switch newBranchType {
+			case configdomain.BranchTypePrototypeBranch:
+				prog.Value.Add(&opcodes.BranchesPrototypeAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypeContributionBranch:
+				prog.Value.Add(&opcodes.BranchesContributionAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypeFeatureBranch:
+			case configdomain.BranchTypeMainBranch:
+			case configdomain.BranchTypeObservedBranch:
+				prog.Value.Add(&opcodes.BranchesObservedAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypeParkedBranch:
+				prog.Value.Add(&opcodes.BranchesParkedAdd{Branch: data.targetBranch})
+			case configdomain.BranchTypePerennialBranch:
+				prog.Value.Add(&opcodes.BranchesPerennialAdd{Branch: data.targetBranch})
+			}
 		}
 	}
 	proposal, hasProposal := data.proposal.Get()

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -25,7 +25,7 @@ type NormalConfigData struct {
 	HostingOriginHostname    Option[HostingOriginHostname]
 	HostingPlatform          Option[HostingPlatform] // Some = override by user, None = auto-detect
 	Lineage                  Lineage
-	NewBranchType            BranchType
+	NewBranchType            Option[BranchType]
 	ObservedBranches         gitdomain.LocalBranchNames
 	ObservedRegex            Option[ObservedRegex]
 	Offline                  Offline
@@ -140,7 +140,7 @@ func DefaultNormalConfig() NormalConfigData {
 		HostingOriginHostname:    None[HostingOriginHostname](),
 		HostingPlatform:          None[HostingPlatform](),
 		Lineage:                  NewLineage(),
-		NewBranchType:            BranchTypeFeatureBranch,
+		NewBranchType:            None[BranchType](),
 		ObservedBranches:         gitdomain.LocalBranchNames{},
 		ObservedRegex:            None[ObservedRegex](),
 		Offline:                  false,

--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -194,7 +194,7 @@ func (self PartialConfig) ToNormalConfig(defaults NormalConfigData) NormalConfig
 		HostingOriginHostname:    self.HostingOriginHostname,
 		HostingPlatform:          self.HostingPlatform,
 		Lineage:                  self.Lineage,
-		NewBranchType:            self.NewBranchType.GetOrElse(defaults.NewBranchType),
+		NewBranchType:            self.NewBranchType.Or(defaults.NewBranchType),
 		ObservedBranches:         self.ObservedBranches,
 		ObservedRegex:            self.ObservedRegex,
 		Offline:                  self.Offline.GetOrElse(defaults.Offline),

--- a/internal/config/configfile/save_test.go
+++ b/internal/config/configfile/save_test.go
@@ -56,7 +56,7 @@ func TestSave(t *testing.T) {
 					HostingOriginHostname:    None[configdomain.HostingOriginHostname](),
 					HostingPlatform:          None[configdomain.HostingPlatform](),
 					Lineage:                  configdomain.NewLineage(),
-					NewBranchType:            configdomain.BranchTypePrototypeBranch,
+					NewBranchType:            Some(configdomain.BranchTypePrototypeBranch),
 					ObservedBranches:         gitdomain.LocalBranchNames{},
 					Offline:                  false,
 					ParkedBranches:           gitdomain.LocalBranchNames{},

--- a/internal/config/configfile/save_test.go
+++ b/internal/config/configfile/save_test.go
@@ -126,7 +126,7 @@ perennials = []
 perennial-regex = ""
 
 [create]
-new-branch-type = "feature"
+new-branch-type = ""
 push-new-branches = false
 
 [hosting]

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -227,7 +227,7 @@ func (self *NormalConfig) SetFeatureRegexLocally(value configdomain.FeatureRegex
 
 // SetContributionBranches marks the given branches as contribution branches.
 func (self *NormalConfig) SetNewBranchType(value configdomain.BranchType) error {
-	self.NewBranchType = value
+	self.NewBranchType = Some(value)
 	return self.GitConfigAccess.SetConfigValue(configdomain.ConfigScopeLocal, configdomain.KeyNewBranchType, value.String())
 }
 

--- a/website/src/preferences/new-branch-type.md
+++ b/website/src/preferences/new-branch-type.md
@@ -4,6 +4,20 @@ The "new-branch-type" setting defines the [type](../branch-types.md) for new
 branches created using the [git town hack](../commands/hack.md),
 [append](../commands/append.md), or [prepend](../commands/prepend.md) commands.
 
+Before setting this, try to configure the branch type using one of these more
+broadly applicable configuration entries:
+
+- [contribution-branches](contribution-branches.md)
+- [contribution-regex](contribution-regex.md)
+- [default-branch-type](default-branch-type.md)
+- [feature-regex](feature-regex.md)
+- [observed-branches](observed-branches.md)
+- [observed-regex](observed-regex.md)
+- [parked-branches](parked-branches.md)
+- [perennial-branches](perennial-branches.md)
+- [perennial-regex](perennial-regex.md)
+- [prototype-branches](prototype-branches.md)
+
 ## values
 
 - `feature` (default)


### PR DESCRIPTION
A `None` value indicates that the user didn't set the setting, and it shouldn't override the branch type for new branches.