### PR TITLE
End-to-end test that reproduces the set-parent bug

### DIFF
--- a/features/set_parent/sync_strategy/rebase/merge_conflict.feature
+++ b/features/set_parent/sync_strategy/rebase/merge_conflict.feature
@@ -1,5 +1,5 @@
 @messyoutput
-Feature: move a branch within a stack
+Feature: remove a branch from a stack
 
   Background:
     Given a Git repo with origin

--- a/features/set_parent/sync_strategy/rebase/remove_from_stack.feature
+++ b/features/set_parent/sync_strategy/rebase/remove_from_stack.feature
@@ -12,14 +12,14 @@ Feature: remove a branch from a stack
       | NAME     | TYPE    | PARENT   | LOCATIONS     |
       | branch-2 | feature | branch-1 | local, origin |
     And the commits
-      | BRANCH   | LOCATION      | MESSAGE  | FILE NAME |
-      | branch-2 | local, origin | commit 2 | file_2    |
+      | BRANCH   | LOCATION      | MESSAGE  | FILE NAME | FILE CONTENT |
+      | branch-2 | local, origin | commit 2 | file_2    | content 2    |
     And the branches
       | NAME     | TYPE    | PARENT   | LOCATIONS     |
       | branch-3 | feature | branch-2 | local, origin |
     And the commits
       | BRANCH   | LOCATION      | MESSAGE  | FILE NAME | FILE CONTENT |
-      | branch-3 | local, origin | commit 3 | file_1    | content 2    |
+      | branch-3 | local, origin | commit 3 | file_1    | content 3    |
     And the current branch is "branch-3"
     And local Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town set-parent" and enter into the dialog:
@@ -44,19 +44,14 @@ Feature: remove a branch from a stack
       |          | git push --force-with-lease --force-if-includes |
     And the current branch is still "branch-3"
     And these commits exist now
-      | BRANCH   | LOCATION      | MESSAGE  |
-      | branch-1 | local, origin | commit 1 |
-      | branch-2 | local, origin | commit 2 |
+      | BRANCH   | LOCATION      | MESSAGE  | FILE NAME | FILE CONTENT |
+      | branch-1 | local, origin | commit 1 | file_1    | content 1    |
+      | branch-2 | local, origin | commit 2 | file_2    | content 2    |
     And this lineage exists now
       | BRANCH   | PARENT   |
       | branch-1 | main     |
       | branch-2 | branch-1 |
       | branch-3 | main     |
-    And the branches contain these files:
-      | BRANCH   | NAME   |
-      | branch-1 | file_1 |
-      | branch-2 | file_1 |
-      |          | file_2 |
 
   Scenario: undo
     When I run "git-town undo"

--- a/features/set_parent/sync_strategy/rebase/remove_from_stack.feature
+++ b/features/set_parent/sync_strategy/rebase/remove_from_stack.feature
@@ -1,4 +1,3 @@
-@messyoutput
 Feature: remove a branch from a stack
 
   Background:
@@ -7,8 +6,8 @@ Feature: remove a branch from a stack
       | NAME     | TYPE    | PARENT | LOCATIONS     |
       | branch-1 | feature | main   | local, origin |
     And the commits
-      | BRANCH   | LOCATION      | MESSAGE  | FILE NAME |
-      | branch-1 | local, origin | commit 1 | file_1    |
+      | BRANCH   | LOCATION      | MESSAGE  | FILE NAME | FILE CONTENT |
+      | branch-1 | local, origin | commit 1 | file_1    | content 1    |
     And the branches
       | NAME     | TYPE    | PARENT   | LOCATIONS     |
       | branch-2 | feature | branch-1 | local, origin |
@@ -19,46 +18,45 @@ Feature: remove a branch from a stack
       | NAME     | TYPE    | PARENT   | LOCATIONS     |
       | branch-3 | feature | branch-2 | local, origin |
     And the commits
-      | BRANCH   | LOCATION      | MESSAGE  | FILE NAME |
-      | branch-3 | local, origin | commit 3 | file_3    |
+      | BRANCH   | LOCATION      | MESSAGE  | FILE NAME | FILE CONTENT |
+      | branch-3 | local, origin | commit 3 | file_1    | content 2    |
     And the current branch is "branch-3"
     And local Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS                 |
-      | parent branch of child | down down down enter |
+      | DIALOG                 | KEYS            |
+      | parent branch of child | down down enter |
 
   Scenario: result
     Then Git Town prints:
       """
-      Selected parent branch for "branch-3": branch-1
+      Selected parent branch for "branch-3": main
       """
     And Git Town prints:
       """
-      branch "branch-3" is now a child of "branch-1"
+      branch "branch-3" is now a child of "main"
       """
     And Git Town runs the commands
       | BRANCH   | COMMAND                                         |
       | branch-3 | git pull                                        |
-      |          | git rebase --onto branch-1 branch-2 branch-3    |
+      |          | git rebase --onto main branch-2 branch-3        |
+      |          | git rm file_1                                   |
+      |          | git -c core.editor=true rebase --continue       |
       |          | git push --force-with-lease --force-if-includes |
     And the current branch is still "branch-3"
     And these commits exist now
       | BRANCH   | LOCATION      | MESSAGE  |
       | branch-1 | local, origin | commit 1 |
       | branch-2 | local, origin | commit 2 |
-      | branch-3 | local, origin | commit 3 |
     And this lineage exists now
       | BRANCH   | PARENT   |
       | branch-1 | main     |
       | branch-2 | branch-1 |
-      | branch-3 | branch-1 |
+      | branch-3 | main     |
     And the branches contain these files:
       | BRANCH   | NAME   |
       | branch-1 | file_1 |
       | branch-2 | file_1 |
       |          | file_2 |
-      | branch-3 | file_1 |
-      |          | file_3 |
 
   Scenario: undo
     When I run "git-town undo"


### PR DESCRIPTION
This test reproduces the error reported in #4638