### PR TITLE
append, hack: do not sync when committing

### DIFF
--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -301,7 +301,7 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo execute.Op
 func appendProgram(data appendFeatureData, finalMessages stringslice.Collector) program.Program {
 	prog := NewMutable(&program.Program{})
 	data.config.CleanupLineage(data.branchInfos, data.nonExistingBranches, finalMessages)
-	if !data.hasOpenChanges {
+	if !data.hasOpenChanges && data.commit.IsFalse() {
 		branchesToDelete := set.New[gitdomain.LocalBranchName]()
 		sync.BranchesProgram(data.branchesToSync, sync.BranchProgramArgs{
 			BranchInfos:         data.branchInfos,

--- a/internal/config/configdomain/commit.go
+++ b/internal/config/configdomain/commit.go
@@ -3,10 +3,10 @@ package configdomain
 // when creating a new branch, whether to commit the currently staged changes into that new branch
 type Commit bool
 
-func (self Commit) IsTrue() bool {
-	return bool(self)
-}
-
 func (self Commit) IsFalse() bool {
 	return !self.IsTrue()
+}
+
+func (self Commit) IsTrue() bool {
+	return bool(self)
 }

--- a/internal/config/configdomain/commit.go
+++ b/internal/config/configdomain/commit.go
@@ -2,3 +2,11 @@ package configdomain
 
 // when creating a new branch, whether to commit the currently staged changes into that new branch
 type Commit bool
+
+func (self Commit) IsTrue() bool {
+	return bool(self)
+}
+
+func (self Commit) IsFalse() bool {
+	return !self.IsTrue()
+}


### PR DESCRIPTION
When the user calls `git town hack` or `append` with the `--commit` flag, it does not sync branches. This allows the user to commit the open changes first, without having to deal with merge conflicts, and then sync later.