### PR TITLE
Make task for running the messy cukes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,13 @@ RELEASE_VERSION := "19.0.0"
 GO_TEST_ARGS = LANG=C GOGC=off BROWSER=
 
 cuke: install  # runs all end-to-end tests except the ones that mess up the output, best for development
-	@env $(GO_TEST_ARGS) skipmessyoutput=1 go test -v
+	@env $(GO_TEST_ARGS) messyoutput=0 go test -v
 
 cukeall: install  # runs all end-to-end tests
 	@env $(GO_TEST_ARGS) go test -v
+
+cukemessy: install  # runs all the end-to-end tests that "cuke all" doesn't run
+	@env $(GO_TEST_ARGS) messyoutput=1 go test -v
 
 cukethis: install  # runs the end-to-end tests that have a @this tag
 	@env $(GO_TEST_ARGS) cukethis=1 go test . -v -count=1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,12 +87,32 @@ go test src/cmd/root_test.go -v -run TestIsAcceptableGitVersion
 
 ## End-to-end tests
 
-Run all end-to-end tests:
+Run the nice looking end-to-end tests:
 
 <a type="make/command" dir="..">
 
 ```
 make cuke
+```
+
+</a>
+
+Run all (nice and messy) end-to-end tests:
+
+<a type="make/command" dir="..">
+
+```
+make cukeall
+```
+
+</a>
+
+Run only the messy end-to-end tests:
+
+<a type="make/command" dir="..">
+
+```
+make cukemessy
 ```
 
 </a>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -97,22 +97,22 @@ make cuke
 
 </a>
 
-Run all (nice and messy) end-to-end tests:
-
-<a type="make/command" dir="..">
-
-```
-make cukeall
-```
-
-</a>
-
 Run only the messy end-to-end tests:
 
 <a type="make/command" dir="..">
 
 ```
 make cukemessy
+```
+
+</a>
+
+Run all (nice and messy) end-to-end tests:
+
+<a type="make/command" dir="..">
+
+```
+make cukeall
 ```
 
 </a>

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func TestMain(_ *testing.M) {
 	options.Paths = pflag.Args()
 	flagThis := len(os.Getenv("cukethis")) > 0
 	flagSmoke := len(os.Getenv("smoke")) > 0
-	flagSkipMessyOutput := len(os.Getenv("skipmessyoutput")) > 0
+	flagMessyOutput := os.Getenv("messyoutput")
 	switch {
 	case flagThis:
 		options.Format = "pretty"
@@ -39,8 +39,13 @@ func TestMain(_ *testing.M) {
 	} else {
 		options.Concurrency = runtime.NumCPU() * 4
 	}
-	if flagSkipMessyOutput {
+	switch flagMessyOutput {
+	case "0":
 		options.Tags = "~@messyoutput"
+	case "1":
+		options.Tags = "@messyoutput"
+	default:
+		panic("unknown value for messyoutput")
 	}
 	if flagSmoke {
 		options.Tags = "@smoke"

--- a/main_test.go
+++ b/main_test.go
@@ -40,6 +40,7 @@ func TestMain(_ *testing.M) {
 		options.Concurrency = runtime.NumCPU() * 4
 	}
 	switch flagMessyOutput {
+	case "":
 	case "0":
 		options.Tags = "~@messyoutput"
 	case "1":


### PR DESCRIPTION
During development, I typically run `make cuke` for a nice development experience and faster feedback loop, followed by `make cukeall` to ensure full coverage. The downside is that `make cukeall` ends up re-running all the tests that `make cuke` already covered.

This PR introduces `make cukemessy`, which runs only the missing tests — the ones skipped by `make cuke`. It help speed up the end-to-end tests by avoiding unnecessary reruns while still catching anything that would otherwise be missed.