### PR TITLE
Set Git editor with GIT_EDITOR instead of core.editor

### DIFF
--- a/features/delete/stack/rebase_sync_strategy/ancestor_conflicts_with_main.feature
+++ b/features/delete/stack/rebase_sync_strategy/ancestor_conflicts_with_main.feature
@@ -37,7 +37,7 @@ Feature: deleting a branch that conflicts with the main branch
       |           | git -c rebase.updateRefs=false rebase --onto main feature-2 |
       |           | git checkout --theirs file                                  |
       |           | git add file                                                |
-      |           | git -c core.editor=true rebase --continue                   |
+      |           | GIT_EDITOR=true git rebase --continue                       |
       |           | git push --force-with-lease                                 |
       |           | git branch -D feature-2                                     |
     And the branches are now

--- a/features/delete/stack/rebase_sync_strategy/middle_of_stack.feature
+++ b/features/delete/stack/rebase_sync_strategy/middle_of_stack.feature
@@ -33,7 +33,7 @@ Feature: deleting a branch that conflicts with the main branch
       | feature-3 | git pull                                                    |
       |           | git -c rebase.updateRefs=false rebase --onto main feature-2 |
       |           | git rm file                                                 |
-      |           | git -c core.editor=true rebase --continue                   |
+      |           | GIT_EDITOR=true git rebase --continue                       |
       |           | git push --force-with-lease                                 |
       |           | git branch -D feature-2                                     |
     And the branches are now

--- a/features/detach/merge_conflict/branch_with_main.feature
+++ b/features/detach/merge_conflict/branch_with_main.feature
@@ -27,7 +27,7 @@ Feature: detaching a branch that conflicts with the main branch
       |          | git -c rebase.updateRefs=false rebase --onto main branch-1 |
       |          | git checkout --theirs file                                 |
       |          | git add file                                               |
-      |          | git -c core.editor=true rebase --continue                  |
+      |          | GIT_EDITOR=true git rebase --continue                      |
       |          | git push --force-with-lease --force-if-includes            |
     And these commits exist now
       | BRANCH   | LOCATION      | MESSAGE     | FILE NAME | FILE CONTENT |

--- a/features/detach/merge_conflict/chain_of_conflicting_edits.feature
+++ b/features/detach/merge_conflict/chain_of_conflicting_edits.feature
@@ -39,7 +39,7 @@ Feature: detaching a branch from a chain that edits the same file
       |          | git -c rebase.updateRefs=false rebase --onto main branch-1     |
       |          | git checkout --theirs file                                     |
       |          | git add file                                                   |
-      |          | git -c core.editor=true rebase --continue                      |
+      |          | GIT_EDITOR=true git rebase --continue                          |
       |          | git push --force-with-lease --force-if-includes                |
       |          | git checkout branch-3                                          |
       | branch-3 | git pull                                                       |
@@ -50,7 +50,7 @@ Feature: detaching a branch from a chain that edits the same file
       |          | git -c rebase.updateRefs=false rebase --onto branch-3 branch-2 |
       |          | git checkout --theirs file                                     |
       |          | git add file                                                   |
-      |          | git -c core.editor=true rebase --continue                      |
+      |          | GIT_EDITOR=true git rebase --continue                          |
       |          | git push --force-with-lease                                    |
       |          | git checkout branch-2                                          |
     And these commits exist now

--- a/features/hack/give_non_existing_branch/on_feature_branch/conflicts/main_local_vs_main_remote.feature
+++ b/features/hack/give_non_existing_branch/on_feature_branch/conflicts/main_local_vs_main_remote.feature
@@ -45,10 +45,10 @@ Feature: conflicts between the main branch and its tracking branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                   |
-      | main   | git -c core.editor=true rebase --continue |
-      |        | git push                                  |
-      |        | git checkout -b new                       |
+      | BRANCH | COMMAND                               |
+      | main   | GIT_EDITOR=true git rebase --continue |
+      |        | git push                              |
+      |        | git checkout -b new                   |
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE                   |
       | main   | local, origin | conflicting origin commit |

