### PR TITLE
Enable linting in tools/tests_sorted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ lint-all: lint tools/rta@${RTA_VERSION}  # runs all linters
 	@(cd tools/stats_release && ../rta golangci-lint run)
 	@echo lint tools/structs_sorted
 	@(cd tools/structs_sorted && ../rta golangci-lint run)
+	@echo lint tools/tests_sorted
+	@(cd tools/tests_sorted && ../rta golangci-lint run --disable prealloc)
 	@echo lint tools/lint_steps
 	@(cd tools/lint_steps && ../rta golangci-lint run)
 

--- a/tools/tests_sorted/lint_func_test.go
+++ b/tools/tests_sorted/lint_func_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -16,7 +15,7 @@ func parseFuncDecl(t *testing.T, fset *token.FileSet, funcText string) *ast.Func
 	// Package declaration is mandatory.
 	// Concatenate the package and the function declaration with ';' to preserve
 	// line numbers in any compilation errors.
-	funcFile := fmt.Sprintf("package test; %s", funcText)
+	funcFile := "package test; " + funcText
 	file, err := parser.ParseFile(fset, "test.go", funcFile, 0)
 	must.NoError(t, err)
 	must.SliceLen(t, 1, file.Decls) // We expect a single function.
@@ -78,6 +77,7 @@ func TestLintFuncDecl(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			fset := token.NewFileSet()
 			funcDecl := parseFuncDecl(t, fset, tc.funcText)
 
@@ -131,6 +131,7 @@ func TestIsTestFunc(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			fType := funcType(t, tc.expr)
 
 			got := isTestFunc(fType)
@@ -199,6 +200,7 @@ func TestTRunSubtestNames(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			statements := funcStatements(t, tc.expr)
 
 			got, err := tRunSubtestNames(statements)

--- a/tools/tests_sorted/matcher/matcher.go
+++ b/tools/tests_sorted/matcher/matcher.go
@@ -1,4 +1,6 @@
 // Package matcher declarative go/ast matchers.
+//
+//nolint:ireturn // Returning Result instead of a private struct.
 package matcher
 
 import (
@@ -193,7 +195,7 @@ func (self *FirstStringArgFromFuncCallExtractor) Extract(expr ast.Expr) (string,
 	// https://go-review.googlesource.com/c/go/+/244960
 	literal, err := strconv.Unquote(quotedLiteral)
 	if err != nil {
-		return "", okResult, fmt.Errorf("the first call argument is an invalid string literal: %v", err)
+		return "", okResult, fmt.Errorf("the first call argument is an invalid string literal: %w", err)
 	}
 	return literal, okResult, nil
 }


### PR DESCRIPTION
- Add missing t.Parallel calls.
- Use %w in fmt.Errorf to wrap errors.
- Disable ireturn in matcher.
- Use string concatenation instead of fmt.Sprintf.
- Use matcher_test package for unit tests.
- Disable prealloc linter. It's generally not recommended as it is a premature optimisation to follow this without a good reason.