### PR TITLE
Improve error message for invalid template expression

### DIFF
--- a/internal/test/handlebars/replace.go
+++ b/internal/test/handlebars/replace.go
@@ -2,7 +2,6 @@ package handlebars
 
 import (
 	"fmt"
-	"log"
 	"maps"
 	"regexp"
 	"strings"
@@ -87,7 +86,7 @@ func Expand(text string, args ExpandArgs) string {
 			}
 			text = strings.Replace(text, match, sha.String(), 1)
 		default:
-			log.Fatalf("DataTable.Expand: unknown template expression %q", text)
+			panic(fmt.Sprintf("DataTable.Expand: unknown template expression %q", match))
 		}
 	}
 	return text


### PR DESCRIPTION
Better to panic loud and red then to print normal text that is easy to miss.