### PR TITLE
Stash changes away with commit message

### DIFF
--- a/features/append/on_feature_branch/uncommitted_changes/compress_sync_strategy.feature
+++ b/features/append/on_feature_branch/uncommitted_changes/compress_sync_strategy.feature
@@ -17,11 +17,11 @@ Feature: append a new feature branch in a dirty workspace using the "compress" s
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND             |
-      | existing | git add -A          |
-      |          | git stash           |
-      |          | git checkout -b new |
-      | new      | git stash pop       |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new         |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -32,12 +32,12 @@ Feature: append a new feature branch in a dirty workspace using the "compress" s
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/append/on_feature_branch/uncommitted_changes/dry_run.feature
+++ b/features/append/on_feature_branch/uncommitted_changes/dry_run.feature
@@ -14,11 +14,11 @@ Feature: dry run appending a new feature branch to an existing feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND             |
-      | existing | git add -A          |
-      |          | git stash           |
-      |          | git checkout -b new |
-      | new      | git stash pop       |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new         |
+      | new      | git stash pop               |
     And the current branch is still "existing"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/append/on_feature_branch/uncommitted_changes/happy_path.feature
+++ b/features/append/on_feature_branch/uncommitted_changes/happy_path.feature
@@ -15,11 +15,11 @@ Feature: append a new feature branch to an existing feature branch with uncommit
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND             |
-      | existing | git add -A          |
-      |          | git stash           |
-      |          | git checkout -b new |
-      | new      | git stash pop       |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new         |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the uncommitted file still exists
     And these commits exist now
@@ -33,12 +33,12 @@ Feature: append a new feature branch to an existing feature branch with uncommit
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/append/on_main_branch/uncommitted_changes/branch_exists/remote_unfetched.feature
+++ b/features/append/on_main_branch/uncommitted_changes/branch_exists/remote_unfetched.feature
@@ -10,11 +10,11 @@ Feature: already existing unfetched remote branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | main     | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b existing |
-      | existing | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | main     | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b existing    |
+      | existing | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And this lineage exists now
@@ -25,12 +25,12 @@ Feature: already existing unfetched remote branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                |
-      | existing | git add -A             |
-      |          | git stash              |
-      |          | git checkout main      |
-      | main     | git branch -D existing |
-      |          | git stash pop          |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout main           |
+      | main     | git branch -D existing      |
+      |          | git stash pop               |
     And the current branch is now "main"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/append/on_main_branch/uncommitted_changes/happy_path.feature
+++ b/features/append/on_main_branch/uncommitted_changes/happy_path.feature
@@ -11,11 +11,11 @@ Feature: on the main branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND             |
-      | main   | git add -A          |
-      |        | git stash           |
-      |        | git checkout -b new |
-      | new    | git stash pop       |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new         |
+      | new    | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -26,12 +26,12 @@ Feature: on the main branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND           |
-      | new    | git add -A        |
-      |        | git stash         |
-      |        | git checkout main |
-      | main   | git branch -D new |
-      |        | git stash pop     |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/append/on_main_branch/uncommitted_changes/on_perennial_branch.feature
+++ b/features/append/on_main_branch/uncommitted_changes/on_perennial_branch.feature
@@ -15,11 +15,11 @@ Feature: append to a perennial branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH     | COMMAND             |
-      | production | git add -A          |
-      |            | git stash           |
-      |            | git checkout -b new |
-      | new        | git stash pop       |
+      | BRANCH     | COMMAND                     |
+      | production | git add -A                  |
+      |            | git stash -m "Git Town WIP" |
+      |            | git checkout -b new         |
+      | new        | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -30,12 +30,12 @@ Feature: append to a perennial branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH     | COMMAND                 |
-      | new        | git add -A              |
-      |            | git stash               |
-      |            | git checkout production |
-      | production | git branch -D new       |
-      |            | git stash pop           |
+      | BRANCH     | COMMAND                     |
+      | new        | git add -A                  |
+      |            | git stash -m "Git Town WIP" |
+      |            | git checkout production     |
+      | production | git branch -D new           |
+      |            | git stash pop               |
     And the current branch is now "production"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/compress/current_branch/branch_types/parked_branch.feature
+++ b/features/compress/current_branch/branch_types/parked_branch.feature
@@ -19,7 +19,7 @@ Feature: compress the commits on a parked branch
       | BRANCH | COMMAND                                         |
       | parked | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --soft main                           |
       |        | git commit -m "commit 1"                        |
       |        | git push --force-with-lease --force-if-includes |
@@ -39,7 +39,7 @@ Feature: compress the commits on a parked branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | parked | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --hard {{ sha 'commit 3' }}           |
       |        | git push --force-with-lease --force-if-includes |
       |        | git stash pop                                   |

--- a/features/compress/current_branch/branch_types/prototype_branch.feature
+++ b/features/compress/current_branch/branch_types/prototype_branch.feature
@@ -19,7 +19,7 @@ Feature: compress the commits on a prototype branch
       | BRANCH    | COMMAND                                         |
       | prototype | git fetch --prune --tags                        |
       |           | git add -A                                      |
-      |           | git stash                                       |
+      |           | git stash -m "Git Town WIP"                     |
       |           | git reset --soft main                           |
       |           | git commit -m "commit 1"                        |
       |           | git push --force-with-lease --force-if-includes |
@@ -39,7 +39,7 @@ Feature: compress the commits on a prototype branch
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                         |
       | prototype | git add -A                                      |
-      |           | git stash                                       |
+      |           | git stash -m "Git Town WIP"                     |
       |           | git reset --hard {{ sha 'commit 3' }}           |
       |           | git push --force-with-lease --force-if-includes |
       |           | git stash pop                                   |

--- a/features/compress/current_branch/commit_message.feature
+++ b/features/compress/current_branch/commit_message.feature
@@ -19,7 +19,7 @@ Feature: compress the commits on a feature branch
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
       |         | git add -A                                      |
-      |         | git stash                                       |
+      |         | git stash -m "Git Town WIP"                     |
       |         | git reset --soft main                           |
       |         | git commit -m compressed                        |
       |         | git push --force-with-lease --force-if-includes |
@@ -39,7 +39,7 @@ Feature: compress the commits on a feature branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git add -A                                      |
-      |         | git stash                                       |
+      |         | git stash -m "Git Town WIP"                     |
       |         | git reset --hard {{ sha 'commit 3' }}           |
       |         | git push --force-with-lease --force-if-includes |
       |         | git stash pop                                   |

--- a/features/compress/current_branch/dry_run.feature
+++ b/features/compress/current_branch/dry_run.feature
@@ -16,13 +16,13 @@ Feature: dry-run compressing the commits on a feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                  |
-      | feature | git fetch --prune --tags |
-      |         | git add -A               |
-      |         | git stash                |
-      |         | git reset --soft main    |
-      |         | git commit -m "commit 1" |
-      |         | git stash pop            |
+      | BRANCH  | COMMAND                     |
+      | feature | git fetch --prune --tags    |
+      |         | git add -A                  |
+      |         | git stash -m "Git Town WIP" |
+      |         | git reset --soft main       |
+      |         | git commit -m "commit 1"    |
+      |         | git stash pop               |
     And all branches are now synchronized
     And the current branch is still "feature"
     And the initial commits exist now

--- a/features/compress/current_branch/tracking_branch/exists/multiple_commits.feature
+++ b/features/compress/current_branch/tracking_branch/exists/multiple_commits.feature
@@ -19,7 +19,7 @@ Feature: compress the commits on a feature branch
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
       |         | git add -A                                      |
-      |         | git stash                                       |
+      |         | git stash -m "Git Town WIP"                     |
       |         | git reset --soft main                           |
       |         | git commit -m "commit 1"                        |
       |         | git push --force-with-lease --force-if-includes |
@@ -39,7 +39,7 @@ Feature: compress the commits on a feature branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git add -A                                      |
-      |         | git stash                                       |
+      |         | git stash -m "Git Town WIP"                     |
       |         | git reset --hard {{ sha 'commit 3' }}           |
       |         | git push --force-with-lease --force-if-includes |
       |         | git stash pop                                   |

--- a/features/compress/current_branch/tracking_branch/exists/offline.feature
+++ b/features/compress/current_branch/tracking_branch/exists/offline.feature
@@ -16,12 +16,12 @@ Feature: compress the commits in offline mode
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                  |
-      | feature | git add -A               |
-      |         | git stash                |
-      |         | git reset --soft main    |
-      |         | git commit -m "commit 1" |
-      |         | git stash pop            |
+      | BRANCH  | COMMAND                     |
+      | feature | git add -A                  |
+      |         | git stash -m "Git Town WIP" |
+      |         | git reset --soft main       |
+      |         | git commit -m "commit 1"    |
+      |         | git stash pop               |
     And the current branch is still "feature"
     And these commits exist now
       | BRANCH  | LOCATION | MESSAGE  |
@@ -37,7 +37,7 @@ Feature: compress the commits in offline mode
     Then Git Town runs the commands
       | BRANCH  | COMMAND                               |
       | feature | git add -A                            |
-      |         | git stash                             |
+      |         | git stash -m "Git Town WIP"           |
       |         | git reset --hard {{ sha 'commit 2' }} |
       |         | git stash pop                         |
     And the current branch is still "feature"

--- a/features/compress/current_branch/tracking_branch/none/local_branch.feature
+++ b/features/compress/current_branch/tracking_branch/none/local_branch.feature
@@ -16,13 +16,13 @@ Feature: compress the commits on a local feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                  |
-      | feature | git fetch --prune --tags |
-      |         | git add -A               |
-      |         | git stash                |
-      |         | git reset --soft main    |
-      |         | git commit -m "commit 1" |
-      |         | git stash pop            |
+      | BRANCH  | COMMAND                     |
+      | feature | git fetch --prune --tags    |
+      |         | git add -A                  |
+      |         | git stash -m "Git Town WIP" |
+      |         | git reset --soft main       |
+      |         | git commit -m "commit 1"    |
+      |         | git stash pop               |
     And all branches are now synchronized
     And the current branch is still "feature"
     And these commits exist now
@@ -38,7 +38,7 @@ Feature: compress the commits on a local feature branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                               |
       | feature | git add -A                            |
