### PR TITLE
Remove unnecessary LC_ALL override

### DIFF
--- a/internal/subshell/backend_runner.go
+++ b/internal/subshell/backend_runner.go
@@ -50,9 +50,6 @@ func (self BackendRunner) execute(executable string, args ...string) (string, er
 	if dir, has := self.Dir.Get(); has {
 		subProcess.Dir = dir
 	}
-	env := subProcess.Environ()
-	env = append(env, "LC_ALL=C")
-	subProcess.Env = env
 	concurrentGitRetriesLeft := concurrentGitRetries
 	var outputText string
 	var outputBytes []byte

--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -1517,7 +1517,6 @@ func runCommand(ctx context.Context, command string) {
 		cmd, args := parts[0], parts[1:]
 		subProcess := exec.Command(cmd, args...) // #nosec
 		subProcess.Dir = state.fixture.Dir
-		subProcess.Env = append(subProcess.Environ(), "LC_ALL=C")
 		outputBytes, _ := subProcess.CombinedOutput()
 		runOutput = string(outputBytes)
 		exitCode = subProcess.ProcessState.ExitCode()


### PR DESCRIPTION
This PR removes the environment override that configures Git to run in English.

I can't get the Spanish language packages to install on GitHub Actions, but I was able to run Git Town tests in Spanish on a local Ubuntu VM. #4860 has the changes needed to make the tests pass when running Git in Spanish. The only changes needed were removing steps like:

```cucumber
    And Git Town prints the error:
      """
      CONFLICT (add/add): Merge conflict in conflicting_file
      """
```

This shows that Git Town no longer depends on parsing English-language porcelain output.