### PR TITLE
GitHub token config gh 4716

### DIFF
--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -46,6 +46,7 @@ type PartialConfig struct {
 func EmptyPartialConfig() PartialConfig {
 	return PartialConfig{
 		Aliases: Aliases{},
+		Lineage: NewLineage(),
 	} //exhaustruct:ignore
 }
 

--- a/internal/config/envconfig/github_api_token.go
+++ b/internal/config/envconfig/github_api_token.go
@@ -1,0 +1,20 @@
+package envconfig
+
+import (
+	"os"
+
+	"github.com/git-town/git-town/v19/internal/config/configdomain"
+	. "github.com/git-town/git-town/v19/pkg/prelude"
+)
+
+func GithubAPIToken() Option[configdomain.GitHubToken] {
+	apiToken := os.Getenv("GITHUB_TOKEN")
+	if len(apiToken) > 0 {
+		return Some(configdomain.GitHubToken(apiToken))
+	}
+	apiToken = os.Getenv("GITHUB_AUTH_TOKEN")
+	if len(apiToken) > 0 {
+		return Some(configdomain.GitHubToken(apiToken))
+	}
+	return None[configdomain.GitHubToken]()
+}

--- a/internal/config/envconfig/load.go
+++ b/internal/config/envconfig/load.go
@@ -1,0 +1,11 @@
+package envconfig
+
+import (
+	"github.com/git-town/git-town/v19/internal/config/configdomain"
+)
+
+func Load() configdomain.PartialConfig {
+	partialConfig := configdomain.EmptyPartialConfig()
+	partialConfig.GitHubToken = GithubAPIToken()
+	return partialConfig
+}

--- a/internal/config/envconfig/load_test.go
+++ b/internal/config/envconfig/load_test.go
@@ -1,0 +1,70 @@
+package envconfig_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/git-town/git-town/v19/internal/config/configdomain"
+	"github.com/git-town/git-town/v19/internal/config/envconfig"
+	"github.com/git-town/git-town/v19/pkg/prelude"
+	"github.com/shoenig/test/must"
+)
+
+func TestLoad(t *testing.T) {
+	tokenText := "my-github-token"
+	authTokenText := "my-github-auth-token"
+
+	tests := []struct {
+		name        string
+		githubToken *string
+		authToken   *string
+		want        prelude.Option[configdomain.GitHubToken]
+	}{
+		{
+			name:        "loads from GITHUB_TOKEN when both are set",
+			githubToken: &tokenText,
+			authToken:   &authTokenText,
+			want:        prelude.Some(configdomain.GitHubToken(tokenText)),
+		},
+		{
+			name:        "loads from GITHUB_AUTH_TOKEN if GITHUB_TOKEN is empty",
+			githubToken: ptr(""),
+			authToken:   &authTokenText,
+			want:        prelude.Some(configdomain.GitHubToken(authTokenText)),
+		},
+		{
+			name:        "loads from GITHUB_TOKEN only",
+			githubToken: &tokenText,
+			authToken:   nil,
+			want:        prelude.Some(configdomain.GitHubToken(tokenText)),
+		},
+		{
+			name:        "returns none when no env is set",
+			githubToken: nil,
+			authToken:   nil,
+			want:        prelude.None[configdomain.GitHubToken](),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear environment
+			os.Unsetenv("GITHUB_TOKEN")
+			os.Unsetenv("GITHUB_AUTH_TOKEN")
+
+			if tt.githubToken != nil {
+				t.Setenv("GITHUB_TOKEN", *tt.githubToken)
+			}
+			if tt.authToken != nil {
+				t.Setenv("GITHUB_AUTH_TOKEN", *tt.authToken)
+			}
+
+			cfg := envconfig.Load()
+			must.Eq(t, tt.want, cfg.GitHubToken)
+		})
+	}
+}
+
+func ptr(s string) *string {
+	return &s
+}

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -86,8 +86,9 @@ func DefaultUnvalidatedConfig(gitAccess gitconfig.Access, gitVersion git.Version
 	}
 }
 
