### PR TITLE
Format SHA in beam dialog with `rev-parse --short`

### DIFF
--- a/internal/cli/dialog/commits_to_beam.go
+++ b/internal/cli/dialog/commits_to_beam.go
@@ -5,25 +5,27 @@ import (
 
 	"github.com/git-town/git-town/v19/internal/cli/dialog/components"
 	"github.com/git-town/git-town/v19/internal/cli/dialog/components/list"
+	"github.com/git-town/git-town/v19/internal/git"
 	"github.com/git-town/git-town/v19/internal/git/gitdomain"
 	"github.com/git-town/git-town/v19/internal/messages"
 )
 
-const (
-	commitsToBeamTitle = `Select the commits to beam into branch %q`
-	shaLength          = 7
-)
+const commitsToBeamTitle = `Select the commits to beam into branch %q`
 
 // lets the user select commits to beam to the target branch
-func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranchName, inputs components.TestInput) (gitdomain.Commits, bool, error) {
+func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranchName, git git.Commands, querier gitdomain.Querier, inputs components.TestInput) (gitdomain.Commits, bool, error) {
 	if len(commits) == 0 {
 		return gitdomain.Commits{}, false, nil
 	}
 	entries := make(list.Entries[gitdomain.Commit], len(commits))
 	for c, commit := range commits {
+		shortSHA, err := git.ShortenSHA(querier, commit.SHA)
+		if err != nil {
+			return gitdomain.Commits{}, false, err
+		}
 		entries[c] = list.Entry[gitdomain.Commit]{
 			Data: commit,
-			Text: fmt.Sprintf("%s (%s)", commit.Message.String(), commit.SHA.TruncateTo(shaLength).String()),
+			Text: fmt.Sprintf("%s (%s)", commit.Message.String(), shortSHA),
 		}
 	}
 	selection, aborted, err := components.CheckList(entries, []int{}, fmt.Sprintf(commitsToBeamTitle, targetBranch), "", inputs)

--- a/internal/cli/dialog/commits_to_beam.go
+++ b/internal/cli/dialog/commits_to_beam.go
@@ -25,7 +25,7 @@ func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranc
 		}
 		entries[c] = list.Entry[gitdomain.Commit]{
 			Data: commit,
-			Text: fmt.Sprintf("%s (%s)", commit.Message.String(), shortSHA),
+			Text: fmt.Sprintf("%s %s", shortSHA, commit.Message.String()),
 		}
 	}
 	selection, aborted, err := components.CheckList(entries, []int{}, fmt.Sprintf(commitsToBeamTitle, targetBranch), "", inputs)

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -287,7 +287,7 @@ func determineAppendData(targetBranch gitdomain.LocalBranchName, beam configdoma
 		if err != nil {
 			return data, false, err
 		}
-		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, dialogTestInputs.Next())
+		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs.Next())
 		if err != nil || exit {
 			return data, exit, err
 		}

--- a/internal/cmd/debug/enter_commits_to_beam.go
+++ b/internal/cmd/debug/enter_commits_to_beam.go
@@ -1,13 +1,14 @@
 package debug
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/git-town/git-town/v19/internal/cli/dialog"
 	"github.com/git-town/git-town/v19/internal/cli/dialog/components"
+	"github.com/git-town/git-town/v19/internal/execute"
 	"github.com/git-town/git-town/v19/internal/git/gitdomain"
+	"github.com/git-town/git-town/v19/test/asserts"
 	"github.com/spf13/cobra"
 )
 
@@ -16,19 +17,22 @@ func enterCommitsToBeam() *cobra.Command {
 		Use:  "commits-to-beam <number of commits>",
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			amount, err := strconv.ParseUint(args[0], 10, 64)
-			if err != nil {
-				return err
-			}
-			commits := []gitdomain.Commit{}
+			amount := asserts.NoError1(strconv.ParseInt(args[0], 10, 64))
+			repo := asserts.NoError1(execute.OpenRepo(execute.OpenRepoArgs{
+				DryRun:           false,
+				PrintBranchNames: true,
+				PrintCommands:    true,
+				ValidateGitRepo:  true,
+				ValidateIsOnline: false,
+				Verbose:          false,
+			}))
+			allCommits := asserts.NoError1(repo.Git.CommitsInPerennialBranch(repo.Backend))
+			commits := make([]gitdomain.Commit, amount)
 			for i := range amount {
-				commits = append(commits, gitdomain.Commit{
-					Message: gitdomain.CommitMessage(fmt.Sprintf("commit %d", i)),
-					SHA:     "1234567",
-				})
+				commits[i] = allCommits[i]
 			}
 			dialogTestInputs := components.LoadTestInputs(os.Environ())
-			_, _, err = dialog.CommitsToBeam(commits, "target-branch", dialogTestInputs.Next())
+			_, _, err := dialog.CommitsToBeam(commits, "target-branch", repo.Git, repo.Backend, dialogTestInputs.Next())
 			return err
 		},
 	}

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -345,7 +345,7 @@ func determineHackData(args []string, repo execute.OpenRepoResult, beam configdo
 		if err != nil {
 			return data, false, err
 		}
-		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, dialogTestInputs.Next())
+		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs.Next())
 		if err != nil || exit {
 			return data, exit, err
 		}

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -300,7 +300,7 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, beam confi
 		if err != nil {
 			return data, false, err
 		}