-      |         | git stash                             |
+      |         | git stash -m "Git Town WIP"           |
       |         | git reset --hard {{ sha 'commit 3' }} |
       |         | git stash pop                         |
     And the current branch is still "feature"

--- a/features/compress/current_branch/verbose.feature
+++ b/features/compress/current_branch/verbose.feature
@@ -31,7 +31,7 @@ Feature: compress the commits on a feature branch verbosely
       |         | git remote get-url origin                          |
       |         | git cherry -v main feature                         |
       | feature | git add -A                                         |
-      |         | git stash                                          |
+      |         | git stash -m "Git Town WIP"                        |
       |         | git reset --soft main                              |
       |         | git commit -m "commit 1"                           |
       | <none>  | git rev-list --left-right feature...origin/feature |
@@ -71,7 +71,7 @@ Feature: compress the commits on a feature branch verbosely
       |         | git rev-parse --verify --abbrev-ref @{-1}          |
       |         | git remote get-url origin                          |
       | feature | git add -A                                         |
-      |         | git stash                                          |
+      |         | git stash -m "Git Town WIP"                        |
       | <none>  | git rev-parse --short HEAD                         |
       | feature | git reset --hard {{ sha 'commit 3' }}              |
       | <none>  | git rev-list --left-right feature...origin/feature |

--- a/features/compress/stack/at_stack_leaf.feature
+++ b/features/compress/stack/at_stack_leaf.feature
@@ -35,7 +35,7 @@ Feature: compress the commits on an entire stack when at the stack root
       | BRANCH | COMMAND                                         |
       | gamma  | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git checkout alpha                              |
       | alpha  | git reset --soft main                           |
       |        | git commit -m "alpha 1"                         |
@@ -72,7 +72,7 @@ Feature: compress the commits on an entire stack when at the stack root
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | gamma  | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git checkout alpha                              |
       | alpha  | git reset --hard {{ sha 'alpha 3' }}            |
       |        | git push --force-with-lease --force-if-includes |

--- a/features/compress/stack/at_stack_root.feature
+++ b/features/compress/stack/at_stack_root.feature
@@ -35,7 +35,7 @@ Feature: compress the commits on an entire stack when at the stack root
       | BRANCH | COMMAND                                         |
       | alpha  | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --soft main                           |
       |        | git commit -m "alpha 1"                         |
       |        | git push --force-with-lease --force-if-includes |
@@ -66,7 +66,7 @@ Feature: compress the commits on an entire stack when at the stack root
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | alpha  | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --hard {{ sha 'alpha 3' }}            |
       |        | git push --force-with-lease --force-if-includes |
       |        | git checkout beta                               |

--- a/features/compress/stack/branch_types/contributing_branch/on_child_branch.feature
+++ b/features/compress/stack/branch_types/contributing_branch/on_child_branch.feature
@@ -25,7 +25,7 @@ Feature: does not compress contribution branches in the stack
       | BRANCH | COMMAND                                         |
       | child  | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --soft contribution                   |
       |        | git commit -m "child 1"                         |
       |        | git push --force-with-lease --force-if-includes |
@@ -48,7 +48,7 @@ Feature: does not compress contribution branches in the stack
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | child  | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --hard {{ sha 'child 2' }}            |
       |        | git push --force-with-lease --force-if-includes |
       |        | git stash pop                                   |

--- a/features/compress/stack/branch_types/contributing_branch/on_contributing_branch.feature
+++ b/features/compress/stack/branch_types/contributing_branch/on_contributing_branch.feature
@@ -25,7 +25,7 @@ Feature: does not compress the active contribution branch
       | BRANCH       | COMMAND                                         |
       | contribution | git fetch --prune --tags                        |
       |              | git add -A                                      |
-      |              | git stash                                       |
+      |              | git stash -m "Git Town WIP"                     |
       |              | git checkout child                              |
       | child        | git reset --soft contribution                   |
       |              | git commit -m "child 1"                         |
@@ -48,7 +48,7 @@ Feature: does not compress the active contribution branch
     Then Git Town runs the commands
       | BRANCH       | COMMAND                                         |
       | contribution | git add -A                                      |
-      |              | git stash                                       |
+      |              | git stash -m "Git Town WIP"                     |
       |              | git checkout child                              |
       | child        | git reset --hard {{ sha 'child 2' }}            |
       |              | git push --force-with-lease --force-if-includes |

--- a/features/compress/stack/branch_types/observed_branch/on_child_branch.feature
+++ b/features/compress/stack/branch_types/observed_branch/on_child_branch.feature
@@ -25,7 +25,7 @@ Feature: does not compress observed branches in the stack
       | BRANCH | COMMAND                                         |
       | child  | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --soft observed                       |
       |        | git commit -m "child 1"                         |
       |        | git push --force-with-lease --force-if-includes |
@@ -48,7 +48,7 @@ Feature: does not compress observed branches in the stack
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | child  | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --hard {{ sha 'child 2' }}            |
       |        | git push --force-with-lease --force-if-includes |
       |        | git stash pop                                   |

--- a/features/compress/stack/branch_types/observed_branch/on_observed_branch.feature
+++ b/features/compress/stack/branch_types/observed_branch/on_observed_branch.feature
@@ -25,7 +25,7 @@ Feature: does not compress an active observed branch
       | BRANCH   | COMMAND                                         |
       | observed | git fetch --prune --tags                        |
       |          | git add -A                                      |
-      |          | git stash                                       |
+      |          | git stash -m "Git Town WIP"                     |
       |          | git checkout child                              |
       | child    | git reset --soft observed                       |
       |          | git commit -m "child 1"                         |
@@ -48,7 +48,7 @@ Feature: does not compress an active observed branch
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                         |
       | observed | git add -A                                      |
-      |          | git stash                                       |
+      |          | git stash -m "Git Town WIP"                     |
       |          | git checkout child                              |
       | child    | git reset --hard {{ sha 'child 2' }}            |
       |          | git push --force-with-lease --force-if-includes |

--- a/features/compress/stack/branch_types/parked/on_child_branch.feature
+++ b/features/compress/stack/branch_types/parked/on_child_branch.feature
@@ -25,7 +25,7 @@ Feature: does not compress non-active parked branches in the stack
       | BRANCH | COMMAND                                         |
       | child  | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --soft parked                         |
       |        | git commit -m "child 1"                         |
       |        | git push --force-with-lease --force-if-includes |
@@ -46,7 +46,7 @@ Feature: does not compress non-active parked branches in the stack
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | child  | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --hard {{ sha 'child 2' }}            |
       |        | git push --force-with-lease --force-if-includes |
       |        | git stash pop                                   |

--- a/features/compress/stack/branch_types/parked/on_parked_branch.feature
+++ b/features/compress/stack/branch_types/parked/on_parked_branch.feature
@@ -25,7 +25,7 @@ Feature: compresses active parked branches
       | BRANCH | COMMAND                                         |
       | parked | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --soft main                           |
       |        | git commit -m "parked 1"                        |
       |        | git push --force-with-lease --force-if-includes |
@@ -50,7 +50,7 @@ Feature: compresses active parked branches
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | parked | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git checkout child                              |
       | child  | git reset --hard {{ sha 'child 2' }}            |
       |        | git push --force-with-lease --force-if-includes |

--- a/features/compress/stack/branch_types/prototype_branch/on_child_branch.feature
+++ b/features/compress/stack/branch_types/prototype_branch/on_child_branch.feature
@@ -25,7 +25,7 @@ Feature: does not compress non-active prototype branches in the stack
       | BRANCH    | COMMAND                                         |
       | child     | git fetch --prune --tags                        |
       |           | git add -A                                      |
-      |           | git stash                                       |
+      |           | git stash -m "Git Town WIP"                     |
       |           | git checkout prototype                          |
       | prototype | git reset --soft main                           |
       |           | git commit -m "prototype 1"                     |
@@ -50,7 +50,7 @@ Feature: does not compress non-active prototype branches in the stack
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                         |
       | child     | git add -A                                      |
-      |           | git stash                                       |
+      |           | git stash -m "Git Town WIP"                     |
       |           | git reset --hard {{ sha 'child 2' }}            |
       |           | git push --force-with-lease --force-if-includes |
       |           | git checkout prototype                          |

--- a/features/compress/stack/branch_types/prototype_branch/on_prototype_branch.feature
+++ b/features/compress/stack/branch_types/prototype_branch/on_prototype_branch.feature
@@ -25,7 +25,7 @@ Feature: compresses active prototype branches
       | BRANCH    | COMMAND                                         |
       | prototype | git fetch --prune --tags                        |
       |           | git add -A                                      |
-      |           | git stash                                       |
+      |           | git stash -m "Git Town WIP"                     |
       |           | git reset --soft main                           |
       |           | git commit -m "prototype 1"                     |
       |           | git push --force-with-lease --force-if-includes |
@@ -50,7 +50,7 @@ Feature: compresses active prototype branches
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                         |
       | prototype | git add -A                                      |
-      |           | git stash                                       |
+      |           | git stash -m "Git Town WIP"                     |
       |           | git checkout child                              |
       | child     | git reset --hard {{ sha 'child 2' }}            |
       |           | git push --force-with-lease --force-if-includes |

--- a/features/contribute/give_existing_branch/multiple_branches.feature
+++ b/features/contribute/give_existing_branch/multiple_branches.feature
@@ -33,10 +33,10 @@ Feature: make multiple other branches contribution branches
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | main   | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And there are now no contribution branches
     And the current branch is still "main"
     And the uncommitted file still exists

--- a/features/contribute/give_no_branch/verbose.feature
+++ b/features/contribute/give_no_branch/verbose.feature
@@ -48,7 +48,7 @@ Feature: make the current branch a contribution branch verbosely
       |         | git rev-parse --verify --abbrev-ref @{-1}             |
       |         | git remote get-url origin                             |
       | feature | git add -A                                            |
-      |         | git stash                                             |
+      |         | git stash -m "Git Town WIP"                           |
       | <none>  | git config --unset git-town-branch.feature.branchtype |
       |         | git stash list                                        |
       | feature | git stash pop                                         |

