### PR TITLE
Update spelling of Bitbucket Data Center

### DIFF
--- a/features/propose/edge_cases/unsupported_hosting_service.feature
+++ b/features/propose/edge_cases/unsupported_hosting_service.feature
@@ -15,7 +15,7 @@ Feature: unsupported hosting platform
 
       This command requires hosting on one of these services:
       * Bitbucket
-      * Bitbucket datacenter
+      * Bitbucket Data Center
       * GitHub
       * GitLab
       * Gitea

--- a/features/repo/edge_cases/unsupported_hosting_service.feature
+++ b/features/repo/edge_cases/unsupported_hosting_service.feature
@@ -9,7 +9,7 @@ Feature: unsupported hosting platform
 
       This command requires hosting on one of these services:
       * Bitbucket
-      * Bitbucket datacenter
+      * Bitbucket Data Center
       * GitHub
       * GitLab
       * Gitea

--- a/internal/cli/dialog/hosting.go
+++ b/internal/cli/dialog/hosting.go
@@ -29,11 +29,11 @@ func HostingPlatform(existingValue Option[configdomain.HostingPlatform], inputs 
 		},
 		{
 			Data: Some(configdomain.HostingPlatformBitbucket),
-			Text: "BitBucket",
+			Text: "Bitbucket",
 		},
 		{
 			Data: Some(configdomain.HostingPlatformBitbucketDatacenter),
-			Text: "BitBucket-Datacenter",
+			Text: "Bitbucket Data Center",
 		},
 		{
 			Data: Some(configdomain.HostingPlatformGitea),

--- a/internal/hosting/detect_test.go
+++ b/internal/hosting/detect_test.go
@@ -31,7 +31,7 @@ func TestDetect(t *testing.T) {
 		must.Eq(t, want, have)
 	})
 
-	t.Run("custom URL, override to BitBucket Datacenter", func(t *testing.T) {
+	t.Run("custom URL, override to Bitbucket Data Center", func(t *testing.T) {
 		t.Parallel()
 		url, has := giturl.Parse("username@custom.org:git-town/docs.git").Get()
 		must.True(t, has)

--- a/internal/hosting/hostingdomain/unsupported_service_error.go
+++ b/internal/hosting/hostingdomain/unsupported_service_error.go
@@ -8,7 +8,7 @@ func UnsupportedServiceError() error {
 
 This command requires hosting on one of these services:
 * Bitbucket
-* Bitbucket datacenter
+* Bitbucket Data Center
 * GitHub
 * GitLab
 * Gitea`)

--- a/website/src/preferences/bitbucket-app-password.md
+++ b/website/src/preferences/bitbucket-app-password.md
@@ -17,10 +17,10 @@ the menu on the left `App passwords`. You need to enable these permissions:
 - repository: read and write
 - pull requests: read and write
 
-## Bitbucket Datacenter
+## Bitbucket Data Center
 
-Git Town can interact with Bitbucket Datacenter in your name. To do so, Git Town
-needs your [Bitbucket username](bitbucket-username.md) and an
+Git Town can interact with Bitbucket Data Center in your name. To do so, Git
+Town needs your [Bitbucket username](bitbucket-username.md) and an
 [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html).
 
 An HTTP access token is not the password of your Bitbucket account. It's a

--- a/website/src/preferences/bitbucket-username.md
+++ b/website/src/preferences/bitbucket-username.md
@@ -5,7 +5,7 @@ pull requests as branches get created, shipped, or deleted. To do so, Git Town
 needs your Bitbucket username and an
 [Bitbucket App Password](bitbucket-app-password.md).
 
-Bitbucket Datacenter capabilities are a little more restricted but the process
+Bitbucket Data Center capabilities are a little more restricted but the process
 is the same as for Bitbucket Cloud.
 
 ## config file


### PR DESCRIPTION
The product name is "Data Center", not "Datacenter".

See: https://www.atlassian.com/enterprise/data-center/bitbucket

~~@kevgo Ideally we would allow `bitbucket-data-center` as a valid hosting platform value, but I don't know how to do it without breaking old configs. Have we ever deprecated a specific config value before? Maybe we should just change it and special case `bitbucket-datacenter` to also parse to `bitbucket-data-center`.~~