### PR TITLE
Skip syncing perennial branches based on detected sync status

### DIFF
--- a/features/append/on_feature_branch/dry_run/enabled.feature
+++ b/features/append/on_feature_branch/dry_run/enabled.feature
@@ -11,16 +11,11 @@ Feature: dry run appending a new feature branch to an existing feature branch
     And the current branch is "existing"
     When I run "git-town append new --dry-run"
 
-  @debug
-  @this
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is still "existing"

--- a/features/append/on_feature_branch/dry_run/enabled.feature
+++ b/features/append/on_feature_branch/dry_run/enabled.feature
@@ -11,6 +11,8 @@ Feature: dry run appending a new feature branch to an existing feature branch
     And the current branch is "existing"
     When I run "git-town append new --dry-run"
 
+  @debug
+  @this
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |

--- a/features/append/on_feature_branch/happy_path.feature
+++ b/features/append/on_feature_branch/happy_path.feature
@@ -16,10 +16,7 @@ Feature: append a new feature branch to an existing feature branch
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"

--- a/features/append/on_feature_branch/new_branch_type/config_file.feature
+++ b/features/append/on_feature_branch/new_branch_type/config_file.feature
@@ -20,10 +20,7 @@ Feature: append a new branch when prototype branches are configured via the conf
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"

--- a/features/append/on_feature_branch/new_branch_type/config_file_deprecated.feature
+++ b/features/append/on_feature_branch/new_branch_type/config_file_deprecated.feature
@@ -19,10 +19,7 @@ Feature: append a new branch when prototype branches are configured via a deprec
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And Git Town prints:

--- a/features/append/on_feature_branch/new_branch_type/create_prototype_branches.feature
+++ b/features/append/on_feature_branch/new_branch_type/create_prototype_branches.feature
@@ -16,10 +16,7 @@ Feature: append a new branch when prototype branches are configured via a deprec
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And Git Town prints:

--- a/features/append/on_feature_branch/new_branch_type/feature.feature
+++ b/features/append/on_feature_branch/new_branch_type/feature.feature
@@ -16,10 +16,7 @@ Feature: append a new branch when feature branches are configured
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"

--- a/features/append/on_feature_branch/new_branch_type/not_set.feature
+++ b/features/append/on_feature_branch/new_branch_type/not_set.feature
@@ -15,10 +15,7 @@ Feature: append a new branch when no new branch type is configured
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"

--- a/features/append/on_feature_branch/new_branch_type/parked.feature
+++ b/features/append/on_feature_branch/new_branch_type/parked.feature
@@ -16,10 +16,7 @@ Feature: append a new branch when parked branches are configured
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"

--- a/features/append/on_feature_branch/new_branch_type/prototype.feature
+++ b/features/append/on_feature_branch/new_branch_type/prototype.feature
@@ -16,10 +16,7 @@ Feature: append a new branch when prototype branches are configured
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |
     And the current branch is now "new"

--- a/features/append/on_feature_branch/new_branch_type/prototype.feature
+++ b/features/append/on_feature_branch/new_branch_type/prototype.feature
@@ -12,6 +12,8 @@ Feature: append a new branch when prototype branches are configured
     And Git setting "git-town.new-branch-type" is "prototype"
     When I run "git-town append new"
 
+  @debug
+  @this
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |

--- a/features/append/on_feature_branch/new_branch_type/prototype.feature
+++ b/features/append/on_feature_branch/new_branch_type/prototype.feature
@@ -12,8 +12,6 @@ Feature: append a new branch when prototype branches are configured
     And Git setting "git-town.new-branch-type" is "prototype"
     When I run "git-town append new"
 
-  @debug
-  @this
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |

--- a/features/append/on_feature_branch/offline/enabled.feature
+++ b/features/append/on_feature_branch/offline/enabled.feature
@@ -15,9 +15,6 @@ Feature: append in offline mode
     When I run "git-town append new"
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
-      | existing | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
       | existing | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git checkout -b new                      |

--- a/features/append/on_feature_branch/sync_strategy/compress.feature
+++ b/features/append/on_feature_branch/sync_strategy/compress.feature
@@ -18,10 +18,7 @@ Feature: append a new feature branch in a clean workspace using the "compress" s
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | existing | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git checkout existing                    |
-      | existing | git merge --no-edit --ff main            |
+      |          | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/existing |
       |          | git reset --soft main                    |
       |          | git commit -m "existing commit 1"        |

--- a/features/append/on_feature_branch/sync_tags/disabled.feature
+++ b/features/append/on_feature_branch/sync_tags/disabled.feature
@@ -11,10 +11,9 @@ Feature: don't sync tags while appending
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | main   | git fetch --prune --no-tags             |
-      |        | git rebase origin/main --no-update-refs |
-      |        | git checkout -b new                     |
+      | BRANCH | COMMAND                     |
+      | main   | git fetch --prune --no-tags |
+      |        | git checkout -b new         |
     And the initial tags exist now
 
   Scenario: undo

--- a/features/append/on_feature_branch/verbose/enabled.feature
+++ b/features/append/on_feature_branch/verbose/enabled.feature
@@ -27,10 +27,6 @@ Feature: display all executed Git commands
       |          | backend  | git rev-parse --verify --abbrev-ref @{-1}            |
       |          | backend  | git remote get-url origin                            |
       |          | backend  | git log main..existing --format=%s --reverse         |
-      | existing | frontend | git checkout main                                    |
-      | main     | frontend | git rebase origin/main --no-update-refs              |
-      |          | backend  | git rev-list --left-right main...origin/main         |
-      | main     | frontend | git checkout existing                                |
       | existing | frontend | git merge --no-edit --ff main                        |
       |          | frontend | git merge --no-edit --ff origin/existing             |
       |          | backend  | git rev-list --left-right existing...origin/existing |
@@ -45,7 +41,7 @@ Feature: display all executed Git commands
       |          | backend  | git stash list                                       |
     And Git Town prints:
       """
-      Ran 29 shell commands.
+      Ran 25 shell commands.
       """
     And the current branch is now "new"
 

--- a/features/append/on_feature_branch/worktree/previous_branch_in_other_worktree.feature
+++ b/features/append/on_feature_branch/worktree/previous_branch_in_other_worktree.feature
@@ -14,10 +14,7 @@ Feature: append a branch when the previous branch is active in another worktree
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | current | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout current                    |
-      | current | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/current |
       |         | git checkout -b new                     |
     And the current branch is now "new"

--- a/features/hack/give_non_existing_branch/on_feature_branch/dry_run/dry_run.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/dry_run/dry_run.feature
@@ -14,11 +14,10 @@ Feature: dry-run hacking a new feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                 |
-      | existing | git fetch --prune --tags                |
-      |          | git checkout main                       |
-      | main     | git rebase origin/main --no-update-refs |
-      |          | git checkout -b new                     |
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git checkout main        |
+      | main     | git checkout -b new      |
     And the current branch is still "existing"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/git_history/previous_branch_in_another_worktree.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/git_history/previous_branch_in_another_worktree.feature
@@ -12,11 +12,10 @@ Feature: previous branch is checked out in another worktree
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                 |
-      | current | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout -b new                     |
+      | BRANCH  | COMMAND                  |
+      | current | git fetch --prune --tags |
+      |         | git checkout main        |
+      | main    | git checkout -b new      |
     And the current branch is now "new"
     And the previous Git branch is now "current"
 

--- a/features/hack/give_non_existing_branch/on_feature_branch/in_subfolder/subfolder_is_committed.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/in_subfolder/subfolder_is_committed.feature
@@ -13,11 +13,10 @@ Feature: inside a committed subfolder that exists only on the current feature br
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                 |
-      | existing | git fetch --prune --tags                |
-      |          | git checkout main                       |
-      | main     | git rebase origin/main --no-update-refs |
-      |          | git checkout -b new                     |
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git checkout main        |
+      | main     | git checkout -b new      |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now

--- a/features/hack/give_non_existing_branch/on_feature_branch/in_subfolder/subfolder_is_uncommitted.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/in_subfolder/subfolder_is_uncommitted.feature
@@ -14,11 +14,10 @@ Feature: inside an uncommitted subfolder on the current feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                 |
-      | existing | git fetch --prune --tags                |
-      |          | git checkout main                       |
-      | main     | git rebase origin/main --no-update-refs |
-      |          | git checkout -b new                     |
+      | BRANCH   | COMMAND                  |
+      | existing | git fetch --prune --tags |
+      |          | git checkout main        |
+      | main     | git checkout -b new      |
     And the current branch is now "new"
     And the initial commits exist now
     And this lineage exists now

