### PR TITLE
Use rev-parse instead of show-ref

### DIFF
--- a/features/append/on_feature_branch/verbose/enabled.feature
+++ b/features/append/on_feature_branch/verbose/enabled.feature
@@ -31,13 +31,13 @@ Feature: display all executed Git commands
       |          | backend  | git log main..existing --format=%s --reverse         |
       | existing | frontend | git merge --no-edit --ff main                        |
       |          | frontend | git merge --no-edit --ff origin/existing             |
-      |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
+      |          | backend  | git rev-parse --verify -q refs/heads/existing        |
       |          | backend  | git rev-list --left-right existing...origin/existing |
-      |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
+      |          | backend  | git rev-parse --verify -q refs/heads/existing        |
       | existing | frontend | git checkout -b new                                  |
-      |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
+      |          | backend  | git rev-parse --verify -q refs/heads/existing        |
       |          | backend  | git config git-town-branch.new.parent existing       |
-      |          | backend  | git show-ref --verify --quiet refs/heads/existing    |
+      |          | backend  | git rev-parse --verify -q refs/heads/existing        |
       |          | backend  | git -c core.abbrev=40 branch -vva --sort=refname     |
       |          | backend  | git config -lz --includes --global                   |
       |          | backend  | git config -lz --includes --local                    |

--- a/features/delete/verbose/verbose.feature
+++ b/features/delete/verbose/verbose.feature
@@ -35,7 +35,7 @@ Feature: display all executed Git commands
       |         | frontend | git checkout other                                |
       | other   | frontend | git branch -D current                             |
       |         | backend  | git config --unset git-town-branch.current.parent |
-      |         | backend  | git show-ref --verify --quiet refs/heads/current  |
+      |         | backend  | git rev-parse --verify -q refs/heads/current      |
       |         | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
       |         | backend  | git config -lz --includes --global                |
       |         | backend  | git config -lz --includes --local                 |

--- a/features/detach/verbose/enabled.feature
+++ b/features/detach/verbose/enabled.feature
@@ -67,7 +67,7 @@ Feature: detaching an omni-branch verbosely
       | branch-4 | git checkout branch-2                                          |
       | (none)   | git config git-town-branch.branch-2.parent main                |
       |          | git config git-town-branch.branch-3.parent branch-1            |
-      |          | git show-ref --verify --quiet refs/heads/branch-4              |
+      |          | git rev-parse --verify -q refs/heads/branch-4                  |
       |          | git -c core.abbrev=40 branch -vva --sort=refname               |
       |          | git config -lz --includes --global                             |
       |          | git config -lz --includes --local                              |
@@ -123,7 +123,7 @@ Feature: detaching an omni-branch verbosely
       | branch-4 | git reset --hard {{ sha 'commit 4b' }}               |
       | (none)   | git rev-list --left-right branch-4...origin/branch-4 |
       | branch-4 | git push --force-with-lease --force-if-includes      |
-      | (none)   | git show-ref --verify --quiet refs/heads/branch-2    |
+      | (none)   | git rev-parse --verify -q refs/heads/branch-2        |
       | branch-4 | git checkout branch-2                                |
       | (none)   | git config git-town-branch.branch-2.parent branch-1  |
       |          | git config git-town-branch.branch-3.parent branch-2  |

--- a/features/hack/give_non_existing_branch/on_feature_branch/verbose/verbose.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/verbose/verbose.feature
@@ -26,13 +26,13 @@ Feature: display all executed Git commands
       |        | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
       |        | backend  | git remote get-url origin                         |
       | main   | frontend | git -c rebase.updateRefs=false rebase origin/main |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main     |
+      |        | backend  | git rev-parse --verify -q refs/heads/main         |
       |        | backend  | git rev-list --left-right main...origin/main      |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main     |
+      |        | backend  | git rev-parse --verify -q refs/heads/main         |
       | main   | frontend | git checkout -b new                               |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main     |
