### PR TITLE
Improve performance of subshell env configuration

### DIFF
--- a/internal/subshell/backend_runner.go
+++ b/internal/subshell/backend_runner.go
@@ -50,8 +50,10 @@ func (self BackendRunner) execute(executable string, args ...string) (string, er
 	if dir, has := self.Dir.Get(); has {
 		subProcess.Dir = dir
 	}
-	subProcess.Env = append(subProcess.Environ(), "LC_ALL=C")
-	subProcess.Env = append(subProcess.Environ(), `GIT_CONFIG_PARAMETERS='core.abbrev=40'`)
+	env := subProcess.Environ()
+	env = append(env, "LC_ALL=C")
+	env = append(env, `GIT_CONFIG_PARAMETERS='core.abbrev=40'`)
+	subProcess.Env = env
 	concurrentGitRetriesLeft := concurrentGitRetries
 	var outputText string
 	var outputBytes []byte


### PR DESCRIPTION
No point in repeatedly reading and modifying the entire environment.