--- a/features/hack/give_non_existing_branch/on_feature_branch/offline/offline.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/offline/offline.feature
@@ -10,9 +10,8 @@ Feature: offline mode
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout -b new                     |
+      | BRANCH | COMMAND             |
+      | main   | git checkout -b new |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE     |

--- a/features/hack/give_non_existing_branch/on_feature_branch/sync_tags/disabled.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/sync_tags/disabled.feature
@@ -11,10 +11,9 @@ Feature: don't sync tags while hacking
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | main   | git fetch --prune --no-tags             |
-      |        | git rebase origin/main --no-update-refs |
-      |        | git checkout -b new                     |
+      | BRANCH | COMMAND                     |
+      | main   | git fetch --prune --no-tags |
+      |        | git checkout -b new         |
     And the initial tags exist now
 
   Scenario: undo

--- a/features/hack/give_non_existing_branch/on_feature_branch/unconfigured/unconfigured.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/unconfigured/unconfigured.feature
@@ -10,10 +10,9 @@ Feature: missing configuration
 
   Scenario: result
     And Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | main   | git fetch --prune --tags                |
-      |        | git rebase origin/main --no-update-refs |
-      |        | git checkout -b feature                 |
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git checkout -b feature  |
     And the main branch is now "main"
     And the current branch is now "feature"
     And this lineage exists now

--- a/features/hack/give_non_existing_branch/on_feature_branch/upstream/with_upstream.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/upstream/with_upstream.feature
@@ -13,7 +13,6 @@ Feature: on a forked repo
     Then Git Town runs the commands
       | BRANCH | COMMAND                                   |
       | main   | git fetch --prune --tags                  |
-      |        | git rebase origin/main --no-update-refs   |
       |        | git fetch upstream main                   |
       |        | git rebase upstream/main --no-update-refs |
       |        | git push                                  |
@@ -26,11 +25,12 @@ Feature: on a forked repo
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND           |
-      | new    | git checkout main |
-      | main   | git branch -D new |
+      | BRANCH | COMMAND                                     |
+      | new    | git checkout main                           |
+      | main   | git reset --hard {{ sha 'initial commit' }} |
+      |        | git branch -D new                           |
     And the current branch is now "main"
     And these commits exist now
-      | BRANCH | LOCATION                | MESSAGE         |
-      | main   | local, origin, upstream | upstream commit |
+      | BRANCH | LOCATION | MESSAGE         |
+      | main   | upstream | upstream commit |
     And no lineage exists now

--- a/features/hack/give_non_existing_branch/on_feature_branch/upstream/with_upstream.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/upstream/with_upstream.feature
@@ -25,12 +25,11 @@ Feature: on a forked repo
   Scenario: undo
     When I run "git-town undo"
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                     |
-      | new    | git checkout main                           |
-      | main   | git reset --hard {{ sha 'initial commit' }} |
-      |        | git branch -D new                           |
+      | BRANCH | COMMAND           |
+      | new    | git checkout main |
+      | main   | git branch -D new |
     And the current branch is now "main"
     And these commits exist now
-      | BRANCH | LOCATION | MESSAGE         |
-      | main   | upstream | upstream commit |
+      | BRANCH | LOCATION                | MESSAGE         |
+      | main   | local, origin, upstream | upstream commit |
     And no lineage exists now

--- a/features/prepend/beam/compress.feature
+++ b/features/prepend/beam/compress.feature
@@ -22,10 +22,7 @@ Feature: prepend a branch to a feature branch using the "compress" sync strategy
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | old    | git fetch --prune --tags                        |
-      |        | git checkout main                               |
-      | main   | git rebase origin/main --no-update-refs         |
-      |        | git checkout old                                |
-      | old    | git merge --no-edit --ff main                   |
+      |        | git merge --no-edit --ff main                   |
       |        | git merge --no-edit --ff origin/old             |
       |        | git reset --soft main                           |
       |        | git commit -m "commit 1"                        |
@@ -52,13 +49,10 @@ Feature: prepend a branch to a feature branch using the "compress" sync strategy
       | parent | main   |
     When I run "git town sync"
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | parent | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout parent                     |
-      | parent | git merge --no-edit --ff main           |
-      |        | git push -u origin parent               |
+      | BRANCH | COMMAND                       |
+      | parent | git fetch --prune --tags      |
+      |        | git merge --no-edit --ff main |
+      |        | git push -u origin parent     |
     And the current branch is now "parent"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE                        |

--- a/features/prepend/beam/merge.feature
+++ b/features/prepend/beam/merge.feature
@@ -22,10 +22,7 @@ Feature: prepend a branch to a feature branch using the "merge" sync strategy
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | old    | git fetch --prune --tags                        |
-      |        | git checkout main                               |
-      | main   | git rebase origin/main --no-update-refs         |
-      |        | git checkout old                                |
-      | old    | git merge --no-edit --ff main                   |
+      |        | git merge --no-edit --ff main                   |
       |        | git merge --no-edit --ff origin/old             |
       |        | git checkout -b parent main                     |
       | parent | git cherry-pick {{ sha-before-run 'commit 2' }} |
@@ -52,13 +49,10 @@ Feature: prepend a branch to a feature branch using the "merge" sync strategy
       | parent | main   |
     When I run "git town sync"
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | parent | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout parent                     |
-      | parent | git merge --no-edit --ff main           |
-      |        | git push -u origin parent               |
+      | BRANCH | COMMAND                       |
+      | parent | git fetch --prune --tags      |
+      |        | git merge --no-edit --ff main |
+      |        | git push -u origin parent     |
     And the current branch is now "parent"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE                        |

--- a/features/prepend/beam/rebase.feature
+++ b/features/prepend/beam/rebase.feature
@@ -22,10 +22,7 @@ Feature: prepend a branch to a feature branch using the "rebase" sync strategy
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | old    | git fetch --prune --tags                        |
-      |        | git checkout main                               |
-      | main   | git rebase origin/main --no-update-refs         |
-      |        | git checkout old                                |
-      | old    | git rebase main --no-update-refs                |
+      |        | git rebase main --no-update-refs                |
       |        | git push --force-with-lease --force-if-includes |
       |        | git checkout -b parent main                     |
       | parent | git cherry-pick {{ sha-before-run 'commit 2' }} |
@@ -49,13 +46,10 @@ Feature: prepend a branch to a feature branch using the "rebase" sync strategy
       | parent | main   |
     When I run "git town sync"
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | parent | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout parent                     |
-      | parent | git rebase main --no-update-refs        |
-      |        | git push -u origin parent               |
+      | BRANCH | COMMAND                          |
+      | parent | git fetch --prune --tags         |
+      |        | git rebase main --no-update-refs |
+      |        | git push -u origin parent        |
     And the current branch is now "parent"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE  |

--- a/features/prepend/create_prototype_branches/config_file.feature
+++ b/features/prepend/create_prototype_branches/config_file.feature
@@ -18,14 +18,11 @@ Feature: prepend a new branch when prototype branches are configured via config 
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b parent main             |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b parent main         |
     And the current branch is now "parent"
     And branch "parent" now has type "prototype"
     And these commits exist now

--- a/features/prepend/create_prototype_branches/enabled.feature
+++ b/features/prepend/create_prototype_branches/enabled.feature
@@ -14,14 +14,11 @@ Feature: prepend a new branch when prototype branches are configured via Git met
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b parent main             |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b parent main         |
     And the current branch is now "parent"
     And branch "parent" now has type "prototype"
     And these commits exist now

--- a/features/prepend/deleted/ancestor_deleted_merge.feature
+++ b/features/prepend/deleted/ancestor_deleted_merge.feature
@@ -20,8 +20,7 @@ Feature: prepend a branch to a branch that was shipped at the remote
       | BRANCH   | COMMAND                                  |
       | branch-2 | git fetch --prune --tags                 |
       |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
-      |          | git branch -D branch-1                   |
+      | main     | git branch -D branch-1                   |
       |          | git checkout branch-2                    |
       | branch-2 | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/branch-2 |