--- a/features/delete/supplied_branch/delete.feature
+++ b/features/delete/supplied_branch/delete.feature
@@ -17,13 +17,13 @@ Feature: delete the given branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | good   | git fetch --prune --tags |
-      |        | git add -A               |
-      |        | git stash                |
-      |        | git push origin :dead    |
-      |        | git branch -D dead       |
-      |        | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | good   | git fetch --prune --tags    |
+      |        | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git push origin :dead       |
+      |        | git branch -D dead          |
+      |        | git stash pop               |
     And the current branch is still "good"
     And the uncommitted file still exists
     And the branches are now
@@ -41,7 +41,7 @@ Feature: delete the given branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                     |
       | good   | git add -A                                  |
-      |        | git stash                                   |
+      |        | git stash -m "Git Town WIP"                 |
       |        | git branch dead {{ sha 'dead-end commit' }} |
       |        | git push -u origin dead                     |
       |        | git stash pop                               |

--- a/features/delete/supplied_branch/edge_cases/conflicting_uncommitted_changes.feature
+++ b/features/delete/supplied_branch/edge_cases/conflicting_uncommitted_changes.feature
@@ -17,13 +17,13 @@ Feature: delete another than the current branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | good   | git fetch --prune --tags |
-      |        | git add -A               |
-      |        | git stash                |
-      |        | git push origin :dead    |
-      |        | git branch -D dead       |
-      |        | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | good   | git fetch --prune --tags    |
+      |        | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git push origin :dead       |
+      |        | git branch -D dead          |
+      |        | git stash pop               |
     And the current branch is still "good"
     And the uncommitted file has content:
       """
@@ -45,7 +45,7 @@ Feature: delete another than the current branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                     |
       | good   | git add -A                                  |
-      |        | git stash                                   |
+      |        | git stash -m "Git Town WIP"                 |
       |        | git branch dead {{ sha 'dead-end commit' }} |
       |        | git push -u origin dead                     |
       |        | git stash pop                               |

--- a/features/delete/supplied_branch/features/local_repo.feature
+++ b/features/delete/supplied_branch/features/local_repo.feature
@@ -16,11 +16,11 @@ Feature: local repository
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND             |
-      | good   | git add -A          |
-      |        | git stash           |
-      |        | git branch -D other |
-      |        | git stash pop       |
+      | BRANCH | COMMAND                     |
+      | good   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git branch -D other         |
+      |        | git stash pop               |
     And the current branch is still "good"
     And the uncommitted file still exists
     And the branches are now
@@ -38,7 +38,7 @@ Feature: local repository
     Then Git Town runs the commands
       | BRANCH | COMMAND                                   |
       | good   | git add -A                                |
-      |        | git stash                                 |
+      |        | git stash -m "Git Town WIP"               |
       |        | git branch other {{ sha 'other commit' }} |
       |        | git stash pop                             |
     And the current branch is still "good"

--- a/features/delete/supplied_branch/features/parent_branch.feature
+++ b/features/delete/supplied_branch/features/parent_branch.feature
@@ -26,13 +26,13 @@ Feature: delete a parent branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH    | COMMAND                    |
-      | feature-3 | git fetch --prune --tags   |
-      |           | git add -A                 |
-      |           | git stash                  |
-      |           | git push origin :feature-2 |
-      |           | git branch -D feature-2    |
-      |           | git stash pop              |
+      | BRANCH    | COMMAND                     |
+      | feature-3 | git fetch --prune --tags    |
+      |           | git add -A                  |
+      |           | git stash -m "Git Town WIP" |
+      |           | git push origin :feature-2  |
+      |           | git branch -D feature-2     |
+      |           | git stash pop               |
     And the current branch is now "feature-3"
     And the uncommitted file still exists
     And the branches are now
@@ -53,7 +53,7 @@ Feature: delete a parent branch
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                           |
       | feature-3 | git add -A                                        |
-      |           | git stash                                         |
+      |           | git stash -m "Git Town WIP"                       |
       |           | git branch feature-2 {{ sha 'feature-2 commit' }} |
       |           | git push -u origin feature-2                      |
       |           | git stash pop                                     |

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/branch_exists/remote_unfetched.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/branch_exists/remote_unfetched.feature
@@ -10,11 +10,11 @@ Feature: already existing remote branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | main     | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b existing |
-      | existing | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | main     | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b existing    |
+      | existing | git stash pop               |
     And the current branch is now "existing"
     And no commits exist now
     And this lineage exists now
@@ -25,12 +25,12 @@ Feature: already existing remote branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                |
-      | existing | git add -A             |
-      |          | git stash              |
-      |          | git checkout main      |
-      | main     | git branch -D existing |
-      |          | git stash pop          |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout main           |
+      | main     | git branch -D existing      |
+      |          | git stash pop               |
     And the current branch is now "main"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/compress_sync_strategy.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/compress_sync_strategy.feature
@@ -16,11 +16,11 @@ Feature: create a new top-level feature branch in a dirty workspace using the "c
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -32,12 +32,12 @@ Feature: create a new top-level feature branch in a dirty workspace using the "c
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/main_local_vs_main_remote.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/main_local_vs_main_remote.feature
@@ -15,11 +15,11 @@ Feature: conflicts between the main branch and its tracking branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -31,12 +31,12 @@ Feature: conflicts between the main branch and its tracking branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -14,11 +14,11 @@ Feature: conflicts between uncommitted changes and the main branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And Git Town prints the error:
       """
       conflicts between your uncommmitted changes and the main branch
@@ -74,12 +74,12 @@ Feature: conflicts between uncommitted changes and the main branch
     And I run "git-town continue" and close the editor
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/dry_run.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/dry_run.feature
@@ -15,11 +15,11 @@ Feature: dry-run hacking a new feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is still "existing"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/happy_path.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/happy_path.feature
@@ -16,11 +16,11 @@ Feature: on a feature branch with uncommitted changes
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -32,12 +32,12 @@ Feature: on a feature branch with uncommitted changes
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/in_subfolder/subfolder_is_committed.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/in_subfolder/subfolder_is_committed.feature
@@ -14,11 +14,11 @@ Feature: inside a committed subfolder that exists only on the current feature br
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -29,12 +29,12 @@ Feature: inside a committed subfolder that exists only on the current feature br
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/in_subfolder/subfolder_is_not_committed.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/in_subfolder/subfolder_is_not_committed.feature
@@ -14,11 +14,11 @@ Feature: inside an uncommitted subfolder on the current feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -29,12 +29,12 @@ Feature: inside an uncommitted subfolder on the current feature branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/local_repo.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/local_repo.feature
@@ -14,11 +14,11 @@ Feature: local repo
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the uncommitted file still exists
     And the initial commits exist now
@@ -30,12 +30,12 @@ Feature: local repo
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/offline.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/offline.feature
@@ -11,11 +11,11 @@ Feature: offline mode
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND             |
-      | main   | git add -A          |
-      |        | git stash           |
-      |        | git checkout -b new |
-      | new    | git stash pop       |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new         |
+      | new    | git stash pop               |
     And the current branch is now "new"
     And the uncommitted file still exists
     And the initial commits exist now
@@ -26,12 +26,12 @@ Feature: offline mode
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND           |
-      | new    | git add -A        |
-      |        | git stash         |
-      |        | git checkout main |
-      | main   | git branch -D new |
-      |        | git stash pop     |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/push_hook/disabled.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/push_hook/disabled.feature
@@ -15,7 +15,7 @@ Feature: auto-push the new branch without running Git push hooks
     Then Git Town runs the commands
       | BRANCH | COMMAND                            |
       | main   | git add -A                         |
-      |        | git stash                          |
+      |        | git stash -m "Git Town WIP"        |
       |        | git checkout -b new                |
       | new    | git push --no-verify -u origin new |
       |        | git stash pop                      |
@@ -29,13 +29,13 @@ Feature: auto-push the new branch without running Git push hooks
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | new    | git add -A           |
-      |        | git stash            |
-      |        | git checkout main    |
-      | main   | git branch -D new    |
-      |        | git push origin :new |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git push origin :new        |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/push_hook/enabled.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/push_hook/enabled.feature
@@ -13,12 +13,12 @@ Feature: auto-push the new branch without running Git push hooks
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                |
-      | main   | git add -A             |
-      |        | git stash              |
-      |        | git checkout -b new    |
-      | new    | git push -u origin new |
-      |        | git stash pop          |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new         |
+      | new    | git push -u origin new      |
+      |        | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -29,13 +29,13 @@ Feature: auto-push the new branch without running Git push hooks
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | new    | git add -A           |
-      |        | git stash            |
-      |        | git checkout main    |
-      | main   | git branch -D new    |
-      |        | git push origin :new |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git push origin :new        |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/push_new_branches.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/push_new_branches.feature
@@ -12,12 +12,12 @@ Feature: auto-push the new branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                |
-      | main   | git add -A             |
-      |        | git stash              |
-      |        | git checkout -b new    |
-      | new    | git push -u origin new |
-      |        | git stash pop          |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new         |
+      | new    | git push -u origin new      |
+      |        | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -28,13 +28,13 @@ Feature: auto-push the new branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | new    | git add -A           |
-      |        | git stash            |
-      |        | git checkout main    |
-      | main   | git branch -D new    |
-      |        | git push origin :new |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git push origin :new        |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/verbose.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/verbose.feature
@@ -24,7 +24,7 @@ Feature: display all executed Git commands with uncommitted changes
       |        | backend  | git remote get-url origin                     |
       |        | backend  | git remote                                    |
       | main   | frontend | git add -A                                    |
-      |        | frontend | git stash                                     |
+      |        | frontend | git stash -m "Git Town WIP"                   |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       | main   | frontend | git checkout -b new                           |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
@@ -59,7 +59,7 @@ Feature: display all executed Git commands with uncommitted changes
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git remote get-url origin                     |
       | new    | frontend | git add -A                                    |
-      |        | frontend | git stash                                     |
+      |        | frontend | git stash -m "Git Town WIP"                   |
       |        | frontend | git checkout main                             |
       | main   | frontend | git branch -D new                             |
       |        | backend  | git config --unset git-town-branch.new.parent |

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/with_upstream.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/with_upstream.feature
@@ -12,11 +12,11 @@ Feature: on a forked repo
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND             |
-      | main   | git add -A          |
-      |        | git stash           |
-      |        | git checkout -b new |
-      | new    | git stash pop       |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new         |
+      | new    | git stash pop               |
     And the current branch is now "new"
     And the uncommitted file still exists
     And the initial commits exist now