+      |        | backend  | git rev-parse --verify -q refs/heads/main         |
       |        | backend  | git config git-town-branch.new.parent main        |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main     |
+      |        | backend  | git rev-parse --verify -q refs/heads/main         |
       |        | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
       |        | backend  | git config -lz --includes --global                |
       |        | backend  | git config -lz --includes --local                 |

--- a/features/prepend/verbose/enabled.feature
+++ b/features/prepend/verbose/enabled.feature
@@ -31,15 +31,15 @@ Feature: display all executed Git commands
       |        | backend  | git log main..old --format=%s --reverse          |
       | old    | frontend | git merge --no-edit --ff main                    |
       |        | frontend | git merge --no-edit --ff origin/old              |
-      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
+      |        | backend  | git rev-parse --verify -q refs/heads/old         |
       |        | backend  | git rev-list --left-right old...origin/old       |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main    |
+      |        | backend  | git rev-parse --verify -q refs/heads/main        |
       | old    | frontend | git checkout -b parent main                      |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main    |
+      |        | backend  | git rev-parse --verify -q refs/heads/main        |
       |        | backend  | git config git-town-branch.parent.parent main    |
-      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
+      |        | backend  | git rev-parse --verify -q refs/heads/old         |
       |        | backend  | git config git-town-branch.old.parent parent     |
-      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
+      |        | backend  | git rev-parse --verify -q refs/heads/old         |
       |        | backend  | git -c core.abbrev=40 branch -vva --sort=refname |
       |        | backend  | git config -lz --includes --global               |
       |        | backend  | git config -lz --includes --local                |

--- a/features/propose/verbose/enabled.feature
+++ b/features/propose/verbose/enabled.feature
@@ -30,10 +30,10 @@ Feature: display all executed Git commands
       |         | backend  | git log main..feature --format=%s --reverse                        |
       | feature | frontend | git merge --no-edit --ff main                                      |
       |         | frontend | git merge --no-edit --ff origin/feature                            |
-      |         | backend  | git show-ref --verify --quiet refs/heads/feature                   |
+      |         | backend  | git rev-parse --verify -q refs/heads/feature                       |
       |         | backend  | git rev-list --left-right feature...origin/feature                 |
       |         | backend  | git rev-parse --abbrev-ref --symbolic-full-name @{u}               |
-      |         | backend  | git show-ref --verify --quiet refs/heads/main                      |
+      |         | backend  | git rev-parse --verify -q refs/heads/main                          |
       |         | backend  | git checkout main                                                  |
       |         | backend  | git checkout feature                                               |
       |         | backend  | which wsl-open                                                     |

--- a/features/rename/verbose/verbose.feature
+++ b/features/rename/verbose/verbose.feature
@@ -35,7 +35,7 @@ Feature: display all executed Git commands
       |        | backend  | git config --unset git-town-branch.old.parent    |
       | new    | frontend | git push -u origin new                           |
       |        | frontend | git push origin :old                             |
-      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
+      |        | backend  | git rev-parse --verify -q refs/heads/old         |
       |        | backend  | git -c core.abbrev=40 branch -vva --sort=refname |
       |        | backend  | git config -lz --includes --global               |
       |        | backend  | git config -lz --includes --local                |

--- a/features/ship/always_merge/current_branch/verbose/verbose.feature
+++ b/features/ship/always_merge/current_branch/verbose/verbose.feature
@@ -33,13 +33,13 @@ Feature: display all executed Git commands when using the always-merge strategy
       |         | backend  | git diff --shortstat main feature                 |
       | feature | frontend | git checkout main                                 |
       | main    | frontend | git merge --no-ff --edit -- feature               |
-      |         | backend  | git show-ref --verify --quiet refs/heads/main     |
+      |         | backend  | git rev-parse --verify -q refs/heads/main         |
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git push                                          |
       |         | backend  | git config --unset git-town-branch.feature.parent |
       | main    | frontend | git push origin :feature                          |
       |         | frontend | git branch -D feature                             |