--- a/features/prepend/deleted/ancestor_deleted_rebase.feature
+++ b/features/prepend/deleted/ancestor_deleted_rebase.feature
@@ -17,16 +17,13 @@ Feature: prepend a branch to a branch that was shipped at the remote
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                 |
-      | branch-2 | git fetch --prune --tags                |
-      |          | git checkout main                       |
-      | main     | git rebase origin/main --no-update-refs |
-      |          | git checkout branch-2                   |
-      | branch-2 | git pull                                |
-      |          | git rebase --onto main branch-1         |
-      |          | git push --force-with-lease             |
-      |          | git branch -D branch-1                  |
-      |          | git checkout -b new main                |
+      | BRANCH   | COMMAND                         |
+      | branch-2 | git fetch --prune --tags        |
+      |          | git pull                        |
+      |          | git rebase --onto main branch-1 |
+      |          | git push --force-with-lease     |
+      |          | git branch -D branch-1          |
+      |          | git checkout -b new main        |
     And Git Town prints:
       """
       deleted branch "branch-1"

--- a/features/prepend/dry_run/enabled.feature
+++ b/features/prepend/dry_run/enabled.feature
@@ -13,14 +13,11 @@ Feature: dry-run prepending a branch to a feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b parent main             |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b parent main         |
     And the current branch is still "old"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/prepend/offline/enabled.feature
+++ b/features/prepend/offline/enabled.feature
@@ -14,13 +14,10 @@ Feature: offline mode
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b new main                |
+      | BRANCH | COMMAND                             |
+      | old    | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b new main            |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE    |

--- a/features/prepend/propose/enabled.feature
+++ b/features/prepend/propose/enabled.feature
@@ -25,9 +25,7 @@ Feature: propose a newly prepended branch
       | BRANCH   | COMMAND                                                                 |
       | existing | git fetch --prune --tags                                                |
       | <none>   | Looking for proposal online ... ok                                      |
-      | existing | git checkout main                                                       |
-      | main     | git rebase origin/main --no-update-refs                                 |
-      |          | git checkout parent                                                     |
+      | existing | git checkout parent                                                     |
       | parent   | git rebase main --no-update-refs                                        |
       |          | git push --force-with-lease --force-if-includes                         |
       |          | git checkout existing                                                   |

--- a/features/prepend/propose/populate_title_and_body.feature
+++ b/features/prepend/propose/populate_title_and_body.feature
@@ -24,9 +24,6 @@ Feature: propose a newly prepended branch
       | BRANCH   | COMMAND                                                                                                |
       | existing | git fetch --prune --tags                                                                               |
       | <none>   | Looking for proposal online ... ok                                                                     |
-      | existing | git checkout main                                                                                      |
-      | main     | git rebase origin/main --no-update-refs                                                                |
-      |          | git checkout existing                                                                                  |
       | existing | git rebase main --no-update-refs                                                                       |
       |          | git push --force-with-lease --force-if-includes                                                        |
       |          | git checkout -b new main                                                                               |

--- a/features/prepend/prototype/enabled.feature
+++ b/features/prepend/prototype/enabled.feature
@@ -14,14 +14,11 @@ Feature: prepend a prototype branch to a feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b parent main             |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b parent main         |
     And the current branch is now "parent"
     And branch "parent" now has type "prototype"
     And these commits exist now

--- a/features/prepend/push_hook/disabled.feature
+++ b/features/prepend/push_hook/disabled.feature
@@ -15,15 +15,12 @@ Feature: auto-push new branches
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b new main                |
-      | new    | git push --no-verify -u origin new      |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b new main            |
+      | new    | git push --no-verify -u origin new  |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |

--- a/features/prepend/push_hook/enabled.feature
+++ b/features/prepend/push_hook/enabled.feature
@@ -15,15 +15,12 @@ Feature: auto-push new branches
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b new main                |
-      | new    | git push -u origin new                  |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b new main            |
+      | new    | git push -u origin new              |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |

--- a/features/prepend/push_new_branches/push_new_branches.feature
+++ b/features/prepend/push_new_branches/push_new_branches.feature
@@ -14,15 +14,12 @@ Feature: auto-push new branches
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b new main                |
-      | new    | git push -u origin new                  |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b new main            |
+      | new    | git push -u origin new              |
     And the current branch is now "new"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE        |

--- a/features/prepend/sync_strategy/compress.feature
+++ b/features/prepend/sync_strategy/compress.feature
@@ -20,8 +20,6 @@ Feature: prepend a branch to a feature branch in a clean workspace using the "co
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                  |
       | branch-2 | git fetch --prune --tags                 |
-      |          | git checkout main                        |
-      | main     | git rebase origin/main --no-update-refs  |
       |          | git checkout branch-1                    |
       | branch-1 | git merge --no-edit --ff main            |
       |          | git merge --no-edit --ff origin/branch-1 |

--- a/features/prepend/sync_tags/enabled.feature
+++ b/features/prepend/sync_tags/enabled.feature
@@ -15,14 +15,11 @@ Feature: don't sync tags while prepending
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --no-tags             |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b new main                |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --no-tags         |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b new main            |
     And the initial tags exist now
 
   Scenario: undo

--- a/features/prepend/tracking_branch/with.feature
+++ b/features/prepend/tracking_branch/with.feature
@@ -14,14 +14,11 @@ Feature: prepend a branch to a feature branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/old     |
-      |        | git checkout -b parent main             |
+      | BRANCH | COMMAND                             |
+      | old    | git fetch --prune --tags            |
+      |        | git merge --no-edit --ff main       |
+      |        | git merge --no-edit --ff origin/old |
+      |        | git checkout -b parent main         |
     And the current branch is now "parent"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE    |

--- a/features/prepend/unknown_lineage/parent.feature
+++ b/features/prepend/unknown_lineage/parent.feature
@@ -11,14 +11,11 @@ Feature: ask for missing parent information
       | DIALOG               | KEYS  |
       | parent branch of old | enter |
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | old    | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout old                        |
-      | old    | git merge --no-edit --ff main           |
-      |        | git push -u origin old                  |
-      |        | git checkout -b new main                |
+      | BRANCH | COMMAND                       |
+      | old    | git fetch --prune --tags      |
+      |        | git merge --no-edit --ff main |
+      |        | git push -u origin old        |
+      |        | git checkout -b new main      |
     And this lineage exists now
       | BRANCH | PARENT |
       | new    | main   |

--- a/features/prepend/verbose/enabled.feature
+++ b/features/prepend/verbose/enabled.feature
@@ -27,10 +27,6 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git remote get-url origin                     |
       |        | backend  | git log main..old --format=%s --reverse       |
-      | old    | frontend | git checkout main                             |
-      | main   | frontend | git rebase origin/main --no-update-refs       |
-      |        | backend  | git rev-list --left-right main...origin/main  |
-      | main   | frontend | git checkout old                              |
       | old    | frontend | git merge --no-edit --ff main                 |
       |        | frontend | git merge --no-edit --ff origin/old           |
       |        | backend  | git rev-list --left-right old...origin/old    |
@@ -47,7 +43,7 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And Git Town prints:
       """
-      Ran 31 shell commands.
+      Ran 27 shell commands.
       """
     And the current branch is now "parent"
 

--- a/features/prepend/worktree/previous_branch_in_another_worktree.feature
+++ b/features/prepend/worktree/previous_branch_in_another_worktree.feature
@@ -12,14 +12,11 @@ Feature: previous branch is checked out in another worktree
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                 |
-      | current | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout current                    |
-      | current | git merge --no-edit --ff main           |
-      |         | git push -u origin current              |
-      |         | git checkout -b new main                |
+      | BRANCH  | COMMAND                       |
+      | current | git fetch --prune --tags      |
+      |         | git merge --no-edit --ff main |
+      |         | git push -u origin current    |
+      |         | git checkout -b new main      |
     And the current branch is now "new"
     And the previous Git branch is now "new"
     And this lineage exists now

--- a/features/propose/branch_types/prototype_child_branch.feature
+++ b/features/propose/branch_types/prototype_child_branch.feature
@@ -18,9 +18,7 @@ Feature: Create proposals for prototype branches
       | BRANCH    | COMMAND                                                                       |
       | prototype | git fetch --prune --tags                                                      |
       | <none>    | Looking for proposal online ... ok                                            |
-      | prototype | git checkout main                                                             |
-      | main      | git rebase origin/main --no-update-refs                                       |
-      |           | git checkout parent                                                           |
+      | prototype | git checkout parent                                                           |
       | parent    | git merge --no-edit --ff main                                                 |
       |           | git push -u origin parent                                                     |
       |           | git checkout prototype                                                        |

--- a/features/propose/deleted/branch_deleted_at_remote.feature
+++ b/features/propose/deleted/branch_deleted_at_remote.feature
@@ -14,11 +14,10 @@ Feature: proposing a branch that was deleted at the remote
 
   Scenario: a PR for this branch exists already
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                 |
-      | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git branch -D feature                   |
+      | BRANCH  | COMMAND                  |
+      | feature | git fetch --prune --tags |
+      |         | git checkout main        |
+      | main    | git branch -D feature    |
     And Git Town prints:
       """
       branch "feature" was deleted at the remote

