### PR TITLE
setup assistant: store only the token of the forge that is actually used

### DIFF
--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -1,0 +1,38 @@
+@messyoutput
+Feature: a global API token of another forge exists
+
+  @this
+  Scenario: on GitHub, with global GitLab token
+    Given a Git repo with origin
+    And my repo's "origin" remote is "git@github.com:git-town/git-town.git"
+    And global Git setting "git-town.gitlab-token" is "987654"
+    When I run "git-town config setup" and enter into the dialog:
+      | DIALOG                      | KEYS              | DESCRIPTION                                 |
+      | welcome                     | enter             |                                             |
+      | aliases                     | enter             |                                             |
+      | main branch                 | enter             |                                             |
+      | perennial branches          |                   | no input here since the dialog doesn't show |
+      | perennial regex             | enter             |                                             |
+      | default branch type         | enter             |                                             |
+      | feature regex               | enter             |                                             |
+      | dev-remote                  | enter             |                                             |
+      | forge type: auto-detect     | enter             |                                             |
+      | github token                | 1 2 3 4 5 6 enter |                                             |
+      | token scope                 | enter             |                                             |
+      | origin hostname             | enter             |                                             |
+      | sync-feature-strategy       | enter             |                                             |
+      | sync-perennial-strategy     | enter             |                                             |
+      | sync-prototype-strategy     | enter             |                                             |
+      | sync-upstream               | enter             |                                             |
+      | sync-tags                   | enter             |                                             |
+      | share-new-branches          | enter             |                                             |
+      | push-hook                   | enter             |                                             |
+      | new-branch-type             | down enter        |                                             |
+      | ship-strategy               | enter             |                                             |
+      | ship-delete-tracking-branch | enter             |                                             |
+      | save config to Git metadata | down enter        |                                             |
+    Then Git Town runs the commands
+      | COMMAND                                         |
+      | git config --local git-town.github-token 123456 |
+    And local Git setting "git-town.forge-type" still doesn't exist
+    And local Git setting "git-town.github-token" is now "123456"

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -35,3 +35,5 @@ Feature: a global API token of another forge exists
       | git config --local git-town.github-token 123456 |
     And local Git setting "git-town.forge-type" still doesn't exist
     And local Git setting "git-town.github-token" is now "123456"
+    And local Git setting "git-town.gitlab-token" now doesn't exist
+    And global Git setting "git-town.gitlab-token" is still "987654"

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: a global API token of another forge exists
 
