### PR TITLE
feat(forge): add codeberg

### DIFF
--- a/internal/forge/codeberg/connector.go
+++ b/internal/forge/codeberg/connector.go
@@ -1,0 +1,239 @@
+package codeberg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk"
+	"github.com/git-town/git-town/v18/internal/cli/colors"
+	"github.com/git-town/git-town/v18/internal/cli/print"
+	"github.com/git-town/git-town/v18/internal/config/configdomain"
+	"github.com/git-town/git-town/v18/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v18/internal/git/gitdomain"
+	"github.com/git-town/git-town/v18/internal/git/giturl"
+	"github.com/git-town/git-town/v18/internal/gohacks/stringslice"
+	"github.com/git-town/git-town/v18/internal/messages"
+	. "github.com/git-town/git-town/v18/pkg/prelude"
+	"golang.org/x/oauth2"
+)
+
+// Connector provides standardized connectivity for the given repository (codeberg.org/owner/repo)
+// via the Codeberg API.
+type Connector struct {
+	forgedomain.Data
+	APIToken Option[configdomain.CodebergToken]
+	client   *codeberg.Client
+	log      print.Logger
+}
+
+func (self Connector) DefaultProposalMessage(proposal forgedomain.Proposal) string {
+	return fmt.Sprintf("%s (#%d)", proposal.Title, proposal.Number)
+}
+
+func (self Connector) FindProposalFn() Option[func(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error)] {
+	if len(forgedomain.ReadProposalOverride()) > 0 {
+		return Some(self.findProposalViaOverride)
+	}
+	if self.APIToken.IsSome() {
+		return Some(self.findProposalViaAPI)
+	}
+	return None[func(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error)]()
+}
+
+func (self Connector) NewProposalURL(branch, parentBranch, _ gitdomain.LocalBranchName, _ gitdomain.ProposalTitle, _ gitdomain.ProposalBody) (string, error) {
+	toCompare := parentBranch.String() + "..." + branch.String()
+	return fmt.Sprintf("%s/compare/%s", self.RepositoryURL(), url.PathEscape(toCompare)), nil
+}
+
+func (self Connector) RepositoryURL() string {
+	return fmt.Sprintf("https://%s/%s/%s", self.HostnameWithStandardPort(), self.Organization, self.Repository)
+}
+
+func (self Connector) SearchProposalFn() Option[func(branch gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error)] {
+	if self.APIToken.IsSome() {
+		return Some(self.searchProposal)
+	}
+	return None[func(branch gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error)]()
+}
+
+func (self Connector) SquashMergeProposalFn() Option[func(number int, message gitdomain.CommitMessage) error] {
+	if self.APIToken.IsSome() {
+		return Some(self.squashMergeProposal)
+	}
+	return None[func(number int, message gitdomain.CommitMessage) error]()
+}
+
+func (self Connector) UpdateProposalSourceFn() Option[func(number int, _ gitdomain.LocalBranchName, finalMessages stringslice.Collector) error] {
+	return None[func(number int, _ gitdomain.LocalBranchName, finalMessages stringslice.Collector) error]()
+}
+
+func (self Connector) UpdateProposalTargetFn() Option[func(number int, target gitdomain.LocalBranchName, _ stringslice.Collector) error] {
+	if self.APIToken.IsSome() {
+		return Some(self.updateProposalTarget)
+	}
+	return None[func(number int, target gitdomain.LocalBranchName, _ stringslice.Collector) error]()
+}
+
+func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {
+	self.log.Start(messages.APIProposalLookupStart)
+	openPullRequests, _, err := self.client.ListRepoPullRequests(self.Organization, self.Repository, codeberg.ListPullRequestsOptions{
+		ListOptions: codeberg.ListOptions{
+			PageSize: 50,
+		},
+		State: codeberg.StateOpen,
+	})
+	if err != nil {
+		self.log.Failed(err.Error())
+		return None[forgedomain.Proposal](), err
+	}
+	pullRequests := FilterPullRequests(openPullRequests, branch, target)
+	switch len(pullRequests) {
+	case 0:
+		self.log.Success("none")
+		return None[forgedomain.Proposal](), nil
+	case 1:
+		proposal := parsePullRequest(pullRequests[0])
+		self.log.Success(proposal.Target.String())
+		return Some(proposal), nil
+	default:
+		return None[forgedomain.Proposal](), fmt.Errorf(messages.ProposalMultipleFromToFound, len(pullRequests), branch, target)
+	}
+}
+
+func (self Connector) findProposalViaOverride(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {
+	self.log.Start(messages.APIProposalLookupStart)
+	self.log.Ok()
+	proposalURLOverride := forgedomain.ReadProposalOverride()
+	if proposalURLOverride == forgedomain.OverrideNoProposal {
+		return None[forgedomain.Proposal](), nil
+	}
+	return Some(forgedomain.Proposal{
+		MergeWithAPI: true,
+		Number:       123,
+		Source:       branch,
+		Target:       target,
+		Title:        "title",
+		URL:          proposalURLOverride,
+	}), nil
+}
+
+func (self Connector) searchProposal(branch gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {
+	self.log.Start(messages.APIParentBranchLookupStart, branch.String())
+	openPullRequests, _, err := self.client.ListRepoPullRequests(self.Organization, self.Repository, codeberg.ListPullRequestsOptions{
+		ListOptions: codeberg.ListOptions{
+			PageSize: 50,
+		},
+		State: codeberg.StateOpen,
+	})
+	if err != nil {
+		self.log.Failed(err.Error())
+		return None[forgedomain.Proposal](), err
+	}
+	pullRequests := FilterPullRequests2(openPullRequests, branch)
+	switch len(pullRequests) {
+	case 0:
+		self.log.Success("none")
+		return None[forgedomain.Proposal](), nil
+	case 1:
+		pullRequest := pullRequests[0]
+		proposal := parsePullRequest(pullRequest)
+		self.log.Success(proposal.Target.String())
+		return Some(proposal), nil
+	default:
+		return None[forgedomain.Proposal](), fmt.Errorf(messages.ProposalMultipleFromFound, len(pullRequests), branch)
+	}
+}
+
+func (self Connector) squashMergeProposal(number int, message gitdomain.CommitMessage) error {
+	if number <= 0 {
+		return errors.New(messages.ProposalNoNumberGiven)
+	}
+	commitMessageParts := message.Parts()
+	self.log.Start(messages.ForgeGithubMergingViaAPI, colors.BoldGreen().Styled(strconv.Itoa(number)))
+	_, _, err := self.client.MergePullRequest(self.Organization, self.Repository, int64(number), codeberg.MergePullRequestOption{
+		Style:   codeberg.MergeStyleSquash,
+		Title:   commitMessageParts.Subject,
+		Message: commitMessageParts.Text,
+	})
+	if err != nil {
+		self.log.Failed(err.Error())
+		return err
+	}
+	self.log.Ok()
+	self.log.Start(messages.APIProposalLookupStart)
+	_, _, err = self.client.GetPullRequest(self.Organization, self.Repository, int64(number))
+	self.log.Ok()
+	return err
+}
+
+func (self Connector) updateProposalTarget(number int, target gitdomain.LocalBranchName, _ stringslice.Collector) error {
+	targetName := target.String()
+	self.log.Start(messages.APIUpdateProposalTarget, colors.BoldGreen().Styled("#"+strconv.Itoa(number)), colors.BoldCyan().Styled(targetName))
+	_, _, err := self.client.EditPullRequest(self.Organization, self.Repository, int64(number), codeberg.EditPullRequestOption{
+		Base: targetName,
+	})
+	if err != nil {
+		self.log.Failed(err.Error())
+		return err
+	}
+	self.log.Ok()
+	return nil
+}
+
+func FilterPullRequests(pullRequests []*codeberg.PullRequest, branch, target gitdomain.LocalBranchName) []*codeberg.PullRequest {
+	result := []*codeberg.PullRequest{}
+	for _, pullRequest := range pullRequests {
+		if pullRequest.Head.Name == branch.String() && pullRequest.Base.Name == target.String() {
+			result = append(result, pullRequest)
+		}
+	}
+	return result
+}
+
+func FilterPullRequests2(pullRequests []*codeberg.PullRequest, branch gitdomain.LocalBranchName) []*codeberg.PullRequest {
+	result := []*codeberg.PullRequest{}
+	for _, pullRequest := range pullRequests {
+		if pullRequest.Head.Name == branch.String() {
+			result = append(result, pullRequest)
+		}
+	}
+	return result
+}
+
+// NewCodebergConfig provides Codeberg configuration data if the current repo is hosted on Codeberg,
+// otherwise nil.
+func NewConnector(args NewConnectorArgs) Connector {
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: args.APIToken.String()})
+	httpClient := oauth2.NewClient(context.Background(), tokenSource)
+	codebergClient := codeberg.NewClientWithHTTP("https://"+args.RemoteURL.Host, httpClient)
+	return Connector{
+		APIToken: args.APIToken,
+		Data: forgedomain.Data{
+			Hostname:     args.RemoteURL.Host,
+			Organization: args.RemoteURL.Org,
+			Repository:   args.RemoteURL.Repo,
+		},
+		client: codebergClient,
+		log:    args.Log,
+	}
+}
+
+type NewConnectorArgs struct {
+	APIToken  Option[configdomain.CodebergToken]
+	Log       print.Logger
+	RemoteURL giturl.Parts
+}
+
+func parsePullRequest(pullRequest *codeberg.PullRequest) forgedomain.Proposal {
+	return forgedomain.Proposal{
+		MergeWithAPI: pullRequest.Mergeable,
+		Number:       int(pullRequest.Index),
+		Source:       gitdomain.NewLocalBranchName(pullRequest.Head.Ref),
+		Target:       gitdomain.NewLocalBranchName(pullRequest.Base.Ref),
+		Title:        pullRequest.Title,
+		URL:          pullRequest.HTMLURL,
+	}
+}

