### PR TITLE
tools/tests_sorted: add lintFuncDecl and tests

### DIFF
--- a/tools/tests_sorted/issue.go
+++ b/tools/tests_sorted/issue.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"go/token"
+	"strings"
+)
+
+type issue struct {
+	expected []string       // the expected order of subtests
+	position token.Position // file, line, and column of the issue
+}
+
+func (self issue) String() string {
+	return fmt.Sprintf(
+		"%s:%d:%d unsorted subtests, expected order:\n\n%s\n\n",
+		self.position.Filename,
+		self.position.Line,
+		self.position.Column,
+		strings.Join(self.expected, "\n"),
+	)
+}
+
+type Issues []issue
+
+func (self Issues) String() string {
+	result := strings.Builder{}
+	for _, issue := range self {
+		result.WriteString(issue.String())
+	}
+	return result.String()
+}


### PR DESCRIPTION
Unlike tools/structs_sorted Issues is returned directly. These slices will be concatenated at a higher level. This API is much simpler to read than passing around a mutable pointer to a slice.