### PR TITLE
Optimize syncing contribution and observed branches

### DIFF
--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -100,7 +100,7 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 	case configdomain.BranchTypeContributionBranch:
 		ContributionBranchProgram(args.Program, branchInfo)
 	case configdomain.BranchTypeObservedBranch:
-		ObservedBranchProgram(branchInfo.RemoteName, args.Program)
+		ObservedBranchProgram(branchInfo, args.Program)
 	case configdomain.BranchTypePrototypeBranch:
 		FeatureBranchProgram(args.Config.NormalConfig.SyncPrototypeStrategy.SyncStrategy(), featureBranchArgs{
 			firstCommitMessage: firstCommitMessage,

--- a/internal/cmd/sync/sync_contribution_branch.go
+++ b/internal/cmd/sync/sync_contribution_branch.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/git-town/git-town/v17/pkg/prelude"
 )
 
-// FeatureBranchProgram adds the opcodes to sync the feature branch with the given name.
+// ContributionBranchProgram adds the opcodes to sync the feature branch with the given name.
 func ContributionBranchProgram(prog Mutable[program.Program], branchInfo gitdomain.BranchInfo) {
 	if trackingBranch, hasTrackingBranch := branchInfo.RemoteName.Get(); hasTrackingBranch {
 		if branchInfo.SyncStatus != gitdomain.SyncStatusUpToDate {

--- a/internal/cmd/sync/sync_contribution_branch.go
+++ b/internal/cmd/sync/sync_contribution_branch.go
@@ -8,8 +8,10 @@ import (
 )
 
 // FeatureBranchProgram adds the opcodes to sync the feature branch with the given name.
-func ContributionBranchProgram(prog Mutable[program.Program], branch gitdomain.BranchInfo) {
-	if trackingBranch, hasTrackingBranch := branch.RemoteName.Get(); hasTrackingBranch {
-		prog.Value.Add(&opcodes.RebaseBranch{Branch: trackingBranch.BranchName()})
+func ContributionBranchProgram(prog Mutable[program.Program], branchInfo gitdomain.BranchInfo) {
+	if trackingBranch, hasTrackingBranch := branchInfo.RemoteName.Get(); hasTrackingBranch {
+		if branchInfo.SyncStatus != gitdomain.SyncStatusUpToDate {
+			prog.Value.Add(&opcodes.RebaseBranch{Branch: trackingBranch.BranchName()})
+		}
 	}
 }

--- a/internal/cmd/sync/sync_observed_branch.go
+++ b/internal/cmd/sync/sync_observed_branch.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/git-town/git-town/v17/pkg/prelude"
 )
 
-// PerennialBranchProgram adds the opcodes to sync the observed branch with the given name.
+// ObservedBranchProgram adds the opcodes to sync the observed branch with the given name.
 func ObservedBranchProgram(branchInfo gitdomain.BranchInfo, prog Mutable[program.Program]) {
 	if remoteBranch, hasRemoteBranch := branchInfo.RemoteName.Get(); hasRemoteBranch {
 		if branchInfo.SyncStatus != gitdomain.SyncStatusUpToDate {

--- a/internal/cmd/sync/sync_observed_branch.go
+++ b/internal/cmd/sync/sync_observed_branch.go
@@ -8,8 +8,10 @@ import (
 )
 
 // PerennialBranchProgram adds the opcodes to sync the observed branch with the given name.
-func ObservedBranchProgram(branch Option[gitdomain.RemoteBranchName], prog Mutable[program.Program]) {
-	if remoteBranch, hasRemoteBranch := branch.Get(); hasRemoteBranch {
-		prog.Value.Add(&opcodes.RebaseBranch{Branch: remoteBranch.BranchName()})
+func ObservedBranchProgram(branchInfo gitdomain.BranchInfo, prog Mutable[program.Program]) {
+	if remoteBranch, hasRemoteBranch := branchInfo.RemoteName.Get(); hasRemoteBranch {
+		if branchInfo.SyncStatus != gitdomain.SyncStatusUpToDate {
+			prog.Value.Add(&opcodes.RebaseBranch{Branch: remoteBranch.BranchName()})
+		}
 	}
 }


### PR DESCRIPTION
Since contribution and observed branches don't merge in changes from their parent, their sync status is known at the time the VM program is compiled. This allows to determine whether they need to be synced at all at compile time.