-      |         | backend  | git show-ref --verify --quiet refs/heads/feature  |
+      |         | backend  | git rev-parse --verify -q refs/heads/feature      |
       |         | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
       |         | backend  | git config -lz --includes --global                |
       |         | backend  | git config -lz --includes --local                 |
@@ -67,7 +67,7 @@ Feature: display all executed Git commands when using the always-merge strategy
       |        | backend  | git remote get-url origin                        |
       | main   | frontend | git branch feature {{ sha 'feature commit' }}    |
       |        | frontend | git push -u origin feature                       |
-      |        | backend  | git show-ref --verify --quiet refs/heads/feature |
+      |        | backend  | git rev-parse --verify -q refs/heads/feature     |
       | main   | frontend | git checkout feature                             |
       |        | backend  | git config git-town-branch.feature.parent main   |
     And Git Town prints:

--- a/features/ship/fast_forward/current_branch/verbose/enabled.feature
+++ b/features/ship/fast_forward/current_branch/verbose/enabled.feature
@@ -33,13 +33,13 @@ Feature: display all executed Git commands when using the fast-forward strategy
       |         | backend  | git diff --shortstat main feature                 |
       | feature | frontend | git checkout main                                 |
       | main    | frontend | git merge --ff-only feature                       |
-      |         | backend  | git show-ref --verify --quiet refs/heads/main     |
+      |         | backend  | git rev-parse --verify -q refs/heads/main         |
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git push                                          |
       |         | backend  | git config --unset git-town-branch.feature.parent |
       | main    | frontend | git push origin :feature                          |
       |         | frontend | git branch -D feature                             |
-      |         | backend  | git show-ref --verify --quiet refs/heads/feature  |
+      |         | backend  | git rev-parse --verify -q refs/heads/feature      |
       |         | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
       |         | backend  | git config -lz --includes --global                |
       |         | backend  | git config -lz --includes --local                 |
@@ -67,7 +67,7 @@ Feature: display all executed Git commands when using the fast-forward strategy
       |        | backend  | git remote get-url origin                        |
       | main   | frontend | git branch feature {{ sha 'feature commit' }}    |
       |        | frontend | git push -u origin feature                       |
-      |        | backend  | git show-ref --verify --quiet refs/heads/feature |
+      |        | backend  | git rev-parse --verify -q refs/heads/feature     |
       | main   | frontend | git checkout feature                             |
       |        | backend  | git config git-town-branch.feature.parent main   |
     And Git Town prints:

--- a/features/ship/squash_merge/current_branch/verbose/verbose.feature
+++ b/features/ship/squash_merge/current_branch/verbose/verbose.feature
@@ -35,13 +35,13 @@ Feature: display all executed Git commands
       | main    | frontend | git merge --squash --ff feature                   |
       |         | frontend | git commit -m done                                |
       |         | backend  | git rev-parse main                                |
-      |         | backend  | git show-ref --verify --quiet refs/heads/main     |
+      |         | backend  | git rev-parse --verify -q refs/heads/main         |
       |         | backend  | git rev-list --left-right main...origin/main      |
       | main    | frontend | git push                                          |
       |         | backend  | git config --unset git-town-branch.feature.parent |
       | main    | frontend | git push origin :feature                          |
       |         | frontend | git branch -D feature                             |
-      |         | backend  | git show-ref --verify --quiet refs/heads/feature  |
+      |         | backend  | git rev-parse --verify -q refs/heads/feature      |
       |         | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
       |         | backend  | git config -lz --includes --global                |
       |         | backend  | git config -lz --includes --local                 |
@@ -69,12 +69,12 @@ Feature: display all executed Git commands
       |        | backend  | git remote get-url origin                        |
       |        | backend  | git log --pretty=format:%H %s -10                |
       | main   | frontend | git revert {{ sha 'done' }}                      |
-      |        | backend  | git show-ref --verify --quiet refs/heads/main    |
+      |        | backend  | git rev-parse --verify -q refs/heads/main        |
       |        | backend  | git rev-list --left-right main...origin/main     |
       | main   | frontend | git push                                         |
       |        | frontend | git branch feature {{ sha 'feature commit' }}    |
       |        | frontend | git push -u origin feature                       |
