### PR TITLE
Don't fetch when committing or beaming

### DIFF
--- a/features/hack/give_non_existing_branch/beam/select_commits.feature
+++ b/features/hack/give_non_existing_branch/beam/select_commits.feature
@@ -20,8 +20,7 @@ Feature: beam multiple commits onto a new feature branch
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                                                                             |
-      | existing | git fetch --prune --tags                                                                            |
-      |          | git checkout -b new main                                                                            |
+      | existing | git checkout -b new main                                                                            |
       | new      | git cherry-pick {{ sha-before-run 'commit 2' }}                                                     |
       |          | git cherry-pick {{ sha-before-run 'commit 4' }}                                                     |
       |          | git checkout existing                                                                               |

--- a/features/prepend/beam/compress.feature
+++ b/features/prepend/beam/compress.feature
@@ -21,8 +21,7 @@ Feature: prepend a branch to a feature branch using the "compress" sync strategy
   Scenario: result
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
-      | old    | git fetch --prune --tags                        |
-      |        | git merge --no-edit --ff main                   |
+      | old    | git merge --no-edit --ff main                   |
       |        | git merge --no-edit --ff origin/old             |
       |        | git reset --soft main                           |
       |        | git commit -m "commit 1"                        |

--- a/features/prepend/beam/merge.feature
+++ b/features/prepend/beam/merge.feature
@@ -21,8 +21,7 @@ Feature: prepend a branch to a feature branch using the "merge" sync strategy
   Scenario: result
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
-      | old    | git fetch --prune --tags                        |
-      |        | git merge --no-edit --ff main                   |
+      | old    | git merge --no-edit --ff main                   |
       |        | git merge --no-edit --ff origin/old             |
       |        | git checkout -b parent main                     |
       | parent | git cherry-pick {{ sha-before-run 'commit 2' }} |

--- a/features/prepend/beam/propose.feature
+++ b/features/prepend/beam/propose.feature
@@ -23,8 +23,7 @@ Feature: propose a newly prepended branch
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                                                 |
-      | existing | git fetch --prune --tags                                                |
-      | (none)   | Looking for proposal online ... ok                                      |
+      |          | Looking for proposal online ... ok                                      |
       | existing | git checkout parent                                                     |
       | parent   | git rebase main --no-update-refs                                        |
       |          | git push --force-with-lease --force-if-includes                         |

--- a/features/prepend/beam/propose_with_title_and_body.feature
+++ b/features/prepend/beam/propose_with_title_and_body.feature
@@ -22,8 +22,7 @@ Feature: propose a newly prepended branch
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                                                                                |
-      | existing | git fetch --prune --tags                                                                               |
-      | (none)   | Looking for proposal online ... ok                                                                     |
+      |          | Looking for proposal online ... ok                                                                     |
       | existing | git rebase main --no-update-refs                                                                       |
       |          | git push --force-with-lease --force-if-includes                                                        |
       |          | git checkout -b new main                                                                               |

--- a/features/prepend/beam/rebase.feature
+++ b/features/prepend/beam/rebase.feature
@@ -21,8 +21,7 @@ Feature: prepend a branch to a feature branch using the "rebase" sync strategy
   Scenario: result
     Then Git Town runs the commands
       | BRANCH | COMMAND                                         |
-      | old    | git fetch --prune --tags                        |
-      |        | git rebase main --no-update-refs                |
+      | old    | git rebase main --no-update-refs                |
       |        | git push --force-with-lease --force-if-includes |
       |        | git checkout -b parent main                     |
       | parent | git cherry-pick {{ sha-before-run 'commit 2' }} |

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -209,7 +209,7 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, repo execute.Op
 		CommandsCounter:       repo.CommandsCounter,
 		ConfigSnapshot:        repo.ConfigSnapshot,
 		DialogTestInputs:      dialogTestInputs,
-		Fetch:                 !repoStatus.OpenChanges,
+		Fetch:                 !repoStatus.OpenChanges && commit.IsFalse(),
 		FinalMessages:         repo.FinalMessages,
 		Frontend:              repo.Frontend,
 		Git:                   repo.Git,

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -250,7 +250,7 @@ func determineHackData(args []string, repo execute.OpenRepoResult, beam configdo
 		CommandsCounter:       repo.CommandsCounter,
 		ConfigSnapshot:        repo.ConfigSnapshot,
 		DialogTestInputs:      dialogTestInputs,
-		Fetch:                 len(args) == 1 && !repoStatus.OpenChanges,
+		Fetch:                 len(args) == 1 && !repoStatus.OpenChanges && beam.IsFalse() && commit.IsFalse(),
 		FinalMessages:         repo.FinalMessages,
 		Frontend:              repo.Frontend,
 		Git:                   repo.Git,

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -237,7 +237,7 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, beam confi
 		CommandsCounter:       repo.CommandsCounter,
 		ConfigSnapshot:        repo.ConfigSnapshot,
 		DialogTestInputs:      dialogTestInputs,
-		Fetch:                 !repoStatus.OpenChanges,
+		Fetch:                 !repoStatus.OpenChanges && beam.IsFalse() && commit.IsFalse(),
 		FinalMessages:         repo.FinalMessages,
 		Frontend:              repo.Frontend,
 		Git:                   repo.Git,


### PR DESCRIPTION
When the user wants to commit or beam something, don't fetch updates from origin. This prevents confusing the user with multiple types of merge conflicts. 