### PR TITLE
Update documentation to reflect Arch Linux packages

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -101,5 +101,5 @@ on a Windows machine using PowerShell.
   [core formulae](https://formulae.brew.sh/formula/git-town)
 - Scoop: Git Town is in the auto-updating
   [core manifests](https://github.com/ScoopInstaller/Main/blob/master/bucket/git-town.json)
-- Arch Linux: the [AUR package](https://aur.archlinux.org/packages/git-town)
-  auto-updates
+- Arch Linux: [official packaging](https://archlinux.org/packages/extra/x86_64/git-town/)
+  uses nvchecker to alert maintainers about updates

--- a/website/src/install.md
+++ b/website/src/install.md
@@ -55,12 +55,10 @@ matching your CPU architecture and run
 rpm -i git-town_linux_intel_64.rpm
 ```
 
-On Arch Linux, install the
-[git-town](https://aur.archlinux.org/packages/git-town) package from the AUR. Or
-download the matching `.pkg.tar.zst` file for your architecture and run:
+On Arch Linux, install the [git-town](https://archlinux.org/packages/extra/x86_64/git-town/) package from official package repositories:
 
 ```
-sudo pacman -U <filename>
+pacman -S git-town
 ```
 
 You can also install Git Town on Linux via


### PR DESCRIPTION
I moved git-town from the AUR to official Arch Linux repositories, so the install instructions should reflect that.