### PR TITLE
Use arg struct for mergeConfigs function

### DIFF
--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -20,6 +20,7 @@ type NormalConfig struct {
 	configdomain.NormalConfigData
 	ConfigFile      Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
 	DryRun          configdomain.DryRun                // whether to only print the Git commands but not execute them
+	EnvConfig       configdomain.PartialConfig         // content of the environment variables
 	GitConfigAccess gitconfig.Access                   // access to the Git configuration settings
 	GitVersion      git.Version                        // version of the installed Git executable
 	GlobalGitConfig configdomain.PartialConfig         // content of the global Git configuration

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -140,8 +140,8 @@ func mergeConfigs(args mergeConfigsArgs) (configdomain.UnvalidatedConfigData, co
 }
 
 type mergeConfigsArgs struct {
-	env    configdomain.PartialConfig
-	file   Option[configdomain.PartialConfig]
-	global configdomain.PartialConfig
-	local  configdomain.PartialConfig
+	env    configdomain.PartialConfig         // configuration data taken from environment variables
+	file   Option[configdomain.PartialConfig] // data of the configuration file
+	global configdomain.PartialConfig         // data from the global Git configuration
+	local  configdomain.PartialConfig         // data from the local Git configuration
 }

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -104,9 +104,7 @@ func NewConfigs(configFile Option[configdomain.PartialConfig], globalGitConfig, 
 	}
 	config = config.Merge(globalGitConfig)
 	config = config.Merge(localGitConfig)
-	normalConfig := config.ToNormalConfig(configdomain.DefaultNormalConfig())
-	unvalidatedConfig := config.ToUnvalidatedConfig()
-	return unvalidatedConfig, normalConfig
+	return config.ToUnvalidatedConfig(), config.ToNormalConfig(configdomain.DefaultNormalConfig())
 }
 
 func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -38,10 +38,10 @@ func (self *UnvalidatedConfig) Reload() (globalSnapshot, localSnapshot configdom
 	localSnapshot, localGitConfig, _ := self.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeLocal, false)    // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	envConfig := envconfig.Load()
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{
+		env:    envConfig,
 		file:   self.NormalConfig.ConfigFile,
 		global: globalGitConfig,
 		local:  localGitConfig,
-		env:    envConfig,
 	})
 	self.UnvalidatedConfig = unvalidatedConfig
 	self.NormalConfig = NormalConfig{
@@ -97,10 +97,10 @@ func DefaultUnvalidatedConfig(gitAccess gitconfig.Access, gitVersion git.Version
 
 func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{
+		env:    args.EnvConfig,
 		file:   args.ConfigFile,
 		global: args.GlobalConfig,
 		local:  args.LocalConfig,
-		env:    args.EnvConfig,
 	})
 	return UnvalidatedConfig{
 		NormalConfig: NormalConfig{
@@ -140,8 +140,8 @@ func mergeConfigs(args mergeConfigsArgs) (configdomain.UnvalidatedConfigData, co
 }
 
 type mergeConfigsArgs struct {
+	env    configdomain.PartialConfig
 	file   Option[configdomain.PartialConfig]
 	global configdomain.PartialConfig
 	local  configdomain.PartialConfig
-	env    configdomain.PartialConfig
 }


### PR DESCRIPTION
This function receives a large number of similarly typed arguments. This makes it super easy to mix up arguments. Using a struct to achieve named arguments prevents this problem.