@@ -24,12 +24,12 @@ Feature: on a forked repo
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND           |
-      | new    | git add -A        |
-      |        | git stash         |
-      |        | git checkout main |
-      | main   | git branch -D new |
-      |        | git stash pop     |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the initial commits exist now
     And no lineage exists now

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/worktree.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/worktree.feature
@@ -17,11 +17,11 @@ Feature: hack a new branch while the main branch is active in another worktree
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                  |
-      | existing | git add -A               |
-      |          | git stash                |
-      |          | git checkout -b new main |
-      | new      | git stash pop            |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout -b new main    |
+      | new      | git stash pop               |
     And the current branch is now "new"
     And the uncommitted file still exists
     And these commits exist now
@@ -37,12 +37,12 @@ Feature: hack a new branch while the main branch is active in another worktree
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
     And the current branch is now "existing"
     And these commits exist now
       | BRANCH   | LOCATION | MESSAGE            |

--- a/features/hack/give_non_existing_branch/on_main_branch/uncommitted_changes/happy_path.feature
+++ b/features/hack/give_non_existing_branch/on_main_branch/uncommitted_changes/happy_path.feature
@@ -11,11 +11,11 @@ Feature: on the main branch with uncommitted changes
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND             |
-      | main   | git add -A          |
-      |        | git stash           |
-      |        | git checkout -b new |
-      | new    | git stash pop       |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new         |
+      | new    | git stash pop               |
     And the current branch is now "new"
     And the uncommitted file still exists
     And the initial commits exist now
@@ -26,12 +26,12 @@ Feature: on the main branch with uncommitted changes
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND           |
-      | new    | git add -A        |
-      |        | git stash         |
-      |        | git checkout main |
-      | main   | git branch -D new |
-      |        | git stash pop     |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_main_branch/uncommitted_changes/in_uncommitted_subfolder.feature
+++ b/features/hack/give_non_existing_branch/on_main_branch/uncommitted_changes/in_uncommitted_subfolder.feature
@@ -10,11 +10,11 @@ Feature: inside an uncommitted subfolder on the current feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND             |
-      | main   | git add -A          |
-      |        | git stash           |
-      |        | git checkout -b new |
-      | new    | git stash pop       |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new         |
+      | new    | git stash pop               |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now
@@ -24,12 +24,12 @@ Feature: inside an uncommitted subfolder on the current feature branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND           |
-      | new    | git add -A        |
-      |        | git stash         |
-      |        | git checkout main |
-      | main   | git branch -D new |
-      |        | git stash pop     |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout main           |
+      | main   | git branch -D new           |
+      |        | git stash pop               |
     And the current branch is now "main"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/merge/uncommitted_changes/with.feature
+++ b/features/merge/uncommitted_changes/with.feature
@@ -19,7 +19,7 @@ Feature: merging a branch with uncommitted changes
       | BRANCH | COMMAND                               |
       | beta   | git fetch --prune --tags              |
       |        | git add -A                            |
-      |        | git stash                             |
+      |        | git stash -m "Git Town WIP"           |
       |        | git checkout alpha                    |
       | alpha  | git merge --no-edit --ff origin/alpha |
       |        | git checkout beta                     |
@@ -49,7 +49,7 @@ Feature: merging a branch with uncommitted changes
     Then Git Town runs the commands
       | BRANCH | COMMAND                                              |
       | beta   | git add -A                                           |
-      |        | git stash                                            |
+      |        | git stash -m "Git Town WIP"                          |
       |        | git reset --hard {{ sha-before-run 'beta commit' }}  |
       |        | git push --force-with-lease --force-if-includes      |
       |        | git branch alpha {{ sha-before-run 'alpha commit' }} |

--- a/features/observe/give_existing_branch/remote_branch.feature
+++ b/features/observe/give_existing_branch/remote_branch.feature
@@ -26,7 +26,7 @@ Feature: make another remote feature branch an observed branch
     Then Git Town runs the commands
       | BRANCH         | COMMAND                      |
       | remote-feature | git add -A                   |
-      |                | git stash                    |
+      |                | git stash -m "Git Town WIP"  |
       |                | git checkout main            |
       | main           | git branch -D remote-feature |
       |                | git stash pop                |

--- a/features/observe/give_no_branch/on_contribution_branch.feature
+++ b/features/observe/give_no_branch/on_contribution_branch.feature
@@ -22,10 +22,10 @@ Feature: observe the current contribution branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH       | COMMAND       |
-      | contribution | git add -A    |
-      |              | git stash     |
-      |              | git stash pop |
+      | BRANCH       | COMMAND                     |
+      | contribution | git add -A                  |
+      |              | git stash -m "Git Town WIP" |
+      |              | git stash pop               |
     And the current branch is still "contribution"
     And branch "contribution" now has type "contribution"
     And there are now no observed branches

--- a/features/observe/give_no_branch/on_feature_branch.feature
+++ b/features/observe/give_no_branch/on_feature_branch.feature
@@ -22,10 +22,10 @@ Feature: observing the current feature branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH  | COMMAND       |
-      | feature | git add -A    |
-      |         | git stash     |
-      |         | git stash pop |
+      | BRANCH  | COMMAND                     |
+      | feature | git add -A                  |
+      |         | git stash -m "Git Town WIP" |
+      |         | git stash pop               |
     And the current branch is still "feature"
     And there are now no observed branches
     And the uncommitted file still exists

--- a/features/observe/give_no_branch/verbose.feature
+++ b/features/observe/give_no_branch/verbose.feature
@@ -48,7 +48,7 @@ Feature: observe the current branch verbosely
       |         | git rev-parse --verify --abbrev-ref @{-1}             |
       |         | git remote get-url origin                             |
       | feature | git add -A                                            |
-      |         | git stash                                             |
+      |         | git stash -m "Git Town WIP"                           |
       | <none>  | git config --unset git-town-branch.feature.branchtype |
       |         | git stash list                                        |
       | feature | git stash pop                                         |

--- a/features/park/give_no_branch/verbose.feature
+++ b/features/park/give_no_branch/verbose.feature
@@ -48,7 +48,7 @@ Feature: park the current branch verbosely
       |         | git rev-parse --verify --abbrev-ref @{-1}             |
       |         | git remote get-url origin                             |
       | feature | git add -A                                            |
-      |         | git stash                                             |
+      |         | git stash -m "Git Town WIP"                           |
       | <none>  | git config --unset git-town-branch.feature.branchtype |
       |         | git stash list                                        |
       | feature | git stash pop                                         |

--- a/features/prepend/uncommitted_changes/branch_exists/remote_unfetched.feature
+++ b/features/prepend/uncommitted_changes/branch_exists/remote_unfetched.feature
@@ -14,7 +14,7 @@ Feature: already existing remote branch
     Then Git Town runs the commands
       | BRANCH   | COMMAND                       |
       | old      | git add -A                    |
-      |          | git stash                     |
+      |          | git stash -m "Git Town WIP"   |
       |          | git checkout -b existing main |
       | existing | git stash pop                 |
     And the current branch is now "existing"
@@ -28,12 +28,12 @@ Feature: already existing remote branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                |
-      | existing | git add -A             |
-      |          | git stash              |
-      |          | git checkout old       |
-      | old      | git branch -D existing |
-      |          | git stash pop          |
+      | BRANCH   | COMMAND                     |
+      | existing | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout old            |
+      | old      | git branch -D existing      |
+      |          | git stash pop               |
     And the current branch is now "old"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/prepend/uncommitted_changes/branch_shipped.feature
+++ b/features/prepend/uncommitted_changes/branch_shipped.feature
@@ -17,11 +17,11 @@ Feature: prepend a branch to a branch that was shipped at the remote
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                    |
-      | child  | git add -A                 |
-      |        | git stash                  |
-      |        | git checkout -b new parent |
-      | new    | git stash pop              |
+      | BRANCH | COMMAND                     |
+      | child  | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new parent  |
+      | new    | git stash pop               |
     And the current branch is now "new"
     And the branches are now
       | REPOSITORY | BRANCHES                 |
@@ -37,12 +37,12 @@ Feature: prepend a branch to a branch that was shipped at the remote
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND            |
-      | new    | git add -A         |
-      |        | git stash          |
-      |        | git checkout child |
-      | child  | git branch -D new  |
-      |        | git stash pop      |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout child          |
+      | child  | git branch -D new           |
+      |        | git stash pop               |
     And the current branch is now "child"
     And the branches are now
       | REPOSITORY | BRANCHES            |

--- a/features/prepend/uncommitted_changes/compress_sync_strategy.feature
+++ b/features/prepend/uncommitted_changes/compress_sync_strategy.feature
@@ -17,7 +17,7 @@ Feature: prepend a branch to a feature branch in a dirty workspace using the "co
     Then Git Town runs the commands
       | BRANCH | COMMAND                     |
       | old    | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout -b parent main |
       | parent | git stash pop               |
     And the current branch is now "parent"
@@ -33,12 +33,12 @@ Feature: prepend a branch to a feature branch in a dirty workspace using the "co
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | parent | git add -A           |
-      |        | git stash            |
-      |        | git checkout old     |
-      | old    | git branch -D parent |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | parent | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout old            |
+      | old    | git branch -D parent        |
+      |        | git stash pop               |
     And the current branch is now "old"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/prepend/uncommitted_changes/dry_run.feature
+++ b/features/prepend/uncommitted_changes/dry_run.feature
@@ -16,7 +16,7 @@ Feature: dry-run prepending a branch to a feature branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                     |
       | old    | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout -b parent main |
       | parent | git stash pop               |
     And the current branch is still "old"

--- a/features/prepend/uncommitted_changes/happy_path.feature
+++ b/features/prepend/uncommitted_changes/happy_path.feature
@@ -17,7 +17,7 @@ Feature: prepend a branch to a feature branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                     |
       | old    | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout -b parent main |
       | parent | git stash pop               |
     And the current branch is now "parent"
@@ -33,12 +33,12 @@ Feature: prepend a branch to a feature branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | parent | git add -A           |
-      |        | git stash            |
-      |        | git checkout old     |
-      | old    | git branch -D parent |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | parent | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout old            |
+      | old    | git branch -D parent        |
+      |        | git stash pop               |
     And the current branch is now "old"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/prepend/uncommitted_changes/offline.feature
