### PR TITLE
Extract logic to format opcodes

### DIFF
--- a/internal/vm/program/program.go
+++ b/internal/vm/program/program.go
@@ -2,9 +2,7 @@ package program
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/git-town/git-town/v19/internal/git/gitdomain"
 	"github.com/git-town/git-town/v19/internal/gohacks/slice"
@@ -93,16 +91,7 @@ func (self *Program) String() string {
 }
 
 func (self *Program) StringIndented(indent string) string {
-	sb := strings.Builder{}
-	if self.IsEmpty() {
-		sb.WriteString("(empty program)\n")
-	} else {
-		sb.WriteString("Program:\n")
-		for o, opcode := range *self {
-			sb.WriteString(fmt.Sprintf("%s%d: %#v\n", indent, o+1, opcode))
-		}
-	}
-	return sb.String()
+	return shared.RenderOpcodes(*self, indent)
 }
 
 func (self *Program) TouchedBranches() []gitdomain.BranchName {

--- a/internal/vm/program/program_test.go
+++ b/internal/vm/program/program_test.go
@@ -265,4 +265,34 @@ func TestProgram(t *testing.T) {
 		})
 	})
 
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		give := `
+[
+	{
+		"data": {
+			"Hard": false,
+			"MustHaveSHA": "abcdef",
+			"SetToSHA": "123456"
+		},
+		"type": "BranchCurrentResetToSHAIfNeeded"
+	},
+	{
+		"data": {},
+		"type": "StashOpenChanges"
+	}
+]`[1:]
+		have := program.Program{}
+		err := json.Unmarshal([]byte(give), &have)
+		must.NoError(t, err)
+		want := program.Program{
+			&opcodes.BranchCurrentResetToSHAIfNeeded{
+				Hard:        false,
+				MustHaveSHA: "abcdef",
+				SetToSHA:    "123456",
+			},
+			&opcodes.StashOpenChanges{},
+		}
+		must.Eq(t, want, have)
+	})
 }

--- a/internal/vm/program/program_test.go
+++ b/internal/vm/program/program_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/git-town/git-town/v19/internal/config/configdomain"
 	"github.com/git-town/git-town/v19/internal/vm/opcodes"
 	"github.com/git-town/git-town/v19/internal/vm/program"
 	"github.com/git-town/git-town/v19/internal/vm/shared"
@@ -266,49 +265,4 @@ func TestProgram(t *testing.T) {
 		})
 	})
 
-	t.Run("String", func(t *testing.T) {
-		t.Parallel()
-		give := program.Program{
-			&opcodes.MergeAbort{},
-			&opcodes.BranchTypeOverrideSet{Branch: "branch", BranchType: configdomain.BranchTypePerennialBranch},
-		}
-		have := give.String()
-		want := `
-Program:
-1: &opcodes.MergeAbort{undeclaredOpcodeMethods:opcodes.undeclaredOpcodeMethods{}}
-2: &opcodes.BranchTypeOverrideSet{Branch:"branch", BranchType:"perennial", undeclaredOpcodeMethods:opcodes.undeclaredOpcodeMethods{}}
-`[1:]
-		must.EqOp(t, want, have)
-	})
-
-	t.Run("UnmarshalJSON", func(t *testing.T) {
-		t.Parallel()
-		give := `
-[
-	{
-		"data": {
-			"Hard": false,
-			"MustHaveSHA": "abcdef",
-			"SetToSHA": "123456"
-		},
-		"type": "BranchCurrentResetToSHAIfNeeded"
-	},
-	{
-		"data": {},
-		"type": "StashOpenChanges"
-	}
-]`[1:]
-		have := program.Program{}
-		err := json.Unmarshal([]byte(give), &have)
-		must.NoError(t, err)
-		want := program.Program{
-			&opcodes.BranchCurrentResetToSHAIfNeeded{
-				Hard:        false,
-				MustHaveSHA: "abcdef",
-				SetToSHA:    "123456",
-			},
-			&opcodes.StashOpenChanges{},
-		}
-		must.Eq(t, want, have)
-	})
 }

--- a/internal/vm/shared/opcode.go
+++ b/internal/vm/shared/opcode.go
@@ -49,5 +49,4 @@ func RenderOpcodes(opcodes []Opcode, indent string) string {
 		}
 	}
 	return sb.String()
-
 }

--- a/internal/vm/shared/opcode.go
+++ b/internal/vm/shared/opcode.go
@@ -1,5 +1,10 @@
 package shared
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Opcode is an atomic operation that the Git Town interpreter can execute.
 // Opcodes implement the command pattern (https://en.wikipedia.org/wiki/Command_pattern)
 // and provide opcodes to continue and abort them.
@@ -31,4 +36,18 @@ type Opcode interface {
 	// The undo program returned here is only for external changes
 	// like updating proposals at the forge.
 	UndoExternalChangesProgram() []Opcode
+}
+
+func RenderOpcodes(opcodes []Opcode, indent string) string {
+	sb := strings.Builder{}
+	if len(opcodes) == 0 {
+		sb.WriteString("(empty program)\n")
+	} else {
+		sb.WriteString("Program:\n")
+		for o, opcode := range opcodes {
+			sb.WriteString(fmt.Sprintf("%s%d: %#v\n", indent, o+1, opcode))
+		}
+	}
+	return sb.String()
+
 }

