### PR TITLE
Remove usage of short SHAs in tests

### DIFF
--- a/features/compress/current_branch/verbose/verbose.feature
+++ b/features/compress/current_branch/verbose/verbose.feature
@@ -64,7 +64,7 @@ Feature: compress the commits on a feature branch verbosely
       |         | git remote get-url origin                          |
       |         | git rev-parse --verify --abbrev-ref @{-1}          |
       |         | git remote get-url origin                          |
-      |         | git rev-parse --short HEAD                         |
+      |         | git rev-parse HEAD                                 |
       | feature | git reset --hard {{ sha 'commit 3' }}              |
       | (none)  | git rev-list --left-right feature...origin/feature |
       | feature | git push --force-with-lease --force-if-includes    |

--- a/features/detach/verbose/enabled.feature
+++ b/features/detach/verbose/enabled.feature
@@ -105,17 +105,17 @@ Feature: detaching an omni-branch verbosely
       |          | git remote get-url origin                            |
       |          | git rev-parse --verify --abbrev-ref @{-1}            |
       |          | git remote get-url origin                            |
-      |          | git rev-parse --short HEAD                           |
+      |          | git rev-parse HEAD                                   |
       | branch-2 | git reset --hard {{ sha 'commit 2b' }}               |
       | (none)   | git rev-list --left-right branch-2...origin/branch-2 |
       | branch-2 | git push --force-with-lease --force-if-includes      |
       |          | git checkout branch-3                                |
-      | (none)   | git rev-parse --short HEAD                           |
+      | (none)   | git rev-parse HEAD                                   |
       | branch-3 | git reset --hard {{ sha 'commit 3b' }}               |
       | (none)   | git rev-list --left-right branch-3...origin/branch-3 |
       | branch-3 | git push --force-with-lease --force-if-includes      |
       |          | git checkout branch-4                                |
-      | (none)   | git rev-parse --short HEAD                           |
+      | (none)   | git rev-parse HEAD                                   |
       | branch-4 | git reset --hard {{ sha 'commit 4b' }}               |
       | (none)   | git rev-list --left-right branch-4...origin/branch-4 |
       | branch-4 | git push --force-with-lease --force-if-includes      |

--- a/features/hack/give_non_existing_branch/on_feature_branch/verbose/verbose.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/verbose/verbose.feature
@@ -55,7 +55,7 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}     |
       |        | backend  | git remote get-url origin                     |
       | new    | frontend | git checkout main                             |
-      |        | backend  | git rev-parse --short HEAD                    |
+      |        | backend  | git rev-parse HEAD                            |
       | main   | frontend | git reset --hard {{ sha 'initial commit' }}   |
       |        | frontend | git branch -D new                             |
       |        | backend  | git config --unset git-town-branch.new.parent |

--- a/features/ship/squash_merge/current_branch/verbose/verbose.feature
+++ b/features/ship/squash_merge/current_branch/verbose/verbose.feature
@@ -32,7 +32,7 @@ Feature: display all executed Git commands
       | feature | frontend | git checkout main                                 |
       | main    | frontend | git merge --squash --ff feature                   |
       |         | frontend | git commit -m done                                |
-      |         | backend  | git rev-parse --short main                        |
+      |         | backend  | git rev-parse main                                |
       |         | backend  | git show-ref --verify --quiet refs/heads/main     |
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git push                                          |

--- a/features/swap/verbose/enabled.feature
+++ b/features/swap/verbose/enabled.feature
@@ -73,17 +73,17 @@ Feature: swapping a feature branch verbosely
       |          | git rev-parse --verify --abbrev-ref @{-1}            |
       |          | git remote get-url origin                            |
       | branch-2 | git checkout branch-1                                |
-      | (none)   | git rev-parse --short HEAD                           |
+      | (none)   | git rev-parse HEAD                                   |
       | branch-1 | git reset --hard {{ sha 'commit 1' }}                |
       | (none)   | git rev-list --left-right branch-1...origin/branch-1 |
       | branch-1 | git push --force-with-lease --force-if-includes      |
       |          | git checkout branch-2                                |
-      | (none)   | git rev-parse --short HEAD                           |
+      | (none)   | git rev-parse HEAD                                   |
       | branch-2 | git reset --hard {{ sha 'commit 2' }}                |
       | (none)   | git rev-list --left-right branch-2...origin/branch-2 |
       | branch-2 | git push --force-with-lease --force-if-includes      |
       |          | git checkout branch-3                                |
-      | (none)   | git rev-parse --short HEAD                           |
+      | (none)   | git rev-parse HEAD                                   |
       | branch-3 | git reset --hard {{ sha 'commit 3' }}                |
       | (none)   | git rev-list --left-right branch-3...origin/branch-3 |
       | branch-3 | git push --force-with-lease --force-if-includes      |

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -766,7 +766,7 @@ func (self *Commands) RootDirectory(querier gitdomain.Querier) Option[gitdomain.
 }
 
 func (self *Commands) SHAForBranch(querier gitdomain.Querier, name gitdomain.BranchName) (gitdomain.SHA, error) {
-	output, err := querier.QueryTrim("git", "rev-parse", "--short", name.String())
+	output, err := querier.QueryTrim("git", "rev-parse", name.String())
 	if err != nil {
 		return gitdomain.SHA(""), fmt.Errorf(messages.BranchLocalSHAProblem, name, err)
 	}


### PR DESCRIPTION
This helps unblock #4722.

Git Town now uses full-length SHAs internally.