### PR TITLE
Move all handling of sync using merge strategy into a single opcode

### DIFF
--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -92,7 +92,7 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 			program:            args.Program,
 			prune:              args.Prune,
 			pushBranches:       args.PushBranches,
-			trackingBranchName: branchInfo.RemoteName,
+			trackingBranch:     branchInfo.RemoteName,
 		})
 	case configdomain.BranchTypePerennialBranch, configdomain.BranchTypeMainBranch:
 		PerennialBranchProgram(branchInfo, args)
@@ -107,7 +107,7 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 			program:            args.Program,
 			prune:              args.Prune,
 			pushBranches:       args.PushBranches,
-			trackingBranchName: branchInfo.RemoteName,
+			trackingBranch:     branchInfo.RemoteName,
 		})
 	case configdomain.BranchTypeContributionBranch:
 		ContributionBranchProgram(args.Program, branchInfo)
@@ -124,7 +124,7 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 			program:            args.Program,
 			prune:              args.Prune,
 			pushBranches:       configdomain.PushBranches(branchInfo.HasTrackingBranch()),
-			trackingBranchName: branchInfo.RemoteName,
+			trackingBranch:     branchInfo.RemoteName,
 		})
 	}
 	if args.PushBranches.IsTrue() && args.Remotes.HasRemote(args.Config.NormalConfig.DevRemote) && args.Config.NormalConfig.IsOnline() && branchType.ShouldPush(localName == args.InitialBranch) {
@@ -148,10 +148,11 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 func pullParentBranchOfCurrentFeatureBranchOpcode(args pullParentBranchOfCurrentFeatureBranchOpcodeArgs) {
 	switch args.syncStrategy {
 	case configdomain.SyncFeatureStrategyMerge:
-		args.program.Value.Add(&opcodes.MergeParentsUntilLocal{
+		args.program.Value.Add(&opcodes.SyncFeatureBranchMerge{
 			Branch:            args.branch,
 			InitialParentName: args.initialParentName,
 			InitialParentSHA:  args.initialParentSHA,
+			TrackingBranch:    args.trackingBranch,
 		})
 	case configdomain.SyncFeatureStrategyRebase:
 		args.program.Value.Add(&opcodes.RebaseParentsUntilLocal{
@@ -159,10 +160,11 @@ func pullParentBranchOfCurrentFeatureBranchOpcode(args pullParentBranchOfCurrent
 			PreviousSHA: args.previousParentSHA,
 		})
 	case configdomain.SyncFeatureStrategyCompress:
-		args.program.Value.Add(&opcodes.MergeParentsUntilLocal{
+		args.program.Value.Add(&opcodes.SyncFeatureBranchMerge{
 			Branch:            args.branch,
 			InitialParentName: args.initialParentName,
 			InitialParentSHA:  args.initialParentSHA,
+			TrackingBranch:    args.trackingBranch,
 		})
 	}
 }
@@ -174,6 +176,7 @@ type pullParentBranchOfCurrentFeatureBranchOpcodeArgs struct {
 	previousParentSHA Option[gitdomain.SHA]
 	program           Mutable[program.Program]
 	syncStrategy      configdomain.SyncFeatureStrategy
+	trackingBranch    Option[gitdomain.RemoteBranchName]
 }
 
 func pushFeatureBranchProgram(prog Mutable[program.Program], branch gitdomain.LocalBranchName, syncFeatureStrategy configdomain.SyncFeatureStrategy) {

--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -148,6 +148,7 @@ func LocalBranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomai
 func pullParentBranchOfCurrentFeatureBranchOpcode(args pullParentBranchOfCurrentFeatureBranchOpcodeArgs) {
 	switch args.syncStrategy {
 	case configdomain.SyncFeatureStrategyMerge:
+		// TODO: merge with variant the compress variant
 		args.program.Value.Add(&opcodes.SyncFeatureBranchMerge{
 			Branch:            args.branch,
 			InitialParentName: args.initialParentName,

--- a/internal/cmd/sync/sync_deleted_branch.go
+++ b/internal/cmd/sync/sync_deleted_branch.go
@@ -55,7 +55,8 @@ func syncDeletedFeatureBranchProgram(prog Mutable[program.Program], branch gitdo
 			previousParentSHA: parentLastRunSHA,
 			program:           prog,
 			syncStrategy:      args.Config.NormalConfig.SyncFeatureStrategy,
-			trackingBranch:    None[gitdomain.RemoteBranchName](),
+			// we sync a branch whose remote was deleted here, so we know for sure there is no tracking branch
+			trackingBranch: None[gitdomain.RemoteBranchName](),
 		})
 		prog.Value.Add(&opcodes.BranchWithRemoteGoneDeleteIfEmptyAtRuntime{Branch: branch})
 	}

--- a/internal/cmd/sync/sync_deleted_branch.go
+++ b/internal/cmd/sync/sync_deleted_branch.go
@@ -55,7 +55,7 @@ func syncDeletedFeatureBranchProgram(prog Mutable[program.Program], branch gitdo
 			previousParentSHA: parentLastRunSHA,
 			program:           prog,
 			syncStrategy:      args.Config.NormalConfig.SyncFeatureStrategy,
-			// we sync a branch whose remote was deleted here, so we know for sure there is no tracking branch
+			// this function syncs a branch whose remote was deleted --> we know for sure there is no tracking branch
 			trackingBranch: None[gitdomain.RemoteBranchName](),
 		})
 		prog.Value.Add(&opcodes.BranchWithRemoteGoneDeleteIfEmptyAtRuntime{Branch: branch})

--- a/internal/cmd/sync/sync_deleted_branch.go
+++ b/internal/cmd/sync/sync_deleted_branch.go
@@ -55,6 +55,7 @@ func syncDeletedFeatureBranchProgram(prog Mutable[program.Program], branch gitdo
 			previousParentSHA: parentLastRunSHA,
 			program:           prog,
 			syncStrategy:      args.Config.NormalConfig.SyncFeatureStrategy,
+			trackingBranch:    None[gitdomain.RemoteBranchName](),
 		})
 		prog.Value.Add(&opcodes.BranchWithRemoteGoneDeleteIfEmptyAtRuntime{Branch: branch})
 	}

--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -35,7 +35,7 @@ type featureBranchArgs struct {
 	program            Mutable[program.Program]          // the program to update
 	prune              configdomain.Prune
 	pushBranches       configdomain.PushBranches
-	trackingBranchName Option[gitdomain.RemoteBranchName]
+	trackingBranch     Option[gitdomain.RemoteBranchName]
 }
 
 func syncFeatureBranchCompress(args featureBranchArgs) {
@@ -46,7 +46,7 @@ func syncFeatureBranchCompress(args featureBranchArgs) {
 			Offline:           args.offline,
 			InitialParentName: args.initialParentName,
 			InitialParentSHA:  args.initialParentSHA,
-			TrackingBranch:    args.trackingBranchName,
+			TrackingBranch:    args.trackingBranch,
 		},
 	)
 }
@@ -55,7 +55,7 @@ func syncFeatureBranchFFOnly(args featureBranchArgs) {
 	// The ff-only strategy does not sync with the parent branch.
 	// It is intended for perennial branches only.
 	if args.offline.IsFalse() {
-		if trackingBranch, hasTrackingBranch := args.trackingBranchName.Get(); hasTrackingBranch {
+		if trackingBranch, hasTrackingBranch := args.trackingBranch.Get(); hasTrackingBranch {
 			args.program.Value.Add(&opcodes.MergeFastForward{Branch: trackingBranch.BranchName()})
 		}
 	}
@@ -63,15 +63,13 @@ func syncFeatureBranchFFOnly(args featureBranchArgs) {
 
 func syncFeatureBranchMerge(args featureBranchArgs) {
 	args.program.Value.Add(
-		&opcodes.MergeParentsUntilLocal{
+		&opcodes.SyncFeatureBranchMerge{
 			Branch:            args.localName,
 			InitialParentName: args.initialParentName,
 			InitialParentSHA:  args.initialParentSHA,
+			TrackingBranch:    args.trackingBranch,
 		},
 	)
-	if trackingBranch, hasTrackingBranch := args.trackingBranchName.Get(); hasTrackingBranch {
-		args.program.Value.Add(&opcodes.MergeIntoCurrentBranch{BranchToMerge: trackingBranch.BranchName()})
-	}
 }
 
 func syncFeatureBranchRebase(args featureBranchArgs) {
@@ -81,7 +79,7 @@ func syncFeatureBranchRebase(args featureBranchArgs) {
 			PreviousSHA: args.parentLastRunSHA,
 		},
 	)
-	if trackingBranch, hasTrackingBranch := args.trackingBranchName.Get(); hasTrackingBranch {
+	if trackingBranch, hasTrackingBranch := args.trackingBranch.Get(); hasTrackingBranch {
 		if args.offline.IsFalse() {
 			args.program.Value.Add(
 				&opcodes.RebaseTrackingBranch{

--- a/internal/vm/opcodes/all.go
+++ b/internal/vm/opcodes/all.go
@@ -66,7 +66,6 @@ func All() []shared.Opcode {
 		&MergeFastForward{},
 		&MergeIntoCurrentBranch{},
 		&MergeParentResolvePhantomConflicts{},
-		&SyncFeatureBranchMerge{},
 		&MergeParent{},
 		&MergeSquashAutoUndo{},
 		&MergeSquashProgram{},
@@ -100,6 +99,7 @@ func All() []shared.Opcode {
 		&StashPopIfNeeded{},
 		&StashPop{},
 		&SyncFeatureBranchCompress{},
+		&SyncFeatureBranchMerge{},
 		&UndoLastCommit{},
 	} //exhaustruct:ignore
 }

--- a/internal/vm/opcodes/all.go
+++ b/internal/vm/opcodes/all.go
@@ -66,7 +66,7 @@ func All() []shared.Opcode {
 		&MergeFastForward{},
 		&MergeIntoCurrentBranch{},
 		&MergeParentResolvePhantomConflicts{},
-		&MergeParentsUntilLocal{},
+		&SyncFeatureBranchMerge{},
 		&MergeParent{},
 		&MergeSquashAutoUndo{},
 		&MergeSquashProgram{},

--- a/internal/vm/opcodes/sync_feature_branch_compress.go
+++ b/internal/vm/opcodes/sync_feature_branch_compress.go
@@ -28,10 +28,11 @@ func (self *SyncFeatureBranchCompress) Run(args shared.RunArgs) error {
 			return err
 		}
 		if !inSyncWithParent {
-			opcodes = append(opcodes, &MergeParentsUntilLocal{
+			opcodes = append(opcodes, &SyncFeatureBranchMerge{
 				Branch:            self.CurrentBranch,
 				InitialParentName: self.InitialParentName,
 				InitialParentSHA:  self.InitialParentSHA,
+				TrackingBranch:    self.TrackingBranch,
 			})
 		}
 		commitsInBranch, err = args.Git.CommitsInFeatureBranch(args.Backend, self.CurrentBranch, parentName)

--- a/internal/vm/opcodes/sync_feature_branch_compress.go
+++ b/internal/vm/opcodes/sync_feature_branch_compress.go
@@ -32,7 +32,10 @@ func (self *SyncFeatureBranchCompress) Run(args shared.RunArgs) error {
 				Branch:            self.CurrentBranch,
 				InitialParentName: self.InitialParentName,
 				InitialParentSHA:  self.InitialParentSHA,
-				TrackingBranch:    self.TrackingBranch,
+				// we deal with the tracking branch below
+				// TODO: once merge also only runs if needed,
+				// set this to the real value and remove the block dealing with the tracking branch below?
+				TrackingBranch: None[gitdomain.RemoteBranchName](),
 			})
 		}
 		commitsInBranch, err = args.Git.CommitsInFeatureBranch(args.Backend, self.CurrentBranch, parentName)

--- a/internal/vm/opcodes/sync_feature_branch_merge.go
+++ b/internal/vm/opcodes/sync_feature_branch_merge.go
@@ -7,15 +7,16 @@ import (
 	. "github.com/git-town/git-town/v20/pkg/prelude"
 )
 
-// MergeParentsUntilLocal merges the parent branches of the given branch until a local parent is found.
-type MergeParentsUntilLocal struct {
+// SyncFeatureBranchMerge merges the parent branches of the given branch until a local parent is found.
+type SyncFeatureBranchMerge struct {
 	Branch                  gitdomain.LocalBranchName
 	InitialParentName       Option[gitdomain.LocalBranchName]
 	InitialParentSHA        Option[gitdomain.SHA]
+	TrackingBranch          Option[gitdomain.RemoteBranchName]
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 
-func (self *MergeParentsUntilLocal) Run(args shared.RunArgs) error {
+func (self *SyncFeatureBranchMerge) Run(args shared.RunArgs) error {
 	program := []shared.Opcode{}
 	branchInfos, hasBranchInfos := args.BranchInfos.Get()
 	if !hasBranchInfos {
@@ -53,6 +54,9 @@ func (self *MergeParentsUntilLocal) Run(args shared.RunArgs) error {
 			}
 		}
 		branch = parent
+	}
+	if trackingBranch, hasTrackingBranch := self.TrackingBranch.Get(); hasTrackingBranch {
+		program = append(program, &MergeIntoCurrentBranch{BranchToMerge: trackingBranch.BranchName()})
 	}
 	args.PrependOpcodes(program...)
 	return nil

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -97,7 +97,6 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.MergeAbort{},
 				&opcodes.MergeAlwaysProgram{Branch: "branch", CommitMessage: Some(gitdomain.CommitMessage("commit message"))},
 				&opcodes.MergeContinue{},
-				&opcodes.SyncFeatureBranchMerge{Branch: "branch", InitialParentName: gitdomain.NewLocalBranchNameOption("original-parent"), InitialParentSHA: Some(gitdomain.NewSHA("123456"))},
 				&opcodes.MergeParentResolvePhantomConflicts{CurrentParent: "parent", InitialParentName: gitdomain.NewLocalBranchNameOption("original-parent"), InitialParentSHA: Some(gitdomain.NewSHA("123456"))},
 				&opcodes.MergeSquashProgram{Authors: []gitdomain.Author{"author 1 <one@acme.com>", "author 2 <two@acme.com>"}, Branch: "branch", CommitMessage: Some(gitdomain.CommitMessage("commit message")), Parent: "parent"},
 				&opcodes.MessageQueue{Message: "message"},
@@ -130,6 +129,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.StashPopIfNeeded{},
 				&opcodes.StashOpenChanges{},
 				&opcodes.SyncFeatureBranchCompress{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, InitialParentName: gitdomain.NewLocalBranchNameOption("parent"), InitialParentSHA: Some(gitdomain.NewSHA("111111")), TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
+				&opcodes.SyncFeatureBranchMerge{Branch: "branch", InitialParentName: gitdomain.NewLocalBranchNameOption("original-parent"), InitialParentSHA: Some(gitdomain.NewSHA("123456")), TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 			},
 			TouchedBranches: []gitdomain.BranchName{"branch-1", "branch-2"},
 			UnfinishedDetails: MutableSome(&runstate.UnfinishedRunStateDetails{
@@ -491,14 +491,6 @@ func TestLoadSave(t *testing.T) {
     },
     {
       "data": {
-        "Branch": "branch",
-        "InitialParentName": "original-parent",
-        "InitialParentSHA": "123456"
-      },
-      "type": "MergeParentsUntilLocal"
-    },
-    {
-      "data": {
         "CurrentParent": "parent",
         "InitialParentName": "original-parent",
         "InitialParentSHA": "123456"
@@ -694,6 +686,15 @@ func TestLoadSave(t *testing.T) {
         "TrackingBranch": "origin/branch"
       },
       "type": "SyncFeatureBranchCompress"
+    },
+    {
+      "data": {
+        "Branch": "branch",
+        "InitialParentName": "original-parent",
+        "InitialParentSHA": "123456",
+        "TrackingBranch": "origin/branch"
+      },
+      "type": "SyncFeatureBranchMerge"
     }
   ],
   "TouchedBranches": [

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -97,7 +97,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.MergeAbort{},
 				&opcodes.MergeAlwaysProgram{Branch: "branch", CommitMessage: Some(gitdomain.CommitMessage("commit message"))},
 				&opcodes.MergeContinue{},
-				&opcodes.MergeParentsUntilLocal{Branch: "branch", InitialParentName: gitdomain.NewLocalBranchNameOption("original-parent"), InitialParentSHA: Some(gitdomain.NewSHA("123456"))},
+				&opcodes.SyncFeatureBranchMerge{Branch: "branch", InitialParentName: gitdomain.NewLocalBranchNameOption("original-parent"), InitialParentSHA: Some(gitdomain.NewSHA("123456"))},
 				&opcodes.MergeParentResolvePhantomConflicts{CurrentParent: "parent", InitialParentName: gitdomain.NewLocalBranchNameOption("original-parent"), InitialParentSHA: Some(gitdomain.NewSHA("123456"))},
 				&opcodes.MergeSquashProgram{Authors: []gitdomain.Author{"author 1 <one@acme.com>", "author 2 <two@acme.com>"}, Branch: "branch", CommitMessage: Some(gitdomain.CommitMessage("commit message")), Parent: "parent"},
 				&opcodes.MessageQueue{Message: "message"},


### PR DESCRIPTION
This is a preparation to sync only if needed when using the merge sync strategy. Implementing this change separately helps ensure correctness and review this complex change separate from other changes.