### PR TITLE
Improve step order

### DIFF
--- a/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -58,8 +58,8 @@ Feature: handle rebase conflicts between main branch and its tracking branch
       |         | git push                                  |
       |         | git checkout main                         |
       | main    | git push --tags                           |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
@@ -80,8 +80,8 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
       |        | git checkout main                         |
       | main   | git rebase origin/main --no-update-refs   |
       |        | git push --tags                           |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
 
   Scenario: resolve, finish the rebase, and continue
     When I resolve the conflict in "conflicting_file"

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -74,8 +74,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | feature | git merge --no-edit --ff main             |
       |         | git merge --no-edit --ff origin/feature   |
       |         | git push                                  |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
@@ -92,8 +92,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | feature | git merge --no-edit --ff main           |
       |         | git merge --no-edit --ff origin/feature |
       |         | git push                                |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/local_repo/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/local_repo/conflict_feature_vs_main.feature
@@ -53,8 +53,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                   |
       | feature | git -c core.editor=true rebase --continue |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
@@ -56,8 +56,8 @@ Feature: handle conflicts between the current feature branch and its tracking br
       | BRANCH  | COMMAND                                         |
       | feature | git -c core.editor=true rebase --continue       |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | feature | conflicting_file | resolved content |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
@@ -74,8 +74,8 @@ Feature: handle conflicts between the current feature branch and the main branch
       | BRANCH  | COMMAND                                         |
       | feature | git -c core.editor=true rebase --continue       |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |
@@ -95,8 +95,8 @@ Feature: handle conflicts between the current feature branch and the main branch
       | BRANCH  | COMMAND                                         |
       | feature | git -c core.editor=true rebase --continue       |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_main_local_vs_main_tracking.feature
@@ -59,8 +59,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | feature | git rebase main --no-update-refs                |
       |         | git rebase origin/feature --no-update-refs      |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
@@ -77,8 +77,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | feature | git rebase main --no-update-refs                |
       |         | git rebase origin/feature --no-update-refs      |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -63,8 +63,8 @@ Feature: handle conflicts between the current feature branch and the main branch
       | feature | git -c core.editor=true rebase --continue       |
       |         | git rebase origin/feature --no-update-refs      |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | main content     |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -75,8 +75,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | feature | git rebase main --no-update-refs                |
       |         | git rebase origin/feature --no-update-refs      |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |
@@ -93,8 +93,8 @@ Feature: handle conflicts between the main branch and its tracking branch
       | feature | git rebase main --no-update-refs                |
       |         | git rebase origin/feature --no-update-refs      |
       |         | git push --force-with-lease --force-if-includes |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH  | NAME             | CONTENT          |
       | main    | conflicting_file | resolved content |

--- a/features/sync/current_branch/perennial_branch/tracking/conflict.feature
+++ b/features/sync/current_branch/perennial_branch/tracking/conflict.feature
@@ -55,8 +55,8 @@ Feature: handle conflicts between the current perennial branch and its tracking 
       | qa     | git -c core.editor=true rebase --continue |
       |        | git push                                  |
       |        | git push --tags                           |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |
@@ -69,8 +69,8 @@ Feature: handle conflicts between the current perennial branch and its tracking 
       | BRANCH | COMMAND         |
       | qa     | git push        |
       |        | git push --tags |
-    And all branches are now synchronized
     And no rebase is now in progress
+    And all branches are now synchronized
     And these committed files exist now
       | BRANCH | NAME             | CONTENT          |
       | qa     | conflicting_file | resolved content |


### PR DESCRIPTION
It's better to first ensure that no rebase is in progress and then verify that the branches are in sync.