### PR TITLE
Separate loading high and low level Git config

### DIFF
--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -30,8 +30,8 @@ func (self *Access) Load(scope configdomain.ConfigScope, updateOutdated bool) (c
 	cmdArgs = append(cmdArgs, scope.GitFlag())
 	output, err := self.Runner.Query("git", cmdArgs...)
 	if err != nil {
-		// TODO: document why we return nil here when there was an error,
-		// or return the error.
+		// TODO: either document why we return nil here when there was an error here,
+		// or start returning the error.
 		// If returning nil, there is a risk that the initial snapshot is accidentally empty,
 		// the final snapshot contains things, and "git town undo" will remove every single Git config value.
 		return snapshot, nil //nolint:nilerr

--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -24,14 +24,16 @@ type Access struct {
 	Runner
 }
 
-func (self *Access) Load(scope configdomain.ConfigScope, updateOutdated bool) (configdomain.SingleSnapshot, configdomain.PartialConfig, error) {
+func (self *Access) LoadSnapshot(scope configdomain.ConfigScope, updateOutdated bool) (configdomain.SingleSnapshot, error) {
 	snapshot := configdomain.SingleSnapshot{}
-	output, err := self.Runner.Query("git", "config", "-lz", "--includes", scope.GitFlag())
+	cmdArgs := []string{"config", "-lz", "--includes"}
+	cmdArgs = append(cmdArgs, scope.GitFlag())
+	output, err := self.Runner.Query("git", cmdArgs...)
 	if err != nil {
-		return snapshot, configdomain.EmptyPartialConfig(), nil //nolint:nilerr
+		return snapshot, nil //nolint:nilerr
 	}
 	if output == "" {
-		return snapshot, configdomain.EmptyPartialConfig(), nil
+		return snapshot, nil
 	}
 	for _, line := range strings.Split(output, "\x00") {
 		if len(line) == 0 {
@@ -78,8 +80,7 @@ func (self *Access) Load(scope configdomain.ConfigScope, updateOutdated bool) (c
 			snapshot[configKey] = value
 		}
 	}
-	partialConfig, err := configdomain.NewPartialConfigFromSnapshot(snapshot, updateOutdated, self.RemoveLocalConfigValue)
-	return snapshot, partialConfig, err
+	return snapshot, err
 }
 
 func (self *Access) RemoteURL(remote gitdomain.Remote) Option[string] {

--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -30,6 +30,10 @@ func (self *Access) Load(scope configdomain.ConfigScope, updateOutdated bool) (c
 	cmdArgs = append(cmdArgs, scope.GitFlag())
 	output, err := self.Runner.Query("git", cmdArgs...)
 	if err != nil {
+		// TODO: document why we return nil here when there was an error,
+		// or return the error.
+		// If returning nil, there is a risk that the initial snapshot is accidentally empty,
+		// the final snapshot contains things, and "git town undo" will remove every single Git config value.
 		return snapshot, nil //nolint:nilerr
 	}
 	if output == "" {

--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -24,7 +24,7 @@ type Access struct {
 	Runner
 }
 
-func (self *Access) LoadSnapshot(scope configdomain.ConfigScope, updateOutdated bool) (configdomain.SingleSnapshot, error) {
+func (self *Access) Load(scope configdomain.ConfigScope, updateOutdated bool) (configdomain.SingleSnapshot, error) {
 	snapshot := configdomain.SingleSnapshot{}
 	cmdArgs := []string{"config", "-lz", "--includes"}
 	cmdArgs = append(cmdArgs, scope.GitFlag())

--- a/internal/config/gitconfig/access.go
+++ b/internal/config/gitconfig/access.go
@@ -30,7 +30,7 @@ func (self *Access) Load(scope configdomain.ConfigScope, updateOutdated bool) (c
 	cmdArgs = append(cmdArgs, scope.GitFlag())
 	output, err := self.Runner.Query("git", cmdArgs...)
 	if err != nil {
-		// TODO: either document why we return nil here when there was an error here,
+		// TODO: either document why we return nil here when there was an error,
 		// or start returning the error.
 		// If returning nil, there is a risk that the initial snapshot is accidentally empty,
 		// the final snapshot contains things, and "git town undo" will remove every single Git config value.

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -34,9 +34,9 @@ func (self *UnvalidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {
 }
 
 func (self *UnvalidatedConfig) Reload() (globalSnapshot, localSnapshot configdomain.SingleSnapshot) {
-	globalSnapshot, _ = self.NormalConfig.GitConfigAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	globalSnapshot, _ = self.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeGlobal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	globalGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(globalSnapshot, false, self.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
-	localSnapshot, _ = self.NormalConfig.GitConfigAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	localSnapshot, _ = self.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeLocal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, self.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
 	envConfig := envconfig.Load()
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -34,8 +34,10 @@ func (self *UnvalidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {
 }
 
 func (self *UnvalidatedConfig) Reload() (globalSnapshot, localSnapshot configdomain.SingleSnapshot) {
-	globalSnapshot, globalGitConfig, _ := self.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeGlobal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	localSnapshot, localGitConfig, _ := self.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeLocal, false)    // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	globalSnapshot, _ = self.NormalConfig.GitConfigAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	globalGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(globalSnapshot, false, self.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
+	localSnapshot, _ = self.NormalConfig.GitConfigAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, self.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
 	envConfig := envconfig.Load()
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{
 		env:    envConfig,

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -35,9 +35,9 @@ func (self *UnvalidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {
 
 func (self *UnvalidatedConfig) Reload() (globalSnapshot, localSnapshot configdomain.SingleSnapshot) {
 	globalSnapshot, _ = self.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeGlobal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	globalGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(globalSnapshot, false, self.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
+	globalGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(globalSnapshot, false, nil)
 	localSnapshot, _ = self.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeLocal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, self.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
+	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, nil)
 	envConfig := envconfig.Load()
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{
 		env:    envConfig,

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -62,7 +62,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 		}
 	}
 	configGitAccess := gitconfig.Access{Runner: backendRunner}
-	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, true)
+	globalSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, true)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
@@ -70,7 +70,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
-	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, true)
+	localSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeLocal, true)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -62,11 +62,19 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 		}
 	}
 	configGitAccess := gitconfig.Access{Runner: backendRunner}
-	globalSnapshot, globalConfig, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, true)
+	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, true)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
-	localSnapshot, localConfig, err := configGitAccess.Load(configdomain.ConfigScopeLocal, true)
+	globalConfig, err := configdomain.NewPartialConfigFromSnapshot(globalSnapshot, true, configGitAccess.RemoveLocalConfigValue)
+	if err != nil {
+		return emptyOpenRepoResult(), err
+	}
+	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, true)
+	if err != nil {
+		return emptyOpenRepoResult(), err
+	}
+	localConfig, err := configdomain.NewPartialConfigFromSnapshot(localSnapshot, true, configGitAccess.RemoveLocalConfigValue)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -345,7 +345,7 @@ func (self *TestCommands) LineageTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("BRANCH", "PARENT")
 	localSnapshot, _ := self.Config.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeLocal, false)
-	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, self.Config.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
+	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, nil)
 	lineage := localGitConfig.Lineage
 	for _, entry := range lineage.Entries() {
 		result.AddRow(entry.Child.String(), entry.Parent.String())

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -344,7 +344,7 @@ func (self *TestCommands) HasFile(name, content string) string {
 func (self *TestCommands) LineageTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("BRANCH", "PARENT")
-	localSnapshot, _ := self.Config.NormalConfig.GitConfigAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
+	localSnapshot, _ := self.Config.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeLocal, false)
 	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, self.Config.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
 	lineage := localGitConfig.Lineage
 	for _, entry := range lineage.Entries() {

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -344,7 +344,8 @@ func (self *TestCommands) HasFile(name, content string) string {
 func (self *TestCommands) LineageTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("BRANCH", "PARENT")
-	_, localGitConfig, _ := self.Config.NormalConfig.GitConfigAccess.Load(configdomain.ConfigScopeLocal, false) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
+	localSnapshot, _ := self.Config.NormalConfig.GitConfigAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
+	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, self.Config.NormalConfig.GitConfigAccess.RemoveLocalConfigValue)
 	lineage := localGitConfig.Lineage
 	for _, entry := range lineage.Entries() {
 		result.AddRow(entry.Child.String(), entry.Parent.String())

--- a/internal/vm/interpreter/config/finished.go
+++ b/internal/vm/interpreter/config/finished.go
@@ -26,11 +26,11 @@ func Finished(args FinishedArgs) error {
 		endBranchesSnapshot = Some(snapshot)
 	}
 	configGitAccess := gitconfig.Access{Runner: args.Backend}
-	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false)
+	globalSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, false)
 	if err != nil {
 		return err
 	}
-	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
+	localSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeLocal, false)
 	if err != nil {
 		return err
 	}

--- a/internal/vm/interpreter/config/finished.go
+++ b/internal/vm/interpreter/config/finished.go
@@ -26,11 +26,11 @@ func Finished(args FinishedArgs) error {
 		endBranchesSnapshot = Some(snapshot)
 	}
 	configGitAccess := gitconfig.Access{Runner: args.Backend}
-	globalSnapshot, _, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, false)
+	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false)
 	if err != nil {
 		return err
 	}
-	localSnapshot, _, err := configGitAccess.Load(configdomain.ConfigScopeLocal, false)
+	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
 	if err != nil {
 		return err
 	}

--- a/internal/vm/interpreter/full/errored.go
+++ b/internal/vm/interpreter/full/errored.go
@@ -22,11 +22,11 @@ func errored(failedOpcode shared.Opcode, runErr error, args ExecuteArgs) error {
 	}
 	args.RunState.EndBranchesSnapshot = Some(endBranchesSnapshot)
 	configGitAccess := gitconfig.Access{Runner: args.Backend}
-	globalSnapshot, _, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, false)
+	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false)
 	if err != nil {
 		return err
 	}
-	localSnapshot, _, err := configGitAccess.Load(configdomain.ConfigScopeLocal, false)
+	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
 	if err != nil {
 		return err
 	}

--- a/internal/vm/interpreter/full/errored.go
+++ b/internal/vm/interpreter/full/errored.go
@@ -22,11 +22,11 @@ func errored(failedOpcode shared.Opcode, runErr error, args ExecuteArgs) error {
 	}
 	args.RunState.EndBranchesSnapshot = Some(endBranchesSnapshot)
 	configGitAccess := gitconfig.Access{Runner: args.Backend}
-	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false)
+	globalSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, false)
 	if err != nil {
 		return err
 	}
-	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
+	localSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeLocal, false)
 	if err != nil {
 		return err
 	}

--- a/internal/vm/interpreter/full/finished.go
+++ b/internal/vm/interpreter/full/finished.go
@@ -24,11 +24,11 @@ func finished(args finishedArgs) error {
 		return err
 	}
 	configGitAccess := gitconfig.Access{Runner: args.Backend}
-	globalSnapshot, _, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, false)
+	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false)
 	if err != nil {
 		return err
 	}
-	localSnapshot, _, err := configGitAccess.Load(configdomain.ConfigScopeLocal, false)
+	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
 	if err != nil {
 		return err
 	}

--- a/internal/vm/interpreter/full/finished.go
+++ b/internal/vm/interpreter/full/finished.go
@@ -24,11 +24,11 @@ func finished(args finishedArgs) error {
 		return err
 	}
 	configGitAccess := gitconfig.Access{Runner: args.Backend}
-	globalSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeGlobal, false)
+	globalSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeGlobal, false)
 	if err != nil {
 		return err
 	}
-	localSnapshot, err := configGitAccess.LoadSnapshot(configdomain.ConfigScopeLocal, false)
+	localSnapshot, err := configGitAccess.Load(configdomain.ConfigScopeLocal, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As part of #4107 we load high-level Git config from a single source, and don't manually merge local and global Git configuration data ourselves anymore.

