### PR TITLE
Disable Codeberg API unit tests by default

### DIFF
--- a/internal/forge/codeberg/connector_test.go
+++ b/internal/forge/codeberg/connector_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/git-town/git-town/v18/internal/forge/forgedomain"
 	"github.com/git-town/git-town/v18/internal/forge/github"
 	"github.com/git-town/git-town/v18/internal/git/giturl"
-	. "github.com/git-town/git-town/v18/pkg/prelude"
+
+	// . "github.com/git-town/git-town/v18/pkg/prelude"
 	"github.com/shoenig/test/must"
 )
 
@@ -29,30 +30,38 @@ func TestConnector(t *testing.T) {
 		must.EqOp(t, want, have)
 	})
 
-	t.Run("NewProposalURL", func(t *testing.T) {
-		t.Parallel()
-		connector, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
-			APIToken:  None[configdomain.CodebergToken](),
-			Log:       print.Logger{},
-			RemoteURL: giturl.Parse("git@codeberg.org:git-town/docs.git").GetOrPanic(),
-		})
-		must.NoError(t, err)
-		have, err := connector.NewProposalURL("feature", "parent", "", "", "")
-		must.NoError(t, err)
-		must.EqOp(t, "https://codeberg.org/git-town/docs/compare/parent...feature", have)
-	})
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE GITEA CONNECTOR.
+	//
+	// t.Run("NewProposalURL", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	connector, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		APIToken:  None[configdomain.CodebergToken](),
+	// 		Log:       print.Logger{},
+	// 		RemoteURL: giturl.Parse("git@codeberg.org:git-town/docs.git").GetOrPanic(),
+	// 	})
+	// 	must.NoError(t, err)
+	// 	have, err := connector.NewProposalURL("feature", "parent", "", "", "")
+	// 	must.NoError(t, err)
+	// 	must.EqOp(t, "https://codeberg.org/git-town/docs/compare/parent...feature", have)
+	// })
 
-	t.Run("RepositoryURL", func(t *testing.T) {
-		t.Parallel()
-		connector, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
-			APIToken:  None[configdomain.CodebergToken](),
-			Log:       print.Logger{},
-			RemoteURL: giturl.Parse("git@codeberg.org:git-town/docs.git").GetOrPanic(),
-		})
-		must.NoError(t, err)
-		have := connector.RepositoryURL()
-		must.EqOp(t, "https://codeberg.org/git-town/docs", have)
-	})
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE GITEA CONNECTOR.
+	//
+	// t.Run("RepositoryURL", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	connector, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		APIToken:  None[configdomain.CodebergToken](),
+	// 		Log:       print.Logger{},
+	// 		RemoteURL: giturl.Parse("git@codeberg.org:git-town/docs.git").GetOrPanic(),
+	// 	})
+	// 	must.NoError(t, err)
+	// 	have := connector.RepositoryURL()
+	// 	must.EqOp(t, "https://codeberg.org/git-town/docs", have)
+	// })
 }
 
 func TestFilterPullRequests(t *testing.T) {
@@ -87,21 +96,25 @@ func TestFilterPullRequests(t *testing.T) {
 func TestNewConnector(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Codeberg SaaS", func(t *testing.T) {
-		t.Parallel()
-		have, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
-			APIToken:  None[configdomain.CodebergToken](),
-			Log:       print.Logger{},
-			RemoteURL: giturl.Parse("git@codeberg.org:git-town/docs.git").GetOrPanic(),
-		})
-		must.NoError(t, err)
-		want := forgedomain.Data{
-			Hostname:     "codeberg.org",
-			Organization: "git-town",
-			Repository:   "docs",
-		}
-		must.EqOp(t, want, have.Data)
-	})
+	// THIS TEST CONNECTS TO AN EXTERNAL INTERNET HOST,
+	// WHICH MAKES IT SLOW AND FLAKY.
+	// DISABLE AS NEEDED TO DEBUG THE GITEA CONNECTOR.
+	//
+	// t.Run("Codeberg SaaS", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	have, err := codeberg.NewConnector(codeberg.NewConnectorArgs{
+	// 		APIToken:  None[configdomain.CodebergToken](),
+	// 		Log:       print.Logger{},
+	// 		RemoteURL: giturl.Parse("git@codeberg.org:git-town/docs.git").GetOrPanic(),
+	// 	})
+	// 	must.NoError(t, err)
+	// 	want := forgedomain.Data{
+	// 		Hostname:     "codeberg.org",
+	// 		Organization: "git-town",
+	// 		Repository:   "docs",
+	// 	}
+	// 	must.EqOp(t, want, have.Data)
+	// })
 
 	t.Run("custom URL", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
While working offline I noticed that the CodeBerg unit tests fail because the Codeberg API library that our driver uses makes a network connection when being instantiated. This is bad behavior, objects shouldn't do work when being constructed. This PR disables the affected unit tests by default, similar to how this was done for the gitea driver, whose underlying API library makes the same mistake. The Codeberg API is considered stable, and the Codeberg driver library has its own tests, so I consider this low risk. The driver tests can be re-enabled if the need to debug issues with them arises.