### PR TITLE
Use consistent variable name for git arguments

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -182,22 +182,22 @@ func (self *Commands) CommentOutSquashCommitMessage(prefix Option[string]) error
 }
 
 func (self *Commands) Commit(runner gitdomain.Runner, useMessage configdomain.UseMessage, author Option[gitdomain.Author]) error {
-	gitArgs := []string{"commit"}
+	args := []string{"commit"}
 	switch {
 	case useMessage.IsCustomMessage():
 		message := useMessage.GetCustomMessageOrPanic()
-		gitArgs = append(gitArgs, "-m", message.String())
+		args = append(args, "-m", message.String())
 	case useMessage.IsUseDefault():
-		gitArgs = append(gitArgs, "--no-edit")
+		args = append(args, "--no-edit")
 	case useMessage.IsEditDefault():
 		// This is the default behaviour of `git commit`.
 	default:
 		return fmt.Errorf("unhandled %#v case", useMessage)
 	}
 	if author, hasAuthor := author.Get(); hasAuthor {
-		gitArgs = append(gitArgs, "--author", author.String())
+		args = append(args, "--author", author.String())
 	}
-	return runner.Run("git", gitArgs...)
+	return runner.Run("git", args...)
 }
 
 func (self *Commands) CommitMessage(querier gitdomain.Querier, sha gitdomain.SHA) (gitdomain.CommitMessage, error) {
@@ -551,24 +551,24 @@ func (self *Commands) MergeFastForward(runner gitdomain.Runner, branch gitdomain
 }
 
 func (self *Commands) MergeNoFastForward(runner gitdomain.Runner, useMessage configdomain.UseMessage, branch gitdomain.LocalBranchName) error {
-	gitArgs := []string{"merge", "--no-ff"}
+	args := []string{"merge", "--no-ff"}
 	switch {
 	case useMessage.IsCustomMessage():
 		message := useMessage.GetCustomMessageOrPanic()
-		gitArgs = append(gitArgs, "-m", message.String())
+		args = append(args, "-m", message.String())
 	case useMessage.IsUseDefault():
-		gitArgs = append(gitArgs, "--no-edit")
+		args = append(args, "--no-edit")
 	case useMessage.IsEditDefault():
 		// Unlike `git commit`, `git merge` only launches the editor in a tty.
 		// Until cucumber tests run git subcommands in a tty we have to explicitly set
 		// `--edit` mode to test commit message behaviour.
-		gitArgs = append(gitArgs, "--edit")
+		args = append(args, "--edit")
 	default:
 		return fmt.Errorf("unhandled %#v case", useMessage)
 	}
 	// Add branch name as the last argument.
-	gitArgs = append(gitArgs, "--", branch.String())
-	return runner.Run("git", gitArgs...)
+	args = append(args, "--", branch.String())
+	return runner.Run("git", args...)
 }
 
 func (self *Commands) OriginHead(querier gitdomain.Querier) Option[gitdomain.LocalBranchName] {


### PR DESCRIPTION
Most functions in this file assemble the arguments to `git` in a variable named `args`. This PR updates the two functions that use a different variable name to match the others.