### PR TITLE
Disable scan for hardcoded credentials for entire codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,15 +61,6 @@ linters:
         text: 'appendAssign: append result not assigned to the same slice'
       - linters:
           - gosec
-        path: internal/cli/dialog/git.*_token.go
-        text: Potential hardcoded credentials
-      - linters:
-          - gosec
-        path: internal/messages/en.go
-        text: Potential hardcoded credentials
-      - linters:
-          - gosec
-        path: pkg/key_github_token.go
         text: Potential hardcoded credentials
       - linters:
           - ireturn

--- a/internal/cli/dialog/bitbucket_app_password.go
+++ b/internal/cli/dialog/bitbucket_app_password.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/git-town/git-town/v19/pkg/prelude"
 )
 
-//nolint:gosec
 const (
 	bitbucketAppPasswordTitle = `Bitbucket App Password/Token`
 	bitbucketAppPasswordHelp  = `

--- a/internal/cli/dialog/codeberg_token.go
+++ b/internal/cli/dialog/codeberg_token.go
@@ -9,9 +9,8 @@ import (
 	. "github.com/git-town/git-town/v19/pkg/prelude"
 )
 
-//nolint:gosec
 const (
-	codebergTokenTitle = `Codeberg API token` //nolint:gosec
+	codebergTokenTitle = `Codeberg API token`
 	codebergTokenHelp  = `
 Git Town can update pull requests and ship branches on codeberg-based forges for you.
 To enable this, please enter a codeberg API token.


### PR DESCRIPTION
This check causes too many false positives and just gets in the way. We don't have credentials to hard-code here, and if we did, we would catch them through code reviews.