### PR TITLE
Ask `git log` for minimal information where possible

### DIFF
--- a/features/detach/verbose/enabled.feature
+++ b/features/detach/verbose/enabled.feature
@@ -50,7 +50,7 @@ Feature: detaching an omni-branch verbosely
       |          | git -c core.abbrev=40 branch -vva --sort=refname               |
       |          | git remote get-url origin                                      |
       |          | git rev-parse --verify --abbrev-ref @{-1}                      |
-      |          | git log --merges branch-1..branch-2                            |
+      |          | git log --merges --format=%H branch-1..branch-2                |
       | branch-2 | git -c rebase.updateRefs=false rebase --onto main branch-1     |
       | (none)   | git rev-list --left-right branch-2...origin/branch-2           |
       | branch-2 | git push --force-with-lease --force-if-includes                |

--- a/features/merge/verbose/enabled.feature
+++ b/features/merge/verbose/enabled.feature
@@ -37,7 +37,7 @@ Feature: merging a branch verbosely
       |        | git rev-parse --verify --abbrev-ref @{-1}        |
       |        | git log alpha..beta --format=%s --reverse        |
       |        | git log main..alpha --format=%s --reverse        |
-      |        | git log --no-merges alpha ^beta                  |
+      |        | git log --no-merges --format=%H alpha ^beta      |
       |        | git config git-town-branch.beta.parent main      |
       |        | git config --unset git-town-branch.alpha.parent  |
       | beta   | git branch -D alpha                              |

--- a/features/swap/verbose/enabled.feature
+++ b/features/swap/verbose/enabled.feature
@@ -33,8 +33,8 @@ Feature: swapping a feature branch verbosely
       |          | git -c core.abbrev=40 branch -vva --sort=refname                                      |
       |          | git remote get-url origin                                                             |
       |          | git rev-parse --verify --abbrev-ref @{-1}                                             |
-      |          | git log --merges branch-1..branch-2                                                   |
-      |          | git log --merges main..branch-1                                                       |
+      |          | git log --merges --format=%H branch-1..branch-2                                       |
+      |          | git log --merges --format=%H main..branch-1                                           |
       | branch-2 | git -c rebase.updateRefs=false rebase --onto main branch-1                            |
       | (none)   | git rev-list --left-right branch-2...origin/branch-2                                  |
       | branch-2 | git push --force-with-lease --force-if-includes                                       |

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -51,7 +51,7 @@ func (self *Commands) BranchAuthors(querier gitdomain.Querier, branch, parent gi
 }
 
 func (self *Commands) BranchContainsMerges(querier gitdomain.Querier, branch, parent gitdomain.LocalBranchName) (bool, error) {
-	output, err := querier.QueryTrim("git", "log", "--merges", fmt.Sprintf("%s..%s", parent, branch))
+	output, err := querier.QueryTrim("git", "log", "--merges", "--format=%H", fmt.Sprintf("%s..%s", parent, branch))
 	return len(output) > 0, err
 }
 
@@ -76,7 +76,7 @@ func (self *Commands) BranchHasUnmergedChanges(querier gitdomain.Querier, branch
 }
 
 func (self *Commands) BranchInSyncWithParent(querier gitdomain.Querier, branch, parent gitdomain.LocalBranchName) (bool, error) {
-	output, err := querier.QueryTrim("git", "log", "--no-merges", parent.String(), "^"+branch.String())
+	output, err := querier.QueryTrim("git", "log", "--no-merges", "--format=%H", parent.String(), "^"+branch.String())
 	return len(output) == 0, err
 }
 


### PR DESCRIPTION
In these cases, we only care about whether `git log` returns anything at all. Output only the commit hashes, not the full commit info.