### PR TITLE
Simplify checking for unexpected Git Town configuration

### DIFF
--- a/test/commands/test_commands.go
+++ b/test/commands/test_commands.go
@@ -519,10 +519,6 @@ func (self *TestCommands) VerifyNoGitTownConfiguration() error {
 	if len(output) > 0 {
 		return fmt.Errorf("unexpected Git Town configuration:\n%s", output)
 	}
-	output, _ = self.Query("git", "config", "--get-regex", "git-town-branch")
-	if len(output) > 0 {
-		return fmt.Errorf("unexpected Git Town configuration:\n%s", output)
-	}
 	self.Config.Reload()
 	for aliasName, aliasValue := range self.Config.NormalConfig.Aliases {
 		if strings.HasPrefix(aliasValue, "town ") {


### PR DESCRIPTION
Anything matched by `git config --get-regex git-town-branch` would already have been found by
`git config --get-regex git-town`.