-		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, dialogTestInputs.Next())
+		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs.Next())
 		if err != nil || exit {
 			return data, exit, err
 		}

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -809,6 +809,14 @@ func (self *Commands) SetOriginHostname(runner gitdomain.Runner, hostname config
 	return runner.Run("git", "config", configdomain.KeyHostingOriginHostname.String(), hostname.String())
 }
 
+func (self *Commands) ShortenSHA(querier gitdomain.Querier, sha gitdomain.SHA) (gitdomain.SHA, error) {
+	output, err := querier.QueryTrim("git", "rev-parse", "--short", sha.String())
+	if err != nil {
+		return gitdomain.SHA(""), fmt.Errorf(messages.BranchLocalSHAProblem, sha, err)
+	}
+	return gitdomain.NewSHA(output), nil
+}
+
 func (self *Commands) SquashMerge(runner gitdomain.Runner, branch gitdomain.LocalBranchName) error {
 	return runner.Run("git", "merge", "--squash", "--ff", branch.String())
 }

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -1355,6 +1355,29 @@ func TestBackendCommands(t *testing.T) {
 		})
 	})
 
+	t.Run("ShortenSHA", func(t *testing.T) {
+		t.Parallel()
+		runtime := testruntime.Create(t)
+		branch := gitdomain.NewLocalBranchName("branch")
+		runtime.CreateBranch(branch, initial.BranchName())
+		runtime.CreateCommit(testgit.Commit{
+			Branch:      branch,
+			FileContent: "file1",
+			FileName:    "file1",
+			Message:     "first commit",
+		})
+		commits, err := runtime.Commands.CommitsInBranch(runtime.TestRunner, "branch", Some(gitdomain.NewLocalBranchName("initial")))
+		must.NoError(t, err)
+		cmds := git.Commands{
+			CurrentBranchCache: &cache.WithPrevious[gitdomain.LocalBranchName]{},
+			RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
+		}
+		have, err := cmds.ShortenSHA(runtime, commits[0].SHA)
+		must.NoError(t, err)
+		must.True(t, len(commits[0].SHA.String()) == 40)
+		must.True(t, len(have.String()) == 7)
+	})
+
 	t.Run("StashEntries", func(t *testing.T) {
 		t.Parallel()
 		t.Run("some stash entries", func(t *testing.T) {

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -1368,14 +1368,11 @@ func TestBackendCommands(t *testing.T) {
 		})
 		commits, err := runtime.Commands.CommitsInBranch(runtime.TestRunner, "branch", Some(gitdomain.NewLocalBranchName("initial")))
 		must.NoError(t, err)
-		cmds := git.Commands{
-			CurrentBranchCache: &cache.WithPrevious[gitdomain.LocalBranchName]{},
-			RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
-		}
-		have, err := cmds.ShortenSHA(runtime, commits[0].SHA)
+		have, err := runtime.ShortenSHA(runtime, commits[0].SHA)
 		must.NoError(t, err)
 		must.True(t, len(commits[0].SHA.String()) == 40)
 		must.True(t, len(have.String()) == 7)
+		must.EqOp(t, have.String(), commits[0].SHA.String()[:7])
 	})
 
 	t.Run("StashEntries", func(t *testing.T) {

--- a/internal/git/gitdomain/sha.go
+++ b/internal/git/gitdomain/sha.go
@@ -51,11 +51,3 @@ func (self SHA) Location() Location {
 func (self SHA) String() string {
 	return string(self)
 }
-
-// TruncateTo provides a new SHA instance that contains a shorter checksum.
-func (self SHA) TruncateTo(newLength int) SHA {
-	if len(self) < newLength {
-		return self
-	}
-	return NewSHA(string(self)[0:newLength])
-}

--- a/internal/git/gitdomain/sha_test.go
+++ b/internal/git/gitdomain/sha_test.go
@@ -51,24 +51,6 @@ func TestSHA(t *testing.T) {
 		})
 	})
 
-	t.Run("TruncateTo", func(t *testing.T) {
-		t.Parallel()
-		t.Run("SHA is longer than the new length", func(t *testing.T) {
-			t.Parallel()
-			sha := gitdomain.NewSHA("123456789abcdef")
-			have := sha.TruncateTo(8)
-			want := gitdomain.NewSHA("12345678")
-			must.EqOp(t, want, have)
-		})
-		t.Run("SHA is shorter than the new length", func(t *testing.T) {
-			t.Parallel()
-			sha := gitdomain.NewSHA("123456789")
-			have := sha.TruncateTo(12)
-			want := gitdomain.NewSHA("123456789")
-			must.EqOp(t, want, have)
-		})
-	})
-
 	t.Run("UnmarshalJSON", func(t *testing.T) {
 		t.Parallel()
 		give := `"123456"`


### PR DESCRIPTION
Ref: https://github.com/git-town/git-town/issues/4519, #4715

> We should also use `git rev-parse --short` to shorten the hash, instead of hard-coding 7.
> 
> 1. Git automatically picks a length for short hashes based on how many objects are in the repository; 7 characters isn't enough to guarantee uniqueness for large repos. For example, in this repo, Git uses 9 characters. See: [git/git@e6c587c](https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892)
> 2. This would also cause Git Town to respect the [core.abbrev](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev) setting.
> 
> I was going to suggest just reading the core.abbrev setting, but while looking into it I learned that Git automatically picks a good length if the setting is unspecified, so I think we should just let Git do the work of abbreviating commits.

https://github.com/git-town/git-town/pull/4715#issuecomment-2808287936

Closes #4726