### PR TITLE
End-to-end test for rebasing amended commits

### DIFF
--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/modified_commits/amended_commit.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/modified_commits/amended_commit.feature
@@ -1,0 +1,62 @@
+Feature: rebase a branch that contains amended commits
+
+  Background:
+    Given a Git repo with origin
+    And the branch
+      | NAME      | TYPE    | PARENT | LOCATIONS |
+      | feature-1 | feature | main   | local     |
+    And the commits
+      | BRANCH    | LOCATION | MESSAGE   | FILE NAME | FILE CONTENT |
+      | feature-1 | local    | commit 1a | file_1    | one          |
+    And the branch
+      | NAME      | TYPE    | PARENT    | LOCATIONS |
+      | feature-2 | feature | feature-1 | local     |
+    And the commits
+      | BRANCH    | LOCATION | MESSAGE  | FILE NAME | FILE CONTENT |
+      | feature-2 | local    | commit 2 | file_2    | two          |
+    And the current branch is "feature-1"
+    And Git setting "git-town.sync-feature-strategy" is "rebase"
+    And I ran "git town sync"
+    And I amend this commit
+      | BRANCH    | LOCATION | MESSAGE   | FILE NAME | FILE CONTENT |
+      | feature-1 | local    | commit 1b | file_1    | another one  |
+    When I run "git-town sync"
+
+  @this
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                                         |
+      | feature | git fetch --prune --tags                        |
+      |         | git checkout main                               |
+      | main    | git rebase origin/main --no-update-refs         |
+      |         | git push                                        |
+      |         | git checkout feature                            |
+      | feature | git rebase main --no-update-refs                |
+      |         | git push --force-with-lease --force-if-includes |
+      |         | git rebase origin/feature --no-update-refs      |
+      |         | git push --force-with-lease --force-if-includes |
+    And all branches are now synchronized
+    And the current branch is still "feature"
+    And these commits exist now
+      | BRANCH  | LOCATION      | MESSAGE               |
+      | main    | local, origin | origin main commit    |
+      |         |               | local main commit     |
+      | feature | local, origin | origin feature commit |
+      |         |               | origin main commit    |
+      |         |               | local main commit     |
+      |         |               | local feature commit  |
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH  | COMMAND                                                                                           |
+      | feature | git reset --hard {{ sha-before-run 'local feature commit' }}                                      |
+      |         | git push --force-with-lease origin {{ sha-in-origin-before-run 'origin feature commit' }}:feature |
+    And the current branch is still "feature"
+    And these commits exist now
+      | BRANCH  | LOCATION      | MESSAGE               |
+      | main    | local, origin | origin main commit    |
+      |         |               | local main commit     |
+      | feature | local         | local feature commit  |
+      |         | origin        | origin feature commit |
+    And the initial branches and lineage exist now

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/modified_commits/amended_commit.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/modified_commits/amended_commit.feature
@@ -18,7 +18,6 @@ Feature: rebase a branch that contains amended commits
       | BRANCH    | LOCATION | MESSAGE   | FILE NAME | FILE CONTENT |
       | feature-1 | local    | commit 1b | file_1    | another one  |
     And the current branch is "feature-2"
-    # And inspect the repo
     When I run "git-town sync"
 
   Scenario: result

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -573,10 +573,6 @@ func defineSteps(sc *godog.ScenarioContext) {
 		devRepo.CreateFile(commit.FileName, commit.FileContent)
 		devRepo.Run("git", "add", commit.FileName)
 		devRepo.Run("git", "commit", "--amend", "--message", commit.Message.String())
-		initialBranch := state.initialCurrentBranch.GetOrPanic()
-		if devRepo.CurrentBranchCache.Value() != initialBranch {
-			devRepo.CheckoutBranch(initialBranch)
-		}
 		return nil
 	})
 

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -571,9 +571,8 @@ func defineSteps(sc *godog.ScenarioContext) {
 		commit := commits[0]
 		devRepo.CheckoutBranch(commit.Branch)
 		devRepo.CreateFile(commit.FileName, commit.FileContent)
-		devRepo.Run("git", "add", commit.FileName)
-		devRepo.Run("git", "commit", "--amend", "--message", commit.Message.String())
-		return nil
+		asserts.NoError(devRepo.Run("git", "add", commit.FileName))
+		return devRepo.Run("git", "commit", "--amend", "--message", commit.Message.String())
 	})
 
 	sc.Step(`^I am not prompted for any parent branches$`, func(ctx context.Context) error {

--- a/test/cucumber/steps.go
+++ b/test/cucumber/steps.go
@@ -563,7 +563,6 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^I amend this commit$`, func(ctx context.Context, table *godog.Table) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		// create the commits
 		commits := testgit.FromGherkinTable(table)
 		if len(commits) != 1 {
 			return errors.New("expected exactly one commit")


### PR DESCRIPTION
This PR adds an end-to-end test that documents the current (not ideal) behavior where the user needs to resolve merge conflicts when rebasing amended commits.

part of #4586