-      |        | backend  | git show-ref --verify --quiet refs/heads/feature |
+      |        | backend  | git rev-parse --verify -q refs/heads/feature     |
       | main   | frontend | git checkout feature                             |
       |        | backend  | git config git-town-branch.feature.parent main   |
     And Git Town prints:

--- a/features/swap/verbose/enabled.feature
+++ b/features/swap/verbose/enabled.feature
@@ -50,7 +50,7 @@ Feature: swapping a feature branch verbosely
       | (none)   | git config git-town-branch.branch-2.parent main                                       |
       |          | git config git-town-branch.branch-1.parent branch-2                                   |
       |          | git config git-town-branch.branch-3.parent branch-1                                   |
-      |          | git show-ref --verify --quiet refs/heads/branch-3                                     |
+      |          | git rev-parse --verify -q refs/heads/branch-3                                         |
       |          | git -c core.abbrev=40 branch -vva --sort=refname                                      |
       |          | git config -lz --includes --global                                                    |
       |          | git config -lz --includes --local                                                     |
@@ -91,7 +91,7 @@ Feature: swapping a feature branch verbosely
       | branch-3 | git reset --hard {{ sha 'commit 3' }}                |
       | (none)   | git rev-list --left-right branch-3...origin/branch-3 |
       | branch-3 | git push --force-with-lease --force-if-includes      |
-      | (none)   | git show-ref --verify --quiet refs/heads/branch-2    |
+      | (none)   | git rev-parse --verify -q refs/heads/branch-2        |
       | branch-3 | git checkout branch-2                                |
       | (none)   | git config git-town-branch.branch-1.parent main      |
       |          | git config git-town-branch.branch-2.parent branch-1  |

--- a/features/sync/current_branch/feature_branch/compress_sync_strategy/verbose/verbose.feature
+++ b/features/sync/current_branch/feature_branch/compress_sync_strategy/verbose/verbose.feature
@@ -35,8 +35,8 @@ Feature: display all executed Git commands for the "compress" sync strategy
       | branch-2 | frontend | git checkout main                                  |
       |          | backend  | git config --unset git-town-branch.branch-2.parent |
       | main     | frontend | git branch -D branch-2                             |
-      |          | backend  | git show-ref --verify --quiet refs/heads/branch-2  |
-      |          | backend  | git show-ref --verify --quiet refs/heads/branch-1  |
+      |          | backend  | git rev-parse --verify -q refs/heads/branch-2      |
+      |          | backend  | git rev-parse --verify -q refs/heads/branch-1      |
       | main     | frontend | git checkout branch-1                              |
       |          | backend  | git -c core.abbrev=40 branch -vva --sort=refname   |
       |          | backend  | git config -lz --includes --global                 |
@@ -56,23 +56,23 @@ Feature: display all executed Git commands for the "compress" sync strategy
   Scenario: undo
     When I run "git-town undo --verbose"
     Then Git Town runs the commands
