### PR TITLE
tools/tests_sorted: make PositionalFields a normal function

### DIFF
--- a/tools/tests_sorted/matcher/matcher.go
+++ b/tools/tests_sorted/matcher/matcher.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"iter"
 	"strconv"
 )
 
@@ -58,7 +57,7 @@ type FieldListMatcher interface {
 	Match(fields *ast.FieldList) Result
 }
 
-// PositionalFields yields (name, field) for each name in ast.FieldList in logical order.
+// PositionalFields returns (name, field) for each name in ast.FieldList in logical order.
 // For example func(a, b string, c int) will result in
 // - fields[0]: ast.Field{Names: []{"a", "b"}}
 // - fields[1]: ast.Field{Names: []{"c"}}
@@ -66,18 +65,14 @@ type FieldListMatcher interface {
 // - ("a", fields[0])
 // - ("b", fields[0])
 // - ("c", fields[1])
-func PositionalFields(fields *ast.FieldList) iter.Seq2[int, PositionalField] {
-	return func(yield func(int, PositionalField) bool) {
-		i := 0
-		for _, field := range fields.List {
-			for _, name := range field.Names {
-				if !yield(i, PositionalField{Name: name, Field: field}) {
-					return // Stopping early.
-				}
-				i++
-			}
+func PositionalFields(fields *ast.FieldList) []PositionalField {
+	var posFields []PositionalField
+	for _, field := range fields.List {
+		for _, name := range field.Names {
+			posFields = append(posFields, PositionalField{Name: name, Field: field})
 		}
 	}
+	return posFields
 }
 
 // IdentSelectorMatcher matches ast.SelectorExpr where both the selector
@@ -148,10 +143,7 @@ type FieldListPrefixMatcher struct {
 }
 
 func (self *FieldListPrefixMatcher) Match(fields *ast.FieldList) Result {
-	var posFields []PositionalField
-	for _, field := range PositionalFields(fields) {
-		posFields = append(posFields, field)
-	}
+	posFields := PositionalFields(fields)
 	for i, fieldMatcher := range self.Prefix {
 		if i >= len(posFields) {
 			return fmtResult("not enough fields, want at least %d, got %d", len(self.Prefix), len(posFields))

--- a/tools/tests_sorted/matcher/matcher_test.go
+++ b/tools/tests_sorted/matcher/matcher_test.go
@@ -37,18 +37,12 @@ func TestPositionalFields(t *testing.T) {
 	must.NoError(t, err)
 	funcType := expr.(*ast.FuncType)
 
-	var positionalIndices []int
-	var positionalFields []PositionalField
-	for i, field := range PositionalFields(funcType.Params) {
-		positionalIndices = append(positionalIndices, i)
-		positionalFields = append(positionalFields, field)
-	}
+	posFields := PositionalFields(funcType.Params)
 
-	must.Eq(t, []int{0, 1, 2}, positionalIndices)
-	must.Eq(t, len(positionalFields), 3)
-	must.Eq(t, "a", positionalFields[0].Name.Name)
-	must.Eq(t, "b", positionalFields[1].Name.Name)
-	must.Eq(t, "c", positionalFields[2].Name.Name)
+	must.Eq(t, len(posFields), 3)
+	must.Eq(t, "a", posFields[0].Name.Name)
+	must.Eq(t, "b", posFields[1].Name.Name)
+	must.Eq(t, "c", posFields[2].Name.Name)
 }
 
 func TestIdentSelectorMatcher(t *testing.T) {


### PR DESCRIPTION
The iterator interface is unnecessary. A simple function is much simpler to use, test and understand.