### PR TITLE
Allow multiple "git town skip" calls

### DIFF
--- a/features/sync/all_branches/merge_sync_strategy/conflicts/multiple_conflicting_branches.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/multiple_conflicting_branches.feature
@@ -1,0 +1,121 @@
+Feature: multiple conflicting branches
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME  | TYPE    | PARENT | LOCATIONS     |
+      | alpha | feature | main   | local, origin |
+      | beta  | feature | main   | local, origin |
+      | gamma | feature | main   | local, origin |
+    And the commits
+      | BRANCH | LOCATION      | MESSAGE            | FILE NAME | FILE CONTENT        |
+      | main   | origin        | main commit        | file      | main content        |
+      | alpha  | local, origin | alpha commit       | file      | alpha content       |
+      | beta   | local         | local beta commit  | file      | local beta content  |
+      |        | origin        | origin beta commit | file      | origin beta content |
+      | gamma  | local, origin | gamma commit       | file      | gamma content       |
+    And the current branch is "main"
+    When I run "git-town sync --all"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                           |
+      | main   | git fetch --prune --tags                          |
+      |        | git -c rebase.updateRefs=false rebase origin/main |
+      |        | git checkout alpha                                |
+      | alpha  | git merge --no-edit --ff main                     |
+    And Git Town prints the error:
+      """
+      CONFLICT (add/add): Merge conflict in file
+      """
+    And a merge is now in progress
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                                     |
+      | alpha  | git merge --abort                           |
+      |        | git checkout main                           |
+      | main   | git reset --hard {{ sha 'initial commit' }} |
+    And the initial commits exist now
+    And the initial branches and lineage exist now
+
+  @this
+  Scenario: skipping all conflicts
+    When I run "git-town skip"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                       |
+      | alpha  | git merge --abort             |
+      |        | git checkout beta             |
+      | beta   | git merge --no-edit --ff main |
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE            |
+      | main   | local, origin | main commit        |
+      | alpha  | local, origin | alpha commit       |
+      | beta   | local         | local beta commit  |
+      |        | origin        | origin beta commit |
+      | gamma  | local, origin | gamma commit       |
+    When I run "git-town skip"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                       |
+      | beta   | git merge --abort             |
+      |        | git checkout gamma            |
+      | gamma  | git merge --no-edit --ff main |
+    And Git Town prints the error:
+      """
+      CONFLICT (add/add): Merge conflict in file
+      """
+    And a merge is now in progress
+    And these commits exist now
+      | BRANCH | LOCATION      | MESSAGE            |
+      | main   | local, origin | main commit        |
+      | alpha  | local, origin | alpha commit       |
+      | beta   | local         | local beta commit  |
+      |        | origin        | origin beta commit |
+      | gamma  | local, origin | gamma commit       |
+
+  Scenario: continue with unresolved conflict
+    When I run "git-town continue"
+    Then Git Town runs no commands
+    And Git Town prints the error:
+      """
+      you must resolve the conflicts before continuing
+      """
+    And a merge is now in progress
+
+  Scenario: resolve and continue
+    When I resolve the conflict in "conflicting_file"
+    And I run "git-town continue"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                       |
+      | beta   | git commit --no-edit          |
+      |        | git push                      |
+      |        | git checkout gamma            |
+      | gamma  | git merge --no-edit --ff main |
+      |        | git push                      |
+      |        | git checkout main             |
+      | main   | git push --tags               |
+    And all branches are now synchronized
+    And no merge is in progress
+    And these committed files exist now
+      | BRANCH | NAME             | CONTENT          |
+      | main   | main_file        | main content     |
+      | alpha  | feature1_file    | alpha content    |
+      |        | main_file        | main content     |
+      | beta   | conflicting_file | resolved content |
+      |        | main_file        | main content     |
+      | gamma  | feature3_file    | gamma content    |
+      |        | main_file        | main content     |
+
+  Scenario: resolve, commit, and continue
+    When I resolve the conflict in "conflicting_file"
+    And I run "git commit --no-edit"
+    And I run "git-town continue"
+    Then Git Town runs the commands
+      | BRANCH | COMMAND                       |
+      | beta   | git push                      |
+      |        | git checkout gamma            |
+      | gamma  | git merge --no-edit --ff main |
+      |        | git push                      |
+      |        | git checkout main             |
+      | main   | git push --tags               |

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/multiple_conflicting_branches.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/multiple_conflicting_branches.feature
@@ -30,16 +30,6 @@ Feature: multiple conflicting branches
       """
     And a merge is now in progress
 
-  Scenario: undo
-    When I run "git-town undo"
-    Then Git Town runs the commands
-      | BRANCH | COMMAND                                     |
-      | alpha  | git merge --abort                           |
-      |        | git checkout main                           |
-      | main   | git reset --hard {{ sha 'initial commit' }} |
-    And the initial commits exist now
-    And the initial branches and lineage exist now
-
   Scenario: skipping all conflicts
     When I run "git-town skip"
     Then Git Town runs the commands
@@ -90,12 +80,3 @@ Feature: multiple conflicting branches
       | beta   | local         | local beta commit  |
       |        | origin        | origin beta commit |
       | gamma  | local, origin | gamma commit       |
-
-  Scenario: continue with unresolved conflict
-    When I run "git-town continue"
-    Then Git Town runs no commands
-    And Git Town prints the error:
-      """
-      you must resolve the conflicts before continuing
-      """
-    And a merge is now in progress

--- a/features/sync/all_branches/merge_sync_strategy/conflicts/multiple_conflicting_branches.feature
+++ b/features/sync/all_branches/merge_sync_strategy/conflicts/multiple_conflicting_branches.feature
@@ -41,13 +41,6 @@ Feature: multiple conflicting branches
       """
       CONFLICT (add/add): Merge conflict in file
       """
-    And these commits exist now
-      | BRANCH | LOCATION      | MESSAGE            |
-      | main   | local, origin | main commit        |
-      | alpha  | local, origin | alpha commit       |
-      | beta   | local         | local beta commit  |
-      |        | origin        | origin beta commit |
-      | gamma  | local, origin | gamma commit       |
     When I run "git-town skip"
     Then Git Town runs the commands
       | BRANCH | COMMAND                       |
@@ -59,13 +52,6 @@ Feature: multiple conflicting branches
       CONFLICT (add/add): Merge conflict in file
       """
     And a merge is now in progress
