### PR TITLE
commands_test: Remove unused Locations field from calls to CreateCommit

### DIFF
--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -951,14 +951,12 @@ func TestBackendCommands(t *testing.T) {
 			Branch:      "branch",
 			FileContent: "branch content",
 			FileName:    "file",
-			Locations:   testgit.Locations{testgit.LocationLocal},
 			Message:     "branch commit",
 		})
 		runtime.CreateCommit(testgit.Commit{
 			Branch:      "initial",
 			FileContent: "initial content",
 			FileName:    "file",
-			Locations:   testgit.Locations{testgit.LocationLocal},
 			Message:     "initial commit",
 		})
 		runtime.CheckoutBranch("branch")


### PR DESCRIPTION
`CreateCommit` doesn't read the `Locations` field from the `Commit` struct, so these lines can be removed.