--- a/features/propose/dry_run/enabled.feature
+++ b/features/propose/dry_run/enabled.feature
@@ -28,9 +28,6 @@ Feature: dry-run proposing changes
       | BRANCH  | COMMAND                                                            |
       | feature | git fetch --prune --tags                                           |
       | <none>  | Looking for proposal online ... ok                                 |
-      | feature | git checkout main                                                  |
-      | main    | git rebase origin/main --no-update-refs                            |
-      |         | git checkout feature                                               |
       | feature | git merge --no-edit --ff main                                      |
       |         | git merge --no-edit --ff origin/feature                            |
       | <none>  | open https://github.com/git-town/git-town/compare/feature?expand=1 |

--- a/features/propose/sync_status/conflict.feature
+++ b/features/propose/sync_status/conflict.feature
@@ -18,13 +18,10 @@ Feature: merge conflict
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                 |
-      | feature | git fetch --prune --tags                |
-      | <none>  | Looking for proposal online ... ok      |
-      | feature | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      | BRANCH  | COMMAND                            |
+      | feature | git fetch --prune --tags           |
+      | <none>  | Looking for proposal online ... ok |
+      | feature | git merge --no-edit --ff main      |
     And Git Town prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file

--- a/features/propose/sync_strategy/compress.feature
+++ b/features/propose/sync_strategy/compress.feature
@@ -22,9 +22,6 @@ Feature: proposing using the "compress" sync strategy
       | BRANCH   | COMMAND                                                             |
       | existing | git fetch --prune --tags                                            |
       | <none>   | Looking for proposal online ... ok                                  |
-      | existing | git checkout main                                                   |
-      | main     | git rebase origin/main --no-update-refs                             |
-      |          | git checkout existing                                               |
       | existing | git merge --no-edit --ff main                                       |
       |          | git merge --no-edit --ff origin/existing                            |
       |          | git reset --soft main                                               |

--- a/features/propose/sync_tags/enabled.feature
+++ b/features/propose/sync_tags/enabled.feature
@@ -21,9 +21,6 @@ Feature: don't sync tags while proposing
       | BRANCH  | COMMAND                                                            |
       | feature | git fetch --prune --no-tags                                        |
       | <none>  | Looking for proposal online ... ok                                 |
-      | feature | git checkout main                                                  |
-      | main    | git rebase origin/main --no-update-refs                            |
-      |         | git checkout feature                                               |
       | feature | git merge --no-edit --ff main                                      |
       |         | git merge --no-edit --ff origin/feature                            |
       | <none>  | open https://github.com/git-town/git-town/compare/feature?expand=1 |

--- a/features/propose/verbose/enabled.feature
+++ b/features/propose/verbose/enabled.feature
@@ -26,15 +26,13 @@ Feature: display all executed Git commands
       |         | backend  | git rev-parse --verify --abbrev-ref @{-1}                          |
       | <none>  | frontend | Looking for proposal online ... ok                                 |
       |         | backend  | git log main..feature --format=%s --reverse                        |
-      | feature | frontend | git checkout main                                                  |
-      | main    | frontend | git rebase origin/main --no-update-refs                            |
-      |         | backend  | git rev-list --left-right main...origin/main                       |
-      | main    | frontend | git checkout feature                                               |
       | feature | frontend | git merge --no-edit --ff main                                      |
       |         | frontend | git merge --no-edit --ff origin/feature                            |
       |         | backend  | git rev-list --left-right feature...origin/feature                 |
       |         | backend  | git rev-parse --abbrev-ref --symbolic-full-name @{u}               |
       |         | backend  | git show-ref --verify --quiet refs/heads/main                      |
+      |         | backend  | git checkout main                                                  |
+      |         | backend  | git checkout feature                                               |
       |         | backend  | which wsl-open                                                     |
       |         | backend  | which garcon-url-handler                                           |
       |         | backend  | which xdg-open                                                     |
@@ -46,7 +44,7 @@ Feature: display all executed Git commands
       |         | backend  | git stash list                                                     |
     And Git Town prints:
       """
-      Ran 30 shell commands.
+      Ran 28 shell commands.
       """
     And "open" launches a new proposal with this url in my browser:
       """

--- a/features/propose/worktree/previous_branch_in_another_worktree.feature
+++ b/features/propose/worktree/previous_branch_in_another_worktree.feature
@@ -19,9 +19,6 @@ Feature: prepend with the previous branch checked out in another worktree
       | BRANCH  | TYPE     | COMMAND                                                            |
       | current | frontend | git fetch --prune --tags                                           |
       | <none>  | frontend | Looking for proposal online ... ok                                 |
-      | current | frontend | git checkout main                                                  |
-      | main    | frontend | git rebase origin/main --no-update-refs                            |
-      |         | frontend | git checkout current                                               |
       | current | frontend | git merge --no-edit --ff main                                      |
       |         | frontend | git push -u origin current                                         |
       | <none>  | frontend | open https://github.com/git-town/git-town/compare/current?expand=1 |

--- a/features/shared/git_config_include_file.feature
+++ b/features/shared/git_config_include_file.feature
@@ -15,7 +15,6 @@ Feature: support Git configuration that includes other files
       """
     When I run "git-town sync"
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | main   | git fetch --prune --tags                |
-      |        | git rebase origin/main --no-update-refs |
-      |        | git push --tags                         |
+      | BRANCH | COMMAND                  |
+      | main   | git fetch --prune --tags |
+      |        | git push --tags          |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
@@ -49,13 +49,11 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
   Scenario: skip
     When I run "git-town skip"
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                  |
-      | beta   | git rebase --abort                       |
-      |        | git checkout gamma                       |
-      | gamma  | git rebase origin/gamma --no-update-refs |
-      |        | git checkout main                        |
-      | main   | git rebase origin/main --no-update-refs  |
-      |        | git push --tags                          |
+      | BRANCH | COMMAND                                 |
+      | beta   | git rebase --abort                      |
+      |        | git checkout main                       |
+      | main   | git rebase origin/main --no-update-refs |
+      |        | git push --tags                         |
     And the current branch is now "main"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE            |
@@ -81,8 +79,6 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       | BRANCH | COMMAND                                   |
       | beta   | git -c core.editor=true rebase --continue |
       |        | git push                                  |
-      |        | git checkout gamma                        |
-      | gamma  | git rebase origin/gamma --no-update-refs  |
       |        | git checkout main                         |
       | main   | git rebase origin/main --no-update-refs   |
       |        | git push --tags                           |
@@ -95,10 +91,8 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And I run "git rebase --continue" and close the editor
     And I run "git-town continue"
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                  |
-      | beta   | git push                                 |
-      |        | git checkout gamma                       |
-      | gamma  | git rebase origin/gamma --no-update-refs |
-      |        | git checkout main                        |
-      | main   | git rebase origin/main --no-update-refs  |
-      |        | git push --tags                          |
+      | BRANCH | COMMAND                                 |
+      | beta   | git push                                |
+      |        | git checkout main                       |
+      | main   | git rebase origin/main --no-update-refs |
+      |        | git push --tags                         |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
@@ -20,12 +20,10 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
   Scenario: result
     Then I am not prompted for any parent branches
     And Git Town runs the commands
