### PR TITLE
Improve usages of `git diff`

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -66,7 +66,7 @@ func (self *Commands) BranchExistsRemotely(runner gitdomain.Runner, branch gitdo
 // BranchHasUnmergedChanges indicates whether the branch with the given name
 // contains changes that were not merged into the main branch.
 func (self *Commands) BranchHasUnmergedChanges(querier gitdomain.Querier, branch, parent gitdomain.LocalBranchName) (bool, error) {
-	out, err := querier.QueryTrim("git", "diff", "--shortstat", parent.String()+".."+branch.String())
+	out, err := querier.QueryTrim("git", "diff", "--shortstat", parent.String(), branch.String())
 	if err != nil {
 		return false, fmt.Errorf(messages.BranchDiffProblem, branch, err)
 	}
@@ -393,7 +393,7 @@ func (self *Commands) DeleteTrackingBranch(runner gitdomain.Runner, name gitdoma
 
 // DiffParent displays the diff between the given branch and its given parent branch.
 func (self *Commands) DiffParent(runner gitdomain.Runner, branch, parentBranch gitdomain.LocalBranchName) error {
-	return runner.Run("git", "diff", parentBranch.String()+".."+branch.String())
+	return runner.Run("git", "diff", parentBranch.String(), branch.String())
 }
 
 func (self *Commands) DiscardOpenChanges(runner gitdomain.Runner) error {
@@ -526,7 +526,7 @@ func (self *Commands) HasMergeInProgress(runner gitdomain.Runner) bool {
 
 // HasShippableChanges indicates whether the given branch has changes not currently in the main branch.
 func (self *Commands) HasShippableChanges(querier gitdomain.Querier, branch, mainBranch gitdomain.LocalBranchName) (bool, error) {
-	out, err := querier.QueryTrim("git", "diff", "--shortstat", mainBranch.String()+".."+branch.String())
+	out, err := querier.QueryTrim("git", "diff", "--shortstat", mainBranch.String(), branch.String())
 	if err != nil {
 		return false, fmt.Errorf(messages.ShippableChangesProblem, branch, err)
 	}

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -66,7 +66,7 @@ func (self *Commands) BranchExistsRemotely(runner gitdomain.Runner, branch gitdo
 // BranchHasUnmergedChanges indicates whether the branch with the given name
 // contains changes that were not merged into the main branch.
 func (self *Commands) BranchHasUnmergedChanges(querier gitdomain.Querier, branch, parent gitdomain.LocalBranchName) (bool, error) {
-	out, err := querier.QueryTrim("git", "diff", parent.String()+".."+branch.String())
+	out, err := querier.QueryTrim("git", "diff", "--shortstat", parent.String()+".."+branch.String())
 	if err != nil {
 		return false, fmt.Errorf(messages.BranchDiffProblem, branch, err)
 	}
@@ -526,7 +526,7 @@ func (self *Commands) HasMergeInProgress(runner gitdomain.Runner) bool {
 
 // HasShippableChanges indicates whether the given branch has changes not currently in the main branch.
 func (self *Commands) HasShippableChanges(querier gitdomain.Querier, branch, mainBranch gitdomain.LocalBranchName) (bool, error) {
-	out, err := querier.QueryTrim("git", "diff", mainBranch.String()+".."+branch.String())
+	out, err := querier.QueryTrim("git", "diff", "--shortstat", mainBranch.String()+".."+branch.String())
 	if err != nil {
 		return false, fmt.Errorf(messages.ShippableChangesProblem, branch, err)
 	}

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -524,15 +524,6 @@ func (self *Commands) HasMergeInProgress(runner gitdomain.Runner) bool {
 	return err == nil
 }
 
-// HasShippableChanges indicates whether the given branch has changes not currently in the main branch.
-func (self *Commands) HasShippableChanges(querier gitdomain.Querier, branch, mainBranch gitdomain.LocalBranchName) (bool, error) {
-	out, err := querier.QueryTrim("git", "diff", "--shortstat", mainBranch.String(), branch.String())
-	if err != nil {
-		return false, fmt.Errorf(messages.ShippableChangesProblem, branch, err)
-	}
-	return len(out) > 0, nil
-}
-
 // HeadCommitMessage provides the commit message for the last commit.
 func (self *Commands) HeadCommitMessage(querier gitdomain.Querier) (gitdomain.CommitMessage, error) {
 	out, err := querier.QueryTrim("git", "log", "-1", "--format=%B")

--- a/internal/messages/en.go
+++ b/internal/messages/en.go
@@ -239,7 +239,6 @@ and will be removed in future versions of Git Town.`
 	ShipMessageWithFastForward              = "shipping with the fast-forward strategy does not use the given commit message"
 	ShipOpenChanges                         = "you have uncommitted changes. Did you mean to commit them before shipping?"
 	ShipStrategyMissing                     = "no ship strategy provided"
-	ShippableChangesProblem                 = "cannot determine whether branch %q has shippable changes: %w"
 	SkipBranchHasConflicts                  = "cannot skip branch that resulted in conflicts"
 	SkipMessage                             = `You can run "git town skip" to skip the currently failing operation.`
 	SkipNothingToDo                         = "nothing to skip"

--- a/internal/vm/opcodes/branch_ensure_shippable_changes.go
+++ b/internal/vm/opcodes/branch_ensure_shippable_changes.go
@@ -20,11 +20,11 @@ func (self *BranchEnsureShippableChanges) AutomaticUndoError() error {
 }
 
 func (self *BranchEnsureShippableChanges) Run(args shared.RunArgs) error {
-	hasShippableChanges, err := args.Git.HasShippableChanges(args.Backend, self.Branch, self.Parent)
+	hasUnmergedChanges, err := args.Git.BranchHasUnmergedChanges(args.Backend, self.Branch, self.Parent)
 	if err != nil {
 		return err
 	}
-	if !hasShippableChanges {
+	if !hasUnmergedChanges {
 		return fmt.Errorf(messages.ShipBranchNothingToDo, self.Branch)
 	}
 	return nil


### PR DESCRIPTION
- Use `--shortstat` when checking if a given branch has changes
	- In these cases, we only check whether the output is empty. We don't need to output the full diff for that.
- Replace `git diff <commit>..<commit>` with `git diff <commit> <commit>`
	- I always forget the difference between `<commit>..<commit>` and <commit>...<commit>. According to [the git-diff docs](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-codegitdiffltoptionsgt--merge-baseltcommitgtltcommitgt--ltpathgtcode), passing the `<commit>`s separately is equivalent to using `..`.
- Remove duplicate function `HasShippableChanges` and replace usages with `BranchHasUnmergedChanges`