--- a/features/set_parent/sync_strategy/rebase/remove_from_stack.feature
+++ b/features/set_parent/sync_strategy/rebase/remove_from_stack.feature
@@ -30,7 +30,7 @@ Feature: remove a branch from a stack
       | branch-3 | git pull                                                   |
       |          | git -c rebase.updateRefs=false rebase --onto main branch-2 |
       |          | git add file_1                                             |
-      |          | git -c core.editor=true rebase --continue                  |
+      |          | GIT_EDITOR=true git rebase --continue                      |
       |          | git push --force-with-lease --force-if-includes            |
     And Git Town prints:
       """

--- a/features/swap/merge_conflict/chain_of_conflicting_edits.feature
+++ b/features/swap/merge_conflict/chain_of_conflicting_edits.feature
@@ -29,19 +29,19 @@ Feature: swapping a feature branch in a stack full of conflicting branches
       | branch-2 | git fetch --prune --tags                                                              |
       |          | git -c rebase.updateRefs=false rebase --onto main branch-1                            |
       |          | git add file                                                                          |
-      |          | git -c core.editor=true rebase --continue                                             |
+      |          | GIT_EDITOR=true git rebase --continue                                                 |
       |          | git push --force-with-lease --force-if-includes                                       |
       |          | git checkout branch-1                                                                 |
       | branch-1 | git -c rebase.updateRefs=false rebase --onto branch-2 main                            |
       |          | git checkout --theirs file                                                            |
       |          | git add file                                                                          |
-      |          | git -c core.editor=true rebase --continue                                             |
+      |          | GIT_EDITOR=true git rebase --continue                                                 |
       |          | git push --force-with-lease --force-if-includes                                       |
       |          | git checkout branch-3                                                                 |
       | branch-3 | git -c rebase.updateRefs=false rebase --onto branch-1 {{ sha-before-run 'commit 2' }} |
       |          | git checkout --theirs file                                                            |
       |          | git add file                                                                          |
-      |          | git -c core.editor=true rebase --continue                                             |
+      |          | GIT_EDITOR=true git rebase --continue                                                 |
       |          | git push --force-with-lease --force-if-includes                                       |
       |          | git checkout branch-2                                                                 |
     And these commits exist now

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/main_branch_rebase_tracking_branch_conflict.feature
@@ -44,15 +44,15 @@ Feature: handle rebase conflicts between main branch and its tracking branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                   |
-      | main    | git -c core.editor=true rebase --continue |
-      |         | git push                                  |
-      |         | git checkout feature                      |
-      | feature | git merge --no-edit --ff main             |
-      |         | git merge --no-edit --ff origin/feature   |
-      |         | git push                                  |
-      |         | git checkout main                         |
-      | main    | git push --tags                           |
+      | BRANCH  | COMMAND                                 |
+      | main    | GIT_EDITOR=true git rebase --continue   |
+      |         | git push                                |
+      |         | git checkout feature                    |
+      | feature | git merge --no-edit --ff main           |
+      |         | git merge --no-edit --ff origin/feature |
+      |         | git push                                |
+      |         | git checkout main                       |
+      | main    | git push --tags                         |
     And no rebase is now in progress
     And all branches are now synchronized
     And these committed files exist now

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/perennial_branch_tracking_branch_conflict.feature
@@ -69,7 +69,7 @@ Feature: handle rebase conflicts between perennial branch and its tracking branc
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH | COMMAND                                           |
-      | beta   | git -c core.editor=true rebase --continue         |
+      | beta   | GIT_EDITOR=true git rebase --continue             |
       |        | git push                                          |
       |        | git checkout main                                 |
       | main   | git -c rebase.updateRefs=false rebase origin/main |

--- a/features/sync/current_branch/contribution_branch/tracking_branch/conflict_local_vs_tracking.feature
+++ b/features/sync/current_branch/contribution_branch/tracking_branch/conflict_local_vs_tracking.feature
@@ -45,9 +45,9 @@ Feature: handle conflicts between the current contribution branch and its tracki
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH       | COMMAND                                   |
-      | contribution | git -c core.editor=true rebase --continue |
-      |              | git push                                  |
+      | BRANCH       | COMMAND                               |
+      | contribution | GIT_EDITOR=true git rebase --continue |
+      |              | git push                              |
     And these commits exist now
       | BRANCH       | LOCATION      | MESSAGE                   |
       | contribution | local, origin | conflicting origin commit |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -62,12 +62,12 @@ Feature: handle conflicts between the main branch and its tracking branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                   |
-      | main    | git -c core.editor=true rebase --continue |
-      |         | git push                                  |
-      |         | git checkout feature                      |
-      | feature | git merge --no-edit --ff main             |
-      |         | git push                                  |
+      | BRANCH  | COMMAND                               |
+      | main    | GIT_EDITOR=true git rebase --continue |
+      |         | git push                              |
+      |         | git checkout feature                  |
+      | feature | git merge --no-edit --ff main         |
+      |         | git push                              |
     And no rebase is now in progress
     And all branches are now synchronized
     And these committed files exist now

--- a/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
+++ b/features/sync/current_branch/feature_branch/mixed_sync_strategies/two_collaborators_different_sync_strategies.feature
@@ -88,11 +88,11 @@ Feature: compatibility between different sync-feature-strategy settings
     And I run "git town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                                                      |
-      | feature | git -c core.editor=true rebase --continue                                    |
+      | feature | GIT_EDITOR=true git rebase --continue                                        |
       |         | git -c rebase.updateRefs=false rebase --onto main {{ sha 'initial commit' }} |
       |         | git checkout --theirs file.txt                                               |
       |         | git add file.txt                                                             |
-      |         | git -c core.editor=true rebase --continue                                    |
+      |         | GIT_EDITOR=true git rebase --continue                                        |
     And Git Town prints the error:
       """
       CONFLICT (add/add): Merge conflict in file.txt