-      | BRANCH | COMMAND                                  |
-      | main   | git fetch --prune --tags                 |
-      |        | git checkout alpha                       |
-      | alpha  | git rebase origin/alpha --no-update-refs |
-      |        | git checkout beta                        |
-      | beta   | git rebase origin/beta --no-update-refs  |
+      | BRANCH | COMMAND                                 |
+      | main   | git fetch --prune --tags                |
+      |        | git checkout beta                       |
+      | beta   | git rebase origin/beta --no-update-refs |
     And Git Town prints the error:
       """
       CONFLICT (add/add): Merge conflict in conflicting_file

--- a/features/sync/all_branches/merge_sync_strategy/stack/already_synced.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/already_synced.feature
@@ -35,23 +35,22 @@ Feature: sync a stack making independent changes
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | main   | git fetch --prune --tags                |
-      |        | git rebase origin/main --no-update-refs |
-      |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/alpha   |
-      |        | git checkout beta                       |
-      | beta   | git merge --no-edit --ff alpha          |
-      |        | git merge --no-edit --ff origin/beta    |
-      |        | git checkout gamma                      |
-      | gamma  | git merge --no-edit --ff beta           |
-      |        | git merge --no-edit --ff origin/gamma   |
-      |        | git checkout delta                      |
-      | delta  | git merge --no-edit --ff gamma          |
-      |        | git merge --no-edit --ff origin/delta   |
-      |        | git checkout main                       |
-      | main   | git push --tags                         |
+      | BRANCH | COMMAND                               |
+      | main   | git fetch --prune --tags              |
+      |        | git checkout alpha                    |
+      | alpha  | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/alpha |
+      |        | git checkout beta                     |
+      | beta   | git merge --no-edit --ff alpha        |
+      |        | git merge --no-edit --ff origin/beta  |
+      |        | git checkout gamma                    |
+      | gamma  | git merge --no-edit --ff beta         |
+      |        | git merge --no-edit --ff origin/gamma |
+      |        | git checkout delta                    |
+      | delta  | git merge --no-edit --ff gamma        |
+      |        | git merge --no-edit --ff origin/delta |
+      |        | git checkout main                     |
+      | main   | git push --tags                       |
     And the current branch is still "main"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/sync/all_branches/merge_sync_strategy/stack/two_stacks.feature
+++ b/features/sync/all_branches/merge_sync_strategy/stack/two_stacks.feature
@@ -55,35 +55,34 @@ Feature: sync a workspace with two independent stacks
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | main   | git fetch --prune --tags                |
-      |        | git rebase origin/main --no-update-refs |
-      |        | git checkout first                      |
-      | first  | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/first   |
-      |        | git checkout second                     |
-      | second | git merge --no-edit --ff first          |
-      |        | git merge --no-edit --ff origin/second  |
-      |        | git checkout third                      |
-      | third  | git merge --no-edit --ff second         |
-      |        | git merge --no-edit --ff origin/third   |
-      |        | git checkout fourth                     |
-      | fourth | git merge --no-edit --ff third          |
-      |        | git merge --no-edit --ff origin/fourth  |
-      |        | git checkout one                        |
-      | one    | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/one     |
-      |        | git checkout two                        |
-      | two    | git merge --no-edit --ff one            |
-      |        | git merge --no-edit --ff origin/two     |
-      |        | git checkout three                      |
-      | three  | git merge --no-edit --ff two            |
-      |        | git merge --no-edit --ff origin/three   |
-      |        | git checkout four                       |
-      | four   | git merge --no-edit --ff three          |
-      |        | git merge --no-edit --ff origin/four    |
-      |        | git checkout main                       |
-      | main   | git push --tags                         |
+      | BRANCH | COMMAND                                |
+      | main   | git fetch --prune --tags               |
+      |        | git checkout first                     |
+      | first  | git merge --no-edit --ff main          |
+      |        | git merge --no-edit --ff origin/first  |
+      |        | git checkout second                    |
+      | second | git merge --no-edit --ff first         |
+      |        | git merge --no-edit --ff origin/second |
+      |        | git checkout third                     |
+      | third  | git merge --no-edit --ff second        |
+      |        | git merge --no-edit --ff origin/third  |
+      |        | git checkout fourth                    |
+      | fourth | git merge --no-edit --ff third         |
+      |        | git merge --no-edit --ff origin/fourth |
+      |        | git checkout one                       |
+      | one    | git merge --no-edit --ff main          |
+      |        | git merge --no-edit --ff origin/one    |
+      |        | git checkout two                       |
+      | two    | git merge --no-edit --ff one           |
+      |        | git merge --no-edit --ff origin/two    |
+      |        | git checkout three                     |
+      | three  | git merge --no-edit --ff two           |
+      |        | git merge --no-edit --ff origin/three  |
+      |        | git checkout four                      |
+      | four   | git merge --no-edit --ff three         |
+      |        | git merge --no-edit --ff origin/four   |
+      |        | git checkout main                      |
+      | main   | git push --tags                        |
     And the current branch is still "main"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/conflicts/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/conflicts/conflict_feature_branch_tracking_branch.feature
@@ -18,10 +18,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/happy_path.feature
@@ -29,10 +29,7 @@ Feature: one person making a series of commits and syncs in between
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -51,10 +48,7 @@ Feature: one person making a series of commits and syncs in between
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -73,10 +67,7 @@ Feature: one person making a series of commits and syncs in between
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/unpushed_local_commits.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/tracking_branch/deleted/unpushed_local_commits.feature
@@ -17,12 +17,9 @@ Feature: using the "compress" strategy, sync a branch with unmerged commits whos
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                 |
-      | branch-2 | git fetch --prune --tags                |
-      |          | git checkout main                       |
-      | main     | git rebase origin/main --no-update-refs |
-      |          | git checkout branch-2                   |
-      | branch-2 | git merge --no-edit --ff main           |
+      | BRANCH   | COMMAND                       |
+      | branch-2 | git fetch --prune --tags      |
+      |          | git merge --no-edit --ff main |
     And Git Town prints:
       """
       Branch "branch-2" was deleted at the remote but the local branch contains unshipped changes.

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_parallel.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_parallel.feature
@@ -36,10 +36,7 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "my first commit"         |
@@ -58,10 +55,7 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """
@@ -90,10 +84,7 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """
@@ -122,10 +113,7 @@ Feature: two people using the "compress" strategy make concurrent conflicting ch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_serial.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/conflicting_changes_serial.feature
@@ -35,10 +35,7 @@ Feature: two people make alternating conflicting changes to the same branch usin
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -54,10 +51,7 @@ Feature: two people make alternating conflicting changes to the same branch usin
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And these commits exist now
       | BRANCH  | LOCATION                | MESSAGE     | FILE NAME        | FILE CONTENT |
@@ -71,10 +65,7 @@ Feature: two people make alternating conflicting changes to the same branch usin
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -91,10 +82,7 @@ Feature: two people make alternating conflicting changes to the same branch usin
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """
@@ -121,10 +109,7 @@ Feature: two people make alternating conflicting changes to the same branch usin
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -141,10 +126,7 @@ Feature: two people make alternating conflicting changes to the same branch usin
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """
@@ -171,10 +153,7 @@ Feature: two people make alternating conflicting changes to the same branch usin
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/nonconflicting_changes_serial.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/two_collaborators/nonconflicting_changes_serial.feature
@@ -35,10 +35,7 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -54,10 +51,7 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And these commits exist now
       | BRANCH  | LOCATION                | MESSAGE     | FILE NAME | FILE CONTENT                         |
@@ -71,10 +65,7 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -91,10 +82,7 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """
@@ -121,10 +109,7 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |
@@ -141,10 +126,7 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """
@@ -171,10 +153,7 @@ Feature: two people make alternating non-conflicting changes to the same branch 
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git reset --soft main                   |
       |         | git commit -m "the feature"             |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/upstream/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/upstream/happy_path.feature
@@ -20,8 +20,7 @@ Feature: "compress" sync with upstream repo
       | BRANCH  | COMMAND                                   |
       | feature | git fetch --prune --tags                  |
       |         | git checkout main                         |
-      | main    | git rebase origin/main --no-update-refs   |
-      |         | git fetch upstream main                   |
+      | main    | git fetch upstream main                   |
       |         | git rebase upstream/main --no-update-refs |
       |         | git push                                  |
       |         | git checkout feature                      |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/verbose/verbose.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/verbose/verbose.feature
@@ -31,8 +31,6 @@ Feature: display all executed Git commands for the "compress" sync strategy
       |          | backend  | git remote get-url origin                          |
       |          | backend  | git log main..branch-2 --format=%s --reverse       |
       | branch-2 | frontend | git checkout main                                  |
-      | main     | frontend | git rebase origin/main --no-update-refs            |
-      |          | backend  | git rev-list --left-right main...origin/main       |
       |          | backend  | git config --unset git-town-branch.branch-2.parent |
       | main     | frontend | git branch -D branch-2                             |
       |          | backend  | git show-ref --verify --quiet refs/heads/branch-2  |
