### PR TITLE
Optimize all generated interpreter programs

### DIFF
--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -291,6 +291,5 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector) 
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	optimizedProgram := optimizer.Optimize(prog.Immutable())
-	return optimizedProgram
+	return optimizer.Optimize(prog.Immutable())
 }

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -22,6 +22,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -290,5 +291,6 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector) 
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	return prog.Immutable()
+	optimizedProgram := optimizer.Optimize(prog.Immutable())
+	return optimizedProgram
 }

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -20,6 +20,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -284,7 +285,8 @@ func compressProgram(data compressBranchesData) program.Program {
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	return prog.Immutable()
+	optimizedProgram := optimizer.Optimize(prog.Immutable())
+	return optimizedProgram
 }
 
 func compressBranchProgram(prog Mutable[program.Program], data compressBranchData, online configdomain.Online, initialBranch gitdomain.LocalBranchName) {

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -285,8 +285,7 @@ func compressProgram(data compressBranchesData) program.Program {
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	optimizedProgram := optimizer.Optimize(prog.Immutable())
-	return optimizedProgram
+	return optimizer.Optimize(prog.Immutable())
 }
 
 func compressBranchProgram(prog Mutable[program.Program], data compressBranchData, online configdomain.Online, initialBranch gitdomain.LocalBranchName) {

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -263,8 +263,7 @@ func deleteProgram(data deleteData, finalMessages stringslice.Collector) (runPro
 		StashOpenChanges:         hasLocalBranchToDelete && data.initialBranch != localBranchNameToDelete && data.hasOpenChanges,
 		PreviousBranchCandidates: []Option[gitdomain.LocalBranchName]{data.previousBranch, Some(data.initialBranch)},
 	})
-	optimizedProgram := optimizer.Optimize(prog.Immutable())
-	return optimizedProgram, undoProg.Immutable()
+	return optimizer.Optimize(prog.Immutable()), undoProg.Immutable()
 }
 
 func deleteFeatureBranch(prog, finalUndoProgram Mutable[program.Program], data deleteData) {

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -262,7 +263,8 @@ func deleteProgram(data deleteData, finalMessages stringslice.Collector) (runPro
 		StashOpenChanges:         hasLocalBranchToDelete && data.initialBranch != localBranchNameToDelete && data.hasOpenChanges,
 		PreviousBranchCandidates: []Option[gitdomain.LocalBranchName]{data.previousBranch, Some(data.initialBranch)},
 	})
-	return prog.Immutable(), undoProg.Immutable()
+	optimizedProgram := optimizer.Optimize(prog.Immutable())
+	return optimizedProgram, undoProg.Immutable()
 }
 
 func deleteFeatureBranch(prog, finalUndoProgram Mutable[program.Program], data deleteData) {

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -341,8 +341,7 @@ func mergeProgram(data mergeData, dryRun configdomain.DryRun) program.Program {
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	optimizedProgram := optimizer.Optimize(prog.Immutable())
-	return optimizedProgram
+	return optimizer.Optimize(prog.Immutable())
 }
 
 func validateMergeData(data mergeData) error {

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -21,6 +21,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -340,7 +341,8 @@ func mergeProgram(data mergeData, dryRun configdomain.DryRun) program.Program {
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	return prog.Immutable()
+	optimizedProgram := optimizer.Optimize(prog.Immutable())
+	return optimizedProgram
 }
 
 func validateMergeData(data mergeData) error {

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -380,8 +380,7 @@ func prependProgram(data prependData, finalMessages stringslice.Collector) progr
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	optimizedProgram := optimizer.Optimize(prog.Immutable())
-	return optimizedProgram
+	return optimizer.Optimize(prog.Immutable())
 }
 
 // provides the strategy to use to sync a branch after beaming some of its commits to its new parent branch

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -25,6 +25,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -379,7 +380,8 @@ func prependProgram(data prependData, finalMessages stringslice.Collector) progr
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	return prog.Immutable()
+	optimizedProgram := optimizer.Optimize(prog.Immutable())
+	return optimizedProgram
 }
 
 // provides the strategy to use to sync a branch after beaming some of its commits to its new parent branch

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -23,6 +23,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -341,7 +342,8 @@ func proposeProgram(repo execute.OpenRepoResult, data proposeData) program.Progr
 		ProposalBody:  data.proposalBody,
 		ProposalTitle: data.proposalTitle,
 	})
