### PR TITLE
Add tools/tests_sorted/matcher.go and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,10 @@ UNIT_TEST_DIRS = \
 	./test/... \
 	./tools/format_self/... \
 	./tools/format_unittests/... \
+	./tools/lint_steps/... \
 	./tools/stats_release/... \
 	./tools/structs_sorted/... \
-	./tools/lint_steps/...
+	./tools/tests_sorted/...
 
 unit: install  # runs only the unit tests for changed code
 	@env GOGC=off go test -timeout=30s $(UNIT_TEST_DIRS)

--- a/go.work
+++ b/go.work
@@ -7,4 +7,5 @@ use (
 	./tools/lint_steps
 	./tools/stats_release
 	./tools/structs_sorted
+	./tools/tests_sorted
 )

--- a/tools/structs_sorted/structs_sorted.go
+++ b/tools/structs_sorted/structs_sorted.go
@@ -23,10 +23,12 @@ var (
 	ignoreTypes = []string{ //nolint:gochecknoglobals
 		"BranchSpan",
 		"Change",
+		"IdentSelectorMatcher", // Field order is meaningful.
 		"InconsistentChange",
 		"Lineage",
 		"LineageData",
 		"Parts",
+		"PositionalField", // Mimics ast.Field.
 	}
 )
 

--- a/tools/tests_sorted/go.mod
+++ b/tools/tests_sorted/go.mod
@@ -1,0 +1,3 @@
+module github.com/git-town/git-town/tools/tests_sorted
+
+go 1.23

--- a/tools/tests_sorted/matcher.go
+++ b/tools/tests_sorted/matcher.go
@@ -1,0 +1,163 @@
+// Package matcher declarative go/ast matchers.
+package matcher
+
+import (
+	"fmt"
+	"go/ast"
+	"iter"
+)
+
+// Result is a match result with a reason.
+// Use Result.Success() to convert it to bool.
+// FailureReason() is useful for unit tests.
+type Result interface {
+	Success() bool
+	FailureReason() string
+}
+
+type stringResult string
+
+func (self stringResult) Success() bool {
+	return self == ""
+}
+
+func (self stringResult) FailureReason() string {
+	return string(self)
+}
+
+const okResult = stringResult("")
+
+func fmtResult(format string, a ...any) stringResult {
+	return stringResult(fmt.Sprintf(format, a...))
+}
+
+// ExprMatcher matches ast.Expr.
+type ExprMatcher interface {
+	Match(expr ast.Expr) Result
+}
+
+// PositionalField represents a logical field from an ast.FieldList.
+// Go allows fields and function parameters to be grouped by type, e.g.
+// `func(a, b string)`, which comes up as a single `ast.Field` element with two
+// `ast.Field.Names`. PositionalField represents a single logical `a string`
+// regardless of syntactic grouping.
+type PositionalField struct {
+	Name  *ast.Ident
+	Field *ast.Field
+}
+
+// PositionalFieldMatcher matches a PositionalField.
+type PositionalFieldMatcher interface {
+	Match(field PositionalField) Result
+}
+
+// FieldListMatcher matches an ast.FieldList.
+type FieldListMatcher interface {
+	Match(fields *ast.FieldList) Result
+}
+
+// PositionalFields yields (name, field) for each name in ast.FieldList in logical order.
+// For example func(a, b string, c int) will result in
+// - fields[0]: ast.Field{Names: []{"a", "b"}}
+// - fields[1]: ast.Field{Names: []{"c"}}
+// So PositionalFields(fields) will yield
+// - ("a", fields[0])
+// - ("b", fields[0])
+// - ("c", fields[1])
+func PositionalFields(fields *ast.FieldList) iter.Seq2[int, PositionalField] {
+	return func(yield func(int, PositionalField) bool) {
+		i := 0
+		for _, field := range fields.List {
+			for _, name := range field.Names {
+				if !yield(i, PositionalField{Name: name, Field: field}) {
+					return // Stopping early.
+				}
+				i++
+			}
+		}
+	}
+}
+
+// IdentSelectorMatcher matches ast.SelectorExpr where both the selector
+// expression (left of the `.`) and the selector itself (right of the `.`) are
+// given `Namespace.Name`.
+type IdentSelectorMatcher struct {
+	Namespace string
+	Name      string
+}
+
+func (self *IdentSelectorMatcher) Match(expr ast.Expr) Result {
+	// Check that the whole expression is `<namespace>.<name>`.
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return stringResult("not an ast.SelectorExpr")
+	}
+	// Check that the `<namespace>` is an identifier.
+	namespace, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return stringResult("namespace is not an ast.Ident")
+	}
+	// Match the names.
+	if self.Namespace != namespace.Name {
+		return fmtResult("namespace doesn't match: want %q, got %q", self.Namespace, namespace.Name)
+	}
+	if self.Name != selector.Sel.Name {
+		return fmtResult("name doesn't match: want %q, got %q", self.Name, selector.Sel.Name)
+	}
+	return okResult
+}
+
+// PointerMatcher matches an ast.StarExpr where the inner expression matcher the InnerMatcher.
+type PointerMatcher struct {
+	InnerMatcher ExprMatcher
+}
+
+func (self *PointerMatcher) Match(expr ast.Expr) Result {
+	// Verify that this is a `*<expr>`.
+	ptr, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return stringResult("not an ast.StarExpr")
+	}
+	// Delegate to the InnerMatcher.
+	return self.InnerMatcher.Match(ptr.X)
+}
+
+// FieldMatcher matches an ast.Field element if it has a given Name and Type.
+type FieldMatcher struct {
+	Name        string
+	TypeMatcher ExprMatcher
+}
+
+func (self *FieldMatcher) Match(field PositionalField) Result {
+	if self.Name != field.Name.Name {
+		return fmtResult("field name doesn't match: want %q, got %q", self.Name, field.Name.Name)
+	}
+	if r := self.TypeMatcher.Match(field.Field.Type); !r.Success() {
+		return fmtResult("field type doesn't match: %v", r)
+	}
+	return okResult
+}
+
+// FieldListPrefixMatcher matches an `ast.FieldList` if
+// - a field list contains at least len(Prefix) elements,
+// - each ast.FieldList logical element i matches Prefix[i].
+type FieldListPrefixMatcher struct {
+	Prefix []PositionalFieldMatcher
+}
+
+func (self *FieldListPrefixMatcher) Match(fields *ast.FieldList) Result {
+	var posFields []PositionalField
+	for _, field := range PositionalFields(fields) {
+		posFields = append(posFields, field)
+	}
+	for i, fieldMatcher := range self.Prefix {
+		if i >= len(posFields) {
+			return fmtResult("not enough fields, want at least %d, got %d", len(self.Prefix), len(posFields))
+		}
+		field := posFields[i]
+		if r := fieldMatcher.Match(field); !r.Success() {
+			return fmtResult("field[%d] doesn't match: %v", i, r.FailureReason())
+		}
+	}
+	return okResult
+}