@@ -43,7 +41,7 @@ Feature: display all executed Git commands for the "compress" sync strategy
       |          | backend  | git stash list                                     |
     And Git Town prints:
       """
-      Ran 24 shell commands.
+      Ran 22 shell commands.
       """
     And the current branch is now "main"
     And the branches are now

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -17,15 +17,12 @@ Feature: sync while the previous branch is checked out in another worktree
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                 |
-      | current | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout current                    |
-      | current | git merge --no-edit --ff main           |
-      |         | git push -u origin current              |
+      | BRANCH  | COMMAND                       |
+      | current | git fetch --prune --tags      |
+      |         | git merge --no-edit --ff main |
+      |         | git push -u origin current    |
     And the current branch is still "current"
-    And the previous Git branch is now "main"
+    And the previous Git branch is still "previous"
 
   Scenario: undo
     When I run "git-town undo"
@@ -33,6 +30,6 @@ Feature: sync while the previous branch is checked out in another worktree
       | BRANCH  | COMMAND                  |
       | current | git push origin :current |
     And the current branch is now "current"
-    And the previous Git branch is now "main"
+    And the previous Git branch is still "previous"
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/features/sync/current_branch/feature_branch/create_branch_in_between.feature
+++ b/features/sync/current_branch/feature_branch/create_branch_in_between.feature
@@ -14,10 +14,7 @@ Feature: do not undo branches that were created while resolving conflicts
     And Git Town runs the commands
       | BRANCH    | COMMAND                                   |
       | feature-1 | git fetch --prune --tags                  |
-      |           | git checkout main                         |
-      | main      | git rebase origin/main --no-update-refs   |
-      |           | git checkout feature-1                    |
-      | feature-1 | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff main             |
       |           | git merge --no-edit --ff origin/feature-1 |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/dev_remote.feature
+++ b/features/sync/current_branch/feature_branch/dev_remote.feature
@@ -15,13 +15,10 @@ Feature: sync a branch to a custom dev-remote
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                               |
-      | branch | git fetch --prune --tags              |
-      |        | git checkout main                     |
-      | main   | git rebase fork/main --no-update-refs |
-      |        | git checkout branch                   |
-      | branch | git merge --no-edit --ff main         |
-      |        | git push -u fork branch               |
+      | BRANCH | COMMAND                       |
+      | branch | git fetch --prune --tags      |
+      |        | git merge --no-edit --ff main |
+      |        | git push -u fork branch       |
     And all branches are now synchronized
     And the current branch is still "branch"
     And these branches exist now

--- a/features/sync/current_branch/feature_branch/fetch_in_between.feature
+++ b/features/sync/current_branch/feature_branch/fetch_in_between.feature
@@ -17,10 +17,7 @@ Feature: do not undo branches that were pulled in through "git fetch" while reso
     And Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/tracking_branch_deleted.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/offline/tracking_branch_deleted.feature
@@ -20,9 +20,6 @@ Feature: sync a branch whose tracking branch was shipped in offline mode
   Scenario: result
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                   |
-      | feature-1 | git checkout main                         |
-      | main      | git rebase origin/main --no-update-refs   |
-      |           | git checkout feature-1                    |
       | feature-1 | git merge --no-edit --ff main             |
       |           | git merge --no-edit --ff origin/feature-1 |
     And the current branch is still "feature-1"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
@@ -17,13 +17,10 @@ Feature: sync the current branch which has a branch-type override
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH       | COMMAND                                 |
-      | contribution | git fetch --prune --tags                |
-      |              | git checkout main                       |
-      | main         | git rebase origin/main --no-update-refs |
-      |              | git checkout contribution               |
-      | contribution | git merge --no-edit --ff main           |
-      |              | git push -u origin contribution         |
+      | BRANCH       | COMMAND                         |
+      | contribution | git fetch --prune --tags        |
+      |              | git merge --no-edit --ff main   |
+      |              | git push -u origin contribution |
     And all branches are now synchronized
     And the current branch is still "contribution"
     And these commits exist now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/happy_path.feature
@@ -16,20 +16,17 @@ Feature: sync inside a folder that doesn't exist on the main branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | alpha  | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git checkout alpha                      |
-      | alpha  | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/alpha   |
-      |        | git push                                |
-      |        | git checkout beta                       |
-      | beta   | git merge --no-edit --ff main           |
-      |        | git merge --no-edit --ff origin/beta    |
-      |        | git push                                |
-      |        | git checkout alpha                      |
-      | alpha  | git push --tags                         |
+      | BRANCH | COMMAND                               |
+      | alpha  | git fetch --prune --tags              |
+      |        | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/alpha |
+      |        | git push                              |
+      |        | git checkout beta                     |
+      | beta   | git merge --no-edit --ff main         |
+      |        | git merge --no-edit --ff origin/beta  |
+      |        | git push                              |
+      |        | git checkout alpha                    |
+      | alpha  | git push --tags                       |
     And all branches are now synchronized
     And the current branch is still "alpha"
     And these commits exist now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/with_conflict.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/subfolder/subfolder_only_on_branch/with_conflict.feature
@@ -17,12 +17,9 @@ Feature: sync inside a folder that doesn't exist on the main branch
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                 |
-      | current | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout current                    |
-      | current | git merge --no-edit --ff main           |
+      | BRANCH  | COMMAND                       |
+      | current | git fetch --prune --tags      |
+      |         | git merge --no-edit --ff main |
     And the current branch is still "current"
     And a merge is now in progress
     And Git Town prints the error:

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
@@ -16,12 +16,9 @@ Feature: sync a branch with unmerged commits whose tracking branch was deleted
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                 |
-      | branch-2 | git fetch --prune --tags                |
-      |          | git checkout main                       |
-      | main     | git rebase origin/main --no-update-refs |
-      |          | git checkout branch-2                   |
-      | branch-2 | git merge --no-edit --ff main           |
+      | BRANCH   | COMMAND                       |
+      | branch-2 | git fetch --prune --tags      |
+      |          | git merge --no-edit --ff main |
     And Git Town prints:
       """
       Branch "branch-2" was deleted at the remote but the local branch contains unshipped changes.

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/verbose.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/verbose.feature
@@ -30,8 +30,6 @@ Feature: display all executed Git commands
       |        | backend  | git remote get-url origin                     |
       |        | backend  | git log main..old --format=%s --reverse       |
       | old    | frontend | git checkout main                             |
-      | main   | frontend | git rebase origin/main --no-update-refs       |
-      |        | backend  | git rev-list --left-right main...origin/main  |
       |        | backend  | git config --unset git-town-branch.old.parent |
       | main   | frontend | git branch -D old                             |
       |        | backend  | git show-ref --verify --quiet refs/heads/old  |
@@ -42,7 +40,7 @@ Feature: display all executed Git commands
       |        | backend  | git stash list                                |
     And Git Town prints:
       """
-      Ran 24 shell commands.
+      Ran 22 shell commands.
       """
     And the current branch is now "main"
     And the branches are now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
@@ -16,10 +16,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/two_collaborators/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/two_collaborators/happy_path.feature
@@ -17,10 +17,7 @@ Feature: collaborative feature branch syncing
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And these commits exist now
@@ -34,10 +31,7 @@ Feature: collaborative feature branch syncing
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
     And all branches are now synchronized
@@ -52,10 +46,7 @@ Feature: collaborative feature branch syncing
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And all branches are now synchronized
     And these commits exist now

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/upstream/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/upstream/happy_path.feature
@@ -18,8 +18,7 @@ Feature: with upstream repo
       | BRANCH  | COMMAND                                   |
       | feature | git fetch --prune --tags                  |
       |         | git checkout main                         |
-      | main    | git rebase origin/main --no-update-refs   |
-      |         | git fetch upstream main                   |
+      | main    | git fetch upstream main                   |
       |         | git rebase upstream/main --no-update-refs |
       |         | git push                                  |
       |         | git checkout feature                      |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/worktree/previous_branch_in_other_worktree.feature
@@ -14,10 +14,7 @@ Feature: sync a branch when the previous branch is active in another worktree
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | current | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout current                    |
-      | current | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/current |
     And the current branch is still "current"
     And no commits exist now

--- a/features/sync/current_branch/feature_branch/missing_lineage_for_unrelated_branches.feature
+++ b/features/sync/current_branch/feature_branch/missing_lineage_for_unrelated_branches.feature
@@ -17,10 +17,7 @@ Feature: do not ask for lineage of branches that don't need to get synced
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                   |
       | feature-1 | git fetch --prune --tags                  |
-      |           | git checkout main                         |
-      | main      | git rebase origin/main --no-update-refs   |
-      |           | git checkout feature-1                    |
-      | feature-1 | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff main             |
       |           | git merge --no-edit --ff origin/feature-1 |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
+++ b/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
@@ -21,10 +21,7 @@ Feature: compatibility between different sync-feature-strategy settings
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE         | FILE NAME | FILE CONTENT |
@@ -39,10 +36,7 @@ Feature: compatibility between different sync-feature-strategy settings
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                 |
       | feature | git fetch --prune --tags                |
-      |         | git checkout main                       |
-      | main    | git rebase origin/main --no-update-refs |
-      |         | git checkout feature                    |
-      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
     And Git Town prints the error:
       """
