### PR TITLE
tools/tests_sorted: add isTestFunc() and tRunSubtestNames()

### DIFF
--- a/tools/tests_sorted/lint_func.go
+++ b/tools/tests_sorted/lint_func.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"go/ast"
+
+	"github.com/git-town/git-town/tools/tests_sorted/matcher"
+)
+
+// isTestFunc returns true if a given funcType describes a test function/helper.
+//
+// `ast.FuncType` does not differentiate between top-level functions, function
+// literals, or between tests or test helpers. This is merely a signature check.
+// The main objective of isTestFunc is to select test functions that are
+// compatible with `tRunSubtestNames` as we make an assumption about the first
+// parameter being `t *testing.T` named `t` specifically.
+func isTestFunc(funcType *ast.FuncType) bool {
+	firstParam := &matcher.FieldMatcher{
+		Name: "t",
+		TypeMatcher: &matcher.PointerMatcher{
+			InnerMatcher: &matcher.IdentSelectorMatcher{
+				Namespace: "testing",
+				Name:      "T",
+			},
+		},
+	}
+	m := &matcher.FieldListPrefixMatcher{
+		Prefix: []matcher.PositionalFieldMatcher{firstParam},
+	}
+	return m.Match(funcType.Params).Success()
+}
+
+// tRunSubtestNames returns a list of subtest names from `t.Run(...)`
+// invocations.
+func tRunSubtestNames(statements []ast.Stmt) ([]string, error) {
+	var subtests []string
+	testNameExtractor := &matcher.FirstStringArgFromFuncCallExtractor{
+		FuncMatcher: &matcher.IdentSelectorMatcher{
+			Namespace: "t",
+			Name:      "Run",
+		},
+	}
+	for _, stmt := range statements {
+		expr, ok := stmt.(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+		subtest, r, err := testNameExtractor.Extract(expr.X)
+		if err != nil {
+			// Failure to extract should be reported.
+			// This may indicate a linter bug.
+			return nil, err
+		}
+		if !r.Success() {
+			continue
+		}
+		subtests = append(subtests, subtest)
+	}
+	return subtests, nil
+}

--- a/tools/tests_sorted/lint_func_test.go
+++ b/tools/tests_sorted/lint_func_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func funcType(t *testing.T, funcText string) *ast.FuncType {
+	expr, err := parser.ParseExpr(funcText)
+	must.NoError(t, err)
+	return expr.(*ast.FuncType)
+}
+
+func TestIsTestFunc(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc string
+		expr string
+		want bool
+	}{
+		{
+			desc: "MultipleParameters",
+			expr: `func(t *testing.T, x bool)`,
+			want: true,
+		}, {
+			desc: "MultipleTParameters",
+			expr: `func(t *testing.T, x *testing.T)`,
+			want: true,
+		}, {
+			desc: "NotT",
+			expr: `func(f *testing.T)`,
+			want: false,
+		}, {
+			desc: "NotTestingT",
+			expr: `func(t *string)`,
+			want: false,
+		}, {
+			desc: "SingleParameter",
+			expr: `func(t *testing.T)`,
+			want: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fType := funcType(t, tc.expr)
+
+			got := isTestFunc(fType)
+
+			must.Eq(t, tc.want, got)
+		})
+	}
+}
+
+func funcStatements(t *testing.T, funcText string) []ast.Stmt {
+	expr, err := parser.ParseExpr(funcText)
+	must.NoError(t, err)
+	funcLit := expr.(*ast.FuncLit)
+	return funcLit.Body.List
+}
+
+func TestTRunSubtestNames(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc             string
+		expr             string
+		wantSubtestNames []string
+	}{
+		{
+			desc: "Multiple",
+			expr: `
+				func() {
+					t.Run("foo")
+					t.Run("bar")
+				}`,
+			wantSubtestNames: []string{"foo", "bar"},
+		},
+		{
+			desc: "Single t.Run",
+			expr: `
+				func() {
+					t.Run("foo")
+				}`,
+			wantSubtestNames: []string{"foo"},
+		},
+		{
+			desc: "Skips non-t.Run",
+			expr: `
+				func() {
+					foo.Run("foo")
+				}`,
+			wantSubtestNames: nil,
+		},
+		{
+			desc: "Skips t.not-Run",
+			expr: `
+				func() {
+					t.Foo("foo")
+				}`,
+			wantSubtestNames: nil,
+		},
+		{
+			desc: "Skips non-literals",
+			expr: `
+				func() {
+					t.Run(""+"")
+				}`,
+			wantSubtestNames: nil,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			statements := funcStatements(t, tc.expr)
+
+			got, err := tRunSubtestNames(statements)
+
+			must.NoError(t, err)
+			must.Eq(t, tc.wantSubtestNames, got)
+		})
+	}
+}

--- a/tools/tests_sorted/matcher/matcher_test.go
+++ b/tools/tests_sorted/matcher/matcher_test.go
@@ -322,8 +322,9 @@ func TestFirstStringArgFromFuncCallExtractor(t *testing.T) {
 					FuncMatcher: tc.funcMatcher,
 				}
 
-				_, r := e.Extract(expr)
+				_, r, err := e.Extract(expr)
 
+				must.NoError(t, err)
 				must.False(t, r.Success())
 				must.Eq(t, tc.wantReason, r.FailureReason())
 			})
@@ -340,10 +341,9 @@ func TestFirstStringArgFromFuncCallExtractor(t *testing.T) {
 				FuncMatcher: &trueMatcher{},
 			}
 
-			_, r := e.Extract(expr)
+			_, _, err = e.Extract(expr)
 
-			must.False(t, r.Success())
-			must.StrHasPrefix(t, "the first call argument is an invalid string literal:", r.FailureReason())
+			must.ErrorContains(t, err, "the first call argument is an invalid string literal:")
 		})
 	})
 
@@ -354,8 +354,9 @@ func TestFirstStringArgFromFuncCallExtractor(t *testing.T) {
 			FuncMatcher: &trueMatcher{},
 		}
 
-		arg, r := e.Extract(expr)
+		arg, r, err := e.Extract(expr)
 
+		must.NoError(t, err)
 		must.True(t, r.Success())
 		must.Eq(t, "arg1", arg)
 	})


### PR DESCRIPTION
Both will be useful for implementing tools/tests_sorted linter.

Also return Extract error as a separate return value instead of mixing it up with a `matcher.Result`. These are two different types covering two distinct situations: code error vs not-a-match.