### PR TITLE
Move rebasing feature branches into an expandable opcode

### DIFF
--- a/internal/cmd/sync/sync_feature_branch.go
+++ b/internal/cmd/sync/sync_feature_branch.go
@@ -72,29 +72,14 @@ func syncFeatureBranchMerge(args featureBranchArgs) {
 	)
 }
 
+// TODO: inline all these helper functions since all they do now is add a single opcode
 func syncFeatureBranchRebase(args featureBranchArgs) {
 	args.program.Value.Add(
-		&opcodes.RebaseParentsUntilLocal{
-			Branch:      args.localName,
-			PreviousSHA: args.parentLastRunSHA,
+		&opcodes.SyncFeatureBranchRebase{
+			Branch:           args.localName,
+			ParentLastRunSHA: args.parentLastRunSHA,
+			PushBranches:     args.pushBranches,
+			TrackingBranch:   args.trackingBranch,
 		},
 	)
-	if trackingBranch, hasTrackingBranch := args.trackingBranch.Get(); hasTrackingBranch {
-		if args.offline.IsOnline() {
-			args.program.Value.Add(
-				&opcodes.RebaseTrackingBranch{
-					RemoteBranch: trackingBranch,
-					PushBranches: args.pushBranches,
-				},
-				&opcodes.RebaseParentsUntilLocal{
-					Branch:      args.localName,
-					PreviousSHA: args.parentLastRunSHA,
-				},
-				&opcodes.PushCurrentBranchForceIfNeeded{
-					CurrentBranch:   args.localName,
-					ForceIfIncludes: true,
-				},
-			)
-		}
-	}
 }

--- a/internal/vm/opcodes/all.go
+++ b/internal/vm/opcodes/all.go
@@ -100,6 +100,7 @@ func All() []shared.Opcode {
 		&StashPop{},
 		&SyncFeatureBranchCompress{},
 		&SyncFeatureBranchMerge{},
+		&SyncFeatureBranchRebase{},
 		&UndoLastCommit{},
 	} //exhaustruct:ignore
 }

--- a/internal/vm/opcodes/sync_feature_branch_rebase.go
+++ b/internal/vm/opcodes/sync_feature_branch_rebase.go
@@ -1,0 +1,52 @@
+package opcodes
+
+import (
+	"github.com/git-town/git-town/v20/internal/config/configdomain"
+	"github.com/git-town/git-town/v20/internal/git/gitdomain"
+	"github.com/git-town/git-town/v20/internal/vm/shared"
+	. "github.com/git-town/git-town/v20/pkg/prelude"
+)
+
+// SyncFeatureBranchMerge merges the parent branches of the given branch until a local parent is found.
+type SyncFeatureBranchRebase struct {
+	Branch gitdomain.LocalBranchName
+	// InitialParentName       Option[gitdomain.LocalBranchName]
+	// InitialParentSHA        Option[gitdomain.SHA]
+	ParentLastRunSHA        Option[gitdomain.SHA]
+	PushBranches            configdomain.PushBranches
+	TrackingBranch          Option[gitdomain.RemoteBranchName]
+	undeclaredOpcodeMethods `exhaustruct:"optional"`
+}
+
+func (self *SyncFeatureBranchRebase) Run(args shared.RunArgs) error {
+	program := []shared.Opcode{
+		&RebaseParentsUntilLocal{
+			Branch:      self.Branch,
+			PreviousSHA: self.ParentLastRunSHA,
+		},
+	}
+	if trackingBranch, hasTrackingBranch := self.TrackingBranch.Get(); hasTrackingBranch {
+		if args.Config.Value.NormalConfig.Offline.IsOnline() {
+			program = append(program,
+				&RebaseTrackingBranch{
+					PushBranches: self.PushBranches,
+					RemoteBranch: trackingBranch,
+				},
+			)
+			program = append(program,
+				&RebaseParentsUntilLocal{
+					Branch:      self.Branch,
+					PreviousSHA: self.ParentLastRunSHA,
+				},
+			)
+			program = append(program,
+				&PushCurrentBranchForceIfNeeded{
+					CurrentBranch:   self.Branch,
+					ForceIfIncludes: true,
+				},
+			)
+		}
+	}
+	args.PrependOpcodes(program...)
+	return nil
+}

--- a/internal/vm/opcodes/sync_feature_branch_rebase.go
+++ b/internal/vm/opcodes/sync_feature_branch_rebase.go
@@ -32,14 +32,10 @@ func (self *SyncFeatureBranchRebase) Run(args shared.RunArgs) error {
 					PushBranches: self.PushBranches,
 					RemoteBranch: trackingBranch,
 				},
-			)
-			program = append(program,
 				&RebaseParentsUntilLocal{
 					Branch:      self.Branch,
 					PreviousSHA: self.ParentLastRunSHA,
 				},
-			)
-			program = append(program,
 				&PushCurrentBranchForceIfNeeded{
 					CurrentBranch:   self.Branch,
 					ForceIfIncludes: true,

--- a/internal/vm/statefile/save_load_test.go
+++ b/internal/vm/statefile/save_load_test.go
@@ -130,6 +130,7 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.StashOpenChanges{},
 				&opcodes.SyncFeatureBranchCompress{CommitMessage: Some(gitdomain.CommitMessage("commit message")), CurrentBranch: "branch", Offline: true, InitialParentName: gitdomain.NewLocalBranchNameOption("parent"), InitialParentSHA: Some(gitdomain.NewSHA("111111")), TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 				&opcodes.SyncFeatureBranchMerge{Branch: "branch", InitialParentName: gitdomain.NewLocalBranchNameOption("original-parent"), InitialParentSHA: Some(gitdomain.NewSHA("123456")), TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
+				&opcodes.SyncFeatureBranchRebase{Branch: "branch", ParentLastRunSHA: Some(gitdomain.NewSHA("111111")), PushBranches: true, TrackingBranch: Some(gitdomain.NewRemoteBranchName("origin/branch"))},
 			},
 			TouchedBranches: []gitdomain.BranchName{"branch-1", "branch-2"},
 			UnfinishedDetails: MutableSome(&runstate.UnfinishedRunStateDetails{
@@ -695,6 +696,15 @@ func TestLoadSave(t *testing.T) {
         "TrackingBranch": "origin/branch"
       },
       "type": "SyncFeatureBranchMerge"
+    },
+    {
+      "data": {
+        "Branch": "branch",
+        "ParentLastRunSHA": "111111",
+        "PushBranches": true,
+        "TrackingBranch": "origin/branch"
+      },
+      "type": "SyncFeatureBranchRebase"
     }
   ],
   "TouchedBranches": [


### PR DESCRIPTION
To allow conditional execution at runtime, this PR moves all logic to rebase a feature branch into an opcode that at runtime expands into the commands needed to conditionally sync this branch.