--- a/internal/forge/codeberg/connector_test.go
+++ b/internal/forge/codeberg/connector_test.go
@@ -1,0 +1,160 @@
+package codeberg_test
+
+import (
+	"testing"
+
+	forgejosdk "codeberg.org/mvdkleijn/forgejo-sdk"
+	"github.com/git-town/git-town/v18/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v18/internal/forge/codeberg"
+	"github.com/shoenig/test/must"
+)
+
+func TestFilterCodebergPullRequests(t *testing.T) {
+	t.Parallel()
+	give := []*forgejosdk.PullRequest{
+		// matching branch
+		{
+			Head: &forgejosdk.PRBranchInfo{
+				Name: "branch",
+			},
+			Base: &forgejosdk.PRBranchInfo{
+				Name: "target",
+			},
+		},
+		// branch with different name
+		{
+			Head: &forgejosdk.PRBranchInfo{
+				Name: "other",
+			},
+			Base: &forgejosdk.PRBranchInfo{
+				Name: "target",
+			},
+		},
+		// branch with different target
+		{
+			Head: &forgejosdk.PRBranchInfo{
+				Name: "branch",
+			},
+			Base: &forgejosdk.PRBranchInfo{
+				Name: "other",
+			},
+		},
+	}
+	want := []*forgejosdk.PullRequest{
+		{
+			Head: &forgejosdk.PRBranchInfo{
+				Name: "branch",
+			},
+			Base: &forgejosdk.PRBranchInfo{
+				Name: "target",
+			},
+		},
+	}
+	have := codeberg.FilterPullRequests(give, "branch", "target")
+	must.Eq(t, want, have)
+}
+
+//nolint:paralleltest  // mocks HTTP
+func TestCodeberg(t *testing.T) {
+	t.Run("DefaultProposalMessage", func(t *testing.T) {
+		give := forgedomain.Proposal{
+			Number: 1,
+			Title:  "my title",
+		}
+		want := "my title (#1)"
+		connector := codeberg.Connector{}
+		have := connector.DefaultProposalMessage(give)
+		must.EqOp(t, want, have)
+	})
+
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE CODEBERG CONNECTOR.
+	//
+	// t.Run("NewProposalURL", func(t *testing.T) {
+	// 	connector, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		HostingPlatform: configdomain.HostingCodeberg,
+	// 		RemoteURL:      giturl.Parse("git@codeberg.org:git-town/docs.git"),
+	// 		APIToken:       "",
+	// 		Log:            log.Silent{},
+	// 	})
+	// 	must.NoError(t, err)
+	// 	have, err := connector.NewProposalURL("feature", "parent")
+	// 	must.NoError(t, err)
+	// 	must.EqOp(t, "https://codeberg.org/git-town/docs/compare/parent...feature", have)
+	// })
+
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE CODEBERG CONNECTOR.
+	//
+	// t.Run("RepositoryURL", func(t *testing.T) {
+	// 	connector, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		HostingPlatform: configdomain.HostingCodeberg,
+	// 		RemoteURL:      giturl.Parse("git@codeberg.org:git-town/docs.git"),
+	// 		APIToken:       "",
+	// 		Log:            log.Silent{},
+	// 	})
+	// 	must.NoError(t, err)
+	// 	have := connector.RepositoryURL()
+	// 	must.EqOp(t, "https://codeberg.org/git-town/docs", have)
+	// })
+}
+
+func TestNewCodebergConnector(t *testing.T) {
+	t.Parallel()
+
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE CODEBERG CONNECTOR.
+	//
+	// t.Run("hosted service type provided manually", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	have, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		HostingPlatform: configdomain.HostingCodeberg,
+	// 		RemoteURL:      giturl.Parse("git@custom-url.com:git-town/docs.git"),
+	// 		APIToken:       "apiToken",
+	// 		Log:            log.Silent{},
+	// 	})
+	// 	must.NoError(t, err)
+	// 	wantConfig := hostingdomain.Config{
+	// 		Hostname:     "custom-url.com",
+	// 		Organization: "git-town",
+	// 		Repository:   "docs",
+	// 	}
+	// 	must.EqOp(t, wantConfig, have.Config)
+	// })
+
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE CODEBERG CONNECTOR.
+	//
+	// t.Run("repo is hosted by another forge type --> no connector", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	have, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		HostingPlatform: configdomain.HostingNone,
+	// 		RemoteURL:      giturl.Parse("git@github.com:git-town/git-town.git"),
+	// 		APIToken:       "",
+	// 		Log:            log.Silent{},
+	// 	})
+	// 	must.Nil(t, have)
+	// 	must.NoError(t, err)
+	// })
+
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE CODEBERG CONNECTOR.
+	//
+	// t.Run("no origin remote --> no connector", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	var remoteURL *giturl.Parts
+	// 	have, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		HostingPlatform: configdomain.HostingNone,
+	// 		RemoteURL:      remoteURL,
+	// 		APIToken:       "",
+	// 		Log:            log.Silent{},
+	// 	})
+	// 	must.Nil(t, have)
+	// 	must.NoError(t, err)
+	// })
+}