-func MergeConfigs(configFile Option[configdomain.PartialConfig], globalGitConfig, localGitConfig configdomain.PartialConfig) (configdomain.UnvalidatedConfigData, configdomain.NormalConfigData) {
+func MergeConfigs(configFile Option[configdomain.PartialConfig], globalGitConfig, localGitConfig, envConfig configdomain.PartialConfig) (configdomain.UnvalidatedConfigData, configdomain.NormalConfigData) {
 	result := configdomain.EmptyPartialConfig()
+	result = result.Merge(envConfig)
 	if configFile, hasConfigFile := configFile.Get(); hasConfigFile {
 		result = result.Merge(configFile)
 	}
@@ -109,7 +110,7 @@ func NewConfigs(configFile Option[configdomain.PartialConfig], globalGitConfig, 
 }
 
 func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {
-	unvalidatedConfig, normalConfig := MergeConfigs(args.ConfigFile, args.GlobalConfig, args.LocalConfig)
+	unvalidatedConfig, normalConfig := MergeConfigs(args.ConfigFile, args.GlobalConfig, args.LocalConfig, args.EnvConfig)
 	return UnvalidatedConfig{
 		NormalConfig: NormalConfig{
 			ConfigFile:       args.ConfigFile,
@@ -128,6 +129,7 @@ type NewUnvalidatedConfigArgs struct {
 	Access        gitconfig.Access
 	ConfigFile    Option[configdomain.PartialConfig]
 	DryRun        configdomain.DryRun
+	EnvConfig     configdomain.PartialConfig
 	FinalMessages stringslice.Collector
 	GitVersion    git.Version
 	GlobalConfig  configdomain.PartialConfig

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -88,12 +88,12 @@ func DefaultUnvalidatedConfig(gitAccess gitconfig.Access, gitVersion git.Version
 
 func MergeConfigs(configFile Option[configdomain.PartialConfig], globalGitConfig, localGitConfig, envConfig configdomain.PartialConfig) (configdomain.UnvalidatedConfigData, configdomain.NormalConfigData) {
 	result := configdomain.EmptyPartialConfig()
-	result = result.Merge(envConfig)
 	if configFile, hasConfigFile := configFile.Get(); hasConfigFile {
 		result = result.Merge(configFile)
 	}
 	result = result.Merge(globalGitConfig)
 	result = result.Merge(localGitConfig)
+	result = result.Merge(envConfig)
 	return result.ToUnvalidatedConfig(), result.ToNormalConfig(configdomain.DefaultNormalConfig())
 }
 

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/git-town/git-town/v19/internal/config"
 	"github.com/git-town/git-town/v19/internal/config/configdomain"
 	"github.com/git-town/git-town/v19/internal/config/configfile"
+	"github.com/git-town/git-town/v19/internal/config/envconfig"
 	"github.com/git-town/git-town/v19/internal/config/gitconfig"
 	"github.com/git-town/git-town/v19/internal/git"
 	"github.com/git-town/git-town/v19/internal/git/gitdomain"
@@ -88,6 +89,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 		Access:        configGitAccess,
 		ConfigFile:    configFile,
 		DryRun:        args.DryRun,
+		EnvConfig:     envconfig.Load(),
 		FinalMessages: finalMessages,
 		GitVersion:    gitVersion,
 		GlobalConfig:  globalConfig,

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strconv"
 
 	"github.com/git-town/git-town/v19/internal/cli/colors"
@@ -180,22 +179,6 @@ func (self Connector) updateProposalTarget(number int, target gitdomain.LocalBra
 	}
 	self.log.Ok()
 	return nil
-}
-
-// getGitHubApiToken returns the GitHub API token to use.
-// It first checks the GITHUB_TOKEN environment variable.
-// If that is not set, it checks the GITHUB_AUTH_TOKEN environment variable.
-// If that is not set, it checks the git config.
-func GetAPIToken(gitConfigToken Option[configdomain.GitHubToken]) Option[configdomain.GitHubToken] {
-	apiToken := os.ExpandEnv("$GITHUB_TOKEN")
-	if len(apiToken) > 0 {
-		return Some(configdomain.GitHubToken(apiToken))
-	}
-	apiToken = os.ExpandEnv("$GITHUB_AUTH_TOKEN")
-	if len(apiToken) > 0 {
-		return Some(configdomain.GitHubToken(apiToken))
-	}
-	return gitConfigToken
 }
 
 // NewConnector provides a fully configured GithubConnector instance

--- a/internal/forge/new_connector.go
+++ b/internal/forge/new_connector.go
@@ -61,7 +61,7 @@ func NewConnector(config config.UnvalidatedConfig, remote gitdomain.Remote, log 
 	case configdomain.ForgeTypeGitHub:
 		var err error
 		connector, err = github.NewConnector(github.NewConnectorArgs{
-			APIToken:  github.GetAPIToken(config.NormalConfig.GitHubToken),
+			APIToken:  config.NormalConfig.GitHubToken,
 			Log:       log,
 			RemoteURL: remoteURL,
 		})

--- a/internal/test/testruntime/test_runtime.go
+++ b/internal/test/testruntime/test_runtime.go
@@ -98,6 +98,7 @@ func New(workingDir, homeDir, binDir string) commands.TestCommands {
 		},
 		ConfigFile:    None[configdomain.PartialConfig](),
 		DryRun:        false,
+		EnvConfig:     configdomain.EmptyPartialConfig(),
 		FinalMessages: stringslice.NewCollector(),
 		GitVersion:    git.Version{Major: 2, Minor: 38},
 		GlobalConfig:  configdomain.EmptyPartialConfig(),


### PR DESCRIPTION
fixes a part of #4716. github api token is added at the time of config construction