@@ -114,7 +114,7 @@ Feature: compatibility between different sync-feature-strategy settings
     And I run "git town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | feature | git -c core.editor=true rebase --continue       |
+      | feature | GIT_EDITOR=true git rebase --continue           |
       |         | git push --force-with-lease --force-if-includes |
     And no rebase is now in progress
     And all branches are now synchronized

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/local_repo/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/local_repo/conflict_feature_vs_main.feature
@@ -45,8 +45,8 @@ Feature: handle conflicts between the current feature branch and the main branch
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and enter "resolved commit" for the commit message
     Then Git Town runs the commands
-      | BRANCH  | COMMAND                                   |
-      | feature | git -c core.editor=true rebase --continue |
+      | BRANCH  | COMMAND                               |
+      | feature | GIT_EDITOR=true git rebase --continue |
     And no rebase is now in progress
     And all branches are now synchronized
     And these committed files exist now

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_branch_tracking_branch.feature
@@ -49,7 +49,7 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And I run "git-town continue" and enter "resolved commit" for the commit message
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | feature | git -c core.editor=true rebase --continue       |
+      | feature | GIT_EDITOR=true git rebase --continue           |
       |         | git -c rebase.updateRefs=false rebase main      |
       |         | git push --force-with-lease --force-if-includes |
     And no rebase is now in progress
@@ -64,6 +64,6 @@ Feature: handle conflicts between the current feature branch and its tracking br
     And I run "git-town continue"
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | feature | git -c core.editor=true rebase --continue       |
+      | feature | GIT_EDITOR=true git rebase --continue           |
       |         | git -c rebase.updateRefs=false rebase main      |
       |         | git push --force-with-lease --force-if-includes |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_feature_vs_main.feature
