### PR TITLE
Disable the "gochecknoglobals" linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - forbidigo # Git Town prints a lot to the CLI
     - forcetypeassert
     - funlen # we keep track of this via code reviews
+    - gochecknoglobals # we keep track of global variables with code reviews
     - gocognit # we keep track of this via code reviews
     - goconst # tests contain a ton of hard-coded test strings, for example branch names
     - gocyclo # we keep track of this via code reviews

--- a/internal/cli/dialog/parent.go
+++ b/internal/cli/dialog/parent.go
@@ -11,7 +11,7 @@ import (
 	"github.com/git-town/git-town/v19/internal/messages"
 )
 
-var PerennialBranchOption = gitdomain.LocalBranchName("<none> (perennial branch)") //nolint:gochecknoglobals
+var PerennialBranchOption = gitdomain.LocalBranchName("<none> (perennial branch)")
 
 const (
 	parentBranchTitleTemplate = `Parent branch for %s`

--- a/internal/cli/format/indent.go
+++ b/internal/cli/format/indent.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	indentOnce sync.Once      //nolint:gochecknoglobals
-	identRE    *regexp.Regexp //nolint:gochecknoglobals
+	indentOnce sync.Once
+	identRE    *regexp.Regexp
 )
 
 // Indent outputs the given string with the given level of indentation

--- a/internal/config/configdomain/key.go
+++ b/internal/config/configdomain/key.go
@@ -104,7 +104,7 @@ const (
 	KeyGitUserName                         = Key("user.name")
 )
 