-      | BRANCH   | TYPE     | COMMAND                                           |
-      |          | backend  | git version                                       |
-      |          | backend  | git rev-parse --show-toplevel                     |
-      |          | backend  | git config -lz --includes --global                |
-      |          | backend  | git config -lz --includes --local                 |
-      |          | backend  | git status -z --ignore-submodules                 |
-      |          | backend  | git rev-parse -q --verify MERGE_HEAD              |
-      |          | backend  | git rev-parse --absolute-git-dir                  |
-      |          | backend  | git stash list                                    |
-      |          | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
-      |          | backend  | git remote get-url origin                         |
-      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
-      |          | backend  | git remote get-url origin                         |
-      | branch-1 | frontend | git branch branch-2 {{ sha 'initial commit' }}    |
-      |          | backend  | git show-ref --verify --quiet refs/heads/branch-2 |
-      | branch-1 | frontend | git checkout branch-2                             |
-      |          | backend  | git config git-town-branch.branch-2.parent main   |
+      | BRANCH   | TYPE     | COMMAND                                          |
+      |          | backend  | git version                                      |
+      |          | backend  | git rev-parse --show-toplevel                    |
+      |          | backend  | git config -lz --includes --global               |
+      |          | backend  | git config -lz --includes --local                |
+      |          | backend  | git status -z --ignore-submodules                |
+      |          | backend  | git rev-parse -q --verify MERGE_HEAD             |
+      |          | backend  | git rev-parse --absolute-git-dir                 |
+      |          | backend  | git stash list                                   |
+      |          | backend  | git -c core.abbrev=40 branch -vva --sort=refname |
+      |          | backend  | git remote get-url origin                        |
+      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}        |
+      |          | backend  | git remote get-url origin                        |
+      | branch-1 | frontend | git branch branch-2 {{ sha 'initial commit' }}   |
+      |          | backend  | git rev-parse --verify -q refs/heads/branch-2    |
+      | branch-1 | frontend | git checkout branch-2                            |
+      |          | backend  | git config git-town-branch.branch-2.parent main  |
     And Git Town prints:
       """
       Ran 16 shell commands.

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/verbose.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/deleted/verbose.feature
@@ -34,8 +34,8 @@ Feature: display all executed Git commands
       | old    | frontend | git checkout main                                |
       |        | backend  | git config --unset git-town-branch.old.parent    |
       | main   | frontend | git branch -D old                                |
-      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
-      |        | backend  | git show-ref --verify --quiet refs/heads/active  |
+      |        | backend  | git rev-parse --verify -q refs/heads/old         |
+      |        | backend  | git rev-parse --verify -q refs/heads/active      |
       | main   | frontend | git checkout active                              |
       |        | backend  | git -c core.abbrev=40 branch -vva --sort=refname |
       |        | backend  | git config -lz --includes --global               |
@@ -69,7 +69,7 @@ Feature: display all executed Git commands
       |        | backend  | git rev-parse --verify --abbrev-ref @{-1}        |
       |        | backend  | git remote get-url origin                        |
       | active | frontend | git branch old {{ sha 'initial commit' }}        |
-      |        | backend  | git show-ref --verify --quiet refs/heads/old     |
+      |        | backend  | git rev-parse --verify -q refs/heads/old         |
       | active | frontend | git checkout old                                 |
       |        | backend  | git config git-town-branch.old.parent main       |
     And Git Town prints:

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/verbose.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/deleted/verbose.feature
@@ -36,8 +36,8 @@ Feature: display all executed Git commands
       |          | backend  | git config --unset git-town-branch.branch-2.parent         |
       | main     | frontend | git -c rebase.updateRefs=false rebase --onto main branch-2 |
       |          | frontend | git branch -D branch-2                                     |
-      |          | backend  | git show-ref --verify --quiet refs/heads/branch-2          |
-      |          | backend  | git show-ref --verify --quiet refs/heads/branch-1          |
+      |          | backend  | git rev-parse --verify -q refs/heads/branch-2              |
+      |          | backend  | git rev-parse --verify -q refs/heads/branch-1              |
       | main     | frontend | git checkout branch-1                                      |
       |          | backend  | git -c core.abbrev=40 branch -vva --sort=refname           |
       |          | backend  | git config -lz --includes --global                         |
@@ -57,23 +57,23 @@ Feature: display all executed Git commands
   Scenario: undo
     When I run "git-town undo --verbose"
     Then Git Town runs the commands
-      | BRANCH   | TYPE     | COMMAND                                           |
-      |          | backend  | git version                                       |
-      |          | backend  | git rev-parse --show-toplevel                     |
-      |          | backend  | git config -lz --includes --global                |
-      |          | backend  | git config -lz --includes --local                 |
-      |          | backend  | git status -z --ignore-submodules                 |
-      |          | backend  | git rev-parse -q --verify MERGE_HEAD              |
-      |          | backend  | git rev-parse --absolute-git-dir                  |
-      |          | backend  | git stash list                                    |
-      |          | backend  | git -c core.abbrev=40 branch -vva --sort=refname  |
-      |          | backend  | git remote get-url origin                         |
-      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}         |
-      |          | backend  | git remote get-url origin                         |
-      | branch-1 | frontend | git branch branch-2 {{ sha 'initial commit' }}    |
-      |          | backend  | git show-ref --verify --quiet refs/heads/branch-2 |
-      | branch-1 | frontend | git checkout branch-2                             |
-      |          | backend  | git config git-town-branch.branch-2.parent main   |
+      | BRANCH   | TYPE     | COMMAND                                          |
+      |          | backend  | git version                                      |
+      |          | backend  | git rev-parse --show-toplevel                    |
+      |          | backend  | git config -lz --includes --global               |
+      |          | backend  | git config -lz --includes --local                |
+      |          | backend  | git status -z --ignore-submodules                |
+      |          | backend  | git rev-parse -q --verify MERGE_HEAD             |
+      |          | backend  | git rev-parse --absolute-git-dir                 |
+      |          | backend  | git stash list                                   |
+      |          | backend  | git -c core.abbrev=40 branch -vva --sort=refname |
+      |          | backend  | git remote get-url origin                        |
+      |          | backend  | git rev-parse --verify --abbrev-ref @{-1}        |
+      |          | backend  | git remote get-url origin                        |
+      | branch-1 | frontend | git branch branch-2 {{ sha 'initial commit' }}   |
+      |          | backend  | git rev-parse --verify -q refs/heads/branch-2    |
+      | branch-1 | frontend | git checkout branch-2                            |
+      |          | backend  | git config git-town-branch.branch-2.parent main  |
     And Git Town prints:
       """
       Ran 16 shell commands.

