### PR TITLE
hack: don't pull main branch updates when beaming

### DIFF
--- a/features/hack/give_non_existing_branch/beam/select_commits.feature
+++ b/features/hack/give_non_existing_branch/beam/select_commits.feature
@@ -21,9 +21,7 @@ Feature: beam multiple commits onto a new feature branch
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                                                                             |
       | existing | git fetch --prune --tags                                                                            |
-      |          | git checkout main                                                                                   |
-      | main     | git rebase origin/main --no-update-refs                                                             |
-      |          | git checkout -b new                                                                                 |
+      |          | git checkout -b new main                                                                            |
       | new      | git cherry-pick {{ sha-before-run 'commit 2' }}                                                     |
       |          | git cherry-pick {{ sha-before-run 'commit 4' }}                                                     |
       |          | git checkout existing                                                                               |
@@ -34,7 +32,7 @@ Feature: beam multiple commits onto a new feature branch
     And no rebase is now in progress
     And these commits exist now
       | BRANCH   | LOCATION      | MESSAGE     |
-      | main     | local, origin | main commit |
+      | main     | origin        | main commit |
       | existing | local, origin | commit 1    |
       |          |               | commit 3    |
       | new      | local         | commit 2    |
@@ -51,9 +49,6 @@ Feature: beam multiple commits onto a new feature branch
       | new      | git checkout existing                                                  |
       | existing | git reset --hard {{ sha-before-run 'commit 4' }}                       |
       |          | git push --force-with-lease origin {{ sha 'initial commit' }}:existing |
-      |          | git checkout main                                                      |
-      | main     | git reset --hard {{ sha 'initial commit' }}                            |
-      |          | git checkout existing                                                  |
-      | existing | git branch -D new                                                      |
+      |          | git branch -D new                                                      |
     And the initial commits exist now
     And the initial branches and lineage exist now

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -168,6 +168,7 @@ func executeAppend(arg string, commit configdomain.Commit, commitMessage Option[
 }
 
 type appendFeatureData struct {
+	beam                      configdomain.Beam
 	branchInfos               gitdomain.BranchInfos
 	branchesSnapshot          gitdomain.BranchesSnapshot
 	branchesToSync            configdomain.BranchesToSync
@@ -273,6 +274,7 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo execute.Op
 	initialAndAncestors := validatedConfig.NormalConfig.Lineage.BranchAndAncestors(initialBranch)
 	slices.Reverse(initialAndAncestors)
 	return appendFeatureData{
+		beam:                      false,
 		branchInfos:               branchesSnapshot.Branches,
 		branchesSnapshot:          branchesSnapshot,
 		branchesToSync:            branchesToSync,
@@ -301,7 +303,7 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo execute.Op
 func appendProgram(data appendFeatureData, finalMessages stringslice.Collector) program.Program {
 	prog := NewMutable(&program.Program{})
 	data.config.CleanupLineage(data.branchInfos, data.nonExistingBranches, finalMessages)
-	if !data.hasOpenChanges && data.commit.IsFalse() {
+	if !data.hasOpenChanges && data.commit.IsFalse() && data.beam.IsFalse() {
 		branchesToDelete := set.New[gitdomain.LocalBranchName]()
 		sync.BranchesProgram(data.branchesToSync, sync.BranchProgramArgs{
 			BranchInfos:         data.branchInfos,

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -351,6 +351,7 @@ func determineHackData(args []string, repo execute.OpenRepoResult, beam configdo
 		}
 	}
 	data = Left[appendFeatureData, convertToFeatureData](appendFeatureData{
+		beam:                      beam,
 		branchInfos:               branchesSnapshot.Branches,
 		branchesSnapshot:          branchesSnapshot,
 		branchesToSync:            branchesToSync,


### PR DESCRIPTION
When the user beams commits onto a new feature branch, don't also pull in updates from the main branch. This avoids confronting the user with two different types of merge conflicts: (1) caused by pulling in updates from main, or (2) caused by beaming the commits. Ideally the user experiences only (2).