### PR TITLE
Run tests with color.ui=always

### DIFF
--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -1517,7 +1517,10 @@ func runCommand(ctx context.Context, command string) {
 		cmd, args := parts[0], parts[1:]
 		subProcess := exec.Command(cmd, args...) // #nosec
 		subProcess.Dir = state.fixture.Dir
-		subProcess.Env = append(subProcess.Environ(), "LC_ALL=C")
+		env := subProcess.Environ()
+		env = append(env, "LC_ALL=C")
+		env = append(env, "GIT_CONFIG_PARAMETERS='color.ui=always'")
+		subProcess.Env = env
 		outputBytes, _ := subProcess.CombinedOutput()
 		runOutput = string(outputBytes)
 		exitCode = subProcess.ProcessState.ExitCode()


### PR DESCRIPTION
This PR probably shouldn't be merged, but it proves that Git Town works even if the user has set `color.ui` to `always`.