--- a/tools/tests_sorted/matcher_test.go
+++ b/tools/tests_sorted/matcher_test.go
@@ -1,0 +1,285 @@
+package matcher
+
+import (
+	"go/ast"
+	"go/parser"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+type trueMatcher struct{}
+
+func (self *trueMatcher) Match(ast.Expr) Result {
+	return okResult
+}
+
+type falseMatcher struct{}
+
+func (self *falseMatcher) Match(ast.Expr) Result {
+	return stringResult("fake failure")
+}
+
+type trueFieldMatcher struct{}
+
+func (self *trueFieldMatcher) Match(PositionalField) Result {
+	return okResult
+}
+
+type falseFieldMatcher struct{}
+
+func (self *falseFieldMatcher) Match(PositionalField) Result {
+	return stringResult("fake field failure")
+}
+
+func TestPositionalFields(t *testing.T) {
+	expr, err := parser.ParseExpr(`func(a, b string, c bool)`)
+	must.NoError(t, err)
+	funcType := expr.(*ast.FuncType)
+
+	var positionalIndices []int
+	var positionalFields []PositionalField
+	for i, field := range PositionalFields(funcType.Params) {
+		positionalIndices = append(positionalIndices, i)
+		positionalFields = append(positionalFields, field)
+	}
+
+	must.Eq(t, []int{0, 1, 2}, positionalIndices)
+	must.Eq(t, len(positionalFields), 3)
+	must.Eq(t, "a", positionalFields[0].Name.Name)
+	must.Eq(t, "b", positionalFields[1].Name.Name)
+	must.Eq(t, "c", positionalFields[2].Name.Name)
+}
+
+func TestIdentSelectorMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Failure", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			expr       string
+			matcher    *IdentSelectorMatcher
+			wantReason string
+		}{
+			{
+				expr:       `func()`,
+				matcher:    &IdentSelectorMatcher{},
+				wantReason: "not an ast.SelectorExpr",
+			},
+			{
+				expr: `foo().bar`,
+				matcher: &IdentSelectorMatcher{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				wantReason: "namespace is not an ast.Ident",
+			},
+			{
+				expr: `notFoo.bar`,
+				matcher: &IdentSelectorMatcher{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				wantReason: `namespace doesn't match: want "foo", got "notFoo"`,
+			},
+			{
+				expr: `foo.notBar`,
+				matcher: &IdentSelectorMatcher{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				wantReason: `name doesn't match: want "bar", got "notBar"`,
+			},
+		} {
+			t.Run(tc.wantReason, func(t *testing.T) {
+				expr, err := parser.ParseExpr(tc.expr)
+				must.NoError(t, err)
+
+				r := tc.matcher.Match(expr)
+
+				must.False(t, r.Success())
+				must.Eq(t, tc.wantReason, r.FailureReason())
+			})
+		}
+		t.Run("Success", func(t *testing.T) {
+			expr, err := parser.ParseExpr(`foo.bar`)
+			must.NoError(t, err)
+			m := &IdentSelectorMatcher{
+				Namespace: "foo",
+				Name:      "bar",
+			}
+
+			r := m.Match(expr)
+
+			must.True(t, r.Success())
+		})
+	})
+}
+
+func TestPointerMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("InnerMatchFailure", func(t *testing.T) {
+		expr, err := parser.ParseExpr(`*foo`)
+		must.NoError(t, err)
+		m := &PointerMatcher{
+			InnerMatcher: &falseMatcher{},
+		}
+
+		r := m.Match(expr)
+
+		must.False(t, r.Success())
+		must.Eq(t, "fake failure", r.FailureReason())
+	})
+
+	t.Run("NotStarExpr", func(t *testing.T) {
+		expr, err := parser.ParseExpr(`Foo`)
+		must.NoError(t, err)
+		m := &PointerMatcher{
+			InnerMatcher: &trueMatcher{},
+		}
+
+		r := m.Match(expr)
+
+		must.False(t, r.Success())
+		must.Eq(t, "not an ast.StarExpr", r.FailureReason())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		expr, err := parser.ParseExpr(`*foo`)
+		must.NoError(t, err)
+		m := &PointerMatcher{
+			InnerMatcher: &trueMatcher{},
+		}
+
+		r := m.Match(expr)
+
+		must.True(t, r.Success())
+	})
+}
+
+func firstFuncParam(t *testing.T, funcTypeText string) PositionalField {
+	t.Helper()
+	expr, err := parser.ParseExpr(funcTypeText)
+	must.NoError(t, err)
+	funcType := expr.(*ast.FuncType)
+	for _, field := range PositionalFields(funcType.Params) {
+		return field
+	}
+	must.Unreachable(t)
+	return PositionalField{}
+}
+
+func TestFieldMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Failure", func(t *testing.T) {
+		field := firstFuncParam(t, `func(notA string)`)
+		m := &FieldMatcher{
+			Name:        "a",
+			TypeMatcher: &trueMatcher{},
+		}
+
+		r := m.Match(field)
+
+		must.False(t, r.Success())
+		must.Eq(t, `field name doesn't match: want "a", got "notA"`, r.FailureReason())
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		field := firstFuncParam(t, `func(a string)`)
+		m := &FieldMatcher{
+			Name:        "a",
+			TypeMatcher: &trueMatcher{},
+		}
+
+		r := m.Match(field)
+
+		must.True(t, r.Success())
+	})
+}
+
+func funcParams(t *testing.T, funcTypeText string) *ast.FieldList {
+	t.Helper()
+	expr, err := parser.ParseExpr(funcTypeText)
+	must.NoError(t, err)
+	funcType := expr.(*ast.FuncType)
+	return funcType.Params
+}
+
+func TestFieldListPrefixMatcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Failure", func(t *testing.T) {
+		t.Parallel()
+		t.Run("NotEnoughFields", func(t *testing.T) {
+			params := funcParams(t, `func()`)
+			m := &FieldListPrefixMatcher{
+				Prefix: []PositionalFieldMatcher{
+					&trueFieldMatcher{},
+					&trueFieldMatcher{},
+				},
+			}
+
+			r := m.Match(params)
+
+			must.False(t, r.Success())
+			must.Eq(t, "not enough fields, want at least 2, got 0", r.FailureReason())
+		})
+		t.Run("FieldDoesNotMatch", func(t *testing.T) {
+			params := funcParams(t, `func(a string)`)
+			m := &FieldListPrefixMatcher{
+				Prefix: []PositionalFieldMatcher{
+					&falseFieldMatcher{},
+				},
+			}
+
+			r := m.Match(params)
+
+			must.False(t, r.Success())
+			must.Eq(t, "field[0] doesn't match: fake field failure", r.FailureReason())
+		})
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			desc    string
+			params  *ast.FieldList
+			matcher *FieldListPrefixMatcher
+		}{
+			{
+				desc:   "EqualLenMatchers",
+				params: funcParams(t, `func(a, b, c string)`),
+				matcher: &FieldListPrefixMatcher{
+					Prefix: []PositionalFieldMatcher{
+						&trueFieldMatcher{},
+						&trueFieldMatcher{},
+						&trueFieldMatcher{},
+					},
+				},
+			}, {
+				desc:   "NoMatchersNoParams",
+				params: funcParams(t, `func()`),
+				matcher: &FieldListPrefixMatcher{
+					Prefix: []PositionalFieldMatcher{},
+				},
+			}, {
+				desc:   "SomeMatchers",
+				params: funcParams(t, `func(a, b, c string)`),
+				matcher: &FieldListPrefixMatcher{
+					Prefix: []PositionalFieldMatcher{
+						&trueFieldMatcher{},
+						&trueFieldMatcher{},
+					},
+				},
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				r := tc.matcher.Match(tc.params)
+
+				must.True(t, r.Success())
+			})
+		}
+	})
+}


### PR DESCRIPTION
tests_sorted is a linter that will verify that top level `t.Run("<test>", ...)` calls are sorted once implemented.

IdentSelectorMatcher and PositionalField are excluded from structs_sorted linter because the filed order is meaningful.