### PR TITLE
Remove Charlie from code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kevgo @charlierudolph
+* @kevgo


### PR DESCRIPTION
Charlie hasn't been active on this project for years, and there is no point tagging him on every pull request and bombarding his email inbox with notifications. He is still a member of the organization with full access and always welcome back!