### PR TITLE
Make sync-perennial-strategies linkable

### DIFF
--- a/website/src/preferences/sync-feature-strategy.md
+++ b/website/src/preferences/sync-feature-strategy.md
@@ -7,7 +7,7 @@ their parent and tracking branches.
 
 ### merge
 
-When using the "merge" feature sync strategy,
+When using the "merge" feature sync strategy (which is the default),
 [git town sync](../commands/sync.md) merges the parent and tracking branches
 into local feature branches.
 

--- a/website/src/preferences/sync-perennial-strategy.md
+++ b/website/src/preferences/sync-perennial-strategy.md
@@ -5,12 +5,16 @@ their tracking branches.
 
 ## options
 
-- `rebase` (default value): Git Town rebases local perennial branches onto their
-  tracking branch.
-- `ff-only`: Git Town fast-forwards the local branch to match the tracking
-  branch. If a fast-forward is not possible, Git Town exits with an error. This
-  is ideal when you want an explicit warning about unpushed local commits.
-- `merge`: Git Town merges the tracking branch into the local perennial branch.
+### rebase
+
+When using the `rebase` sync strategy, (which is the default), Git Town rebases
+local perennial branches onto their tracking branch.
+
+### ff-only
+
+Git Town fast-forwards the local branch to match the tracking branch. If a
+fast-forward is not possible, Git Town exits with a descriptive error message.
+This is ideal when you want an explicit warning about unpushed local commits.
 
 ## in config file
 


### PR DESCRIPTION
- make the `sync-perennial-strategy` webpage match the structure of the `sync-feature-strategy` page so that each listed strategy is linkable
- don't document the `merge` option for `sync-perennial-strategy` because it doesn't make sense