### PR TITLE
Move all code to sync-compress feature branches into one opcode

### DIFF
--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -40,22 +40,15 @@ type featureBranchArgs struct {
 
 func syncFeatureBranchCompress(args featureBranchArgs) {
 	args.program.Value.Add(
-		&opcodes.MergeParentsUntilLocal{
-			Branch:             args.localName,
-			OriginalParentName: args.originalParentName,
-			OriginalParentSHA:  args.originalParentSHA,
+		&opcodes.CompressMergeTrackingBranch{
+			CurrentBranch:  args.localName,
+			CommitMessage:  args.firstCommitMessage,
+			Offline:        args.offline,
+			ParentName:     args.originalParentName,
+			ParentSHA:      args.originalParentSHA,
+			TrackingBranch: args.trackingBranchName,
 		},
 	)
-	if trackingBranch, hasTrackingBranch := args.trackingBranchName.Get(); hasTrackingBranch {
-		args.program.Value.Add(
-			&opcodes.CompressMergeTrackingBranch{
-				CurrentBranch:  args.localName,
-				CommitMessage:  args.firstCommitMessage,
-				Offline:        args.offline,
-				TrackingBranch: trackingBranch,
-			},
-		)
-	}
 }
 
 func syncFeatureBranchFFOnly(args featureBranchArgs) {

--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -40,7 +40,7 @@ type featureBranchArgs struct {
 
 func syncFeatureBranchCompress(args featureBranchArgs) {
 	args.program.Value.Add(
-		&opcodes.SyncFeatureBranchCompressStrategy{
+		&opcodes.SyncFeatureBranchCompress{
 			CurrentBranch:  args.localName,
 			CommitMessage:  args.firstCommitMessage,
 			Offline:        args.offline,

--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -40,7 +40,7 @@ type featureBranchArgs struct {
 
 func syncFeatureBranchCompress(args featureBranchArgs) {
 	args.program.Value.Add(
-		&opcodes.CompressMergeTrackingBranch{
+		&opcodes.SyncFeatureBranchCompressStrategy{
 			CurrentBranch:  args.localName,
 			CommitMessage:  args.firstCommitMessage,
 			Offline:        args.offline,

--- a/internal/vm/opcodes/all.go
+++ b/internal/vm/opcodes/all.go
@@ -47,7 +47,7 @@ func All() []shared.Opcode {
 		&CommitRevert{},
 		&CommitWithMessage{},
 		&Commit{},
-		&CompressMergeTrackingBranch{},
+		&SyncFeatureBranchCompressStrategy{},
 		&ConfigRemove{},
 		&ConfigSet{},
 		&ConflictPhantomFinalize{},

--- a/internal/vm/opcodes/all.go
+++ b/internal/vm/opcodes/all.go
@@ -47,7 +47,7 @@ func All() []shared.Opcode {
 		&CommitRevert{},
 		&CommitWithMessage{},
 		&Commit{},
-		&SyncFeatureBranchCompressStrategy{},
+		&SyncFeatureBranchCompress{},
 		&ConfigRemove{},
 		&ConfigSet{},
 		&ConflictPhantomFinalize{},

--- a/internal/vm/opcodes/all.go
+++ b/internal/vm/opcodes/all.go
@@ -47,7 +47,6 @@ func All() []shared.Opcode {
 		&CommitRevert{},
 		&CommitWithMessage{},
 		&Commit{},
-		&SyncFeatureBranchCompress{},
 		&ConfigRemove{},
 		&ConfigSet{},
 		&ConflictPhantomFinalize{},
@@ -100,6 +99,7 @@ func All() []shared.Opcode {
 		&StashOpenChanges{},
 		&StashPopIfNeeded{},
 		&StashPop{},
+		&SyncFeatureBranchCompress{},
 		&UndoLastCommit{},
 	} //exhaustruct:ignore
 }

--- a/internal/vm/opcodes/compress_merge_tracking_branch.go
+++ b/internal/vm/opcodes/compress_merge_tracking_branch.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/git-town/git-town/v20/pkg/prelude"
 )
 
-// CompressMergeTrackingBranch merges the tracking branch when syncing using the "compress" strategy.
-type CompressMergeTrackingBranch struct {
+// SyncFeatureBranchCompressStrategy expands to all opcodes needed to sync a feature branch using the "compress" sync strategy.
+type SyncFeatureBranchCompressStrategy struct {
 	CommitMessage           Option[gitdomain.CommitMessage]
 	CurrentBranch           gitdomain.LocalBranchName
 	Offline                 configdomain.Offline
@@ -18,7 +18,7 @@ type CompressMergeTrackingBranch struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *CompressMergeTrackingBranch) Run(args shared.RunArgs) error {
+func (self *SyncFeatureBranchCompressStrategy) Run(args shared.RunArgs) error {
 	opcodes := []shared.Opcode{
 		&MergeParentsUntilLocal{
 			Branch:             self.CurrentBranch,

--- a/internal/vm/opcodes/sync_feature_branch_compress.go
+++ b/internal/vm/opcodes/sync_feature_branch_compress.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/git-town/git-town/v20/pkg/prelude"
 )
 
-// SyncFeatureBranchCompressStrategy expands to all opcodes needed to sync a feature branch using the "compress" sync strategy.
-type SyncFeatureBranchCompressStrategy struct {
+// SyncFeatureBranchCompress expands to all opcodes needed to sync a feature branch using the "compress" sync strategy.
+type SyncFeatureBranchCompress struct {
 	CommitMessage           Option[gitdomain.CommitMessage]
 	CurrentBranch           gitdomain.LocalBranchName
 	Offline                 configdomain.Offline
@@ -18,7 +18,7 @@ type SyncFeatureBranchCompressStrategy struct {
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *SyncFeatureBranchCompressStrategy) Run(args shared.RunArgs) error {
+func (self *SyncFeatureBranchCompress) Run(args shared.RunArgs) error {
 	opcodes := []shared.Opcode{
 		&MergeParentsUntilLocal{
 			Branch:             self.CurrentBranch,

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -80,7 +80,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.CommitRevert{SHA: "123456"},
 				&opcodes.CommitRevertIfNeeded{SHA: "123456"},
 				&opcodes.CommitWithMessage{AuthorOverride: Some(gitdomain.Author("user@acme.com")), Message: "my message", CommitHook: configdomain.CommitHookEnabled},
-				&opcodes.CompressMergeTrackingBranch{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
+				&opcodes.SyncFeatureBranchCompressStrategy{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 				&opcodes.ConfigRemove{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal},
 				&opcodes.ConfigSet{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal, Value: "1"},
 				&opcodes.ConflictPhantomResolveAll{ParentBranch: Some(gitdomain.NewLocalBranchName("parent")), ParentSHA: Some(gitdomain.NewSHA("123456")), Resolution: gitdomain.ConflictResolutionOurs},

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -80,7 +80,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.CommitRevert{SHA: "123456"},
 				&opcodes.CommitRevertIfNeeded{SHA: "123456"},
 				&opcodes.CommitWithMessage{AuthorOverride: Some(gitdomain.Author("user@acme.com")), Message: "my message", CommitHook: configdomain.CommitHookEnabled},
-				&opcodes.SyncFeatureBranchCompressStrategy{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
+				&opcodes.SyncFeatureBranchCompress{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 				&opcodes.ConfigRemove{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal},
 				&opcodes.ConfigSet{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal, Value: "1"},
 				&opcodes.ConflictPhantomResolveAll{ParentBranch: Some(gitdomain.NewLocalBranchName("parent")), ParentSHA: Some(gitdomain.NewSHA("123456")), Resolution: gitdomain.ConflictResolutionOurs},

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -80,7 +80,6 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.CommitRevert{SHA: "123456"},
 				&opcodes.CommitRevertIfNeeded{SHA: "123456"},
 				&opcodes.CommitWithMessage{AuthorOverride: Some(gitdomain.Author("user@acme.com")), Message: "my message", CommitHook: configdomain.CommitHookEnabled},
-				&opcodes.SyncFeatureBranchCompress{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 				&opcodes.ConfigRemove{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal},
 				&opcodes.ConfigSet{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal, Value: "1"},
 				&opcodes.ConflictPhantomResolveAll{ParentBranch: Some(gitdomain.NewLocalBranchName("parent")), ParentSHA: Some(gitdomain.NewSHA("123456")), Resolution: gitdomain.ConflictResolutionOurs},
@@ -130,6 +129,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.StashPop{},
 				&opcodes.StashPopIfNeeded{},
 				&opcodes.StashOpenChanges{},
+				&opcodes.SyncFeatureBranchCompress{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, ParentName: gitdomain.NewLocalBranchNameOption("parent"), ParentSHA: Some(gitdomain.NewSHA("111111")), TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 			},
 			TouchedBranches: []gitdomain.BranchName{"branch-1", "branch-2"},
 			UnfinishedDetails: MutableSome(&runstate.UnfinishedRunStateDetails{
@@ -376,15 +376,6 @@ func TestLoadSave(t *testing.T) {
         "Message": "my message"
       },
       "type": "CommitWithMessage"
-    },
-    {
-      "data": {
-        "CommitMessage": "commit message",
-        "CurrentBranch": "branch",
-        "Offline": true,
-        "TrackingBranch": "origin/branch"
-      },
-      "type": "CompressMergeTrackingBranch"
     },
     {
       "data": {
@@ -692,6 +683,17 @@ func TestLoadSave(t *testing.T) {
     {
       "data": {},
       "type": "StashOpenChanges"
+    },
+    {
+      "data": {
+        "CommitMessage": "commit message",
+        "CurrentBranch": "branch",
+        "Offline": true,
+        "ParentName": "parent",
+        "ParentSHA": "111111",
+        "TrackingBranch": "origin/branch"
+      },
+      "type": "SyncFeatureBranchCompress"
     }
   ],
   "TouchedBranches": [

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -80,7 +80,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.CommitRevert{SHA: "123456"},
 				&opcodes.CommitRevertIfNeeded{SHA: "123456"},
 				&opcodes.CommitWithMessage{AuthorOverride: Some(gitdomain.Author("user@acme.com")), Message: "my message", CommitHook: configdomain.CommitHookEnabled},
-				&opcodes.CompressMergeTrackingBranch{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, TrackingBranch: "origin/branch"},
+				&opcodes.CompressMergeTrackingBranch{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 				&opcodes.ConfigRemove{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal},
 				&opcodes.ConfigSet{Key: configdomain.KeyOffline, Scope: configdomain.ConfigScopeLocal, Value: "1"},
 				&opcodes.ConflictPhantomResolveAll{ParentBranch: Some(gitdomain.NewLocalBranchName("parent")), ParentSHA: Some(gitdomain.NewSHA("123456")), Resolution: gitdomain.ConflictResolutionOurs},


### PR DESCRIPTION
This PR enables the option to make sync-compressing feature branches optional at runtime, which is needed for #4342.