@@ -52,7 +52,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And I run "git-town continue" and enter "resolved conflict between main and feature branch" for the commit message
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | feature | git -c core.editor=true rebase --continue       |
+      | feature | GIT_EDITOR=true git rebase --continue           |
       |         | git push --force-with-lease --force-if-includes |
       |         | git -c rebase.updateRefs=false rebase main      |
     And no rebase is now in progress

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/with/conflict_main_local_vs_main_tracking.feature
@@ -48,7 +48,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | main    | git -c core.editor=true rebase --continue       |
+      | main    | GIT_EDITOR=true git rebase --continue           |
       |         | git push                                        |
       |         | git checkout feature                            |
       | feature | git -c rebase.updateRefs=false rebase main      |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -54,7 +54,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And I run "git-town continue" and enter "resolved commit" for the commit message
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | feature | git -c core.editor=true rebase --continue       |
+      | feature | GIT_EDITOR=true git rebase --continue           |
       |         | git push --force-with-lease --force-if-includes |
       |         | git -c rebase.updateRefs=false rebase main      |
     And no rebase is now in progress
@@ -69,7 +69,7 @@ Feature: handle conflicts between the current feature branch and the main branch
     And I run "git-town continue" and enter "resolved commit" for the commit message
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | feature | git -c core.editor=true rebase --continue       |
+      | feature | GIT_EDITOR=true git rebase --continue           |
       |         | git push --force-with-lease --force-if-includes |
       |         | git -c rebase.updateRefs=false rebase main      |
     And all branches are now synchronized

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -64,7 +64,7 @@ Feature: handle conflicts between the main branch and its tracking branch
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | main    | git -c core.editor=true rebase --continue       |
+      | main    | GIT_EDITOR=true git rebase --continue           |
       |         | git push                                        |
       |         | git checkout feature                            |
       | feature | git -c rebase.updateRefs=false rebase main      |

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/two_collaborators/conflicting_commits.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/two_collaborators/conflicting_commits.feature
@@ -55,7 +55,7 @@ Feature: two people using rebase make conflicting changes to a branch
     And the coworker runs "git town continue" and closes the editor
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                         |
-      | feature | git -c core.editor=true rebase --continue       |
+      | feature | GIT_EDITOR=true git rebase --continue           |
       |         | git -c rebase.updateRefs=false rebase main      |
       |         | git push --force-with-lease --force-if-includes |
     And all branches are now synchronized
@@ -83,7 +83,7 @@ Feature: two people using rebase make conflicting changes to a branch
     And I run "git town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH  | COMMAND                                                                             |
-      | feature | git -c core.editor=true rebase --continue                                           |
+      | feature | GIT_EDITOR=true git rebase --continue                                               |
       |         | git -c rebase.updateRefs=false rebase --onto main {{ sha 'persisted config file' }} |
       |         | git push --force-with-lease --force-if-includes                                     |
     And all branches are now synchronized

--- a/features/sync/current_branch/main_branch/conflicts/local_vs_tracking.feature
+++ b/features/sync/current_branch/main_branch/conflicts/local_vs_tracking.feature
@@ -45,10 +45,10 @@ Feature: handle conflicts between the main branch and its tracking branch when s
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                   |
-      | main   | git -c core.editor=true rebase --continue |
-      |        | git push                                  |
-      |        | git push --tags                           |
+      | BRANCH | COMMAND                               |
+      | main   | GIT_EDITOR=true git rebase --continue |
+      |        | git push                              |
+      |        | git push --tags                       |
     And all branches are now synchronized
     And these committed files exist now
       | BRANCH | NAME             | CONTENT          |

--- a/features/sync/current_branch/observed_branch/conflicts/local_vs_origin.feature
+++ b/features/sync/current_branch/observed_branch/conflicts/local_vs_origin.feature
@@ -51,8 +51,8 @@ Feature: handle conflicts between the current observed branch and its tracking b
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                   |
-      | observed | git -c core.editor=true rebase --continue |
+      | BRANCH   | COMMAND                               |
+      | observed | GIT_EDITOR=true git rebase --continue |
     And these commits exist now
       | BRANCH   | LOCATION      | MESSAGE                   |
       | observed | local, origin | conflicting origin commit |

--- a/features/sync/current_branch/perennial_branch/tracking/conflict.feature
+++ b/features/sync/current_branch/perennial_branch/tracking/conflict.feature
@@ -51,10 +51,10 @@ Feature: handle conflicts between the current perennial branch and its tracking 
     When I resolve the conflict in "conflicting_file"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                   |
