### PR TITLE
Fix one last porcelain issue: `git show` in Cucumber tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ RTA_VERSION = 0.15.0  # run-that-app version to use
 # internal data and state
 .DEFAULT_GOAL := help
 RELEASE_VERSION := "19.0.0"
-GO_TEST_ARGS = LANG=C GOGC=off BROWSER= "GIT_CONFIG_PARAMETERS='color.ui=always'"
+GO_TEST_ARGS = LANG=C GOGC=off BROWSER=
 
 cuke: install  # runs all end-to-end tests in a way that looks nice during development
 	@env $(GO_TEST_ARGS) messyoutput=0 go test -v

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ RTA_VERSION = 0.15.0  # run-that-app version to use
 # internal data and state
 .DEFAULT_GOAL := help
 RELEASE_VERSION := "19.0.0"
-GO_TEST_ARGS = LANG=C GOGC=off BROWSER=
+GO_TEST_ARGS = LANG=C GOGC=off BROWSER= "GIT_CONFIG_PARAMETERS='color.ui=always'"
 
 cuke: install  # runs all end-to-end tests in a way that looks nice during development
 	@env $(GO_TEST_ARGS) messyoutput=0 go test -v

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -130,7 +130,10 @@ func (self *TestCommands) CommitsInBranch(branch gitdomain.LocalBranchName, pare
 			commit.FileName = strings.Join(filenames, ", ")
 		}
 		if slices.Contains(fields, "FILE CONTENT") {
-			filecontent := self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
+			filecontent := ""
+			if commit.FileName != "" {
+				filecontent = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
+			}
 			commit.FileContent = filecontent
 		}
 		result = append(result, commit)
@@ -260,10 +263,6 @@ func (self *TestCommands) FileContentErr(filename string) (string, error) {
 // FileContentInCommit provides the content of the file with the given name in the commit with the given SHA.
 func (self *TestCommands) FileContentInCommit(location gitdomain.Location, filename string) string {
 	output := self.MustQuery("git", "show", location.String()+":"+filename)
-	if strings.HasPrefix(output, "tree ") {
-		// merge commits get an empty file content instead of "tree <SHA>"
-		return ""
-	}
 	return output
 }
 


### PR DESCRIPTION
In the Cucumber tests, we run `git show <commit>:<filename>` to get the contents of a file at a particular commit. If we run `git show <commit>:`, Git will show the list of files at that commit with a colored header that starts with `tree <commit>:`.

This can happen during the "these commits exist now" step. If the table has the headers "FILE NAME" and "FILE CONTENT", and we leave the "FILE NAME" column empty, we run a Git command like `git show <commit>:`.

```
$ rg '\| .*? \| .*? \| .*? \|  + \|  + \|' features
features/sync/stack/merge_sync_strategy/branches_gone/dependent_ancestor_shipped_and_main_unrelated_updated.feature
45:      |        |               | Merge branch 'main' into beta |           |               |

features/sync/stack/merge_sync_strategy/branches_gone/dependent_ancestor_shipped.feature
43:      |        |               | Merge branch 'main' into beta |           |               |

features/compress/current_branch/merge_commit/with.feature
42:      |         |               | merge       |           |              |
```

We only have tests like this for merge commits, which explains why the workaround has a comment that mentions merges, but this can happen with any commit.

```
$ git show origin/public: | head -7; echo ...
tree origin/public:

.contest.json
.devcontainer/
.gherkin-lintignore
.gherkin-lintrc
.git-branches.toml
...
```

Our workaround of checking to see if the output starts with "tree " breaks if Git outputs in color (see the test failure on the first commit in this PR), and it would be fooled if we checked for a file that said "tree leaves rustled in the gentle breeze". Instead, just avoid querying the file contents if the file name is blank.