### PR TITLE
Docs: Update `go get` URLs to use correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://github.com/git-town/git-town/actions/workflows/unit.yml/badge.svg" alt="unit test status">
   <img src="https://github.com/git-town/git-town/actions/workflows/lint_docs.yml/badge.svg" alt="linters and documentation test status">
   <img src="https://github.com/git-town/git-town/actions/workflows/windows.yml/badge.svg" alt="windows tests">
-  <a href="https://goreportcard.com/report/github.com/git-town/git-town"><img src="https://goreportcard.com/badge/github.com/git-town/git-town" alt="Go report card status"></a>
+  <a href="https://goreportcard.com/report/github.com/git-town/git-town"><img src="https://goreportcard.com/badge/github.com/git-town/git-town/v17" alt="Go report card status"></a>
   <img src="https://api.netlify.com/api/v1/badges/c2ea5505-be48-42e5-bb8a-b807d18d99ed/deploy-status" alt="Netlify deploy status">
 </p>
 

--- a/website/src/install.md
+++ b/website/src/install.md
@@ -96,7 +96,7 @@ If you have the [Go compiler](https://go.dev) installed, you can compile the
 latest version of Git Town from source by running:
 
 ```
-go get github.com/git-town/git-town
+go get github.com/git-town/git-town/v17
 ```
 
 ## New releases


### PR DESCRIPTION
I discovered this when debugging why the Go Report Card was out of date. It turns out that they fetch the latest info the same way that `go get` does, which results in an outdated version being analyzed.

- https://pkg.go.dev/github.com/git-town/git-town shows v7.3.0+incompatible
- https://goreportcard.com/report/github.com/git-town/git-town shows v6.0.2+incompatible
- Changing `github.com/git-town/git-town` -> `github.com/git-town/git-town/v17` fixes both issues.