### PR TITLE
Update Node to v22

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -11,9 +11,9 @@ golangci-lint 1.62.2
 goreleaser 1.26.2
 govulncheck 1.1.3
 mdbook 0.4.43
-node 20.17.0
-npm 20.17.0
-npx 20.17.0
+node 22.12.0
+npm 22.12.0
+npx 22.12.0
 scc 3.4.0
 shellcheck system 0.10.0
 shfmt 3.10.0


### PR DESCRIPTION
Node >= v21 is required to use glob syntax with the Node test runner. See #4487.