-var keys = []Key{ //nolint:gochecknoglobals
+var keys = []Key{
 	KeyHostingOriginHostname,
 	KeyBitbucketAppPassword,
 	KeyBitbucketUsername,
@@ -175,7 +175,7 @@ func ParseKey(name string) Option[Key] {
 }
 
 // DeprecatedKeys defines the up-to-date counterparts to deprecated configuration settings.
-var DeprecatedKeys = map[Key]Key{ //nolint:gochecknoglobals
+var DeprecatedKeys = map[Key]Key{
 	KeyDeprecatedCodeHostingDriver:         KeyForgeType,
 	KeyDeprecatedCodeHostingOriginHostname: KeyHostingOriginHostname,
 	KeyDeprecatedCodeHostingPlatform:       KeyForgeType,
@@ -190,11 +190,11 @@ var DeprecatedKeys = map[Key]Key{ //nolint:gochecknoglobals
 }
 
 // ObsoleteKeys defines the keys that are sunset and should get deleted
-var ObsoleteKeys = []Key{ //nolint:gochecknoglobals
+var ObsoleteKeys = []Key{
 	KeyObsoleteSyncBeforeShip,
 }
 
-var ObsoleteBranchLists = map[Key]BranchType{ //nolint:gochecknoglobals
+var ObsoleteBranchLists = map[Key]BranchType{
 	KeyDeprecatedContributionBranches: BranchTypeContributionBranch,
 	KeyDeprecatedObservedBranches:     BranchTypeObservedBranch,
 	KeyDeprecatedParkedBranches:       BranchTypeParkedBranch,
@@ -202,7 +202,7 @@ var ObsoleteBranchLists = map[Key]BranchType{ //nolint:gochecknoglobals
 }
 
 // ConfigUpdates defines the config that should have its keys and values to be updated
-var ConfigUpdates = []ConfigUpdate{ //nolint:gochecknoglobals
+var ConfigUpdates = []ConfigUpdate{
 	{
 		Before: ConfigSetting{
 			Key:   KeyDeprecatedAliasKill,

--- a/internal/git/phantom_merge_conflict.go
+++ b/internal/git/phantom_merge_conflict.go
@@ -35,7 +35,7 @@ const (
 )
 
 // all possile UnmergedStages instances
-var UnmergedStages = []UnmergedStage{ //nolint:gochecknoglobals
+var UnmergedStages = []UnmergedStage{
 	UnmergedStageBase,
 	UnmergedStageCurrentBranch,
 	UnmergedStageIncoming,

--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -36,7 +36,7 @@ import (
 )
 
 // the global FixtureFactory instance.
-var fixtureFactory *fixture.Factory //nolint:gochecknoglobals
+var fixtureFactory *fixture.Factory
 
 // dedicated type for storing data in context.Context
 type key int

--- a/internal/test/testgit/commit.go
+++ b/internal/test/testgit/commit.go
@@ -19,7 +19,7 @@ type Commit struct {
 	SHA         gitdomain.SHA `exhaustruct:"optional"`
 }
 
-var counter helpers.AtomicCounter //nolint:gochecknoglobals
+var counter helpers.AtomicCounter
 
 // Set assigns the given value to the property with the given Gherkin table name.
 func (self *Commit) Set(name, value string) {

--- a/internal/test/testgit/location.go
+++ b/internal/test/testgit/location.go
@@ -25,7 +25,7 @@ const (
 	LocationUpstream = Location("upstream")
 )
 
-var allLocations = Locations{ //nolint:gochecknoglobals
+var allLocations = Locations{
 	LocationLocal,
 	LocationOrigin,
 	LocationCoworker,

--- a/tools/lint_steps/lint_steps.go
+++ b/tools/lint_steps/lint_steps.go
@@ -14,7 +14,7 @@ const (
 	featureDir = "../../features"
 )
 
-var stepUsageRE *regexp.Regexp //nolint:gochecknoglobals
+var stepUsageRE *regexp.Regexp
 
 func main() {
 	stepsFileBytes := asserts.NoError1(os.ReadFile(filePath))

--- a/tools/lint_steps/stepdef_usage.go
+++ b/tools/lint_steps/stepdef_usage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/git-town/git-town/v19/pkg/set"
 )
 
-var unusedWhitelist = []string{ //nolint:gochecknoglobals
+var unusedWhitelist = []string{
 	`^display "([^"]+)"$`,
 	`^inspect the commits$`,
 	`^inspect the repo$`,

--- a/tools/stats_release/console/cyan.go
+++ b/tools/stats_release/console/cyan.go
@@ -2,4 +2,4 @@ package console
 
 import "github.com/muesli/termenv"
 
-var Cyan = termenv.String().Foreground(termenv.ANSICyan) //nolint:gochecknoglobals
+var Cyan = termenv.String().Foreground(termenv.ANSICyan)

--- a/tools/stats_release/console/green.go
+++ b/tools/stats_release/console/green.go
@@ -2,4 +2,4 @@ package console
 
 import "github.com/muesli/termenv"
 
-var Green = termenv.String().Foreground(termenv.ANSIGreen) //nolint:gochecknoglobals
+var Green = termenv.String().Foreground(termenv.ANSIGreen)

--- a/tools/structs_sorted/structs_sorted.go
+++ b/tools/structs_sorted/structs_sorted.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// file paths to ignore
-	ignorePaths = []string{ //nolint:gochecknoglobals
+	ignorePaths = []string{
 		"internal/config/configdomain/lineage_test.go",
 		"src/config/configfile/data.go",
 		"tools/structs_sorted/test.go",
@@ -20,7 +20,7 @@ var (
 	}
 
 	// struct types to ignore
-	ignoreTypes = []string{ //nolint:gochecknoglobals
+	ignoreTypes = []string{
 		"BranchSpan",
 		"Change",
 		"IdentSelectorMatcher", // Field order is meaningful.

--- a/tools/tests_sorted/tests_sorted.go
+++ b/tools/tests_sorted/tests_sorted.go
@@ -11,7 +11,7 @@ import (
 )
 
 // file paths to ignore
-var ignorePaths = []string{ //nolint:gochecknoglobals
+var ignorePaths = []string{
 	"vendor/",
 }
 


### PR DESCRIPTION
1. We need plenty of global variables, for various reasons.
2. We check them using code reviews.
3. This linter requires too many exceptions, with zero bugs catched so far.