-      | qa     | git -c core.editor=true rebase --continue |
-      |        | git push                                  |
-      |        | git push --tags                           |
+      | BRANCH | COMMAND                               |
+      | qa     | GIT_EDITOR=true git rebase --continue |
+      |        | git push                              |
+      |        | git push --tags                       |
     And no rebase is now in progress
     And all branches are now synchronized
     And these committed files exist now

--- a/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/conflict.feature
+++ b/features/sync/current_branch/prototype_branch/no_sync_prototype_strategy/feature_sync_strategy_rebase/tracking_branch/conflict.feature
@@ -55,7 +55,7 @@ Feature: handle conflicts between the current prototype branch and its tracking 
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH    | COMMAND                                         |
-      | prototype | git -c core.editor=true rebase --continue       |
+      | prototype | GIT_EDITOR=true git rebase --continue           |
       |           | git -c rebase.updateRefs=false rebase main      |
       |           | git push --force-with-lease --force-if-includes |
     And these commits exist now

--- a/features/sync/stack/compress_sync_strategy/branches_gone/dependent_ancestor_shipped_and_related_change_on_main.feature
+++ b/features/sync/stack/compress_sync_strategy/branches_gone/dependent_ancestor_shipped_and_related_change_on_main.feature
@@ -38,12 +38,12 @@ Feature: shipped the head branch of a synced stack with dependent changes that c
     When I resolve the conflict in "file" with "resolved main content"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                   |
-      | main   | git -c core.editor=true rebase --continue |
-      |        | git push                                  |
-      |        | git branch -D alpha                       |
-      |        | git checkout beta                         |
-      | beta   | git merge --no-edit --ff main             |
+      | BRANCH | COMMAND                               |
+      | main   | GIT_EDITOR=true git rebase --continue |
+      |        | git push                              |
+      |        | git branch -D alpha                   |
+      |        | git checkout beta                     |
+      | beta   | git merge --no-edit --ff main         |
     And Git Town prints the error:
       """
       CONFLICT (add/add): Merge conflict in file

--- a/features/sync/stack/merge_sync_strategy/branches_gone/dependent_ancestor_shipped_and_main_updates_same_location.feature
+++ b/features/sync/stack/merge_sync_strategy/branches_gone/dependent_ancestor_shipped_and_main_updates_same_location.feature
@@ -38,12 +38,12 @@ Feature: shipped the head branch of a synced stack with dependent changes that c
     When I resolve the conflict in "file" with "resolved main content"
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
-      | BRANCH | COMMAND                                   |
-      | main   | git -c core.editor=true rebase --continue |
-      |        | git push                                  |
-      |        | git branch -D alpha                       |
-      |        | git checkout beta                         |
-      | beta   | git merge --no-edit --ff main             |
+      | BRANCH | COMMAND                               |
+      | main   | GIT_EDITOR=true git rebase --continue |
+      |        | git push                              |
+      |        | git branch -D alpha                   |
+      |        | git checkout beta                     |
+      | beta   | git merge --no-edit --ff main         |
     And Git Town prints the error:
       """
       CONFLICT (add/add): Merge conflict in file

--- a/features/sync/stack/rebase_sync_strategy/branches_gone/ancestor_shipped_and_main_updates_same_file.feature
+++ b/features/sync/stack/rebase_sync_strategy/branches_gone/ancestor_shipped_and_main_updates_same_file.feature
@@ -39,14 +39,14 @@ Feature: shipped the head branch of a synced stack with dependent changes that c
     And I run "git-town continue" and close the editor
     Then Git Town runs the commands
       | BRANCH | COMMAND                                                 |
-      | main   | git -c core.editor=true rebase --continue               |
+      | main   | GIT_EDITOR=true git rebase --continue                   |
       |        | git push                                                |
       |        | git checkout beta                                       |
       | beta   | git pull                                                |
       |        | git -c rebase.updateRefs=false rebase --onto main alpha |
       |        | git checkout --theirs file                              |
       |        | git add file                                            |