-  @this
   Scenario: on GitHub, with global GitLab token
     Given a Git repo with origin
     And my repo's "origin" remote is "git@github.com:git-town/git-town.git"

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -67,11 +67,11 @@ func executeConfigSetup(verbose configdomain.Verbose) error {
 	if err != nil || exit {
 		return err
 	}
-	aborted, tokenScope, err := enterData(repo.UnvalidatedConfig, repo.Git, repo.Backend, &data)
+	aborted, tokenScope, forgeTypeOpt, err := enterData(repo.UnvalidatedConfig, repo.Git, repo.Backend, &data)
 	if err != nil || aborted {
 		return err
 	}
-	err = saveAll(data.userInput, repo.UnvalidatedConfig, tokenScope, repo.Git, repo.Frontend)
+	err = saveAll(data.userInput, repo.UnvalidatedConfig, tokenScope, forgeTypeOpt, repo.Git, repo.Frontend)
 	if err != nil {
 		return err
 	}
@@ -113,15 +113,15 @@ func determineHostingPlatform(config config.UnvalidatedConfig, userChoice Option
 	return None[configdomain.ForgeType]()
 }
 
-func enterData(config config.UnvalidatedConfig, gitCommands git.Commands, backend gitdomain.RunnerQuerier, data *setupData) (aborted bool, tokenScope configdomain.ConfigScope, err error) {
+func enterData(config config.UnvalidatedConfig, gitCommands git.Commands, backend gitdomain.RunnerQuerier, data *setupData) (aborted bool, tokenScope configdomain.ConfigScope, forgeTypeOpt Option[configdomain.ForgeType], err error) {
 	tokenScope = configdomain.ConfigScopeLocal
 	aborted, err = dialog.Welcome(data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.Aliases, aborted, err = dialog.Aliases(configdomain.AllAliasableCommands(), config.NormalConfig.Aliases, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	existingMainBranch := config.UnvalidatedConfig.MainBranch
 	if existingMainBranch.IsNone() {
@@ -132,151 +132,152 @@ func enterData(config config.UnvalidatedConfig, gitCommands git.Commands, backen
 	}
 	mainBranch, aborted, err := dialog.MainBranch(data.localBranches.Names(), existingMainBranch, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.UnvalidatedConfig.MainBranch = Some(mainBranch)
 	data.userInput.config.NormalConfig.PerennialBranches, aborted, err = dialog.PerennialBranches(data.localBranches.Names(), config.NormalConfig.PerennialBranches, mainBranch, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.PerennialRegex, aborted, err = dialog.PerennialRegex(config.NormalConfig.PerennialRegex, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.DefaultBranchType, aborted, err = dialog.DefaultBranchType(config.NormalConfig.DefaultBranchType, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.FeatureRegex, aborted, err = dialog.FeatureRegex(config.NormalConfig.FeatureRegex, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.DevRemote, aborted, err = dialog.DevRemote(config.NormalConfig.DevRemote, data.remotes, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.ForgeType, aborted, err = dialog.ForgeType(config.NormalConfig.ForgeType, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
-	if forgeType, hasForgeType := determineHostingPlatform(config, data.userInput.config.NormalConfig.ForgeType).Get(); hasForgeType {
+	forgeTypeOpt = determineHostingPlatform(config, data.userInput.config.NormalConfig.ForgeType)
+	if forgeType, hasForgeType := forgeTypeOpt.Get(); hasForgeType {
 		switch forgeType {
 		case configdomain.ForgeTypeBitbucket, configdomain.ForgeTypeBitbucketDatacenter:
 			data.userInput.config.NormalConfig.BitbucketUsername, aborted, err = dialog.BitbucketUsername(config.NormalConfig.BitbucketUsername, data.dialogInputs.Next())
 			if err != nil || aborted {
-				return aborted, tokenScope, err
+				return aborted, tokenScope, None[configdomain.ForgeType](), err
 			}
 			data.userInput.config.NormalConfig.BitbucketAppPassword, aborted, err = dialog.BitbucketAppPassword(config.NormalConfig.BitbucketAppPassword, data.dialogInputs.Next())
 			if err != nil || aborted {
-				return aborted, tokenScope, err
+				return aborted, tokenScope, None[configdomain.ForgeType](), err
 			}
 			if showScopeDialog(data.userInput.config.NormalConfig.BitbucketUsername, config.NormalConfig.BitbucketUsername) &&
 				showScopeDialog(data.userInput.config.NormalConfig.BitbucketAppPassword, config.NormalConfig.BitbucketAppPassword) {
 				scope := determineScope(config.NormalConfig.GlobalGitConfig.BitbucketAppPassword)
 				tokenScope, aborted, err = dialog.TokenScope(scope, data.dialogInputs.Next())
 				if err != nil || aborted {
-					return aborted, tokenScope, err
+					return aborted, tokenScope, None[configdomain.ForgeType](), err
 				}
 			}
 		case configdomain.ForgeTypeCodeberg:
 			data.userInput.config.NormalConfig.CodebergToken, aborted, err = dialog.CodebergToken(config.NormalConfig.CodebergToken, data.dialogInputs.Next())
 			if err != nil || aborted {
-				return aborted, tokenScope, err
+				return aborted, tokenScope, None[configdomain.ForgeType](), err
 			}
 			if showScopeDialog(data.userInput.config.NormalConfig.CodebergToken, config.NormalConfig.CodebergToken) {
 				scope := determineScope(config.NormalConfig.GlobalGitConfig.CodebergToken)
 				tokenScope, aborted, err = dialog.TokenScope(scope, data.dialogInputs.Next())
 				if err != nil || aborted {
-					return aborted, tokenScope, err
+					return aborted, tokenScope, None[configdomain.ForgeType](), err
 				}
 			}
 		case configdomain.ForgeTypeGitea:
 			data.userInput.config.NormalConfig.GiteaToken, aborted, err = dialog.GiteaToken(config.NormalConfig.GiteaToken, data.dialogInputs.Next())
 			if err != nil || aborted {
-				return aborted, tokenScope, err
+				return aborted, tokenScope, None[configdomain.ForgeType](), err
 			}
 			if showScopeDialog(data.userInput.config.NormalConfig.GiteaToken, config.NormalConfig.GiteaToken) {
 				scope := determineScope(config.NormalConfig.GlobalGitConfig.GiteaToken)
 				tokenScope, aborted, err = dialog.TokenScope(scope, data.dialogInputs.Next())
 				if err != nil || aborted {
-					return aborted, tokenScope, err
+					return aborted, tokenScope, None[configdomain.ForgeType](), err
 				}
 			}
 		case configdomain.ForgeTypeGitHub:
 			data.userInput.config.NormalConfig.GitHubToken, aborted, err = dialog.GitHubToken(config.NormalConfig.GitHubToken, data.dialogInputs.Next())
 			if err != nil || aborted {
-				return aborted, tokenScope, err
+				return aborted, tokenScope, None[configdomain.ForgeType](), err
 			}
 			if showScopeDialog(data.userInput.config.NormalConfig.GitHubToken, config.NormalConfig.GitHubToken) {
 				scope := determineScope(config.NormalConfig.GlobalGitConfig.GitHubToken)
 				tokenScope, aborted, err = dialog.TokenScope(scope, data.dialogInputs.Next())
 				if err != nil || aborted {
-					return aborted, tokenScope, err
+					return aborted, tokenScope, None[configdomain.ForgeType](), err
 				}
 			}
 		case configdomain.ForgeTypeGitLab:
 			data.userInput.config.NormalConfig.GitLabToken, aborted, err = dialog.GitLabToken(config.NormalConfig.GitLabToken, data.dialogInputs.Next())
 			if err != nil || aborted {
-				return aborted, tokenScope, err
+				return aborted, tokenScope, None[configdomain.ForgeType](), err
 			}
 			if showScopeDialog(data.userInput.config.NormalConfig.GitLabToken, config.NormalConfig.GitLabToken) {
 				scope := determineScope(config.NormalConfig.GlobalGitConfig.GitLabToken)
 				tokenScope, aborted, err = dialog.TokenScope(scope, data.dialogInputs.Next())
 				if err != nil || aborted {
-					return aborted, tokenScope, err
+					return aborted, tokenScope, None[configdomain.ForgeType](), err
 				}
 			}
 		}
 	}
 	data.userInput.config.NormalConfig.HostingOriginHostname, aborted, err = dialog.OriginHostname(config.NormalConfig.HostingOriginHostname, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.SyncFeatureStrategy, aborted, err = dialog.SyncFeatureStrategy(config.NormalConfig.SyncFeatureStrategy, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.SyncPerennialStrategy, aborted, err = dialog.SyncPerennialStrategy(config.NormalConfig.SyncPerennialStrategy, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.SyncPrototypeStrategy, aborted, err = dialog.SyncPrototypeStrategy(config.NormalConfig.SyncPrototypeStrategy, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.SyncUpstream, aborted, err = dialog.SyncUpstream(config.NormalConfig.SyncUpstream, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.SyncTags, aborted, err = dialog.SyncTags(config.NormalConfig.SyncTags, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.ShareNewBranches, aborted, err = dialog.ShareNewBranches(config.NormalConfig.ShareNewBranches, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.PushHook, aborted, err = dialog.PushHook(config.NormalConfig.PushHook, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.NewBranchType, aborted, err = dialog.NewBranchType(config.NormalConfig.NewBranchType, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.ShipStrategy, aborted, err = dialog.ShipStrategy(config.NormalConfig.ShipStrategy, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.config.NormalConfig.ShipDeleteTrackingBranch, aborted, err = dialog.ShipDeleteTrackingBranch(config.NormalConfig.ShipDeleteTrackingBranch, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
 	data.userInput.configStorage, aborted, err = dialog.ConfigStorage(data.hasConfigFile, data.dialogInputs.Next())
 	if err != nil || aborted {
-		return aborted, tokenScope, err
+		return aborted, tokenScope, None[configdomain.ForgeType](), err
 	}
-	return false, tokenScope, nil
+	return false, tokenScope, forgeTypeOpt, nil
 }
 
 type option interface {
@@ -337,7 +338,7 @@ func loadSetupData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (d
 	}, exit, nil
 }
 
-func saveAll(userInput userInput, oldConfig config.UnvalidatedConfig, tokenScope configdomain.ConfigScope, gitCommands git.Commands, frontend gitdomain.Runner) error {
+func saveAll(userInput userInput, oldConfig config.UnvalidatedConfig, tokenScope configdomain.ConfigScope, forgeTypeOpt Option[configdomain.ForgeType], gitCommands git.Commands, frontend gitdomain.Runner) error {
 	err := saveAliases(oldConfig.NormalConfig.Aliases, userInput.config.NormalConfig.Aliases, gitCommands, frontend)
 	if err != nil {
 		return err

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -343,29 +343,31 @@ func saveAll(userInput userInput, oldConfig config.UnvalidatedConfig, tokenScope
 	if err != nil {
 		return err
 	}
-	err = saveBitbucketUsername(oldConfig.NormalConfig.BitbucketUsername, userInput.config.NormalConfig.BitbucketUsername, tokenScope, gitCommands, frontend)
-	if err != nil {
-		return err
-	}
-	err = saveBitbucketAppPassword(oldConfig.NormalConfig.BitbucketAppPassword, userInput.config.NormalConfig.BitbucketAppPassword, tokenScope, gitCommands, frontend)
-	if err != nil {
-		return err
-	}
-	err = saveCodebergToken(oldConfig.NormalConfig.CodebergToken, userInput.config.NormalConfig.CodebergToken, tokenScope, gitCommands, frontend)
-	if err != nil {
-		return err
-	}
-	err = saveGiteaToken(oldConfig.NormalConfig.GiteaToken, userInput.config.NormalConfig.GiteaToken, tokenScope, gitCommands, frontend)
-	if err != nil {
-		return err
-	}
-	err = saveGitHubToken(oldConfig.NormalConfig.GitHubToken, userInput.config.NormalConfig.GitHubToken, tokenScope, gitCommands, frontend)
-	if err != nil {
-		return err
-	}
-	err = saveGitLabToken(oldConfig.NormalConfig.GitLabToken, userInput.config.NormalConfig.GitLabToken, tokenScope, gitCommands, frontend)
-	if err != nil {
-		return err
+	if forgeType, hasForgeType := forgeTypeOpt.Get(); hasForgeType {
+		err = saveBitbucketUsername(oldConfig.NormalConfig.BitbucketUsername, userInput.config.NormalConfig.BitbucketUsername, tokenScope, gitCommands, frontend)
+		if err != nil {
+			return err
+		}
+		err = saveBitbucketAppPassword(oldConfig.NormalConfig.BitbucketAppPassword, userInput.config.NormalConfig.BitbucketAppPassword, tokenScope, gitCommands, frontend)
+		if err != nil {
+			return err
+		}
+		err = saveCodebergToken(oldConfig.NormalConfig.CodebergToken, userInput.config.NormalConfig.CodebergToken, tokenScope, gitCommands, frontend)
+		if err != nil {
+			return err
+		}
+		err = saveGiteaToken(oldConfig.NormalConfig.GiteaToken, userInput.config.NormalConfig.GiteaToken, tokenScope, gitCommands, frontend)
+		if err != nil {
+			return err
+		}
+		err = saveGitHubToken(oldConfig.NormalConfig.GitHubToken, userInput.config.NormalConfig.GitHubToken, tokenScope, gitCommands, frontend)
+		if err != nil {
+			return err
+		}
+		err = saveGitLabToken(oldConfig.NormalConfig.GitLabToken, userInput.config.NormalConfig.GitLabToken, tokenScope, gitCommands, frontend)
+		if err != nil {
+			return err
+		}
 	}
 	switch userInput.configStorage {
 	case dialog.ConfigStorageOptionFile:

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -344,29 +344,36 @@ func saveAll(userInput userInput, oldConfig config.UnvalidatedConfig, tokenScope
 		return err
 	}
 	if forgeType, hasForgeType := forgeTypeOpt.Get(); hasForgeType {
-		err = saveBitbucketUsername(oldConfig.NormalConfig.BitbucketUsername, userInput.config.NormalConfig.BitbucketUsername, tokenScope, gitCommands, frontend)
-		if err != nil {
-			return err
-		}
-		err = saveBitbucketAppPassword(oldConfig.NormalConfig.BitbucketAppPassword, userInput.config.NormalConfig.BitbucketAppPassword, tokenScope, gitCommands, frontend)
-		if err != nil {
-			return err
-		}
-		err = saveCodebergToken(oldConfig.NormalConfig.CodebergToken, userInput.config.NormalConfig.CodebergToken, tokenScope, gitCommands, frontend)
-		if err != nil {
-			return err
-		}
-		err = saveGiteaToken(oldConfig.NormalConfig.GiteaToken, userInput.config.NormalConfig.GiteaToken, tokenScope, gitCommands, frontend)
-		if err != nil {
-			return err
-		}
-		err = saveGitHubToken(oldConfig.NormalConfig.GitHubToken, userInput.config.NormalConfig.GitHubToken, tokenScope, gitCommands, frontend)
-		if err != nil {
-			return err
-		}
-		err = saveGitLabToken(oldConfig.NormalConfig.GitLabToken, userInput.config.NormalConfig.GitLabToken, tokenScope, gitCommands, frontend)
-		if err != nil {
-			return err
+		switch forgeType {
+		case configdomain.ForgeTypeBitbucket, configdomain.ForgeTypeBitbucketDatacenter:
+			err = saveBitbucketUsername(oldConfig.NormalConfig.BitbucketUsername, userInput.config.NormalConfig.BitbucketUsername, tokenScope, gitCommands, frontend)
+			if err != nil {
+				return err
+			}
+			err = saveBitbucketAppPassword(oldConfig.NormalConfig.BitbucketAppPassword, userInput.config.NormalConfig.BitbucketAppPassword, tokenScope, gitCommands, frontend)
+			if err != nil {
+				return err
+			}
+		case configdomain.ForgeTypeCodeberg:
+			err = saveCodebergToken(oldConfig.NormalConfig.CodebergToken, userInput.config.NormalConfig.CodebergToken, tokenScope, gitCommands, frontend)
+			if err != nil {
+				return err
+			}
+		case configdomain.ForgeTypeGitHub:
+			err = saveGitHubToken(oldConfig.NormalConfig.GitHubToken, userInput.config.NormalConfig.GitHubToken, tokenScope, gitCommands, frontend)
+			if err != nil {
+				return err
+			}
+		case configdomain.ForgeTypeGitLab:
+			err = saveGitLabToken(oldConfig.NormalConfig.GitLabToken, userInput.config.NormalConfig.GitLabToken, tokenScope, gitCommands, frontend)
+			if err != nil {
+				return err
+			}
+		case configdomain.ForgeTypeGitea:
+			err = saveGiteaToken(oldConfig.NormalConfig.GiteaToken, userInput.config.NormalConfig.GiteaToken, tokenScope, gitCommands, frontend)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	switch userInput.configStorage {

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -159,8 +159,8 @@ func enterData(config config.UnvalidatedConfig, gitCommands git.Commands, backen
 	if err != nil || aborted {
 		return aborted, tokenScope, err
 	}
-	if platform, has := determineHostingPlatform(config, data.userInput.config.NormalConfig.ForgeType).Get(); has {
-		switch platform {
+	if forgeType, hasForgeType := determineHostingPlatform(config, data.userInput.config.NormalConfig.ForgeType).Get(); hasForgeType {
+		switch forgeType {
 		case configdomain.ForgeTypeBitbucket, configdomain.ForgeTypeBitbucketDatacenter:
 			data.userInput.config.NormalConfig.BitbucketUsername, aborted, err = dialog.BitbucketUsername(config.NormalConfig.BitbucketUsername, data.dialogInputs.Next())
 			if err != nil || aborted {


### PR DESCRIPTION
resolves #4819

The setup assistant asks only for tokens of this forge, so it should only store tokens of that forge.