+++ b/features/prepend/uncommitted_changes/offline.feature
@@ -15,11 +15,11 @@ Feature: offline mode
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | old    | git add -A               |
-      |        | git stash                |
-      |        | git checkout -b new main |
-      | new    | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | old    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new main    |
+      | new    | git stash pop               |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE    |
@@ -33,12 +33,12 @@ Feature: offline mode
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND           |
-      | new    | git add -A        |
-      |        | git stash         |
-      |        | git checkout old  |
-      | old    | git branch -D new |
-      |        | git stash pop     |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout old            |
+      | old    | git branch -D new           |
+      |        | git stash pop               |
     And the current branch is now "old"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/prepend/uncommitted_changes/push_hook/disabled.feature
+++ b/features/prepend/uncommitted_changes/push_hook/disabled.feature
@@ -18,7 +18,7 @@ Feature: auto-push new branches
     Then Git Town runs the commands
       | BRANCH | COMMAND                            |
       | old    | git add -A                         |
-      |        | git stash                          |
+      |        | git stash -m "Git Town WIP"        |
       |        | git checkout -b new main           |
       | new    | git push --no-verify -u origin new |
       |        | git stash pop                      |
@@ -35,13 +35,13 @@ Feature: auto-push new branches
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | new    | git add -A           |
-      |        | git stash            |
-      |        | git checkout old     |
-      | old    | git branch -D new    |
-      |        | git push origin :new |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout old            |
+      | old    | git branch -D new           |
+      |        | git push origin :new        |
+      |        | git stash pop               |
     And the current branch is now "old"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/prepend/uncommitted_changes/push_hook/enabled.feature
+++ b/features/prepend/uncommitted_changes/push_hook/enabled.feature
@@ -16,12 +16,12 @@ Feature: auto-push new branches
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | old    | git add -A               |
-      |        | git stash                |
-      |        | git checkout -b new main |
-      | new    | git push -u origin new   |
-      |        | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | old    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new main    |
+      | new    | git push -u origin new      |
+      |        | git stash pop               |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |
@@ -35,13 +35,13 @@ Feature: auto-push new branches
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | new    | git add -A           |
-      |        | git stash            |
-      |        | git checkout old     |
-      | old    | git branch -D new    |
-      |        | git push origin :new |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout old            |
+      | old    | git branch -D new           |
+      |        | git push origin :new        |
+      |        | git stash pop               |
     And the current branch is now "old"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/prepend/uncommitted_changes/push_new_branches.feature
+++ b/features/prepend/uncommitted_changes/push_new_branches.feature
@@ -15,12 +15,12 @@ Feature: auto-push new branches
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | old    | git add -A               |
-      |        | git stash                |
-      |        | git checkout -b new main |
-      | new    | git push -u origin new   |
-      |        | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | old    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout -b new main    |
+      | new    | git push -u origin new      |
+      |        | git stash pop               |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |
@@ -34,13 +34,13 @@ Feature: auto-push new branches
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND              |
-      | new    | git add -A           |
-      |        | git stash            |
-      |        | git checkout old     |
-      | old    | git branch -D new    |
-      |        | git push origin :new |
-      |        | git stash pop        |
+      | BRANCH | COMMAND                     |
+      | new    | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git checkout old            |
+      | old    | git branch -D new           |
+      |        | git push origin :new        |
+      |        | git stash pop               |
     And the current branch is now "old"
     And the initial commits exist now
     And the initial lineage exists now

--- a/features/prepend/uncommitted_changes/verbose.feature
+++ b/features/prepend/uncommitted_changes/verbose.feature
@@ -28,7 +28,7 @@ Feature: display all executed Git commands
       |        | backend  | git remote get-url origin                     |
       |        | backend  | git log main..old --format=%s --reverse       |
       | old    | frontend | git add -A                                    |
-      |        | frontend | git stash                                     |
+      |        | frontend | git stash -m "Git Town WIP"                   |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
       | old    | frontend | git checkout -b parent main                   |
       |        | backend  | git show-ref --verify --quiet refs/heads/main |
@@ -64,7 +64,7 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}        |
       |        | backend  | git remote get-url origin                        |
       | parent | frontend | git add -A                                       |
-      |        | frontend | git stash                                        |
+      |        | frontend | git stash -m "Git Town WIP"                      |
       |        | frontend | git checkout old                                 |
       | old    | frontend | git branch -D parent                             |
       |        | backend  | git config --unset git-town-branch.parent.parent |

--- a/features/propose/features/on_outdated_branch.feature
+++ b/features/propose/features/on_outdated_branch.feature
@@ -28,7 +28,7 @@ Feature: sync before proposing
       | child  | git fetch --prune --tags                                                  |
       | <none> | Looking for proposal online ... ok                                        |
       | child  | git add -A                                                                |
-      |        | git stash                                                                 |
+      |        | git stash -m "Git Town WIP"                                               |
       |        | git checkout main                                                         |
       | main   | git rebase origin/main --no-update-refs                                   |
       |        | git push                                                                  |

--- a/features/prototype/give_no_branch/verbose.feature
+++ b/features/prototype/give_no_branch/verbose.feature
@@ -48,7 +48,7 @@ Feature: prototype the current branch verbosely
       |         | git rev-parse --verify --abbrev-ref @{-1}             |
       |         | git remote get-url origin                             |
       | feature | git add -A                                            |
-      |         | git stash                                             |
+      |         | git stash -m "Git Town WIP"                           |
       | <none>  | git config --unset git-town-branch.feature.branchtype |
       |         | git stash list                                        |
       | feature | git stash pop                                         |

--- a/features/ship/always_merge/supplied_branch/empty_branch.feature
+++ b/features/ship/always_merge/supplied_branch/empty_branch.feature
@@ -17,11 +17,11 @@ Feature: does not ship empty feature branches using the always-merge strategy
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | other  | git fetch --prune --tags |
-      |        | git add -A               |
-      |        | git stash                |
-      |        | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | other  | git fetch --prune --tags    |
+      |        | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And Git Town prints the error:
       """
       the branch "empty" has no shippable changes

--- a/features/ship/always_merge/supplied_branch/happy_path.feature
+++ b/features/ship/always_merge/supplied_branch/happy_path.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied feature branch
       | BRANCH | COMMAND                             |
       | other  | git fetch --prune --tags            |
       |        | git add -A                          |
-      |        | git stash                           |
+      |        | git stash -m "Git Town WIP"         |
       |        | git checkout main                   |
       | main   | git merge --no-ff --edit -- feature |
       |        | git push                            |
@@ -45,7 +45,7 @@ Feature: ship the supplied feature branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git push -u origin feature                    |
       |        | git stash pop                                 |

--- a/features/ship/always_merge/supplied_branch/in_subfolder.feature
+++ b/features/ship/always_merge/supplied_branch/in_subfolder.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied feature branch from a subfolder using the always-merg
       | BRANCH | COMMAND                                        |
       | other  | git fetch --prune --tags                       |
       |        | git add -A                                     |
-      |        | git stash                                      |
+      |        | git stash -m "Git Town WIP"                    |
       |        | git checkout main                              |
       | main   | git merge --no-ff -m "feature done" -- feature |
       |        | git push                                       |
@@ -45,7 +45,7 @@ Feature: ship the supplied feature branch from a subfolder using the always-merg
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git stash pop                                 |
     And the current branch is now "other"

--- a/features/ship/always_merge/supplied_branch/merge_conflict/feature_and_main.feature
+++ b/features/ship/always_merge/supplied_branch/merge_conflict/feature_and_main.feature
@@ -20,7 +20,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | BRANCH | COMMAND                             |
       | other  | git fetch --prune --tags            |
       |        | git add -A                          |
-      |        | git stash                           |
+      |        | git stash -m "Git Town WIP"         |
       |        | git checkout main                   |
       | main   | git merge --no-ff --edit -- feature |
       |        | git merge --abort                   |

--- a/features/ship/always_merge/supplied_branch/tracking_branch/local_repo.feature
+++ b/features/ship/always_merge/supplied_branch/tracking_branch/local_repo.feature
@@ -18,7 +18,7 @@ Feature: ship the supplied feature branch in a local repo using the always-merge
     Then Git Town runs the commands
       | BRANCH | COMMAND                             |
       | other  | git add -A                          |
-      |        | git stash                           |
+      |        | git stash -m "Git Town WIP"         |
       |        | git checkout main                   |
       | main   | git merge --no-ff --edit -- feature |
       |        | git checkout other                  |
@@ -42,7 +42,7 @@ Feature: ship the supplied feature branch in a local repo using the always-merge
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git checkout main                             |
       | main   | git reset --hard {{ sha 'initial commit' }}   |
       |        | git branch feature {{ sha 'feature commit' }} |

--- a/features/ship/always_merge/supplied_branch/tracking_branch/without.feature
+++ b/features/ship/always_merge/supplied_branch/tracking_branch/without.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied local feature branch
       | BRANCH | COMMAND                             |
       | other  | git fetch --prune --tags            |
       |        | git add -A                          |
-      |        | git stash                           |
+      |        | git stash -m "Git Town WIP"         |
       |        | git checkout main                   |
       | main   | git merge --no-ff --edit -- feature |
       |        | git push                            |
@@ -44,7 +44,7 @@ Feature: ship the supplied local feature branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git stash pop                                 |
     And the current branch is now "other"

--- a/features/ship/fast_forward/supplied_branch/empty_branch.feature
+++ b/features/ship/fast_forward/supplied_branch/empty_branch.feature
@@ -17,11 +17,11 @@ Feature: does not ship empty feature branches using the fast-forward strategy
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | other  | git fetch --prune --tags |
-      |        | git add -A               |
-      |        | git stash                |
-      |        | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | other  | git fetch --prune --tags    |
+      |        | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And Git Town prints the error:
       """
       the branch "empty" has no shippable changes

--- a/features/ship/fast_forward/supplied_branch/happy_path.feature
+++ b/features/ship/fast_forward/supplied_branch/happy_path.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied feature branch
       | BRANCH | COMMAND                     |
       | other  | git fetch --prune --tags    |
       |        | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout main           |
       | main   | git merge --ff-only feature |
       |        | git push                    |