-      |        | git -c core.editor=true rebase --continue               |
+      |        | GIT_EDITOR=true git rebase --continue                   |
       |        | git push --force-with-lease                             |
       |        | git branch -D alpha                                     |
     And all branches are now synchronized

--- a/features/sync/stack/rebase_sync_strategy/branches_gone/parent_deleted_grandchild_conflict.feature
+++ b/features/sync/stack/rebase_sync_strategy/branches_gone/parent_deleted_grandchild_conflict.feature
@@ -28,7 +28,7 @@ Feature: a grandchild branch has conflicts while its parent was deleted remotely
       |            | git -c rebase.updateRefs=false rebase --onto main child |
       |            | git checkout --theirs conflicting_file                  |
       |            | git add conflicting_file                                |
-      |            | git -c core.editor=true rebase --continue               |
+      |            | GIT_EDITOR=true git rebase --continue                   |
       |            | git push --force-with-lease                             |
       |            | git branch -D child                                     |
       |            | git push --tags                                         |

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -324,7 +324,7 @@ func (self *Commands) ContentBlobInfo(querier gitdomain.Querier, branch gitdomai
 }
 
 func (self *Commands) ContinueRebase(runner gitdomain.Runner) error {
-	return runner.Run("git", "-c", "core.editor=true", "rebase", "--continue")
+	return runner.RunWithEnv([]string{"GIT_EDITOR=true"}, "git", "rebase", "--continue")
 }
 
 // CreateAndCheckoutBranch creates a new branch with the given name and checks it out using a single Git operation.