--- a/features/sync/features/verbose.feature
+++ b/features/sync/features/verbose.feature
@@ -34,16 +34,16 @@ Feature: display all executed Git commands
       |         | backend  | git log main..feature --format=%s --reverse        |
       | feature | frontend | git checkout main                                  |
       | main    | frontend | git -c rebase.updateRefs=false rebase origin/main  |
-      |         | backend  | git show-ref --verify --quiet refs/heads/main      |
+      |         | backend  | git rev-parse --verify -q refs/heads/main          |
       |         | backend  | git rev-list --left-right main...origin/main       |
       | main    | frontend | git push                                           |
       |         | frontend | git checkout feature                               |
       | feature | frontend | git merge --no-edit --ff main                      |
       |         | frontend | git merge --no-edit --ff origin/feature            |
-      |         | backend  | git show-ref --verify --quiet refs/heads/feature   |
+      |         | backend  | git rev-parse --verify -q refs/heads/feature       |
       |         | backend  | git rev-list --left-right feature...origin/feature |
       | feature | frontend | git push                                           |
-      |         | backend  | git show-ref --verify --quiet refs/heads/feature   |
+      |         | backend  | git rev-parse --verify -q refs/heads/feature       |
       |         | backend  | git -c core.abbrev=40 branch -vva --sort=refname   |
       |         | backend  | git config -lz --includes --global                 |
       |         | backend  | git config -lz --includes --local                  |

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -55,7 +55,7 @@ func (self *Commands) BranchContainsMerges(querier gitdomain.Querier, branch, pa
 }
 
 func (self *Commands) BranchExists(runner gitdomain.Runner, branch gitdomain.LocalBranchName) bool {
-	err := runner.Run("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch.String())
+	err := runner.Run("git", "rev-parse", "--verify", "-q", "refs/heads/"+branch.String())
 	return err == nil
 }
 


### PR DESCRIPTION
Either works, but `rev-parse` feels more accurate. `show-ref`'s main purpose is to show all the refs that match a string, although it requires exact matches with `--verify`. `rev-parse`'s purpose is to look up details of a reference.

https://stackoverflow.com/a/44994778