@@ -44,7 +44,7 @@ Feature: ship the supplied feature branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git push -u origin feature                    |
       |        | git stash pop                                 |

--- a/features/ship/fast_forward/supplied_branch/in_subfolder.feature
+++ b/features/ship/fast_forward/supplied_branch/in_subfolder.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied feature branch from a subfolder using the fast-forwar
       | BRANCH | COMMAND                     |
       | other  | git fetch --prune --tags    |
       |        | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout main           |
       | main   | git merge --ff-only feature |
       |        | git push                    |
@@ -44,7 +44,7 @@ Feature: ship the supplied feature branch from a subfolder using the fast-forwar
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git stash pop                                 |
     And the current branch is now "other"

--- a/features/ship/fast_forward/supplied_branch/merge_conflict/feature_and_main.feature
+++ b/features/ship/fast_forward/supplied_branch/merge_conflict/feature_and_main.feature
@@ -20,7 +20,7 @@ Feature: does not ship an unsynced feature branch using the fast-forward strateg
       | BRANCH | COMMAND                     |
       | other  | git fetch --prune --tags    |
       |        | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout main           |
       | main   | git merge --ff-only feature |
       |        | git merge --abort           |

--- a/features/ship/fast_forward/supplied_branch/tracking_branch/local_repo.feature
+++ b/features/ship/fast_forward/supplied_branch/tracking_branch/local_repo.feature
@@ -18,7 +18,7 @@ Feature: ship the supplied feature branch in a local repo using the fast-forward
     Then Git Town runs the commands
       | BRANCH | COMMAND                     |
       | other  | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout main           |
       | main   | git merge --ff-only feature |
       |        | git checkout other          |
@@ -41,7 +41,7 @@ Feature: ship the supplied feature branch in a local repo using the fast-forward
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git checkout main                             |
       | main   | git reset --hard {{ sha 'initial commit' }}   |
       |        | git branch feature {{ sha 'feature commit' }} |

--- a/features/ship/fast_forward/supplied_branch/tracking_branch/without.feature
+++ b/features/ship/fast_forward/supplied_branch/tracking_branch/without.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied local feature branch
       | BRANCH | COMMAND                     |
       | other  | git fetch --prune --tags    |
       |        | git add -A                  |
-      |        | git stash                   |
+      |        | git stash -m "Git Town WIP" |
       |        | git checkout main           |
       | main   | git merge --ff-only feature |
       |        | git push                    |
@@ -43,7 +43,7 @@ Feature: ship the supplied local feature branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git branch feature {{ sha 'feature commit' }} |
       |        | git stash pop                                 |
     And the current branch is now "other"

--- a/features/ship/squash_merge/supplied_branch/commit_message/empty.feature
+++ b/features/ship/squash_merge/supplied_branch/commit_message/empty.feature
@@ -21,7 +21,7 @@ Feature: abort the ship via empty commit message
       | BRANCH | COMMAND                         |
       | other  | git fetch --prune --tags        |
       |        | git add -A                      |
-      |        | git stash                       |
+      |        | git stash -m "Git Town WIP"     |
       |        | git checkout main               |
       | main   | git merge --squash --ff feature |
       |        | git commit                      |

--- a/features/ship/squash_merge/supplied_branch/commit_message/via_cli.feature
+++ b/features/ship/squash_merge/supplied_branch/commit_message/via_cli.feature
@@ -19,7 +19,7 @@ Feature: provide the commit message via a CLI argument
       | BRANCH | COMMAND                         |
       | other  | git fetch --prune --tags        |
       |        | git add -A                      |
-      |        | git stash                       |
+      |        | git stash -m "Git Town WIP"     |
       |        | git checkout main               |
       | main   | git merge --squash --ff feature |
       |        | git commit -m "feature done"    |
@@ -45,7 +45,7 @@ Feature: provide the commit message via a CLI argument
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git checkout main                             |
       | main   | git revert {{ sha 'feature done' }}           |
       |        | git push                                      |

--- a/features/ship/squash_merge/supplied_branch/empty_branch/empty_branch.feature
+++ b/features/ship/squash_merge/supplied_branch/empty_branch/empty_branch.feature
@@ -17,11 +17,11 @@ Feature: does not ship empty feature branches
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                  |
-      | other  | git fetch --prune --tags |
-      |        | git add -A               |
-      |        | git stash                |
-      |        | git stash pop            |
+      | BRANCH | COMMAND                     |
+      | other  | git fetch --prune --tags    |
+      |        | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And Git Town prints the error:
       """
       the branch "empty" has no shippable changes

--- a/features/ship/squash_merge/supplied_branch/in_subfolder/in_subfolder.feature
+++ b/features/ship/squash_merge/supplied_branch/in_subfolder/in_subfolder.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied feature branch from a subfolder
       | BRANCH | COMMAND                         |
       | other  | git fetch --prune --tags        |
       |        | git add -A                      |
-      |        | git stash                       |
+      |        | git stash -m "Git Town WIP"     |
       |        | git checkout main               |
       | main   | git merge --squash --ff feature |
       |        | git commit -m "feature done"    |
@@ -45,7 +45,7 @@ Feature: ship the supplied feature branch from a subfolder
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git checkout main                             |
       | main   | git revert {{ sha 'feature done' }}           |
       |        | git push                                      |

--- a/features/ship/squash_merge/supplied_branch/merge_conflict/feature_vs_main.feature
+++ b/features/ship/squash_merge/supplied_branch/merge_conflict/feature_vs_main.feature
@@ -20,7 +20,7 @@ Feature: handle conflicts between the supplied feature branch and the main branc
       | BRANCH | COMMAND                         |
       | other  | git fetch --prune --tags        |
       |        | git add -A                      |
-      |        | git stash                       |
+      |        | git stash -m "Git Town WIP"     |
       |        | git checkout main               |
       | main   | git merge --squash --ff feature |
       |        | git reset --hard                |

--- a/features/ship/squash_merge/supplied_branch/tracking_branch/local_repo.feature
+++ b/features/ship/squash_merge/supplied_branch/tracking_branch/local_repo.feature
@@ -18,7 +18,7 @@ Feature: ship the supplied feature branch in a local repo
     Then Git Town runs the commands
       | BRANCH | COMMAND                         |
       | other  | git add -A                      |
-      |        | git stash                       |
+      |        | git stash -m "Git Town WIP"     |
       |        | git checkout main               |
       | main   | git merge --squash --ff feature |
       |        | git commit -m "feature done"    |
@@ -42,7 +42,7 @@ Feature: ship the supplied feature branch in a local repo
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git checkout main                             |
       | main   | git reset --hard {{ sha 'initial commit' }}   |
       |        | git branch feature {{ sha 'feature commit' }} |

--- a/features/ship/squash_merge/supplied_branch/tracking_branch/with.feature
+++ b/features/ship/squash_merge/supplied_branch/tracking_branch/with.feature
@@ -20,7 +20,7 @@ Feature: ship the supplied feature branch
       | BRANCH | COMMAND                         |
       | other  | git fetch --prune --tags        |
       |        | git add -A                      |
-      |        | git stash                       |
+      |        | git stash -m "Git Town WIP"     |
       |        | git checkout main               |
       | main   | git merge --squash --ff feature |
       |        | git commit                      |
@@ -46,7 +46,7 @@ Feature: ship the supplied feature branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git checkout main                             |
       | main   | git revert {{ sha 'feature done' }}           |
       |        | git push                                      |

--- a/features/ship/squash_merge/supplied_branch/tracking_branch/without.feature
+++ b/features/ship/squash_merge/supplied_branch/tracking_branch/without.feature
@@ -19,7 +19,7 @@ Feature: ship the supplied feature branch without a tracking branch
       | BRANCH | COMMAND                         |
       | other  | git fetch --prune --tags        |
       |        | git add -A                      |
-      |        | git stash                       |
+      |        | git stash -m "Git Town WIP"     |
       |        | git checkout main               |
       | main   | git merge --squash --ff feature |
       |        | git commit -m "feature done"    |
@@ -44,7 +44,7 @@ Feature: ship the supplied feature branch without a tracking branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                       |
       | other  | git add -A                                    |
-      |        | git stash                                     |
+      |        | git stash -m "Git Town WIP"                   |
       |        | git checkout main                             |
       | main   | git revert {{ sha 'feature done' }}           |
       |        | git push                                      |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/conflict_feature_branch_main_branch.feature
@@ -22,7 +22,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
       | alpha  | git merge --no-edit --ff main           |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/local_repo.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/local_repo.feature
@@ -21,7 +21,7 @@ Feature: handle merge conflicts between feature branch and main branch in a loca
     Then Git Town runs the commands
       | BRANCH | COMMAND                       |
       | main   | git add -A                    |
-      |        | git stash                     |
+      |        | git stash -m "Git Town WIP"   |
       |        | git checkout alpha            |
       | alpha  | git merge --no-edit --ff main |
       |        | git checkout beta             |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/shipped_changes_conflict_with_existing_feature_branch.feature
@@ -20,7 +20,7 @@ Feature: shipped changes conflict with multiple existing feature branches
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
       | alpha  | git merge --no-edit --ff main           |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_main_branch_conflict/tracking_branch_updates.feature
@@ -23,7 +23,7 @@ Feature: handle merge conflicts between feature branch and main branch
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
       | alpha  | git merge --no-edit --ff main           |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/feature_branch_tracking_branch_conflict.feature
@@ -23,7 +23,7 @@ Feature: handle merge conflicts between feature branches and their tracking bran
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
       | alpha  | git merge --no-edit --ff main           |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -19,7 +19,7 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
     And Git Town prints the error:
       """

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
@@ -24,7 +24,7 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       | BRANCH | COMMAND                                  |
       | main   | git fetch --prune --tags                 |
       |        | git add -A                               |
-      |        | git stash                                |
+      |        | git stash -m "Git Town WIP"              |
       |        | git checkout alpha                       |
       | alpha  | git rebase origin/alpha --no-update-refs |
       |        | git checkout beta                        |

--- a/features/sync/all_branches/merge_sync_strategy/stack/already_synced.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/already_synced.feature
@@ -39,7 +39,7 @@ Feature: sync a stack making independent changes
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
       | alpha  | git merge --no-edit --ff main           |
