### PR TITLE
Remove empty lines from source code

### DIFF
--- a/features/append/uncommitted_changes/compress_sync_strategy.feature
+++ b/features/append/uncommitted_changes/compress_sync_strategy.feature
@@ -1,8 +1,5 @@
 Feature: append a new feature branch in a dirty workspace using the "compress" sync strategy
 
-# TODO: move to a subfolder of "clean_workspace"
-# and remove the "clean_workspace" folder from the folder hierarchy
-
   Background:
     Given a Git repo with origin
     And the branches

--- a/internal/forge/bitbucketdatacenter/connector.go
+++ b/internal/forge/bitbucketdatacenter/connector.go
@@ -98,14 +98,10 @@ func (self Connector) apiBaseURL() string {
 
 func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {
 	self.log.Start(messages.APIProposalLookupStart)
-
 	ctx := context.TODO()
-
 	fromRefID := fmt.Sprintf("refs/heads/%v", branch)
 	toRefID := fmt.Sprintf("refs/heads/%v", target)
-
 	var resp PullRequestResponse
-
 	err := requests.URL(self.apiBaseURL()).
 		BasicAuth(self.username, self.token).
 		Param("at", toRefID).
@@ -115,28 +111,22 @@ func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchNam
 		self.log.Failed(err.Error())
 		return None[forgedomain.Proposal](), err
 	}
-
 	if len(resp.Values) == 0 {
 		self.log.Success("none")
 		return None[forgedomain.Proposal](), nil
 	}
-
 	var needle *PullRequest
-
 	for _, pr := range resp.Values {
 		if pr.FromRef.ID == fromRefID && pr.ToRef.ID == toRefID {
 			needle = &pr
 			break
 		}
 	}
-
 	if needle == nil {
 		self.log.Success("no PR found matching source and target branch")
 		return None[forgedomain.Proposal](), nil
 	}
-
 	proposal := parsePullRequest(*needle, self.RepositoryURL())
-
 	self.log.Success(fmt.Sprintf("#%d", proposal.Number))
 	return Some(proposal), nil
 }
@@ -160,13 +150,9 @@ func (self Connector) findProposalViaOverride(branch, target gitdomain.LocalBran
 
 func (self Connector) searchProposal(branch gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {
 	self.log.Start(messages.APIProposalLookupStart)
-
 	ctx := context.TODO()
-
 	fromRefID := fmt.Sprintf("refs/heads/%v", branch)
-
 	var resp PullRequestResponse
-
 	err := requests.URL(self.apiBaseURL()).
 		BasicAuth(self.username, self.token).
 		ToJSON(&resp).
@@ -175,28 +161,22 @@ func (self Connector) searchProposal(branch gitdomain.LocalBranchName) (Option[f
 		self.log.Failed(err.Error())
 		return None[forgedomain.Proposal](), err
 	}
-
 	if len(resp.Values) == 0 {
 		self.log.Success("none")
 		return None[forgedomain.Proposal](), nil
 	}
-
 	var needle *PullRequest
-
 	for _, pr := range resp.Values {
 		if pr.FromRef.ID == fromRefID {
 			needle = &pr
 			break
 		}
 	}
-
 	if needle == nil {
 		self.log.Success("no PR found matching source branch")
 		return None[forgedomain.Proposal](), nil
 	}
-
 	proposal := parsePullRequest(*needle, self.RepositoryURL())
-
 	self.log.Success(fmt.Sprintf("#%d", proposal.Number))
 	return Some(proposal), nil
 }


### PR DESCRIPTION
This code base does not use empty lines in function bodies, since function bodies are short, and empty lines are used to delineate function boundaries.