@@ -70,10 +64,7 @@ Feature: compatibility between different sync-feature-strategy settings
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
       |         | git rebase origin/feature --no-update-refs      |
     And Git Town prints the error:

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/subfolder/subfolder_only_on_feature/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/subfolder/subfolder_only_on_feature/happy_path.feature
@@ -19,10 +19,7 @@ Feature: sync inside a folder that doesn't exist on the main branch
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
       | alpha  | git fetch --prune --tags                        |
-      |        | git checkout main                               |
-      | main   | git rebase origin/main --no-update-refs         |
-      |        | git checkout alpha                              |
-      | alpha  | git rebase main --no-update-refs                |
+      |        | git rebase main --no-update-refs                |
       |        | git push --force-with-lease --force-if-includes |
       |        | git checkout beta                               |
       | beta   | git rebase main --no-update-refs                |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/deleted_unmerged_branch.feature
@@ -17,12 +17,9 @@ Feature: sync a branch with unmerged commits whose tracking branch was deleted
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                 |
-      | branch-2 | git fetch --prune --tags                |
-      |          | git checkout main                       |
-      | main     | git rebase origin/main --no-update-refs |
-      |          | git checkout branch-2                   |
-      | branch-2 | git rebase main --no-update-refs        |
+      | BRANCH   | COMMAND                          |
+      | branch-2 | git fetch --prune --tags         |
+      |          | git rebase main --no-update-refs |
     And Git Town prints:
       """
       Branch "branch-2" was deleted at the remote but the local branch contains unshipped changes.

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/verbose.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/verbose.feature
@@ -31,8 +31,6 @@ Feature: display all executed Git commands
       |          | backend  | git remote get-url origin                          |
       |          | backend  | git log main..branch-2 --format=%s --reverse       |
       | branch-2 | frontend | git checkout main                                  |
-      | main     | frontend | git rebase origin/main --no-update-refs            |
-      |          | backend  | git rev-list --left-right main...origin/main       |
       |          | backend  | git config --unset git-town-branch.branch-2.parent |
       | main     | frontend | git rebase --onto main branch-2                    |
       |          | frontend | git branch -D branch-2                             |
@@ -44,7 +42,7 @@ Feature: display all executed Git commands
       |          | backend  | git stash list                                     |
     And Git Town prints:
       """
-      Ran 25 shell commands.
+      Ran 23 shell commands.
       """
     And the current branch is now "main"
     And the branches are now

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
@@ -18,10 +18,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
       |         | git rebase origin/feature --no-update-refs      |
     And Git Town prints the error:

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/two_collaborators/conflicting_commits.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/two_collaborators/conflicting_commits.feature
@@ -28,10 +28,7 @@ Feature: two people using rebase make conflicting changes to a branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE         | FILE NAME | FILE CONTENT |
@@ -46,10 +43,7 @@ Feature: two people using rebase make conflicting changes to a branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
       |         | git rebase origin/feature --no-update-refs      |
     And Git Town prints the error:
@@ -76,10 +70,7 @@ Feature: two people using rebase make conflicting changes to a branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
       |         | git rebase origin/feature --no-update-refs      |
     And Git Town prints the error:

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/two_collaborators/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/two_collaborators/happy_path.feature
@@ -26,10 +26,7 @@ Feature: two people with rebase strategy sync changes made by them
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
     And these commits exist now
       | BRANCH  | LOCATION      | MESSAGE         |
@@ -42,10 +39,7 @@ Feature: two people with rebase strategy sync changes made by them
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
       |         | git rebase origin/feature --no-update-refs      |
       |         | git push --force-with-lease --force-if-includes |
@@ -60,10 +54,7 @@ Feature: two people with rebase strategy sync changes made by them
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
-      |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git checkout feature                            |
-      | feature | git rebase main --no-update-refs                |
+      |         | git rebase main --no-update-refs                |
       |         | git push --force-with-lease --force-if-includes |
       |         | git rebase origin/feature --no-update-refs      |
       |         | git push --force-with-lease --force-if-includes |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/upstream/happy_path.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/upstream/happy_path.feature
@@ -19,8 +19,7 @@ Feature: with upstream repo
       | BRANCH  | COMMAND                                         |
       | feature | git fetch --prune --tags                        |
       |         | git checkout main                               |
-      | main    | git rebase origin/main --no-update-refs         |
-      |         | git fetch upstream main                         |
+      | main    | git fetch upstream main                         |
       |         | git rebase upstream/main --no-update-refs       |
       |         | git push                                        |
       |         | git checkout feature                            |

--- a/features/sync/current_branch/main_branch/sync_upstream/true.feature
+++ b/features/sync/current_branch/main_branch/sync_upstream/true.feature
@@ -14,7 +14,6 @@ Feature: on the main branch with an upstream repo
     Then Git Town runs the commands
       | BRANCH | COMMAND                                   |
       | main   | git fetch --prune --tags                  |
-      |        | git rebase origin/main --no-update-refs   |
       |        | git fetch upstream main                   |
       |        | git rebase upstream/main --no-update-refs |
       |        | git push                                  |

--- a/features/sync/current_branch/parked_branch/tracking_branch/deleted.feature
+++ b/features/sync/current_branch/parked_branch/tracking_branch/deleted.feature
@@ -15,11 +15,10 @@ Feature: remove a parked branch as soon as the tracking branch is gone, even if 
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                 |
-      | parked | git fetch --prune --tags                |
-      |        | git checkout main                       |
-      | main   | git rebase origin/main --no-update-refs |
-      |        | git branch -D parked                    |
+      | BRANCH | COMMAND                  |
+      | parked | git fetch --prune --tags |
+      |        | git checkout main        |
+      | main   | git branch -D parked     |
     And the current branch is now "main"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE     |

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/conflict.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/conflict.feature
@@ -16,10 +16,7 @@ Feature: handle conflicts between the current prototype branch and its tracking 
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                   |
       | prototype | git fetch --prune --tags                  |
-      |           | git checkout main                         |
-      | main      | git rebase origin/main --no-update-refs   |
-      |           | git checkout prototype                    |
-      | prototype | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff main             |
       |           | git merge --no-edit --ff origin/prototype |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/deleted.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_merge/tracking_branch/deleted.feature
@@ -15,11 +15,10 @@ Feature: remove a prototype branch as soon as its tracking branch is gone, even 
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH    | COMMAND                                 |
-      | prototype | git fetch --prune --tags                |
-      |           | git checkout main                       |
-      | main      | git rebase origin/main --no-update-refs |
-      |           | git branch -D prototype                 |
+      | BRANCH    | COMMAND                  |
+      | prototype | git fetch --prune --tags |
+      |           | git checkout main        |
+      | main      | git branch -D prototype  |
     And the current branch is now "main"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE     |

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/conflict.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/conflict.feature
@@ -17,10 +17,7 @@ Feature: handle conflicts between the current prototype branch and its tracking 
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                      |
       | prototype | git fetch --prune --tags                     |
-      |           | git checkout main                            |
-      | main      | git rebase origin/main --no-update-refs      |
-      |           | git checkout prototype                       |
-      | prototype | git rebase main --no-update-refs             |
+      |           | git rebase main --no-update-refs             |
       |           | git rebase origin/prototype --no-update-refs |
     And Git Town prints the error:
       """

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/deleted.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/deleted.feature
@@ -16,12 +16,11 @@ Feature: remove a prototype branch as soon as its tracking branch is gone, even 
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH    | COMMAND                                 |
-      | prototype | git fetch --prune --tags                |
-      |           | git checkout main                       |
-      | main      | git rebase origin/main --no-update-refs |
-      |           | git rebase --onto main prototype        |
-      |           | git branch -D prototype                 |
+      | BRANCH    | COMMAND                          |
+      | prototype | git fetch --prune --tags         |
+      |           | git checkout main                |
+      | main      | git rebase --onto main prototype |
+      |           | git branch -D prototype          |
     And the current branch is now "main"
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE     |

