### PR TITLE
Pop stash even if encountering conflicts

### DIFF
--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -19,23 +19,29 @@ Feature: conflicts between uncommitted changes and the main branch
       |          | git stash                |
       |          | git checkout -b new main |
       | new      | git stash pop            |
-    And Git Town prints the error:
-      """
-      conflicts between your uncommmitted changes and the main branch
-      """
-    And file "conflicting_file" still contains unresolved conflicts
+      |          | git stash drop           |
+    And file "conflicting_file" now contains unresolved conflicts
 
+  @this
   Scenario: undo with unresolved merge conflict
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                              |
-      | new      | git add -A                                           |
-      |          | git commit -m "Committing open changes to undo them" |
-      |          | git checkout existing                                |
-      | existing | git branch -D new                                    |
-      |          | git stash pop                                        |
+      | BRANCH   | COMMAND               |
+      | new      | git add -A            |
+      |          | git stash             |
+      |          | git checkout existing |
+      | existing | git branch -D new     |
+      |          | git stash pop         |
+      |          | git stash drop        |
     And the current branch is now "existing"
-    And file "conflicting_file" still has content "conflicting content"
+    And file "conflicting_file" now has content:
+      """
+      <<<<<<< Updated upstream
+      main content
+      =======
+      conflicting content
+      >>>>>>> Stashed changes
+      """
 
   Scenario: resolve and undo
     Given I resolve the conflict in "conflicting_file"

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -32,13 +32,13 @@ Feature: conflicts between uncommitted changes and the main branch
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH   | COMMAND               |
-      | new      | git add -A            |
-      |          | git stash             |
-      |          | git checkout existing |
-      | existing | git branch -D new     |
-      |          | git stash pop         |
-      |          | git stash drop        |
+      | BRANCH   | COMMAND                     |
+      | new      | git add -A                  |
+      |          | git stash -m "Git Town WIP" |
+      |          | git checkout existing       |
+      | existing | git branch -D new           |
+      |          | git stash pop               |
+      |          | git stash drop              |
     And the current branch is now "existing"
     And file "conflicting_file" still has content:
       """

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -28,6 +28,10 @@ Feature: conflicts between uncommitted changes and the main branch
       conflicting content
       >>>>>>> Stashed changes
       """
+    And Git Town prints:
+      """
+      conflicts between your uncommmitted changes and the main branch
+      """
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -20,6 +20,10 @@ Feature: conflicts between uncommitted changes and the main branch
       |          | git checkout -b new main    |
       | new      | git stash pop               |
       |          | git stash drop              |
+    And Git Town prints:
+      """
+      conflicts between your uncommmitted changes and the main branch
+      """
     And file "conflicting_file" now has content:
       """
       <<<<<<< Updated upstream
@@ -27,10 +31,6 @@ Feature: conflicts between uncommitted changes and the main branch
       =======
       conflicting content
       >>>>>>> Stashed changes
-      """
-    And Git Town prints:
-      """
-      conflicts between your uncommmitted changes and the main branch
       """
 
   Scenario: undo

--- a/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/uncommitted_changes/conflicts/uncommitted_changes_vs_main.feature
@@ -59,29 +59,4 @@ Feature: conflicts between uncommitted changes and the main branch
   Scenario: resolve and continue
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
-    <<<<<<< HEAD
     Then Git Town runs no commands