-	return prog.Immutable()
+	optimizedProgram := optimizer.Optimize(prog.Immutable())
+	return optimizedProgram
 }
 
 func validateBranchTypeToPropose(branchType configdomain.BranchType) error {

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -342,8 +342,7 @@ func proposeProgram(repo execute.OpenRepoResult, data proposeData) program.Progr
 		ProposalBody:  data.proposalBody,
 		ProposalTitle: data.proposalTitle,
 	})
-	optimizedProgram := optimizer.Optimize(prog.Immutable())
-	return optimizedProgram
+	return optimizer.Optimize(prog.Immutable())
 }
 
 func validateBranchTypeToPropose(branchType configdomain.BranchType) error {

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -319,8 +319,7 @@ func renameProgram(data renameData, finalMessages stringslice.Collector) program
 		StashOpenChanges:         false,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	optimizedProgram := optimizer.Optimize(result.Immutable())
-	return optimizedProgram
+	return optimizer.Optimize(result.Immutable())
 }
 
 func updateChildBranchProposalsToBranch(prog *program.Program, proposals []hostingdomain.Proposal, target gitdomain.LocalBranchName) {

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -22,6 +22,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -318,7 +319,8 @@ func renameProgram(data renameData, finalMessages stringslice.Collector) program
 		StashOpenChanges:         false,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	return result.Immutable()
+	optimizedProgram := optimizer.Optimize(result.Immutable())
+	return optimizedProgram
 }
 
 func updateChildBranchProposalsToBranch(prog *program.Program, proposals []hostingdomain.Proposal, target gitdomain.LocalBranchName) {

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -263,19 +263,19 @@ func determineRenameData(args []string, force configdomain.Force, repo execute.O
 }
 
 func renameProgram(data renameData, finalMessages stringslice.Collector) program.Program {
-	result := NewMutable(&program.Program{})
+	prog := NewMutable(&program.Program{})
 	data.config.CleanupLineage(data.branchesSnapshot.Branches, data.nonExistingBranches, finalMessages)
 	oldLocalBranch, hasOldLocalBranch := data.oldBranch.LocalName.Get()
 	if !hasOldLocalBranch {
-		return result.Immutable()
+		return prog.Immutable()
 	}
-	result.Value.Add(&opcodes.BranchLocalRename{OldName: oldLocalBranch, NewName: data.newBranch})
+	prog.Value.Add(&opcodes.BranchLocalRename{OldName: oldLocalBranch, NewName: data.newBranch})
 	if data.initialBranch == oldLocalBranch {
-		result.Value.Add(&opcodes.CheckoutIfNeeded{Branch: data.newBranch})
+		prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: data.newBranch})
 	}
 	if !data.dryRun {
 		if override, hasBranchTypeOverride := data.config.NormalConfig.BranchTypeOverrides[oldLocalBranch]; hasBranchTypeOverride {
-			result.Value.Add(
+			prog.Value.Add(
 				&opcodes.ConfigSet{
 					Key:   configdomain.NewBranchTypeOverrideKeyForBranch(data.newBranch).Key,
 					Scope: configdomain.ConfigScopeLocal,
@@ -288,38 +288,38 @@ func renameProgram(data renameData, finalMessages stringslice.Collector) program
 			)
 		}
 		if parentBranch, hasParent := data.config.NormalConfig.Lineage.Parent(oldLocalBranch).Get(); hasParent {
-			result.Value.Add(&opcodes.LineageParentSet{Branch: data.newBranch, Parent: parentBranch})
+			prog.Value.Add(&opcodes.LineageParentSet{Branch: data.newBranch, Parent: parentBranch})
 		}
-		result.Value.Add(&opcodes.LineageParentRemove{Branch: oldLocalBranch})
+		prog.Value.Add(&opcodes.LineageParentRemove{Branch: oldLocalBranch})
 	}
 	for _, child := range data.config.NormalConfig.Lineage.Children(oldLocalBranch) {
-		result.Value.Add(&opcodes.LineageParentSet{Branch: child, Parent: data.newBranch})
+		prog.Value.Add(&opcodes.LineageParentSet{Branch: child, Parent: data.newBranch})
 	}
 	if oldTrackingBranch, hasOldTrackingBranch := data.oldBranch.RemoteName.Get(); hasOldTrackingBranch {
 		if data.oldBranch.HasTrackingBranch() && data.config.NormalConfig.IsOnline() {
-			result.Value.Add(&opcodes.BranchTrackingCreate{Branch: data.newBranch})
-			updateChildBranchProposalsToBranch(result.Value, data.proposalsOfChildBranches, data.newBranch)
+			prog.Value.Add(&opcodes.BranchTrackingCreate{Branch: data.newBranch})
+			updateChildBranchProposalsToBranch(prog.Value, data.proposalsOfChildBranches, data.newBranch)
 			proposal, hasProposal := data.proposal.Get()
 			connector, hasConnector := data.connector.Get()
 			connectorCanUpdateProposalSource := hasConnector && connector.UpdateProposalSourceFn().IsSome()
 			if hasProposal && hasConnector && connectorCanUpdateProposalSource {
-				result.Value.Add(&opcodes.ProposalUpdateSource{
+				prog.Value.Add(&opcodes.ProposalUpdateSource{
 					NewBranch:      data.newBranch,
 					OldBranch:      data.oldBranch.LocalBranchName(),
 					ProposalNumber: proposal.Number,
 				})
 			}
-			result.Value.Add(&opcodes.BranchTrackingDelete{Branch: oldTrackingBranch})
+			prog.Value.Add(&opcodes.BranchTrackingDelete{Branch: oldTrackingBranch})
 		}
 	}
 	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.newBranch), data.previousBranch}
-	cmdhelpers.Wrap(result, cmdhelpers.WrapOptions{
+	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.dryRun,
 		RunInGitRoot:             false,
 		StashOpenChanges:         false,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	return optimizer.Optimize(result.Immutable())
+	return optimizer.Optimize(prog.Immutable())
 }
 
 func updateChildBranchProposalsToBranch(prog *program.Program, proposals []hostingdomain.Proposal, target gitdomain.LocalBranchName) {

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -296,6 +296,5 @@ func setParentProgram(dialogOutcome dialog.ParentOutcome, selectedBranch gitdoma
 			)
 		}
 	}
-	optimizedProgram := optimizer.Optimize(prog)
-	return optimizedProgram, false
+	return optimizer.Optimize(prog), false
 }

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -295,5 +296,6 @@ func setParentProgram(dialogOutcome dialog.ParentOutcome, selectedBranch gitdoma
 			)
 		}
 	}