--- a/features/sync/features/other_remote.feature
+++ b/features/sync/features/other_remote.feature
@@ -17,10 +17,7 @@ Feature: ignores other Git remotes
     Then Git Town runs the commands
       | BRANCH  | TYPE     | COMMAND                                 |
       | feature | frontend | git fetch --prune --tags                |
-      |         | frontend | git checkout main                       |
-      | main    | frontend | git rebase origin/main --no-update-refs |
-      |         | frontend | git checkout feature                    |
-      | feature | frontend | git merge --no-edit --ff main           |
+      |         | frontend | git merge --no-edit --ff main           |
       |         | frontend | git merge --no-edit --ff origin/feature |
       |         | frontend | git push                                |
 

--- a/features/sync/features/uncommitted_files.feature
+++ b/features/sync/features/uncommitted_files.feature
@@ -20,10 +20,7 @@ Feature: sync all feature branches in the presence of uncommitted changes
       | feature-1 | git fetch --prune --tags                  |
       |           | git add -A                                |
       |           | git stash -m "Git Town WIP"               |
-      |           | git checkout main                         |
-      | main      | git rebase origin/main --no-update-refs   |
-      |           | git checkout feature-1                    |
-      | feature-1 | git merge --no-edit --ff main             |
+      |           | git merge --no-edit --ff main             |
       |           | git merge --no-edit --ff origin/feature-1 |
       |           | git checkout feature-2                    |
       | feature-2 | git merge --no-edit --ff main             |

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 
@@ -291,5 +292,6 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector) 
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
+	fmt.Println("1111111111111111111111111111111111111111111\n", prog)
 	return optimizer.Optimize(prog.Immutable())
 }

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"slices"
 
@@ -292,6 +291,5 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector) 
 		StashOpenChanges:         data.hasOpenChanges,
 		PreviousBranchCandidates: previousBranchCandidates,
 	})
-	fmt.Println("1111111111111111111111111111111111111111111\n", prog)
 	return optimizer.Optimize(prog.Immutable())
 }

--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -114,10 +114,11 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 		})
 	}
 	if args.PushBranches.IsTrue() && args.Remotes.HasRemote(args.Config.NormalConfig.DevRemote) && args.Config.NormalConfig.IsOnline() && branchType.ShouldPush(localName == args.InitialBranch) {
+		isPerennialBranch := branchType == configdomain.BranchTypePerennialBranch
 		switch {
 		case !branchInfo.HasTrackingBranch():
 			args.Program.Value.Add(&opcodes.BranchTrackingCreate{Branch: localName})
-		case isMainOrPerennialBranch && !shouldPushPerennialBranch(branchInfo.SyncStatus):
+		case isPerennialBranch && !shouldPushPerennialBranch(branchInfo.SyncStatus):
 		case isMainOrPerennialBranch:
 			args.Program.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: localName})
 		default:

--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -119,6 +119,7 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 		case !branchInfo.HasTrackingBranch():
 			args.Program.Value.Add(&opcodes.BranchTrackingCreate{Branch: localName})
 		case isPerennialBranch && !shouldPushPerennialBranch(branchInfo.SyncStatus):
+			// don't push if its a perennial branch that doesn't need pushing
 		case isMainOrPerennialBranch:
 			args.Program.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: localName})
 		default:

--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -114,11 +114,13 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 		})
 	}
 	if args.PushBranches.IsTrue() && args.Remotes.HasRemote(args.Config.NormalConfig.DevRemote) && args.Config.NormalConfig.IsOnline() && branchType.ShouldPush(localName == args.InitialBranch) {
-		isPerennialBranch := branchType == configdomain.BranchTypePerennialBranch
+		isMainBranch := branchType == configdomain.BranchTypeMainBranch
 		switch {
 		case !branchInfo.HasTrackingBranch():
 			args.Program.Value.Add(&opcodes.BranchTrackingCreate{Branch: localName})
-		case isPerennialBranch && !shouldPushPerennialBranch(branchInfo.SyncStatus):
+		case isMainBranch && args.Remotes.HasUpstream() && args.Config.NormalConfig.SyncUpstream.IsTrue():
+			args.Program.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: localName})
+		case isMainOrPerennialBranch && !shouldPushPerennialBranch(branchInfo.SyncStatus):
 			// don't push if its a perennial branch that doesn't need pushing
 		case isMainOrPerennialBranch:
 			args.Program.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: localName})

--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -117,6 +117,7 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 		switch {
 		case !branchInfo.HasTrackingBranch():
 			args.Program.Value.Add(&opcodes.BranchTrackingCreate{Branch: localName})
+		case isMainOrPerennialBranch && !shouldPushPerennialBranch(branchInfo.SyncStatus):
 		case isMainOrPerennialBranch:
 			args.Program.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: localName})
 		default:
@@ -195,6 +196,23 @@ type RemoveAncestorCommitsArgs struct {
 	HasTrackingBranch bool
 	Program           Mutable[program.Program]
 	RebaseOnto        gitdomain.LocalBranchName
+}
+
+func shouldPushPerennialBranch(syncStatus gitdomain.SyncStatus) bool {
+	switch syncStatus {
+	case
+		gitdomain.SyncStatusAhead,
+		gitdomain.SyncStatusBehind,
+		gitdomain.SyncStatusLocalOnly,
+		gitdomain.SyncStatusNotInSync:
+		return true
+	case
+		gitdomain.SyncStatusDeletedAtRemote,
+		gitdomain.SyncStatusOtherWorktree,
+		gitdomain.SyncStatusRemoteOnly,
+		gitdomain.SyncStatusUpToDate:
+	}
+	return false
 }
 
 // updateCurrentPerennialBranchOpcode provides the opcode to update the current perennial branch with changes from the given other branch.

--- a/internal/cmd/sync/sync_perennial_branch.go
+++ b/internal/cmd/sync/sync_perennial_branch.go
@@ -6,11 +6,13 @@ import (
 )
 
 // PerennialBranchProgram adds the opcodes to sync the perennial branch with the given name.
-func PerennialBranchProgram(branch gitdomain.BranchInfo, args BranchProgramArgs) {
-	if remoteBranch, hasRemoteBranch := branch.RemoteName.Get(); hasRemoteBranch {
-		updateCurrentPerennialBranchOpcode(args.Program, remoteBranch, args.Config.NormalConfig.SyncPerennialStrategy)
+func PerennialBranchProgram(branchInfo gitdomain.BranchInfo, args BranchProgramArgs) {
+	if remoteBranch, hasRemoteBranch := branchInfo.RemoteName.Get(); hasRemoteBranch {
+		if branchInfo.SyncStatus != gitdomain.SyncStatusUpToDate {
+			updateCurrentPerennialBranchOpcode(args.Program, remoteBranch, args.Config.NormalConfig.SyncPerennialStrategy)
+		}
 	}
-	if localBranch, hasLocalBranch := branch.LocalName.Get(); hasLocalBranch {
+	if localBranch, hasLocalBranch := branchInfo.LocalName.Get(); hasLocalBranch {
 		if localBranch == args.Config.ValidatedConfigData.MainBranch && args.Remotes.HasUpstream() && args.Config.NormalConfig.SyncUpstream.IsTrue() {
 			args.Program.Value.Add(&opcodes.FetchUpstream{Branch: args.Config.ValidatedConfigData.MainBranch})
 			args.Program.Value.Add(&opcodes.RebaseBranch{Branch: gitdomain.NewBranchName("upstream/" + args.Config.ValidatedConfigData.MainBranch.String())})


### PR DESCRIPTION
Perennial branches are unique in the sense that they don't get changes merged in from their parent. This means we know at the time we compile the sync program whether we even need to sync a perennial branch or not. This PR eliminates unnecessary syncs of perennial branches.

This reduces the time to run `make cuke` from 22.5 sec to 21.5 sec. :muscle: 

TODO: also apply this to contribution and observed branches?