### PR TITLE
Provide current branch to opcode

### DIFF
--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -333,7 +333,7 @@ func compressBranchProgram(prog Mutable[program.Program], data compressBranchDat
 		Message:        data.newCommitMessage,
 	})
 	if data.hasTracking && online.IsTrue() {
-		prog.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true})
+		prog.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: data.name, ForceIfIncludes: true})
 	}
 }
 

--- a/internal/cmd/detach.go
+++ b/internal/cmd/detach.go
@@ -317,7 +317,7 @@ func detachProgram(data detachData, finalMessages stringslice.Collector) program
 	)
 	if data.branchToDetachInfo.HasTrackingBranch() {
 		prog.Value.Add(
-			&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true},
+			&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: data.branchToDetachName, ForceIfIncludes: true},
 		)
 	}
 	lastParent := data.parentBranch
@@ -331,7 +331,7 @@ func detachProgram(data detachData, finalMessages stringslice.Collector) program
 		})
 		if descendent.info.HasTrackingBranch() {
 			prog.Value.Add(
-				&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true},
+				&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: descendent.name, ForceIfIncludes: true},
 			)
 		}
 		lastParent = descendent.name

--- a/internal/cmd/swap.go
+++ b/internal/cmd/swap.go
@@ -319,7 +319,7 @@ func swapProgram(data swapData, finalMessages stringslice.Collector) program.Pro
 	)
 	if data.branchToSwapInfo.HasTrackingBranch() {
 		prog.Value.Add(
-			&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true},
+			&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: data.branchToSwapName, ForceIfIncludes: true},
 		)
 	}
 	prog.Value.Add(
@@ -334,7 +334,7 @@ func swapProgram(data swapData, finalMessages stringslice.Collector) program.Pro
 	)
 	if data.parentBranchInfo.HasTrackingBranch() {
 		prog.Value.Add(
-			&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true},
+			&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: data.parentBranch, ForceIfIncludes: true},
 		)
 	}
 	for _, child := range data.children {
@@ -357,6 +357,7 @@ func swapProgram(data swapData, finalMessages stringslice.Collector) program.Pro
 		if child.info.HasTrackingBranch() {
 			prog.Value.Add(
 				&opcodes.PushCurrentBranchForceIfNeeded{
+					CurrentBranch:   child.name,
 					ForceIfIncludes: true,
 				},
 			)

--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -181,9 +181,9 @@ func pushFeatureBranchProgram(prog Mutable[program.Program], branch gitdomain.Lo
 	case configdomain.SyncFeatureStrategyMerge:
 		prog.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: branch})
 	case configdomain.SyncFeatureStrategyRebase:
-		prog.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true})
+		prog.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: branch, ForceIfIncludes: true})
 	case configdomain.SyncFeatureStrategyCompress:
-		prog.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: false})
+		prog.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: branch, ForceIfIncludes: false})
 	}
 }
 

--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -84,7 +84,7 @@ func FeatureTrackingBranchProgram(trackingBranch gitdomain.RemoteBranchName, syn
 			})
 		}
 		if args.Offline.IsFalse() {
-			args.Program.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: false})
+			args.Program.Value.Add(&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: args.LocalName, ForceIfIncludes: false})
 		}
 	case configdomain.SyncStrategyMerge:
 		args.Program.Value.Add(&opcodes.MergeIntoCurrentBranch{BranchToMerge: trackingBranch.BranchName()})
@@ -100,6 +100,7 @@ func FeatureTrackingBranchProgram(trackingBranch gitdomain.RemoteBranchName, syn
 					PreviousSHA: args.LastRunParentSHA,
 				},
 				&opcodes.PushCurrentBranchForceIfNeeded{
+					CurrentBranch:   args.LocalName,
 					ForceIfIncludes: true,
 				},
 			)

--- a/internal/undo/undobranches/branch_changes.go
+++ b/internal/undo/undobranches/branch_changes.go
@@ -79,7 +79,7 @@ func (self BranchChanges) UndoProgram(args BranchChangesUndoProgramArgs) program
 		change := omniChangedFeatures[branch]
 		result.Add(&opcodes.CheckoutIfNeeded{Branch: branch})
 		result.Add(&opcodes.BranchCurrentResetToSHAIfNeeded{MustHaveSHA: change.After, SetToSHA: change.Before, Hard: true})
-		result.Add(&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true})
+		result.Add(&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: branch, ForceIfIncludes: true})
 	}
 
 	// re-create removed omni-branches

--- a/internal/undo/undobranches/branch_changes_test.go
+++ b/internal/undo/undobranches/branch_changes_test.go
@@ -783,7 +783,7 @@ func TestChanges(t *testing.T) {
 			// reset the feature branch to the previous SHA
 			&opcodes.CheckoutIfNeeded{Branch: "feature-branch"},
 			&opcodes.BranchCurrentResetToSHAIfNeeded{MustHaveSHA: "666666", SetToSHA: "333333", Hard: true},
-			&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true},
+			&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: "feature-branch", ForceIfIncludes: true},
 			// check out the initial branch
 			&opcodes.CheckoutIfExists{Branch: "feature-branch"},
 		}

--- a/internal/vm/opcodes/push_current_branch_force_if_needed.go
+++ b/internal/vm/opcodes/push_current_branch_force_if_needed.go
@@ -1,21 +1,19 @@
 package opcodes
 
 import (
+	"github.com/git-town/git-town/v20/internal/git/gitdomain"
 	"github.com/git-town/git-town/v20/internal/vm/shared"
 )
 
 // PushCurrentBranchForceIfNeeded force-pushes the branch with the given name to the origin remote.
 type PushCurrentBranchForceIfNeeded struct {
+	CurrentBranch           gitdomain.LocalBranchName
 	ForceIfIncludes         bool
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
 func (self *PushCurrentBranchForceIfNeeded) Run(args shared.RunArgs) error {
-	currentBranch, err := args.Git.CurrentBranch(args.Backend)
-	if err != nil {
-		return err
-	}
-	inSync, err := args.Git.BranchInSyncWithTracking(args.Backend, currentBranch, args.Config.Value.NormalConfig.DevRemote)
+	inSync, err := args.Git.BranchInSyncWithTracking(args.Backend, self.CurrentBranch, args.Config.Value.NormalConfig.DevRemote)
 	if err != nil {
 		return err
 	}

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -109,7 +109,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.PullCurrentBranch{},
 				&opcodes.PushCurrentBranch{},
 				&opcodes.PushCurrentBranchForce{ForceIfIncludes: true},
-				&opcodes.PushCurrentBranchForceIfNeeded{ForceIfIncludes: true},
+				&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: "branch", ForceIfIncludes: true},
 				&opcodes.PushCurrentBranchForceIgnoreError{},
 				&opcodes.PushCurrentBranchIfLocal{CurrentBranch: "branch"},
 				&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: "branch"},
@@ -575,6 +575,7 @@ func TestLoadSave(t *testing.T) {
     },
     {
       "data": {
+        "CurrentBranch": "branch",
         "ForceIfIncludes": true
       },
       "type": "PushCurrentBranchForceIfNeeded"


### PR DESCRIPTION
We always know what the current branch is, so we can provide this information to the PushCurrentBranchForceIfNeeded opcode.