@@ -64,10 +64,10 @@ Feature: sync a stack making independent changes
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | main   | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And the current branch is still "main"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/sync/all_branches/merge_sync_strategy/stack/conflicting_changes.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/conflicting_changes.feature
@@ -18,7 +18,7 @@ Feature: sync a stack that makes conflicting changes
       | BRANCH | COMMAND                                 |
       | alpha  | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
@@ -66,7 +66,7 @@ Feature: sync a stack that makes conflicting changes
     Then Git Town runs the commands
       | BRANCH | COMMAND                                               |
       | alpha  | git add -A                                            |
-      |        | git stash                                             |
+      |        | git stash -m "Git Town WIP"                           |
       |        | git reset --hard {{ sha-before-run 'alpha commit' }}  |
       |        | git push --force-with-lease --force-if-includes       |
       |        | git checkout beta                                     |

--- a/features/sync/all_branches/merge_sync_strategy/stack/two_stacks.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/two_stacks.feature
@@ -59,7 +59,7 @@ Feature: sync a workspace with two independent stacks
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
       |        | git checkout first                      |
       | first  | git merge --no-edit --ff main           |
@@ -96,10 +96,10 @@ Feature: sync a workspace with two independent stacks
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | main   | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And the current branch is still "main"
     And the uncommitted file still exists
     And the initial commits exist now

--- a/features/sync/current_branch/contribution_branch/local_repo/local_repo.feature
+++ b/features/sync/current_branch/contribution_branch/local_repo/local_repo.feature
@@ -16,10 +16,10 @@ Feature: sync the current contribution branch in a local repo
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH       | COMMAND       |
-      | contribution | git add -A    |
-      |              | git stash     |
-      |              | git stash pop |
+      | BRANCH       | COMMAND                     |
+      | contribution | git add -A                  |
+      |              | git stash -m "Git Town WIP" |
+      |              | git stash pop               |
     And all branches are now synchronized
     And the current branch is still "contribution"
     And the uncommitted file still exists
@@ -29,10 +29,10 @@ Feature: sync the current contribution branch in a local repo
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH       | COMMAND       |
-      | contribution | git add -A    |
-      |              | git stash     |
-      |              | git stash pop |
+      | BRANCH       | COMMAND                     |
+      | contribution | git add -A                  |
+      |              | git stash -m "Git Town WIP" |
+      |              | git stash pop               |
     And the current branch is still "contribution"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/contribution_branch/tracking/with/conflict_local_vs_tracking.feature
+++ b/features/sync/current_branch/contribution_branch/tracking/with/conflict_local_vs_tracking.feature
@@ -18,7 +18,7 @@ Feature: handle conflicts between the current contribution branch and its tracki
       | BRANCH       | COMMAND                                         |
       | contribution | git fetch --prune --tags                        |
       |              | git add -A                                      |
-      |              | git stash                                       |
+      |              | git stash -m "Git Town WIP"                     |
       |              | git rebase origin/contribution --no-update-refs |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
@@ -21,7 +21,7 @@ Feature: using the "compress" strategy, sync a branch with unmerged commits whos
       | BRANCH   | COMMAND                                 |
       | branch-2 | git fetch --prune --tags                |
       |          | git add -A                              |
-      |          | git stash                               |
+      |          | git stash -m "Git Town WIP"             |
       |          | git checkout main                       |
       | main     | git rebase origin/main --no-update-refs |
       |          | git checkout branch-2                   |
@@ -42,10 +42,10 @@ Feature: using the "compress" strategy, sync a branch with unmerged commits whos
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND       |
-      | branch-2 | git add -A    |
-      |          | git stash     |
-      |          | git stash pop |
+      | BRANCH   | COMMAND                     |
+      | branch-2 | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git stash pop               |
     And the current branch is now "branch-2"
     And the uncommitted file still exists
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/happy_path.feature
@@ -23,7 +23,7 @@ Feature: using the "compress" strategy, sync a branch whose tracking branch was 
       | BRANCH    | COMMAND                                 |
       | feature-1 | git fetch --prune --tags                |
       |           | git add -A                              |
-      |           | git stash                               |
+      |           | git stash -m "Git Town WIP"             |
       |           | git checkout main                       |
       | main      | git rebase origin/main --no-update-refs |
       |           | git branch -D feature-1                 |
@@ -46,7 +46,7 @@ Feature: using the "compress" strategy, sync a branch whose tracking branch was 
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                             |
       | main      | git add -A                                          |
-      |           | git stash                                           |
+      |           | git stash -m "Git Town WIP"                         |
       |           | git reset --hard {{ sha 'initial commit' }}         |
       |           | git branch feature-1 {{ sha 'feature-1 commit B' }} |
       |           | git checkout feature-1                              |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/unmerged_local_commits.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/unmerged_local_commits.feature
@@ -20,7 +20,7 @@ Feature: using the "compress" strategy, sync a branch with unshipped local chang
       | BRANCH  | COMMAND                                 |
       | shipped | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout shipped                    |
@@ -39,7 +39,7 @@ Feature: using the "compress" strategy, sync a branch with unshipped local chang
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                                  |
       | shipped | git add -A                                               |
-      |         | git stash                                                |
+      |         | git stash -m "Git Town WIP"                              |
       |         | git checkout main                                        |
       | main    | git reset --hard {{ sha 'initial commit' }}              |
       |         | git checkout shipped                                     |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
@@ -20,7 +20,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
@@ -21,7 +21,7 @@ Feature: while syncing using the "compress" strategy, handle conflicts between t
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -20,7 +20,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/local_repo/conflict_feature_branch_vs_main_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/local_repo/conflict_feature_branch_vs_main_branch.feature
@@ -17,7 +17,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                       |
       | feature | git add -A                    |
-      |         | git stash                     |
+      |         | git stash -m "Git Town WIP"   |
       |         | git merge --no-edit --ff main |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/tracking_branch_deleted.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/tracking_branch_deleted.feature
@@ -22,7 +22,7 @@ Feature: sync a branch whose tracking branch was shipped in offline mode
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                   |
       | feature-1 | git add -A                                |
-      |           | git stash                                 |
+      |           | git stash -m "Git Town WIP"               |
       |           | git checkout main                         |
       | main      | git rebase origin/main --no-update-refs   |
       |           | git checkout feature-1                    |
@@ -36,10 +36,10 @@ Feature: sync a branch whose tracking branch was shipped in offline mode
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH    | COMMAND       |
-      | feature-1 | git add -A    |
-      |           | git stash     |
-      |           | git stash pop |
+      | BRANCH    | COMMAND                     |
+      | feature-1 | git add -A                  |
+      |           | git stash -m "Git Town WIP" |
+      |           | git stash pop               |
     And the current branch is now "feature-1"
     And the uncommitted file still exists
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/happy_path.feature
@@ -20,7 +20,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
       | BRANCH | COMMAND                                 |
       | alpha  | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git checkout main                       |
       | main   | git rebase origin/main --no-update-refs |
       |        | git checkout alpha                      |
@@ -50,7 +50,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | alpha  | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git reset --hard {{ sha 'folder commit' }}      |
       |        | git push --force-with-lease --force-if-includes |
       |        | git checkout beta                               |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/with_conflict.feature
@@ -21,7 +21,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
       | BRANCH  | COMMAND                                 |
       | current | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout current                    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
@@ -20,7 +20,7 @@ Feature: sync a branch with unmerged commits whose tracking branch was deleted
       | BRANCH   | COMMAND                                 |
       | branch-2 | git fetch --prune --tags                |
       |          | git add -A                              |
-      |          | git stash                               |
+      |          | git stash -m "Git Town WIP"             |
       |          | git checkout main                       |
       | main     | git rebase origin/main --no-update-refs |
       |          | git checkout branch-2                   |
@@ -41,10 +41,10 @@ Feature: sync a branch with unmerged commits whose tracking branch was deleted
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND       |
-      | branch-2 | git add -A    |
-      |          | git stash     |
-      |          | git stash pop |
+      | BRANCH   | COMMAND                     |
+      | branch-2 | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git stash pop               |
     And the current branch is now "branch-2"
     And the uncommitted file still exists
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/happy_path.feature
@@ -21,7 +21,7 @@ Feature: sync a branch whose tracking branch was shipped
       | BRANCH    | COMMAND                                 |
       | feature-1 | git fetch --prune --tags                |
       |           | git add -A                              |
-      |           | git stash                               |
+      |           | git stash -m "Git Town WIP"             |
       |           | git checkout main                       |
       | main      | git rebase origin/main --no-update-refs |
       |           | git branch -D feature-1                 |
@@ -46,7 +46,7 @@ Feature: sync a branch whose tracking branch was shipped
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                           |
       | feature-2 | git add -A                                        |
-      |           | git stash                                         |
+      |           | git stash -m "Git Town WIP"                       |
       |           | git checkout main                                 |
       | main      | git reset --hard {{ sha 'initial commit' }}       |
       |           | git branch feature-1 {{ sha 'feature-1 commit' }} |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/unshipped_local_changes.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/unshipped_local_changes.feature
@@ -19,7 +19,7 @@ Feature: sync a branch with unshipped local changes whose tracking branch was de
       | BRANCH  | COMMAND                                 |
       | shipped | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout shipped                    |
@@ -38,7 +38,7 @@ Feature: sync a branch with unshipped local changes whose tracking branch was de
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                                  |
       | shipped | git add -A                                               |
-      |         | git stash                                                |
+      |         | git stash -m "Git Town WIP"                              |
       |         | git checkout main                                        |
       | main    | git reset --hard {{ sha 'initial commit' }}              |
       |         | git checkout shipped                                     |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
@@ -18,7 +18,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout feature                    |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
@@ -19,7 +19,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -18,7 +18,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -18,7 +18,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
     And Git Town prints the error:

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/local_repo/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/local_repo/conflict_feature_vs_main.feature
@@ -19,7 +19,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                          |
       | feature | git add -A                       |
-      |         | git stash                        |
+      |         | git stash -m "Git Town WIP"      |
       |         | git rebase main --no-update-refs |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/subfolder/subfolder_only_on_feature/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/subfolder/subfolder_only_on_feature/happy_path.feature
