### PR TITLE
Remove unnecessary color.ui override

### DIFF
--- a/internal/subshell/backend_runner.go
+++ b/internal/subshell/backend_runner.go
@@ -52,7 +52,6 @@ func (self BackendRunner) execute(executable string, args ...string) (string, er
 	}
 	env := subProcess.Environ()
 	env = append(env, "LC_ALL=C")
-	env = append(env, `GIT_CONFIG_PARAMETERS='color.ui=never'`)
 	subProcess.Env = env
 	concurrentGitRetriesLeft := concurrentGitRetries
 	var outputText string

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -130,7 +130,10 @@ func (self *TestCommands) CommitsInBranch(branch gitdomain.LocalBranchName, pare
 			commit.FileName = strings.Join(filenames, ", ")
 		}
 		if slices.Contains(fields, "FILE CONTENT") {
-			filecontent := self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
+			filecontent := ""
+			if commit.FileName != "" {
+				filecontent = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
+			}
 			commit.FileContent = filecontent
 		}
 		result = append(result, commit)
@@ -260,10 +263,6 @@ func (self *TestCommands) FileContentErr(filename string) (string, error) {
 // FileContentInCommit provides the content of the file with the given name in the commit with the given SHA.
 func (self *TestCommands) FileContentInCommit(location gitdomain.Location, filename string) string {
 	output := self.MustQuery("git", "show", location.String()+":"+filename)
-	if strings.HasPrefix(output, "tree ") {
-		// merge commits get an empty file content instead of "tree <SHA>"
-		return ""
-	}
 	return output
 }
 


### PR DESCRIPTION
Now that we're not parsing Git porcelain output in Git Town, we can safely run Git commands without caring about the user's `color.ui` setting.

See #4717, #4735