--- a/internal/vm/shared/opcode_test.go
+++ b/internal/vm/shared/opcode_test.go
@@ -5,18 +5,18 @@ import (
 
 	"github.com/git-town/git-town/v19/internal/config/configdomain"
 	"github.com/git-town/git-town/v19/internal/vm/opcodes"
-	"github.com/git-town/git-town/v19/internal/vm/program"
+	"github.com/git-town/git-town/v19/internal/vm/shared"
 	"github.com/shoenig/test/must"
 )
 
 func TestOpcode(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
 		t.Parallel()
-		give := program.Program{
+		give := []shared.Opcode{
 			&opcodes.MergeAbort{},
 			&opcodes.BranchTypeOverrideSet{Branch: "branch", BranchType: configdomain.BranchTypePerennialBranch},
 		}
-		have := give.String()
+		have := shared.RenderOpcodes(give, "")
 		want := `
 Program:
 1: &opcodes.MergeAbort{undeclaredOpcodeMethods:opcodes.undeclaredOpcodeMethods{}}

--- a/internal/vm/shared/opcode_test.go
+++ b/internal/vm/shared/opcode_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestOpcode(t *testing.T) {
 	t.Parallel()
+
 	t.Run("String", func(t *testing.T) {
 		t.Parallel()
 		give := []shared.Opcode{

--- a/internal/vm/shared/opcode_test.go
+++ b/internal/vm/shared/opcode_test.go
@@ -1,7 +1,6 @@
 package shared_test
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/git-town/git-town/v19/internal/config/configdomain"
@@ -24,36 +23,5 @@ Program:
 2: &opcodes.BranchTypeOverrideSet{Branch:"branch", BranchType:"perennial", undeclaredOpcodeMethods:opcodes.undeclaredOpcodeMethods{}}
 `[1:]
 		must.EqOp(t, want, have)
-	})
-
-	t.Run("UnmarshalJSON", func(t *testing.T) {
-		t.Parallel()
-		give := `
-[
-	{
-		"data": {
-			"Hard": false,
-			"MustHaveSHA": "abcdef",
-			"SetToSHA": "123456"
-		},
-		"type": "BranchCurrentResetToSHAIfNeeded"
-	},
-	{
-		"data": {},
-		"type": "StashOpenChanges"
-	}
-]`[1:]
-		have := program.Program{}
-		err := json.Unmarshal([]byte(give), &have)
-		must.NoError(t, err)
-		want := program.Program{
-			&opcodes.BranchCurrentResetToSHAIfNeeded{
-				Hard:        false,
-				MustHaveSHA: "abcdef",
-				SetToSHA:    "123456",
-			},
-			&opcodes.StashOpenChanges{},
-		}
-		must.Eq(t, want, have)
 	})
 }

--- a/internal/vm/shared/opcode_test.go
+++ b/internal/vm/shared/opcode_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestOpcode(t *testing.T) {
+	t.Parallel()
 	t.Run("String", func(t *testing.T) {
 		t.Parallel()
 		give := []shared.Opcode{

--- a/internal/vm/shared/opcode_test.go
+++ b/internal/vm/shared/opcode_test.go
@@ -1,0 +1,59 @@
+package shared_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/git-town/git-town/v19/internal/config/configdomain"
+	"github.com/git-town/git-town/v19/internal/vm/opcodes"
+	"github.com/git-town/git-town/v19/internal/vm/program"
+	"github.com/shoenig/test/must"
+)
+
+func TestOpcode(t *testing.T) {
+	t.Run("String", func(t *testing.T) {
+		t.Parallel()
+		give := program.Program{
+			&opcodes.MergeAbort{},
+			&opcodes.BranchTypeOverrideSet{Branch: "branch", BranchType: configdomain.BranchTypePerennialBranch},
+		}
+		have := give.String()
+		want := `
+Program:
+1: &opcodes.MergeAbort{undeclaredOpcodeMethods:opcodes.undeclaredOpcodeMethods{}}
+2: &opcodes.BranchTypeOverrideSet{Branch:"branch", BranchType:"perennial", undeclaredOpcodeMethods:opcodes.undeclaredOpcodeMethods{}}
+`[1:]
+		must.EqOp(t, want, have)
+	})
+
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		give := `
+[
+	{
+		"data": {
+			"Hard": false,
+			"MustHaveSHA": "abcdef",
+			"SetToSHA": "123456"
+		},
+		"type": "BranchCurrentResetToSHAIfNeeded"
+	},
+	{
+		"data": {},
+		"type": "StashOpenChanges"
+	}
+]`[1:]
+		have := program.Program{}
+		err := json.Unmarshal([]byte(give), &have)
+		must.NoError(t, err)
+		want := program.Program{
+			&opcodes.BranchCurrentResetToSHAIfNeeded{
+				Hard:        false,
+				MustHaveSHA: "abcdef",
+				SetToSHA:    "123456",
+			},
+			&opcodes.StashOpenChanges{},
+		}
+		must.Eq(t, want, have)
+	})
+}


### PR DESCRIPTION
Extracting this logic into the `shared` package makes it available for debugging opcode internals.