### PR TITLE
Add undo warning test for the always-merge shipping strategy

### DIFF
--- a/features/ship/always_merge/current_branch/undo_warning.feature
+++ b/features/ship/always_merge/current_branch/undo_warning.feature
@@ -1,0 +1,22 @@
+Feature: git-town undo prints a warning message for a merge commit
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the current branch is "feature"
+    And the commits
+      | BRANCH  | LOCATION      | MESSAGE        |
+      | feature | local, origin | feature commit |
+    And Git setting "git-town.ship-strategy" is "always-merge"
+    # "I ran" verifies the exit status.
+    And I ran "git-town ship -m 'feature done'"
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town prints something like:
+      # ".*" is the merge commit created by `git town ship`.
+      """
+      Cannot undo commit ".*" because it is on a perennial branch
+      """


### PR DESCRIPTION
See #4381 and #4455.