--- a/internal/forge/codeberg/detect.go
+++ b/internal/forge/codeberg/detect.go
@@ -1,0 +1,8 @@
+package codeberg
+
+import "github.com/git-town/git-town/v18/internal/git/giturl"
+
+// Detect indicates whether the current repository is hosted on a Codeberg server.
+func Detect(remoteURL giturl.Parts) bool {
+	return remoteURL.Host == "codeberg.org"
+}

--- a/internal/forge/codeberg/detect_test.go
+++ b/internal/forge/codeberg/detect_test.go
@@ -1,0 +1,24 @@
+package codeberg_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v18/internal/forge/codeberg"
+	"github.com/git-town/git-town/v18/internal/git/giturl"
+	"github.com/shoenig/test/must"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+	tests := map[string]bool{
+		"git@codeberg.org:git-town/docs.git":   true,  // SAAS URL
+		"git@custom-url.com:git-town/docs.git": false, // custom URL
+		"git@gitlab.com:git-town/git-town.git": false, // other hosting URL
+	}
+	for give, want := range tests {
+		url, has := giturl.Parse(give).Get()
+		must.True(t, has)
+		have := codeberg.Detect(url)
+		must.EqOp(t, want, have)
+	}
+}

--- a/internal/forge/codeberg/doc.go
+++ b/internal/forge/codeberg/doc.go
@@ -1,0 +1,2 @@
+// Package codeberg provides the forge connector for Codeberg.
+package codeberg


### PR DESCRIPTION
I'm out of my depth here but I did my best to get the Codeberg integration up and running as described in #4581.

Since I found a [Forgejo SDK for Go](https://codeberg.org/mvdkleijn/forgejo-sdk), I based my changes on the [Gitea driver](https://github.com/git-town/git-town/tree/main/internal/forge/gitea) and tried to make it work as best as I could. 

Unfortunately, `make test-go` fails and I have no idea why.

Any help in making this work would be greatly appreciated 🙏