### PR TITLE
Move netlify configuration into the website folder

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,0 @@
-[build]
-  base = "website/"
-  publish = "book/html"
-  command = "sudo apt remove mise && make build"
-  ignore = "/bin/false"

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+#  base = "website/"
+  publish = "book/html"
+  command = "make build"
+  ignore = "/bin/false"


### PR DESCRIPTION
Netlify is trying to be too smart for its own good. This PR moves all website related files into the `website` folder, and tells Netlify to only look there. Hopefully this avoids the false errors around mise that the current build produces.