-    And these commits exist now
-      | BRANCH | LOCATION      | MESSAGE            |
-      | main   | local, origin | main commit        |
-      | alpha  | local, origin | alpha commit       |
-      | beta   | local         | local beta commit  |
-      |        | origin        | origin beta commit |
-      | gamma  | local, origin | gamma commit       |
     When I run "git-town skip"
     Then Git Town runs the commands
       | BRANCH | COMMAND           |
@@ -73,10 +59,3 @@ Feature: multiple conflicting branches
       |        | git checkout main |
       | main   | git push --tags   |
     And no merge is in progress
-    And these commits exist now
-      | BRANCH | LOCATION      | MESSAGE            |
-      | main   | local, origin | main commit        |
-      | alpha  | local, origin | alpha commit       |
-      | beta   | local         | local beta commit  |
-      |        | origin        | origin beta commit |
-      | gamma  | local, origin | gamma commit       |

--- a/internal/skip/execute.go
+++ b/internal/skip/execute.go
@@ -34,6 +34,7 @@ func Execute(args ExecuteArgs) error {
 		Git:           args.Git,
 		Prog:          args.RunState.AbortProgram,
 	})
+	args.RunState.AbortProgram = program.Program{}
 	err := revertChangesToCurrentBranch(args)
 	if err != nil {
 		return err

--- a/internal/skip/execute.go
+++ b/internal/skip/execute.go
@@ -38,7 +38,7 @@ func Execute(args ExecuteArgs) error {
 	if err != nil {
 		return err
 	}
-	args.RunState.RunProgram = removeOpcodesForCurrentBranch(args.RunState.RunProgram)
+	args.RunState.RunProgram = RemoveOpcodesForCurrentBranch(args.RunState.RunProgram)
 	return fullInterpreter.Execute(fullInterpreter.ExecuteArgs{
 		Backend:                 args.Backend,
 		CommandsCounter:         args.CommandsCounter,
@@ -78,11 +78,11 @@ type ExecuteArgs struct {
 }
 
 // removes the remaining opcodes for the current branch from the given program
-func removeOpcodesForCurrentBranch(prog program.Program) program.Program {
+func RemoveOpcodesForCurrentBranch(prog program.Program) program.Program {
 	result := make(program.Program, 0, len(prog)-1)
 	skipping := true
 	for _, opcode := range prog {
-		if shared.IsEndOfBranchProgramOpcode(opcode) {
+		if shared.IsEndOfBranchProgramOpcode(opcode) && skipping {
 			skipping = false
 			continue
 		}

--- a/internal/skip/execute_test.go
+++ b/internal/skip/execute_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestRemoveOpcodesForCurrentBranch(t *testing.T) {
 	t.Parallel()
+
 	t.Run("program contains multiple branches", func(t *testing.T) {
 		t.Parallel()
 		give := program.Program{
@@ -35,6 +36,7 @@ func TestRemoveOpcodesForCurrentBranch(t *testing.T) {
 		}
 		must.Eq(t, want.String(), have.String())
 	})
+
 	t.Run("program contains no end of branch markers", func(t *testing.T) {
 		t.Parallel()
 		give := program.Program{

--- a/internal/skip/execute_test.go
+++ b/internal/skip/execute_test.go
@@ -35,4 +35,18 @@ func TestRemoveOpcodesForCurrentBranch(t *testing.T) {
 		}
 		must.Eq(t, want.String(), have.String())
 	})
+	t.Run("program contains no end of branch markers", func(t *testing.T) {
+		t.Parallel()
+		give := program.Program{
+			&opcodes.Checkout{Branch: "branch-1"},
+			&opcodes.PullCurrentBranch{},
+			&opcodes.Checkout{Branch: "branch-2"},
+			&opcodes.PullCurrentBranch{},
+			&opcodes.Checkout{Branch: "branch-3"},
+			&opcodes.PullCurrentBranch{},
+		}
+		have := skip.RemoveOpcodesForCurrentBranch(give)
+		want := program.Program{}
+		must.Eq(t, want.String(), have.String())
+	})
 }

--- a/internal/skip/execute_test.go
+++ b/internal/skip/execute_test.go
@@ -1,0 +1,38 @@
+package skip_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v20/internal/skip"
+	"github.com/git-town/git-town/v20/internal/vm/opcodes"
+	"github.com/git-town/git-town/v20/internal/vm/program"
+	"github.com/shoenig/test/must"
+)
+
+func TestRemoveOpcodesForCurrentBranch(t *testing.T) {
+	t.Parallel()
+	t.Run("program contains multiple branches", func(t *testing.T) {
+		t.Parallel()
+		give := program.Program{
+			&opcodes.Checkout{Branch: "branch-1"},
+			&opcodes.PullCurrentBranch{},
+			&opcodes.ProgramEndOfBranch{},
+			&opcodes.Checkout{Branch: "branch-2"},
+			&opcodes.PullCurrentBranch{},
+			&opcodes.ProgramEndOfBranch{},
+			&opcodes.Checkout{Branch: "branch-3"},
+			&opcodes.PullCurrentBranch{},
+			&opcodes.ProgramEndOfBranch{},
+		}
+		have := skip.RemoveOpcodesForCurrentBranch(give)
+		want := program.Program{
+			&opcodes.Checkout{Branch: "branch-2"},
+			&opcodes.PullCurrentBranch{},
+			&opcodes.ProgramEndOfBranch{},
+			&opcodes.Checkout{Branch: "branch-3"},
+			&opcodes.PullCurrentBranch{},
+			&opcodes.ProgramEndOfBranch{},
+		}
+		must.Eq(t, want.String(), have.String())
+	})
+}


### PR DESCRIPTION
This PR fixes a bug in the routine that skips branches, which was causing all "end of branch" markers to be removed.