### PR TITLE
netlify: remove mise

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
   base = "website/"
   publish = "book/html"
-  command = "make build"
+  command = "sudo apt remove mise && make build"
   ignore = "/bin/false"


### PR DESCRIPTION
The docker image used by Netlify suddenly tries to execute `mise` because it finds a `.tool-versions` file. This PR is trying to disable this behavior since our file isn't compatible with mise.