-    =======
-    Then Git Town runs the commands
-      | BRANCH | COMMAND        |
-      | new    | git stash drop |
-    And the current branch is now "new"
-    And the initial commits exist now
-    And file "conflicting_file" now has content "resolved content"
-
-  Scenario: resolve, continue, and undo undoes the hack but cannot get back to the original branch due to merge conflicts
-    Given I resolve the conflict in "conflicting_file"
-    And I run "git-town continue" and close the editor
-    When I run "git-town undo"
-    Then Git Town runs the commands
-      | BRANCH   | COMMAND                     |
-      | new      | git add -A                  |
-      |          | git stash -m "Git Town WIP" |
-      |          | git checkout existing       |
-      | existing | git branch -D new           |
-      |          | git stash pop               |
-    And the current branch is now "existing"
-    And the initial commits exist now
-    And the initial branches and lineage exist now
-    And file "conflicting_file" now has content "resolved content"
->>>>>>> main

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -576,7 +576,7 @@ func (self *Commands) PopStash(runner gitdomain.Runner) error {
 	if err != nil {
 		_ = runner.Run("git", "stash", "drop")
 	}
-	return nil
+	return err
 }
 
 // PreviouslyCheckedOutBranch provides the name of the branch that was previously checked out in this repo.

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -572,7 +572,11 @@ func (self *Commands) OriginHead(querier gitdomain.Querier) Option[gitdomain.Loc
 
 // PopStash restores stashed-away changes into the workspace.
 func (self *Commands) PopStash(runner gitdomain.Runner) error {
-	return runner.Run("git", "stash", "pop")
+	err := runner.Run("git", "stash", "pop")
+	if err != nil {
+		_ = runner.Run("git", "stash", "drop")
+	}
+	return nil
 }
 
 // PreviouslyCheckedOutBranch provides the name of the branch that was previously checked out in this repo.

--- a/internal/vm/opcodes/stash_pop.go
+++ b/internal/vm/opcodes/stash_pop.go
@@ -1,8 +1,6 @@
 package opcodes
 
 import (
-	"errors"
-
 	"github.com/git-town/git-town/v17/internal/messages"
 	"github.com/git-town/git-town/v17/internal/vm/shared"
 )
@@ -19,7 +17,7 @@ func (self *StashPop) ContinueProgram() []shared.Opcode {
 func (self *StashPop) Run(args shared.RunArgs) error {
 	err := args.Git.PopStash(args.Frontend)
 	if err != nil {
-		return errors.New(messages.DiffConflictWithMain)
+		args.FinalMessages.Add(messages.DiffConflictWithMain)
 	}
 	return nil
 }

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -317,16 +317,6 @@ func defineSteps(sc *godog.ScenarioContext) {
 		return nil
 	})
 
-	sc.Step(`^file "([^"]+)" still contains unresolved conflicts$`, func(ctx context.Context, name string) error {
-		state := ctx.Value(keyScenarioState).(*ScenarioState)
-		devRepo := state.fixture.DevRepo.GetOrPanic()
-		content := devRepo.FileContent(name)
-		if !strings.Contains(content, "<<<<<<<") {
-			return fmt.Errorf("file %q does not contain unresolved conflicts", name)
-		}
-		return nil
-	})
-
 	sc.Step(`^file "([^"]+)" with content$`, func(ctx context.Context, name string, content *godog.DocString) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -297,12 +297,22 @@ func defineSteps(sc *godog.ScenarioContext) {
 		return err
 	})
 
+	sc.Step(`^file "([^"]*)" (?:now|still) has content:$`, func(ctx context.Context, file string, expectedContent *godog.DocString) error {
+		state := ctx.Value(keyScenarioState).(*ScenarioState)
+		devRepo := state.fixture.DevRepo.GetOrPanic()
+		actualContent := strings.TrimSpace(devRepo.FileContent(file))
+		if expectedContent.Content != actualContent {
+			return fmt.Errorf("file content does not match\n\nEXPECTED:\n%q\n\nACTUAL:\n\n%q\n----------------------------", expectedContent.Content, actualContent)
+		}
+		return nil
+	})
+
 	sc.Step(`^file "([^"]*)" (?:now|still) has content "([^"]*)"$`, func(ctx context.Context, file, expectedContent string) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		actualContent := devRepo.FileContent(file)
 		if expectedContent != actualContent {
-			return fmt.Errorf("file content does not match\n\nEXPECTED: %q\n\nACTUAL:\n\n%q\n----------------------------", expectedContent, actualContent)
+			return fmt.Errorf("file content does not match\n\nEXPECTED:\n%s\n\nACTUAL:\n\n%s\n----------------------------", expectedContent, actualContent)
 		}
 		return nil
 	})


### PR DESCRIPTION
When the uncommitted changes that got stashed away conflicts with the branch that Git Town ends on, it leaves the stashed away changes on the stash. Technically the user should run `git town continue` to try to pop the stash again and finish the command. In practice, this is super easy to forget, and when using Git Town for a while the Git stash accumulates entries. This PR changes the behavior of Git Town commands so that they never leave the entry they created on the stash.

Following the principle of least surprise, this improves the ergonomics of Git Town commands.