--- a/internal/git/gitdomain/runner.go
+++ b/internal/git/gitdomain/runner.go
@@ -2,6 +2,7 @@ package gitdomain
 
 type Runner interface {
 	Run(executable string, args ...string) error
+	RunWithEnv(env []string, executable string, args ...string) error
 }
 
 type RunnerQuerier interface {

--- a/internal/subshell/backend_runner.go
+++ b/internal/subshell/backend_runner.go
@@ -28,25 +28,31 @@ type BackendRunner struct {
 }
 
 func (self BackendRunner) Query(executable string, args ...string) (string, error) {
-	return self.execute(executable, args...)
+	return self.execute([]string{}, executable, args...)
 }
 
 func (self BackendRunner) QueryTrim(executable string, args ...string) (string, error) {
-	output, err := self.execute(executable, args...)
+	output, err := self.execute([]string{}, executable, args...)
 	return strings.TrimSpace(stripansi.Strip(output)), err
 }
 
 func (self BackendRunner) Run(executable string, args ...string) error {
-	_, err := self.execute(executable, args...)
+	_, err := self.execute([]string{}, executable, args...)
 	return err
 }
 
-func (self BackendRunner) execute(executable string, args ...string) (string, error) {
+func (self BackendRunner) RunWithEnv(env []string, executable string, args ...string) error {
+	_, err := self.execute(env, executable, args...)
+	return err
+}
+
+func (self BackendRunner) execute(env []string, executable string, args ...string) (string, error) {
 	self.CommandsCounter.Value.Inc()
 	if self.Verbose {
 		printHeader(executable, args...)
 	}
 	subProcess := exec.Command(executable, args...) // #nosec
+	subProcess.Env = append(subProcess.Environ(), env...)
 	if dir, has := self.Dir.Get(); has {
 		subProcess.Dir = dir
 	}

--- a/internal/subshell/backend_runner.go
+++ b/internal/subshell/backend_runner.go
@@ -49,7 +49,7 @@ func (self BackendRunner) RunWithEnv(env []string, executable string, args ...st
 func (self BackendRunner) execute(env []string, executable string, args ...string) (string, error) {
 	self.CommandsCounter.Value.Inc()
 	if self.Verbose {
-		printHeader(executable, args...)
+		printHeader(env, executable, args...)
 	}
 	subProcess := exec.Command(executable, args...) // #nosec
 	subProcess.Env = append(subProcess.Environ(), env...)
@@ -100,9 +100,13 @@ func containsConcurrentGitAccess(text string) bool {
 	return strings.Contains(text, "fatal: Unable to create '") && strings.Contains(text, "index.lock': File exists.")
 }
 
-func printHeader(cmd string, args ...string) {
+func printHeader(env []string, cmd string, args ...string) {
 	quoted := stringslice.SurroundEmptyWith(args, `"`)
 	quoted = stringslice.SurroundSpacesWith(quoted, `"`)
-	text := "\n(verbose) " + cmd + " " + strings.Join(quoted, " ")
+	text := "\n(verbose) "
+	if len(env) > 0 {
+		text += strings.Join(env, " ") + " "
+	}
+	text += cmd + " " + strings.Join(quoted, " ")
 	fmt.Println(colors.Bold().Styled(text))
 }

--- a/internal/subshell/frontend_dry_runner.go
+++ b/internal/subshell/frontend_dry_runner.go
@@ -19,17 +19,17 @@ type FrontendDryRunner struct {
 }
 
 func (self *FrontendDryRunner) Run(cmd string, args ...string) error {
-	err := self.execute(cmd, args...)
+	err := self.execute([]string{}, cmd, args...)
 	return err
 }
 
-func (self *FrontendDryRunner) RunWithEnv(_ []string, cmd string, args ...string) error {
-	err := self.execute(cmd, args...)
+func (self *FrontendDryRunner) RunWithEnv(env []string, cmd string, args ...string) error {
+	err := self.execute(env, cmd, args...)
 	return err
 }
 
 // Run runs the given command in this ShellRunner's directory.
-func (self *FrontendDryRunner) Run(executable string, args ...string) error {
+func (self *FrontendDryRunner) execute(env []string, executable string, args ...string) error {
 	var currentBranch gitdomain.LocalBranchName
 	if self.PrintBranchNames {
 		var err error
@@ -39,7 +39,7 @@ func (self *FrontendDryRunner) Run(executable string, args ...string) error {
 		}
 	}
 	if self.PrintCommands {
-		PrintCommand(currentBranch, self.PrintBranchNames, executable, args...)
+		PrintCommand(currentBranch, self.PrintBranchNames, env, executable, args...)
 		fmt.Println("(dry run)")
 	}
 	return nil

--- a/internal/subshell/frontend_dry_runner.go
+++ b/internal/subshell/frontend_dry_runner.go
@@ -18,6 +18,16 @@ type FrontendDryRunner struct {
 	PrintCommands    bool
 }
 
+func (self *FrontendDryRunner) Run(cmd string, args ...string) error {
+	err := self.execute(cmd, args...)
+	return err
+}
+
+func (self *FrontendDryRunner) RunWithEnv(_ []string, cmd string, args ...string) error {
+	err := self.execute(cmd, args...)
+	return err
+}
+
 // Run runs the given command in this ShellRunner's directory.
 func (self *FrontendDryRunner) Run(executable string, args ...string) error {
 	var currentBranch gitdomain.LocalBranchName

--- a/internal/subshell/frontend_dry_runner.go
+++ b/internal/subshell/frontend_dry_runner.go
@@ -19,13 +19,11 @@ type FrontendDryRunner struct {
 }
 
 func (self *FrontendDryRunner) Run(cmd string, args ...string) error {
-	err := self.execute([]string{}, cmd, args...)
-	return err
+	return self.execute([]string{}, cmd, args...)
 }
 
 func (self *FrontendDryRunner) RunWithEnv(env []string, cmd string, args ...string) error {
-	err := self.execute(env, cmd, args...)
-	return err
+	return self.execute(env, cmd, args...)
 }
 
 // Run runs the given command in this ShellRunner's directory.

--- a/internal/subshell/frontend_runner.go
+++ b/internal/subshell/frontend_runner.go
@@ -51,8 +51,18 @@ func PrintCommand(branch gitdomain.LocalBranchName, printBranch bool, cmd string
 	fmt.Println(colors.Bold().Styled(header))
 }
 
-// Run runs the given command in this ShellRunner's directory.
-func (self *FrontendRunner) Run(cmd string, args ...string) (err error) {
+func (self *FrontendRunner) Run(cmd string, args ...string) error {
+	err := self.execute([]string{}, cmd, args...)
+	return err
+}
+
+func (self *FrontendRunner) RunWithEnv(env []string, cmd string, args ...string) error {
+	err := self.execute(env, cmd, args...)
+	return err
+}
+
+// runs the given command in this ShellRunner's directory.
+func (self *FrontendRunner) execute(env []string, cmd string, args ...string) (err error) {
 	self.CommandsCounter.Value.Inc()
 	var branchName gitdomain.LocalBranchName
 	if self.PrintBranchNames {
@@ -71,6 +81,7 @@ func (self *FrontendRunner) Run(cmd string, args ...string) (err error) {
 	concurrentGitRetriesLeft := concurrentGitRetries
 	for {
 		subProcess := exec.Command(cmd, args...)
+		subProcess.Env = append(subProcess.Environ(), env...)
 		var stderrBuffer bytes.Buffer // we only need to look at STDERR since that's where Git will print error messages
 		subProcess.Stderr = io.MultiWriter(os.Stderr, &stderrBuffer)
 		subProcess.Stdin = os.Stdin

--- a/internal/subshell/frontend_runner.go
+++ b/internal/subshell/frontend_runner.go
@@ -54,13 +54,11 @@ func PrintCommand(branch gitdomain.LocalBranchName, printBranch bool, env []stri
 }
 
 func (self *FrontendRunner) Run(cmd string, args ...string) error {
-	err := self.execute([]string{}, cmd, args...)
-	return err
+	return self.execute([]string{}, cmd, args...)
 }
 
 func (self *FrontendRunner) RunWithEnv(env []string, cmd string, args ...string) error {
-	err := self.execute(env, cmd, args...)
-	return err
+	return self.execute(env, cmd, args...)
 }
 
 // runs the given command in this ShellRunner's directory.

--- a/internal/subshell/frontend_runner_test.go
+++ b/internal/subshell/frontend_runner_test.go
@@ -21,7 +21,7 @@ func TestFormat(t *testing.T) {
 		`git config perennial-branches ""`: {printBranch: false, branch: "branch", executable: "git", args: []string{"config", "perennial-branches", ""}},
 	}
 	for want, give := range tests {
-		have := subshell.FormatCommand(give.branch, give.printBranch, give.executable, give.args...)
+		have := subshell.FormatCommand(give.branch, give.printBranch, []string{}, give.executable, give.args...)
 		must.EqOp(t, want, have)
 	}
 }

--- a/internal/test/subshell/test_runner.go
+++ b/internal/test/subshell/test_runner.go
@@ -270,6 +270,11 @@ func (self *TestRunner) Run(name string, arguments ...string) error {
 	return err
 }
 
+func (self *TestRunner) RunWithEnv(env []string, name string, arguments ...string) error {
+	_, err := self.QueryWith(&Options{Env: env, IgnoreOutput: true}, name, arguments...)
+	return err
+}
+
 // SetTestOrigin adds the given environment variable to subsequent runs of commands.
 func (self *TestRunner) SetProposalOverride(content string) {
 	self.ProposalOverride = Some(content)


### PR DESCRIPTION
When Git Town rebases a branch, it tries to prevent opening an editor for commit messages by running Git with the `core.editor` config option. However, the `GIT_EDITOR` environment variable overrides the `core.editor` config option (see&nbsp;[git-var in the Git docs](https://git-scm.com/docs/git-var#Documentation/git-var.txt-GITEDITOR)).

I run into this issue regularly when I run `make cuke` in the dev container. VS Code sets the GIT_EDITOR environment variable so that commit messages open in VS Code. Because this overrides the `code.editor` config option, any test that uses the rebase sync strategy opens a new tab in VS Code.

Here's a recording of before and after when working in the dev container:

https://github.com/user-attachments/assets/3fda3318-3bec-4064-b836-e10b2029c94c