@@ -21,7 +21,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
       | BRANCH | COMMAND                                         |
       | alpha  | git fetch --prune --tags                        |
       |        | git add -A                                      |
-      |        | git stash                                       |
+      |        | git stash -m "Git Town WIP"                     |
       |        | git checkout main                               |
       | main   | git rebase origin/main --no-update-refs         |
       |        | git checkout alpha                              |
@@ -47,7 +47,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                               |
       | alpha  | git add -A                                            |
-      |        | git stash                                             |
+      |        | git stash -m "Git Town WIP"                           |
       |        | git reset --hard {{ sha-before-run 'folder commit' }} |
       |        | git push --force-with-lease --force-if-includes       |
       |        | git checkout beta                                     |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
@@ -21,7 +21,7 @@ Feature: sync a branch with unmerged commits whose tracking branch was deleted
       | BRANCH   | COMMAND                                 |
       | branch-2 | git fetch --prune --tags                |
       |          | git add -A                              |
-      |          | git stash                               |
+      |          | git stash -m "Git Town WIP"             |
       |          | git checkout main                       |
       | main     | git rebase origin/main --no-update-refs |
       |          | git checkout branch-2                   |
@@ -42,10 +42,10 @@ Feature: sync a branch with unmerged commits whose tracking branch was deleted
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND       |
-      | branch-2 | git add -A    |
-      |          | git stash     |
-      |          | git stash pop |
+      | BRANCH   | COMMAND                     |
+      | branch-2 | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git stash pop               |
     And the current branch is now "branch-2"
     And the uncommitted file still exists
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/happy_path.feature
@@ -22,7 +22,7 @@ Feature: sync a branch whose tracking branch was shipped
       | BRANCH    | COMMAND                                 |
       | feature-1 | git fetch --prune --tags                |
       |           | git add -A                              |
-      |           | git stash                               |
+      |           | git stash -m "Git Town WIP"             |
       |           | git checkout main                       |
       | main      | git rebase origin/main --no-update-refs |
       |           | git rebase --onto main feature-1        |
@@ -46,7 +46,7 @@ Feature: sync a branch whose tracking branch was shipped
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                           |
       | main      | git add -A                                        |
-      |           | git stash                                         |
+      |           | git stash -m "Git Town WIP"                       |
       |           | git reset --hard {{ sha 'initial commit' }}       |
       |           | git branch feature-1 {{ sha 'feature-1 commit' }} |
       |           | git checkout feature-1                            |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/unmerged_local_commits.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/unmerged_local_commits.feature
@@ -20,7 +20,7 @@ Feature: sync a branch with unshipped local changes whose tracking branch was de
       | BRANCH  | COMMAND                                 |
       | shipped | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git checkout shipped                    |
@@ -39,7 +39,7 @@ Feature: sync a branch with unshipped local changes whose tracking branch was de
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                       |
       | shipped | git add -A                                    |
-      |         | git stash                                     |
+      |         | git stash -m "Git Town WIP"                   |
       |         | git checkout main                             |
       | main    | git reset --hard {{ sha 'initial commit' }}   |
       |         | git checkout shipped                          |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
@@ -20,7 +20,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
       |         | git add -A                                      |
-      |         | git stash                                       |
+      |         | git stash -m "Git Town WIP"                     |
       |         | git checkout main                               |
       | main    | git rebase origin/main --no-update-refs         |
       |         | git checkout feature                            |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
@@ -21,7 +21,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_main_local_vs_main_tracking.feature
@@ -19,7 +19,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
     And Git Town prints the error:

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -20,7 +20,7 @@ Feature: handle conflicts between the current feature branch and the main branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
       |         | git push                                |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -19,7 +19,7 @@ Feature: handle conflicts between the main branch and its tracking branch
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
       |         | git add -A                              |
-      |         | git stash                               |
+      |         | git stash -m "Git Town WIP"             |
       |         | git checkout main                       |
       | main    | git rebase origin/main --no-update-refs |
     And Git Town prints the error:

--- a/features/sync/current_branch/main_branch/tracking_branch/with/conflict.feature
+++ b/features/sync/current_branch/main_branch/tracking_branch/with/conflict.feature
@@ -14,7 +14,7 @@ Feature: handle conflicts between the main branch and its tracking branch when s
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/main_branch/tracking_branch/with/sync_current_main_branch.feature
+++ b/features/sync/current_branch/main_branch/tracking_branch/with/sync_current_main_branch.feature
@@ -14,7 +14,7 @@ Feature: sync the main branch
       | BRANCH | COMMAND                                 |
       | main   | git fetch --prune --tags                |
       |        | git add -A                              |
-      |        | git stash                               |
+      |        | git stash -m "Git Town WIP"             |
       |        | git rebase origin/main --no-update-refs |
       |        | git push                                |
       |        | git push --tags                         |
@@ -30,10 +30,10 @@ Feature: sync the main branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | main   | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | main   | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And the current branch is still "main"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE       |

--- a/features/sync/current_branch/observed_branch/local_repo/happy_path.feature
+++ b/features/sync/current_branch/observed_branch/local_repo/happy_path.feature
@@ -15,10 +15,10 @@ Feature: sync the current observed branch in a local repo
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | other  | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | other  | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And all branches are now synchronized
     And the current branch is still "other"
     And the uncommitted file still exists
@@ -28,10 +28,10 @@ Feature: sync the current observed branch in a local repo
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | other  | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | other  | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And the current branch is still "other"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/observed_branch/tracking_branch/with/conflict.feature
+++ b/features/sync/current_branch/observed_branch/tracking_branch/with/conflict.feature
@@ -18,7 +18,7 @@ Feature: handle conflicts between the current observed branch and its tracking b
       | BRANCH   | COMMAND                                     |
       | observed | git fetch --prune --tags                    |
       |          | git add -A                                  |
-      |          | git stash                                   |
+      |          | git stash -m "Git Town WIP"                 |
       |          | git rebase origin/observed --no-update-refs |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/perennial_branch/local_repo/happy_path.feature
+++ b/features/sync/current_branch/perennial_branch/local_repo/happy_path.feature
@@ -16,10 +16,10 @@ Feature: sync the current perennial branch in a local repo
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | qa     | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | qa     | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And all branches are now synchronized
     And the current branch is still "qa"
     And the uncommitted file still exists
@@ -28,10 +28,10 @@ Feature: sync the current perennial branch in a local repo
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND       |
-      | qa     | git add -A    |
-      |        | git stash     |
-      |        | git stash pop |
+      | BRANCH | COMMAND                     |
+      | qa     | git add -A                  |
+      |        | git stash -m "Git Town WIP" |
+      |        | git stash pop               |
     And the current branch is still "qa"
     And these commits exist now
       | BRANCH | LOCATION | MESSAGE      |

--- a/features/sync/current_branch/perennial_branch/tracking/exists/conflict.feature
+++ b/features/sync/current_branch/perennial_branch/tracking/exists/conflict.feature
@@ -19,7 +19,7 @@ Feature: handle conflicts between the current perennial branch and its tracking 
       | BRANCH | COMMAND                               |
       | qa     | git fetch --prune --tags              |
       |        | git add -A                            |
-      |        | git stash                             |
+      |        | git stash -m "Git Town WIP"           |
       |        | git rebase origin/qa --no-update-refs |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/local_repo/happy_path.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/local_repo/happy_path.feature
@@ -17,7 +17,7 @@ Feature: sync the current prototype branch in a local repo
     Then Git Town runs the commands
       | BRANCH    | COMMAND                       |
       | prototype | git add -A                    |
-      |           | git stash                     |
+      |           | git stash -m "Git Town WIP"   |
       |           | git merge --no-edit --ff main |
       |           | git stash pop                 |
     And these commits exist now
@@ -35,7 +35,7 @@ Feature: sync the current prototype branch in a local repo
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                              |
       | prototype | git add -A                                           |
-      |           | git stash                                            |
+      |           | git stash -m "Git Town WIP"                          |
       |           | git reset --hard {{ sha-before-run 'local commit' }} |
       |           | git stash pop                                        |
     And the current branch is still "prototype"

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/with/conflict.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/with/conflict.feature
@@ -18,7 +18,7 @@ Feature: handle conflicts between the current prototype branch and its tracking 
       | BRANCH    | COMMAND                                   |
       | prototype | git fetch --prune --tags                  |
       |           | git add -A                                |
-      |           | git stash                                 |
+      |           | git stash -m "Git Town WIP"               |
       |           | git checkout main                         |
       | main      | git rebase origin/main --no-update-refs   |
       |           | git checkout prototype                    |

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/local_repo/happy_path.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/local_repo/happy_path.feature
@@ -18,7 +18,7 @@ Feature: sync the current prototype branch in a local repo
     Then Git Town runs the commands
       | BRANCH    | COMMAND                          |
       | prototype | git add -A                       |
-      |           | git stash                        |
+      |           | git stash -m "Git Town WIP"      |
       |           | git rebase main --no-update-refs |
       |           | git stash pop                    |
     And all branches are now synchronized
@@ -35,7 +35,7 @@ Feature: sync the current prototype branch in a local repo
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                              |
       | prototype | git add -A                                           |
-      |           | git stash                                            |
+      |           | git stash -m "Git Town WIP"                          |
       |           | git reset --hard {{ sha-before-run 'local commit' }} |
       |           | git stash pop                                        |
     And the current branch is still "prototype"

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/with/conflict.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/with/conflict.feature
@@ -19,7 +19,7 @@ Feature: handle conflicts between the current prototype branch and its tracking 
       | BRANCH    | COMMAND                                      |
       | prototype | git fetch --prune --tags                     |
       |           | git add -A                                   |
-      |           | git stash                                    |
+      |           | git stash -m "Git Town WIP"                  |
       |           | git checkout main                            |
       | main      | git rebase origin/main --no-update-refs      |
       |           | git checkout prototype                       |

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -819,7 +819,7 @@ func (self *Commands) Stash(runner gitdomain.Runner) error {
 	if err != nil {
 		return err
 	}
-	return runner.Run("git", "stash")
+	return runner.Run("git", "stash", "-m", "Git Town WIP")
 }
 
 // StashSize provides the number of stashes in this repository.


### PR DESCRIPTION
Stashing open changes away with a commit message allows users to identify Git stash entries created by Git Town.