-	return prog, false
+	optimizedProgram := optimizer.Optimize(prog)
+	return optimizedProgram, false
 }

--- a/internal/cmd/ship/cmd.go
+++ b/internal/cmd/ship/cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/git-town/git-town/v17/internal/validate"
 	fullInterpreter "github.com/git-town/git-town/v17/internal/vm/interpreter/full"
 	"github.com/git-town/git-town/v17/internal/vm/opcodes"
+	"github.com/git-town/git-town/v17/internal/vm/optimizer"
 	"github.com/git-town/git-town/v17/internal/vm/program"
 	"github.com/git-town/git-town/v17/internal/vm/runstate"
 	. "github.com/git-town/git-town/v17/pkg/prelude"
@@ -133,6 +134,7 @@ func executeShip(args []string, message Option[gitdomain.CommitMessage], dryRun 
 		}
 		shipProgramSquashMerge(prog, sharedData, squashMergeData, message)
 	}
+	optimizedProgram := optimizer.Optimize(prog.Immutable())
 	runState := runstate.RunState{
 		BeginBranchesSnapshot: sharedData.branchesSnapshot,
 		BeginConfigSnapshot:   repo.ConfigSnapshot,
@@ -142,8 +144,8 @@ func executeShip(args []string, message Option[gitdomain.CommitMessage], dryRun 
 		EndBranchesSnapshot:   None[gitdomain.BranchesSnapshot](),
 		EndConfigSnapshot:     None[undoconfig.ConfigSnapshot](),
 		EndStashSize:          None[gitdomain.StashSize](),
-		RunProgram:            prog.Immutable(),
-		TouchedBranches:       prog.Value.TouchedBranches(),
+		RunProgram:            optimizedProgram,
+		TouchedBranches:       optimizedProgram.TouchedBranches(),
 		UndoAPIProgram:        program.Program{},
 	}
 	return fullInterpreter.Execute(fullInterpreter.ExecuteArgs{


### PR DESCRIPTION
Git Town provides the functionality to exit when it encounters an issue that it cannot resolve on its own, let the user deal with the issue, and resume the previously interrupted command. This is made possible by executing "programs" (more like linear lists of activities to do) that consist mainly of Git operations.

Some Git Town commands use a little optimizer, which mostly reduces multiple consecutive checkouts of different branches to a single checkout of the last branch.

This PR makes all Git Town commands use this optimizer. This lays the groundwork for further optimizations in subsequent PRs.