### PR TITLE
Consistently name abort variable exit

### DIFF
--- a/internal/cli/dialog/aliases.go
+++ b/internal/cli/dialog/aliases.go
@@ -28,7 +28,7 @@ If you're unsure, it's safe to enable all of them - you can always adjust later.
 
 // Aliases lets the user select which Git Town commands should have shorter aliases.
 // This includes asking the user and updating the respective settings based on the user selection.
-func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliases configdomain.Aliases, inputs components.TestInput) (configdomain.Aliases, dialogdomain.Aborted, error) {
+func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliases configdomain.Aliases, inputs components.TestInput) (configdomain.Aliases, dialogdomain.Exit, error) {
 	program := tea.NewProgram(AliasesModel{
 		AllAliasableCommands: allAliasableCommands,
 		CurrentSelections:    NewAliasSelections(allAliasableCommands, existingAliases),

--- a/internal/cli/dialog/bitbucket_app_password.go
+++ b/internal/cli/dialog/bitbucket_app_password.go
@@ -24,7 +24,7 @@ If you leave this empty, Git Town will not use the Bitbucket API.
 )
 
 // BitbucketAppPassword lets the user enter the Bitbucket API token.
-func BitbucketAppPassword(oldValue Option[configdomain.BitbucketAppPassword], inputs components.TestInput) (Option[configdomain.BitbucketAppPassword], dialogdomain.Aborted, error) {
+func BitbucketAppPassword(oldValue Option[configdomain.BitbucketAppPassword], inputs components.TestInput) (Option[configdomain.BitbucketAppPassword], dialogdomain.Exit, error) {
 	text, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          bitbucketAppPasswordHelp,

--- a/internal/cli/dialog/bitbucket_username.go
+++ b/internal/cli/dialog/bitbucket_username.go
@@ -21,7 +21,7 @@ If you leave this empty, Git Town will not use the Bitbucket API.
 `
 )
 
-func BitbucketUsername(oldValue Option[configdomain.BitbucketUsername], inputs components.TestInput) (Option[configdomain.BitbucketUsername], dialogdomain.Aborted, error) {
+func BitbucketUsername(oldValue Option[configdomain.BitbucketUsername], inputs components.TestInput) (Option[configdomain.BitbucketUsername], dialogdomain.Exit, error) {
 	text, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          bitbucketUsernameHelp,

--- a/internal/cli/dialog/codeberg_token.go
+++ b/internal/cli/dialog/codeberg_token.go
@@ -23,7 +23,7 @@ If you leave this empty, Git Town will not use the codeberg API.
 )
 
 // CodebergToken lets the user enter the Gitea API token.
-func CodebergToken(oldValue Option[configdomain.CodebergToken], inputs components.TestInput) (Option[configdomain.CodebergToken], dialogdomain.Aborted, error) {
+func CodebergToken(oldValue Option[configdomain.CodebergToken], inputs components.TestInput) (Option[configdomain.CodebergToken], dialogdomain.Exit, error) {
 	text, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          codebergTokenHelp,

--- a/internal/cli/dialog/commits_to_beam.go
+++ b/internal/cli/dialog/commits_to_beam.go
@@ -14,7 +14,7 @@ import (
 const commitsToBeamTitle = `Select the commits to beam into branch %q`
 
 // lets the user select commits to beam to the target branch
-func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranchName, git git.Commands, querier gitdomain.Querier, inputs components.TestInput) (gitdomain.Commits, dialogdomain.Aborted, error) {
+func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranchName, git git.Commands, querier gitdomain.Querier, inputs components.TestInput) (gitdomain.Commits, dialogdomain.Exit, error) {
 	if len(commits) == 0 {
 		return gitdomain.Commits{}, false, nil
 	}

--- a/internal/cli/dialog/components/checklist.go
+++ b/internal/cli/dialog/components/checklist.go
@@ -11,7 +11,7 @@ import (
 )
 
 // lets the user select zero, one, or many of the given entries
-func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInput) (selected []S, aborted dialogdomain.Aborted, err error) {
+func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInput) (selected []S, exit dialogdomain.Exit, err error) {
 	program := tea.NewProgram(CheckListModel[S]{
 		List:       list.NewList(entries, 0),
 		Selections: selections,

--- a/internal/cli/dialog/components/colors.go
+++ b/internal/cli/dialog/components/colors.go
@@ -6,8 +6,8 @@ import (
 )
 
 // FormattedToken provides the given API token in a printable format.
-func FormattedSecret(secret string, aborted dialogdomain.Aborted) string {
-	if aborted {
+func FormattedSecret(secret string, exit dialogdomain.Exit) string {
+	if exit {
 		return colors.Red().Styled("(aborted)")
 	}
 	if secret == "" {
@@ -17,16 +17,16 @@ func FormattedSecret(secret string, aborted dialogdomain.Aborted) string {
 }
 
 // FormattedSelection provides the given dialog choice in a printable format.
-func FormattedSelection(selection string, aborted dialogdomain.Aborted) string {
-	if aborted {
+func FormattedSelection(selection string, exit dialogdomain.Exit) string {
+	if exit {
 		return colors.Red().Styled("(aborted)")
 	}
 	return colors.Green().Styled(selection)
 }
 
 // FormattedToken provides the given API token in a printable format.
-func FormattedToken(token string, aborted dialogdomain.Aborted) string {
-	if aborted {
+func FormattedToken(token string, exit dialogdomain.Exit) string {
+	if exit {
 		return colors.Red().Styled("(aborted)")
 	}
 	if token == "" {

--- a/internal/cli/dialog/components/list/list.go
+++ b/internal/cli/dialog/components/list/list.go
@@ -34,8 +34,8 @@ func NewList[S comparable](entries Entries[S], cursor int) List[S] {
 	}
 }
 
-// Aborted indicates whether the user has Aborted this components.
-func (self *List[S]) Aborted() dialogdomain.Aborted {
+// Aborted indicates whether the user has chosen to abort this component.
+func (self *List[S]) Aborted() dialogdomain.Exit {
 	return self.Status == StatusAborted
 }
 

--- a/internal/cli/dialog/components/radiolist.go
+++ b/internal/cli/dialog/components/radiolist.go
@@ -13,7 +13,7 @@ import (
 const WindowSize = 9
 
 // RadioList lets the user select one of the given entries.
-func RadioList[S comparable](entries list.Entries[S], cursor int, title, help string, inputs TestInput) (selected S, aborted dialogdomain.Aborted, err error) { //nolint:ireturn
+func RadioList[S comparable](entries list.Entries[S], cursor int, title, help string, inputs TestInput) (selected S, exit dialogdomain.Exit, err error) { //nolint:ireturn
 	program := tea.NewProgram(radioListModel[S]{
 		List:  list.NewList(entries, cursor),
 		help:  help,

--- a/internal/cli/dialog/components/text_display.go
+++ b/internal/cli/dialog/components/text_display.go
@@ -9,7 +9,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
 )
 
-func TextDisplay(title, text string, inputs TestInput) (dialogdomain.Aborted, error) {
+func TextDisplay(title, text string, inputs TestInput) (dialogdomain.Exit, error) {
 	model := textDisplayModel{
 		colors: colors.NewDialogColors(),
 		status: list.StatusActive,

--- a/internal/cli/dialog/components/text_field.go
+++ b/internal/cli/dialog/components/text_field.go
@@ -10,7 +10,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
 )
 
-func TextField(args TextFieldArgs) (string, dialogdomain.Aborted, error) {
+func TextField(args TextFieldArgs) (string, dialogdomain.Exit, error) {
 	textInput := textinput.New()
 	textInput.SetValue(args.ExistingValue)
 	textInput.Prompt = args.Prompt

--- a/internal/cli/dialog/config_storage.go
+++ b/internal/cli/dialog/config_storage.go
@@ -32,7 +32,7 @@ const (
 	ConfigStorageOptionGit  ConfigStorageOption = `Git metadata`
 )
 
-func ConfigStorage(inputs components.TestInput) (ConfigStorageOption, dialogdomain.Aborted, error) {
+func ConfigStorage(inputs components.TestInput) (ConfigStorageOption, dialogdomain.Exit, error) {
 	entries := list.NewEntries(
 		ConfigStorageOptionFile,
 		ConfigStorageOptionGit,

--- a/internal/cli/dialog/dev_remote.go
+++ b/internal/cli/dialog/dev_remote.go
@@ -21,7 +21,7 @@ Typically that's the "origin" remote.
 `
 )
 
-func DevRemote(existingValue gitdomain.Remote, options gitdomain.Remotes, inputs components.TestInput) (gitdomain.Remote, dialogdomain.Aborted, error) {
+func DevRemote(existingValue gitdomain.Remote, options gitdomain.Remotes, inputs components.TestInput) (gitdomain.Remote, dialogdomain.Exit, error) {
 	cursor := slice.Index(options, existingValue).GetOrElse(0)
 	selection, aborted, err := components.RadioList(list.NewEntries(options...), cursor, DevRemoteTypeTitle, DevRemoteHelp, inputs)
 	fmt.Printf(messages.DevRemote, components.FormattedSelection(selection.String(), aborted))

--- a/internal/cli/dialog/dialogdomain/aborted.go
+++ b/internal/cli/dialog/dialogdomain/aborted.go
@@ -1,6 +1,0 @@
-package dialogdomain
-
-// Aborted indicates that the user has aborted a dialog
-// and wishes to abort the entire Git Town command
-// that displayed the dialog.
-type Aborted bool

--- a/internal/cli/dialog/dialogdomain/exit.go
+++ b/internal/cli/dialog/dialogdomain/exit.go
@@ -1,0 +1,6 @@
+package dialogdomain
+
+// Exit indicates that the user has aborted a dialog
+// and wishes to exit the entire Git Town command
+// that displayed the dialog.
+type Exit bool

--- a/internal/cli/dialog/feature_regex.go
+++ b/internal/cli/dialog/feature_regex.go
@@ -20,7 +20,7 @@ is set to something other than "feature".
 `
 )
 
-func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs components.TestInput) (Option[configdomain.FeatureRegex], dialogdomain.Aborted, error) {
+func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs components.TestInput) (Option[configdomain.FeatureRegex], dialogdomain.Exit, error) {
 	value, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: existingValue.String(),
 		Help:          FeatureRegexHelp,

--- a/internal/cli/dialog/forge_type.go
+++ b/internal/cli/dialog/forge_type.go
@@ -22,7 +22,7 @@ Only change this if your forge is hosted at a custom URL.
 `
 )
 
-func ForgeType(existingValue Option[forgedomain.ForgeType], inputs components.TestInput) (Option[forgedomain.ForgeType], dialogdomain.Aborted, error) {
+func ForgeType(existingValue Option[forgedomain.ForgeType], inputs components.TestInput) (Option[forgedomain.ForgeType], dialogdomain.Exit, error) {
 	entries := list.Entries[Option[forgedomain.ForgeType]]{
 		{
 			Data: None[forgedomain.ForgeType](),

--- a/internal/cli/dialog/gitea_token.go
+++ b/internal/cli/dialog/gitea_token.go
@@ -23,7 +23,7 @@ If you leave this empty, Git Town will not use the gitea API.
 )
 
 // GiteaToken lets the user enter the Gitea API token.
-func GiteaToken(oldValue Option[configdomain.GiteaToken], inputs components.TestInput) (Option[configdomain.GiteaToken], dialogdomain.Aborted, error) {
+func GiteaToken(oldValue Option[configdomain.GiteaToken], inputs components.TestInput) (Option[configdomain.GiteaToken], dialogdomain.Exit, error) {
 	text, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          giteaTokenHelp,

--- a/internal/cli/dialog/github_token.go
+++ b/internal/cli/dialog/github_token.go
@@ -27,7 +27,7 @@ Git Town will not interact with the GitHub API.
 )
 
 // GitHubToken lets the user enter the GitHub API token.
-func GitHubToken(oldValue Option[configdomain.GitHubToken], inputs components.TestInput) (Option[configdomain.GitHubToken], dialogdomain.Aborted, error) {
+func GitHubToken(oldValue Option[configdomain.GitHubToken], inputs components.TestInput) (Option[configdomain.GitHubToken], dialogdomain.Exit, error) {
 	text, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          gitHubTokenHelp,

--- a/internal/cli/dialog/gitlab_token.go
+++ b/internal/cli/dialog/gitlab_token.go
@@ -23,7 +23,7 @@ If you leave this empty, Git Town will not use the GitLab API.
 )
 
 // GitLabToken lets the user enter the GitHub API token.
-func GitLabToken(oldValue Option[configdomain.GitLabToken], inputs components.TestInput) (Option[configdomain.GitLabToken], dialogdomain.Aborted, error) {
+func GitLabToken(oldValue Option[configdomain.GitLabToken], inputs components.TestInput) (Option[configdomain.GitLabToken], dialogdomain.Exit, error) {
 	text, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          gitLabTokenHelp,

--- a/internal/cli/dialog/lineage.go
+++ b/internal/cli/dialog/lineage.go
@@ -14,7 +14,7 @@ import (
 // Lineage validates that the given lineage contains the ancestry for all given branches.
 // Prompts missing lineage information from the user.
 // Returns the new lineage and perennial branches to add to the config storage.
-func Lineage(args LineageArgs) (additionalLineage configdomain.Lineage, additionalPerennials gitdomain.LocalBranchNames, aborted dialogdomain.Aborted, err error) {
+func Lineage(args LineageArgs) (additionalLineage configdomain.Lineage, additionalPerennials gitdomain.LocalBranchNames, exit dialogdomain.Exit, err error) {
 	additionalLineage = configdomain.NewLineage()
 	branchesToVerify := args.BranchesToVerify
 	for i := 0; i < len(branchesToVerify); i++ {

--- a/internal/cli/dialog/main_and_perennial.go
+++ b/internal/cli/dialog/main_and_perennial.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
-func MainAndPerennials(args MainAndPerennialsArgs) (mainBranch gitdomain.LocalBranchName, perennials gitdomain.LocalBranchNames, aborted dialogdomain.Aborted, err error) {
+func MainAndPerennials(args MainAndPerennialsArgs) (mainBranch gitdomain.LocalBranchName, perennials gitdomain.LocalBranchNames, exit dialogdomain.Exit, err error) {
 	unvalidatedMain, hasMain := args.UnvalidatedMain.Get()
 	if hasMain {
 		return unvalidatedMain, args.UnvalidatedPerennials, false, nil
@@ -20,12 +20,12 @@ func MainAndPerennials(args MainAndPerennialsArgs) (mainBranch gitdomain.LocalBr
 		return unvalidatedMain, args.UnvalidatedPerennials, false, errors.New(messages.ConfigMainbranchInConfigFile)
 	}
 	fmt.Print(messages.ConfigNeeded)
-	mainBranch, aborted, err = MainBranch(args.LocalBranches, args.GetDefaultBranch(args.Backend), args.DialogInputs.Next())
-	if err != nil || aborted {
-		return mainBranch, args.UnvalidatedPerennials, aborted, err
+	mainBranch, exit, err = MainBranch(args.LocalBranches, args.GetDefaultBranch(args.Backend), args.DialogInputs.Next())
+	if err != nil || exit {
+		return mainBranch, args.UnvalidatedPerennials, exit, err
 	}
-	perennials, aborted, err = PerennialBranches(args.LocalBranches, args.UnvalidatedPerennials, mainBranch, args.DialogInputs.Next())
-	return mainBranch, perennials, aborted, err
+	perennials, exit, err = PerennialBranches(args.LocalBranches, args.UnvalidatedPerennials, mainBranch, args.DialogInputs.Next())
+	return mainBranch, perennials, exit, err
 }
 
 type MainAndPerennialsArgs struct {

--- a/internal/cli/dialog/main_branch.go
+++ b/internal/cli/dialog/main_branch.go
@@ -26,7 +26,7 @@ This is typically the branch called
 )
 
 // MainBranch lets the user select a new main branch for this repo.
-func MainBranch(localBranches gitdomain.LocalBranchNames, defaultEntryOpt Option[gitdomain.LocalBranchName], inputs components.TestInput) (gitdomain.LocalBranchName, dialogdomain.Aborted, error) {
+func MainBranch(localBranches gitdomain.LocalBranchNames, defaultEntryOpt Option[gitdomain.LocalBranchName], inputs components.TestInput) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
 	cursor := 0
 	if defaultEntry, hasDefaultEntry := defaultEntryOpt.Get(); hasDefaultEntry {
 		cursor = slice.Index(localBranches, defaultEntry).GetOrElse(0)

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -22,7 +22,7 @@ More details: https://www.git-town.com/preferences/new-branch-type.
 `
 )
 
-func NewBranchType(existingOpt Option[configdomain.BranchType], inputs components.TestInput) (Option[configdomain.BranchType], dialogdomain.Aborted, error) {
+func NewBranchType(existingOpt Option[configdomain.BranchType], inputs components.TestInput) (Option[configdomain.BranchType], dialogdomain.Exit, error) {
 	entries := list.Entries[Option[configdomain.BranchType]]{
 		{
 			Data: Some(configdomain.BranchTypeFeatureBranch),
@@ -47,10 +47,10 @@ func NewBranchType(existingOpt Option[configdomain.BranchType], inputs component
 			defaultPos = e
 		}
 	}
-	selection, aborted, err := components.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs)
-	if err != nil || aborted {
-		return None[configdomain.BranchType](), aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs)
+	if err != nil || exit {
+		return None[configdomain.BranchType](), exit, err
 	}
-	fmt.Println(messages.CreatePrototypeBranches, components.FormattedSelection(selection.String(), aborted))
-	return selection, aborted, err
+	fmt.Println(messages.CreatePrototypeBranches, components.FormattedSelection(selection.String(), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/origin_hostname.go
+++ b/internal/cli/dialog/origin_hostname.go
@@ -21,7 +21,7 @@ Only update this if Git Town's auto-detection doesn't work.
 `
 )
 
-func OriginHostname(oldValue Option[configdomain.HostingOriginHostname], inputs components.TestInput) (Option[configdomain.HostingOriginHostname], dialogdomain.Aborted, error) {
+func OriginHostname(oldValue Option[configdomain.HostingOriginHostname], inputs components.TestInput) (Option[configdomain.HostingOriginHostname], dialogdomain.Exit, error) {
 	token, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          OriginHostnameHelp,

--- a/internal/cli/dialog/parent.go
+++ b/internal/cli/dialog/parent.go
@@ -29,9 +29,9 @@ func Parent(args ParentArgs) (ParentOutcome, gitdomain.LocalBranchName, error) {
 	cursor := slice.Index(parentCandidates, args.DefaultChoice).GetOrElse(0)
 	title := fmt.Sprintf(parentBranchTitleTemplate, args.Branch)
 	help := fmt.Sprintf(parentBranchHelpTemplate, args.Branch, args.MainBranch)
-	selection, aborted, err := components.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.DialogTestInput)
-	fmt.Printf(messages.ParentDialogSelected, args.Branch, components.FormattedSelection(selection.String(), aborted))
-	if aborted {
+	selection, exit, err := components.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.DialogTestInput)
+	fmt.Printf(messages.ParentDialogSelected, args.Branch, components.FormattedSelection(selection.String(), exit))
+	if exit {
 		return ParentOutcomeAborted, selection, err
 	}
 	if selection == PerennialBranchOption {

--- a/internal/cli/dialog/perennial_branches.go
+++ b/internal/cli/dialog/perennial_branches.go
@@ -28,7 +28,7 @@ to match branch names dynamically.
 
 // PerennialBranches lets the user update the perennial branches.
 // This includes asking the user and updating the respective settings based on the user selection.
-func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBranches gitdomain.LocalBranchNames, mainBranch gitdomain.LocalBranchName, inputs components.TestInput) (gitdomain.LocalBranchNames, dialogdomain.Aborted, error) {
+func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBranches gitdomain.LocalBranchNames, mainBranch gitdomain.LocalBranchName, inputs components.TestInput) (gitdomain.LocalBranchNames, dialogdomain.Exit, error) {
 	perennialCandidates := localBranches.Remove(mainBranch).AppendAllMissing(oldPerennialBranches...)
 	if len(perennialCandidates) == 0 {
 		return gitdomain.LocalBranchNames{}, false, nil

--- a/internal/cli/dialog/perennial_regex.go
+++ b/internal/cli/dialog/perennial_regex.go
@@ -24,7 +24,7 @@ it's safe to leave it blank.
 `
 )
 
-func PerennialRegex(oldValue Option[configdomain.PerennialRegex], inputs components.TestInput) (Option[configdomain.PerennialRegex], dialogdomain.Aborted, error) {
+func PerennialRegex(oldValue Option[configdomain.PerennialRegex], inputs components.TestInput) (Option[configdomain.PerennialRegex], dialogdomain.Exit, error) {
 	value, aborted, err := components.TextField(components.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          PerennialRegexHelp,

--- a/internal/cli/dialog/push_hook.go
+++ b/internal/cli/dialog/push_hook.go
@@ -27,7 +27,7 @@ More details: https://www.git-town.com/preferences/push-hook.
 `
 )
 
-func PushHook(existing configdomain.PushHook, inputs components.TestInput) (configdomain.PushHook, dialogdomain.Aborted, error) {
+func PushHook(existing configdomain.PushHook, inputs components.TestInput) (configdomain.PushHook, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.PushHook]{
 		{
 			Data: true,
@@ -39,10 +39,10 @@ func PushHook(existing configdomain.PushHook, inputs components.TestInput) (conf
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, pushHookTitle, PushHookHelp, inputs)
-	if err != nil || aborted {
-		return true, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, pushHookTitle, PushHookHelp, inputs)
+	if err != nil || exit {
+		return true, exit, err
 	}
-	fmt.Printf(messages.PushHook, components.FormattedSelection(format.Bool(selection.IsTrue()), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.PushHook, components.FormattedSelection(format.Bool(selection.IsTrue()), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/select_squash_commit_author.go
+++ b/internal/cli/dialog/select_squash_commit_author.go
@@ -13,7 +13,7 @@ import (
 const squashCommitAuthorTitle = `Squash commit author`
 
 // SelectSquashCommitAuthor allows the user to select an author amongst a given list of authors.
-func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []gitdomain.Author, dialogTestInputs components.TestInput) (gitdomain.Author, dialogdomain.Aborted, error) {
+func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []gitdomain.Author, dialogTestInputs components.TestInput) (gitdomain.Author, dialogdomain.Exit, error) {
 	if len(authors) == 1 {
 		return authors[0], false, nil
 	}

--- a/internal/cli/dialog/share_new_branches.go
+++ b/internal/cli/dialog/share_new_branches.go
@@ -24,7 +24,7 @@ Possible options:
 `
 )
 
-func ShareNewBranches(existing configdomain.ShareNewBranches, inputs components.TestInput) (configdomain.ShareNewBranches, dialogdomain.Aborted, error) {
+func ShareNewBranches(existing configdomain.ShareNewBranches, inputs components.TestInput) (configdomain.ShareNewBranches, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.ShareNewBranches]{
 		{
 			Data: configdomain.ShareNewBranchesNone,
@@ -40,10 +40,10 @@ func ShareNewBranches(existing configdomain.ShareNewBranches, inputs components.
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, shareNewBranchesTitle, ShareNewBranchesHelp, inputs)
-	if err != nil || aborted {
-		return configdomain.ShareNewBranchesNone, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, shareNewBranchesTitle, ShareNewBranchesHelp, inputs)
+	if err != nil || exit {
+		return configdomain.ShareNewBranchesNone, exit, err
 	}
-	fmt.Printf(messages.ShareNewBranches, components.FormattedSelection(selection.String(), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.ShareNewBranches, components.FormattedSelection(selection.String(), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/ship_delete_tracking_branch.go
+++ b/internal/cli/dialog/ship_delete_tracking_branch.go
@@ -22,7 +22,7 @@ automatically deletes branches when pull requests are merged through its UI.
 `
 )
 
-func ShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, inputs components.TestInput) (configdomain.ShipDeleteTrackingBranch, dialogdomain.Aborted, error) {
+func ShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, inputs components.TestInput) (configdomain.ShipDeleteTrackingBranch, dialogdomain.Exit, error) {
 	entries := list.Entries[bool]{
 		{
 			Data: true,
@@ -39,10 +39,10 @@ func ShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, in
 	} else {
 		defaultPos = 1
 	}
-	selection, aborted, err := components.RadioList(entries, defaultPos, shipDeleteTrackingBranchTitle, ShipDeleteTrackingBranchHelp, inputs)
-	if err != nil || aborted {
-		return true, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, shipDeleteTrackingBranchTitle, ShipDeleteTrackingBranchHelp, inputs)
+	if err != nil || exit {
+		return true, exit, err
 	}
-	fmt.Printf(messages.ShipDeletesTrackingBranches, components.FormattedSelection(format.Bool(selection), aborted))
-	return configdomain.ShipDeleteTrackingBranch(selection), aborted, err
+	fmt.Printf(messages.ShipDeletesTrackingBranches, components.FormattedSelection(format.Bool(selection), exit))
+	return configdomain.ShipDeleteTrackingBranch(selection), exit, err
 }

--- a/internal/cli/dialog/ship_strategy.go
+++ b/internal/cli/dialog/ship_strategy.go
@@ -27,7 +27,7 @@ Options:
 `
 )
 
-func ShipStrategy(existing configdomain.ShipStrategy, inputs components.TestInput) (configdomain.ShipStrategy, dialogdomain.Aborted, error) {
+func ShipStrategy(existing configdomain.ShipStrategy, inputs components.TestInput) (configdomain.ShipStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.ShipStrategy]{
 		{
 			Data: configdomain.ShipStrategyAPI,
@@ -47,12 +47,12 @@ func ShipStrategy(existing configdomain.ShipStrategy, inputs components.TestInpu
 		},
 	}
 	defaultPos := shipStrategyEntryIndex(entries, existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, shipStrategyTitle, ShipStrategyHelp, inputs)
-	if err != nil || aborted {
-		return configdomain.ShipStrategyAPI, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, shipStrategyTitle, ShipStrategyHelp, inputs)
+	if err != nil || exit {
+		return configdomain.ShipStrategyAPI, exit, err
 	}
-	fmt.Printf(messages.ShipDeletesTrackingBranches, components.FormattedSelection(selection.String(), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.ShipDeletesTrackingBranches, components.FormattedSelection(selection.String(), exit))
+	return selection, exit, err
 }
 
 func shipStrategyEntryIndex(entries list.Entries[configdomain.ShipStrategy], needle configdomain.ShipStrategy) int {

--- a/internal/cli/dialog/switch_branch.go
+++ b/internal/cli/dialog/switch_branch.go
@@ -167,7 +167,7 @@ func ShouldDisplayBranchType(branchType configdomain.BranchType) bool {
 	panic("unhandled branch type:" + branchType.String())
 }
 
-func SwitchBranch(entries []SwitchBranchEntry, cursor int, uncommittedChanges bool, displayTypes configdomain.DisplayTypes, inputs components.TestInput) (gitdomain.LocalBranchName, dialogdomain.Aborted, error) {
+func SwitchBranch(entries []SwitchBranchEntry, cursor int, uncommittedChanges bool, displayTypes configdomain.DisplayTypes, inputs components.TestInput) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
 	dialogProgram := tea.NewProgram(SwitchModel{
 		DisplayBranchTypes: displayTypes,
 		InitialBranchPos:   cursor,

--- a/internal/cli/dialog/sync_feature_strategy.go
+++ b/internal/cli/dialog/sync_feature_strategy.go
@@ -22,7 +22,7 @@ Commonly used for developing new features and bug fixes.
 `
 )
 
-func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs components.TestInput) (configdomain.SyncFeatureStrategy, dialogdomain.Aborted, error) {
+func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs components.TestInput) (configdomain.SyncFeatureStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncFeatureStrategy]{
 		{
 			Data: configdomain.SyncFeatureStrategyMerge,
@@ -38,10 +38,10 @@ func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs compo
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs)
-	if err != nil || aborted {
-		return configdomain.SyncFeatureStrategyMerge, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs)
+	if err != nil || exit {
+		return configdomain.SyncFeatureStrategyMerge, exit, err
 	}
-	fmt.Printf(messages.SyncFeatureBranches, components.FormattedSelection(selection.String(), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.SyncFeatureBranches, components.FormattedSelection(selection.String(), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_perennial_strategy.go
+++ b/internal/cli/dialog/sync_perennial_strategy.go
@@ -21,7 +21,7 @@ via new commits pushed to their tracking branch from elsewhere.
 `
 )
 
-func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs components.TestInput) (configdomain.SyncPerennialStrategy, dialogdomain.Aborted, error) {
+func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs components.TestInput) (configdomain.SyncPerennialStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncPerennialStrategy]{
 		{
 			Data: configdomain.SyncPerennialStrategyFFOnly,
@@ -33,10 +33,10 @@ func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs c
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs)
-	if err != nil || aborted {
-		return configdomain.SyncPerennialStrategyRebase, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs)
+	if err != nil || exit {
+		return configdomain.SyncPerennialStrategyRebase, exit, err
 	}
-	fmt.Printf(messages.SyncPerennialBranches, components.FormattedSelection(selection.String(), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.SyncPerennialBranches, components.FormattedSelection(selection.String(), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_prototype_strategy.go
+++ b/internal/cli/dialog/sync_prototype_strategy.go
@@ -22,7 +22,7 @@ and limiting the sharing of confidential changes.
 `
 )
 
-func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs components.TestInput) (configdomain.SyncPrototypeStrategy, dialogdomain.Aborted, error) {
+func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs components.TestInput) (configdomain.SyncPrototypeStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncPrototypeStrategy]{
 		{
 			Data: configdomain.SyncPrototypeStrategyMerge,
@@ -38,10 +38,10 @@ func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs c
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs)
-	if err != nil || aborted {
-		return configdomain.SyncPrototypeStrategyMerge, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs)
+	if err != nil || exit {
+		return configdomain.SyncPrototypeStrategyMerge, exit, err
 	}
-	fmt.Printf(messages.SyncPrototypeBranches, components.FormattedSelection(selection.String(), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.SyncPrototypeBranches, components.FormattedSelection(selection.String(), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_tags.go
+++ b/internal/cli/dialog/sync_tags.go
@@ -19,7 +19,7 @@ Should "git town sync" sync Git tags with origin?
 `
 )
 
-func SyncTags(existing configdomain.SyncTags, inputs components.TestInput) (configdomain.SyncTags, dialogdomain.Aborted, error) {
+func SyncTags(existing configdomain.SyncTags, inputs components.TestInput) (configdomain.SyncTags, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncTags]{
 		{
 			Data: true,
@@ -31,10 +31,10 @@ func SyncTags(existing configdomain.SyncTags, inputs components.TestInput) (conf
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, syncTagsTitle, SyncTagsHelp, inputs)
-	if err != nil || aborted {
-		return true, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, syncTagsTitle, SyncTagsHelp, inputs)
+	if err != nil || exit {
+		return true, exit, err
 	}
-	fmt.Printf(messages.SyncTags, components.FormattedSelection(format.Bool(selection.IsTrue()), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.SyncTags, components.FormattedSelection(format.Bool(selection.IsTrue()), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_upstream.go
+++ b/internal/cli/dialog/sync_upstream.go
@@ -26,7 +26,7 @@ with changes made to the original project.
 `
 )
 
-func SyncUpstream(existing configdomain.SyncUpstream, inputs components.TestInput) (configdomain.SyncUpstream, dialogdomain.Aborted, error) {
+func SyncUpstream(existing configdomain.SyncUpstream, inputs components.TestInput) (configdomain.SyncUpstream, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncUpstream]{
 		{
 			Data: true,
@@ -38,10 +38,10 @@ func SyncUpstream(existing configdomain.SyncUpstream, inputs components.TestInpu
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, aborted, err := components.RadioList(entries, defaultPos, syncUpstreamTitle, SyncUpstreamHelp, inputs)
-	if err != nil || aborted {
-		return true, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, syncUpstreamTitle, SyncUpstreamHelp, inputs)
+	if err != nil || exit {
+		return true, exit, err
 	}
-	fmt.Printf(messages.SyncWithUpstream, components.FormattedSelection(format.Bool(selection.IsTrue()), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.SyncWithUpstream, components.FormattedSelection(format.Bool(selection.IsTrue()), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/token_scope.go
+++ b/internal/cli/dialog/token_scope.go
@@ -20,7 +20,7 @@ just for this Git repo or for all Git repos on this machine?
 )
 
 // GitHubToken lets the user enter the GitHub API token.
-func TokenScope(oldValue configdomain.ConfigScope, inputs components.TestInput) (configdomain.ConfigScope, dialogdomain.Aborted, error) {
+func TokenScope(oldValue configdomain.ConfigScope, inputs components.TestInput) (configdomain.ConfigScope, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.ConfigScope]{
 		{
 			Data: configdomain.ConfigScopeGlobal,
@@ -32,10 +32,10 @@ func TokenScope(oldValue configdomain.ConfigScope, inputs components.TestInput) 
 		},
 	}
 	defaultPos := entries.IndexOf(oldValue)
-	selection, aborted, err := components.RadioList(entries, defaultPos, tokenScopeTitle, tokenScopeHelp, inputs)
-	if err != nil || aborted {
-		return configdomain.ConfigScopeLocal, aborted, err
+	selection, exit, err := components.RadioList(entries, defaultPos, tokenScopeTitle, tokenScopeHelp, inputs)
+	if err != nil || exit {
+		return configdomain.ConfigScopeLocal, exit, err
 	}
-	fmt.Printf(messages.ForgeAPITokenLocation, components.FormattedSelection(selection.String(), aborted))
-	return selection, aborted, err
+	fmt.Printf(messages.ForgeAPITokenLocation, components.FormattedSelection(selection.String(), exit))
+	return selection, exit, err
 }

--- a/internal/cli/dialog/unfinished_run_state.go
+++ b/internal/cli/dialog/unfinished_run_state.go
@@ -36,7 +36,7 @@ const (
 )
 
 // AskHowToHandleUnfinishedRunState prompts the user for how to handle the unfinished run state.
-func AskHowToHandleUnfinishedRunState(command string, endBranch gitdomain.LocalBranchName, endTime time.Time, canSkip bool, dialogTestInput components.TestInput) (Response, dialogdomain.Aborted, error) {
+func AskHowToHandleUnfinishedRunState(command string, endBranch gitdomain.LocalBranchName, endTime time.Time, canSkip bool, dialogTestInput components.TestInput) (Response, dialogdomain.Exit, error) {
 	entries := list.Entries[Response]{
 		{
 			Data: ResponseQuit,

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -24,7 +24,7 @@ on the next screen.
 `
 )
 
-func UnknownBranchType(existingValue configdomain.BranchType, inputs components.TestInput) (configdomain.BranchType, dialogdomain.Aborted, error) {
+func UnknownBranchType(existingValue configdomain.BranchType, inputs components.TestInput) (configdomain.BranchType, dialogdomain.Exit, error) {
 	options := []configdomain.BranchType{
 		configdomain.BranchTypeContributionBranch,
 		configdomain.BranchTypeFeatureBranch,

--- a/internal/cli/dialog/welcome.go
+++ b/internal/cli/dialog/welcome.go
@@ -27,6 +27,6 @@ When you're ready, press ENTER or O to continue.
 )
 
 // MainBranch lets the user select a new main branch for this repo.
-func Welcome(inputs components.TestInput) (dialogdomain.Aborted, error) {
+func Welcome(inputs components.TestInput) (dialogdomain.Exit, error) {
 	return components.TextDisplay(welcomeTitle, welcomeText, inputs)
 }

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -206,7 +206,7 @@ type appendFeatureData struct {
 	targetBranch              gitdomain.LocalBranchName
 }
 
-func determineAppendData(targetBranch gitdomain.LocalBranchName, beam configdomain.Beam, repo execute.OpenRepoResult, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data appendFeatureData, exit dialogdomain.Aborted, err error) {
+func determineAppendData(targetBranch gitdomain.LocalBranchName, beam configdomain.Beam, repo execute.OpenRepoResult, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data appendFeatureData, exit dialogdomain.Exit, err error) {
 	fc := execute.FailureCollector{}
 	preFetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {

--- a/internal/cmd/branch.go
+++ b/internal/cmd/branch.go
@@ -65,7 +65,7 @@ func executeBranch(verbose configdomain.Verbose) error {
 	return nil
 }
 
-func determineBranchData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data branchData, exit dialogdomain.Aborted, err error) {
+func determineBranchData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data branchData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -182,7 +182,7 @@ type compressBranchData struct {
 	parentBranch     gitdomain.LocalBranchName
 }
 
-func determineCompressBranchesData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose, message Option[gitdomain.CommitMessage], compressEntireStack configdomain.FullStack) (data compressBranchesData, exit dialogdomain.Aborted, err error) {
+func determineCompressBranchesData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose, message Option[gitdomain.CommitMessage], compressEntireStack configdomain.FullStack) (data compressBranchesData, exit dialogdomain.Exit, err error) {
 	previousBranch := repo.Git.PreviouslyCheckedOutBranch(repo.Backend)
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -70,8 +70,8 @@ func executeConfigSetup(verbose configdomain.Verbose) error {
 	if err != nil || exit {
 		return err
 	}
-	aborted, tokenScope, forgeTypeOpt, err := enterData(repo, &data)
-	if err != nil || aborted {
+	exit, tokenScope, forgeTypeOpt, err := enterData(repo, &data)
+	if err != nil || exit {
 		return err
 	}
 	err = saveAll(data.userInput, repo.UnvalidatedConfig, data.configFile, tokenScope, forgeTypeOpt, repo.Git, repo.Frontend)
@@ -116,16 +116,17 @@ func determineHostingPlatform(config config.UnvalidatedConfig, userChoice Option
 	return None[forgedomain.ForgeType]()
 }
 
-func enterData(repo execute.OpenRepoResult, data *setupData) (aborted dialogdomain.Aborted, tokenScope configdomain.ConfigScope, forgeTypeOpt Option[forgedomain.ForgeType], err error) {
+// TODO: return exit as the second to last value
+func enterData(repo execute.OpenRepoResult, data *setupData) (exit dialogdomain.Exit, tokenScope configdomain.ConfigScope, forgeTypeOpt Option[forgedomain.ForgeType], err error) {
 	tokenScope = configdomain.ConfigScopeLocal
 	configFile := data.configFile.GetOrDefault()
-	aborted, err = dialog.Welcome(data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, None[forgedomain.ForgeType](), err
+	exit, err = dialog.Welcome(data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, None[forgedomain.ForgeType](), err
 	}
-	data.userInput.config.NormalConfig.Aliases, aborted, err = dialog.Aliases(configdomain.AllAliasableCommands(), repo.UnvalidatedConfig.NormalConfig.Aliases, data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, None[forgedomain.ForgeType](), err
+	data.userInput.config.NormalConfig.Aliases, exit, err = dialog.Aliases(configdomain.AllAliasableCommands(), repo.UnvalidatedConfig.NormalConfig.Aliases, data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, None[forgedomain.ForgeType](), err
 	}
 	var mainBranch gitdomain.LocalBranchName
 	if configFileMainBranch, configFileHasMainBranch := configFile.MainBranch.Get(); configFileHasMainBranch {
@@ -138,212 +139,212 @@ func enterData(repo execute.OpenRepoResult, data *setupData) (aborted dialogdoma
 		if existingMainBranch.IsNone() {
 			existingMainBranch = repo.Git.OriginHead(repo.Backend)
 		}
-		mainBranch, aborted, err = dialog.MainBranch(data.localBranches.Names(), existingMainBranch, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		mainBranch, exit, err = dialog.MainBranch(data.localBranches.Names(), existingMainBranch, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 		data.userInput.config.UnvalidatedConfig.MainBranch = Some(mainBranch)
 	}
 	if len(configFile.PerennialBranches) == 0 {
-		data.userInput.config.NormalConfig.PerennialBranches, aborted, err = dialog.PerennialBranches(data.localBranches.Names(), repo.UnvalidatedConfig.NormalConfig.PerennialBranches, mainBranch, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.PerennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), repo.UnvalidatedConfig.NormalConfig.PerennialBranches, mainBranch, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.PerennialRegex.IsNone() {
-		data.userInput.config.NormalConfig.PerennialRegex, aborted, err = dialog.PerennialRegex(repo.UnvalidatedConfig.NormalConfig.PerennialRegex, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.PerennialRegex, exit, err = dialog.PerennialRegex(repo.UnvalidatedConfig.NormalConfig.PerennialRegex, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.FeatureRegex.IsNone() {
-		data.userInput.config.NormalConfig.FeatureRegex, aborted, err = dialog.FeatureRegex(repo.UnvalidatedConfig.NormalConfig.FeatureRegex, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.FeatureRegex, exit, err = dialog.FeatureRegex(repo.UnvalidatedConfig.NormalConfig.FeatureRegex, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.UnknownBranchType.IsNone() {
-		data.userInput.config.NormalConfig.UnknownBranchType, aborted, err = dialog.UnknownBranchType(repo.UnvalidatedConfig.NormalConfig.UnknownBranchType, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.UnknownBranchType, exit, err = dialog.UnknownBranchType(repo.UnvalidatedConfig.NormalConfig.UnknownBranchType, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.DevRemote.IsNone() {
-		data.userInput.config.NormalConfig.DevRemote, aborted, err = dialog.DevRemote(repo.UnvalidatedConfig.NormalConfig.DevRemote, data.remotes, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.DevRemote, exit, err = dialog.DevRemote(repo.UnvalidatedConfig.NormalConfig.DevRemote, data.remotes, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.ForgeType.IsNone() {
-		data.userInput.config.NormalConfig.ForgeType, aborted, err = dialog.ForgeType(repo.UnvalidatedConfig.NormalConfig.ForgeType, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.ForgeType, exit, err = dialog.ForgeType(repo.UnvalidatedConfig.NormalConfig.ForgeType, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
-	aborted, tokenScope, forgeTypeOpt, err = enterForge(repo, data)
-	if err != nil || aborted {
-		return aborted, tokenScope, None[forgedomain.ForgeType](), err
+	exit, tokenScope, forgeTypeOpt, err = enterForge(repo, data)
+	if err != nil || exit {
+		return exit, tokenScope, None[forgedomain.ForgeType](), err
 	}
 	if configFile.HostingOriginHostname.IsNone() {
-		data.userInput.config.NormalConfig.HostingOriginHostname, aborted, err = dialog.OriginHostname(repo.UnvalidatedConfig.NormalConfig.HostingOriginHostname, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.HostingOriginHostname, exit, err = dialog.OriginHostname(repo.UnvalidatedConfig.NormalConfig.HostingOriginHostname, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.SyncFeatureStrategy.IsNone() {
-		data.userInput.config.NormalConfig.SyncFeatureStrategy, aborted, err = dialog.SyncFeatureStrategy(repo.UnvalidatedConfig.NormalConfig.SyncFeatureStrategy, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.SyncFeatureStrategy, exit, err = dialog.SyncFeatureStrategy(repo.UnvalidatedConfig.NormalConfig.SyncFeatureStrategy, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.SyncPerennialStrategy.IsNone() {
-		data.userInput.config.NormalConfig.SyncPerennialStrategy, aborted, err = dialog.SyncPerennialStrategy(repo.UnvalidatedConfig.NormalConfig.SyncPerennialStrategy, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.SyncPerennialStrategy, exit, err = dialog.SyncPerennialStrategy(repo.UnvalidatedConfig.NormalConfig.SyncPerennialStrategy, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.SyncPrototypeStrategy.IsNone() {
-		data.userInput.config.NormalConfig.SyncPrototypeStrategy, aborted, err = dialog.SyncPrototypeStrategy(repo.UnvalidatedConfig.NormalConfig.SyncPrototypeStrategy, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.SyncPrototypeStrategy, exit, err = dialog.SyncPrototypeStrategy(repo.UnvalidatedConfig.NormalConfig.SyncPrototypeStrategy, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.SyncUpstream.IsNone() {
-		data.userInput.config.NormalConfig.SyncUpstream, aborted, err = dialog.SyncUpstream(repo.UnvalidatedConfig.NormalConfig.SyncUpstream, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.SyncUpstream, exit, err = dialog.SyncUpstream(repo.UnvalidatedConfig.NormalConfig.SyncUpstream, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.SyncTags.IsNone() {
-		data.userInput.config.NormalConfig.SyncTags, aborted, err = dialog.SyncTags(repo.UnvalidatedConfig.NormalConfig.SyncTags, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.SyncTags, exit, err = dialog.SyncTags(repo.UnvalidatedConfig.NormalConfig.SyncTags, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.ShareNewBranches.IsNone() {
-		data.userInput.config.NormalConfig.ShareNewBranches, aborted, err = dialog.ShareNewBranches(repo.UnvalidatedConfig.NormalConfig.ShareNewBranches, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.ShareNewBranches, exit, err = dialog.ShareNewBranches(repo.UnvalidatedConfig.NormalConfig.ShareNewBranches, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.PushHook.IsNone() {
-		data.userInput.config.NormalConfig.PushHook, aborted, err = dialog.PushHook(repo.UnvalidatedConfig.NormalConfig.PushHook, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.PushHook, exit, err = dialog.PushHook(repo.UnvalidatedConfig.NormalConfig.PushHook, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.NewBranchType.IsNone() {
-		data.userInput.config.NormalConfig.NewBranchType, aborted, err = dialog.NewBranchType(repo.UnvalidatedConfig.NormalConfig.NewBranchType, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.NewBranchType, exit, err = dialog.NewBranchType(repo.UnvalidatedConfig.NormalConfig.NewBranchType, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.ShipStrategy.IsNone() {
-		data.userInput.config.NormalConfig.ShipStrategy, aborted, err = dialog.ShipStrategy(repo.UnvalidatedConfig.NormalConfig.ShipStrategy, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.ShipStrategy, exit, err = dialog.ShipStrategy(repo.UnvalidatedConfig.NormalConfig.ShipStrategy, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
 	if configFile.ShipDeleteTrackingBranch.IsNone() {
-		data.userInput.config.NormalConfig.ShipDeleteTrackingBranch, aborted, err = dialog.ShipDeleteTrackingBranch(repo.UnvalidatedConfig.NormalConfig.ShipDeleteTrackingBranch, data.dialogInputs.Next())
-		if err != nil || aborted {
-			return aborted, tokenScope, None[forgedomain.ForgeType](), err
+		data.userInput.config.NormalConfig.ShipDeleteTrackingBranch, exit, err = dialog.ShipDeleteTrackingBranch(repo.UnvalidatedConfig.NormalConfig.ShipDeleteTrackingBranch, data.dialogInputs.Next())
+		if err != nil || exit {
+			return exit, tokenScope, None[forgedomain.ForgeType](), err
 		}
 	}
-	data.userInput.configStorage, aborted, err = dialog.ConfigStorage(data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, None[forgedomain.ForgeType](), err
+	data.userInput.configStorage, exit, err = dialog.ConfigStorage(data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, None[forgedomain.ForgeType](), err
 	}
 	return false, tokenScope, forgeTypeOpt, nil
 }
 
-func enterForge(repo execute.OpenRepoResult, data *setupData) (aborted dialogdomain.Aborted, tokenScope configdomain.ConfigScope, forgeTypeOpt Option[forgedomain.ForgeType], err error) {
+func enterForge(repo execute.OpenRepoResult, data *setupData) (exit dialogdomain.Exit, tokenScope configdomain.ConfigScope, forgeTypeOpt Option[forgedomain.ForgeType], err error) {
 	forgeTypeOpt = determineHostingPlatform(repo.UnvalidatedConfig, data.userInput.config.NormalConfig.ForgeType)
 	if forgeType, hasForgeType := forgeTypeOpt.Get(); hasForgeType {
 		switch forgeType {
 		case forgedomain.ForgeTypeBitbucket, forgedomain.ForgeTypeBitbucketDatacenter:
-			aborted, tokenScope, err = enterBitbucketToken(data, repo)
+			exit, tokenScope, err = enterBitbucketToken(data, repo)
 		case forgedomain.ForgeTypeCodeberg:
-			aborted, tokenScope, err = enterCodebergToken(data, repo)
+			exit, tokenScope, err = enterCodebergToken(data, repo)
 		case forgedomain.ForgeTypeGitea:
-			aborted, tokenScope, err = enterGiteaToken(data, repo)
+			exit, tokenScope, err = enterGiteaToken(data, repo)
 		case forgedomain.ForgeTypeGitHub:
-			aborted, tokenScope, err = enterGithubToken(data, repo)
+			exit, tokenScope, err = enterGithubToken(data, repo)
 		case forgedomain.ForgeTypeGitLab:
-			aborted, tokenScope, err = enterGitlabToken(data, repo)
+			exit, tokenScope, err = enterGitlabToken(data, repo)
 		}
 	}
-	return aborted, tokenScope, forgeTypeOpt, err
+	return exit, tokenScope, forgeTypeOpt, err
 }
 
-func enterBitbucketToken(data *setupData, repo execute.OpenRepoResult) (aborted dialogdomain.Aborted, tokenScope configdomain.ConfigScope, err error) {
-	data.userInput.config.NormalConfig.BitbucketUsername, aborted, err = dialog.BitbucketUsername(repo.UnvalidatedConfig.NormalConfig.BitbucketUsername, data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, err
+func enterBitbucketToken(data *setupData, repo execute.OpenRepoResult) (exit dialogdomain.Exit, tokenScope configdomain.ConfigScope, err error) {
+	data.userInput.config.NormalConfig.BitbucketUsername, exit, err = dialog.BitbucketUsername(repo.UnvalidatedConfig.NormalConfig.BitbucketUsername, data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, err
 	}
-	data.userInput.config.NormalConfig.BitbucketAppPassword, aborted, err = dialog.BitbucketAppPassword(repo.UnvalidatedConfig.NormalConfig.BitbucketAppPassword, data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, err
+	data.userInput.config.NormalConfig.BitbucketAppPassword, exit, err = dialog.BitbucketAppPassword(repo.UnvalidatedConfig.NormalConfig.BitbucketAppPassword, data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, err
 	}
 	showScopeDialog := existsAndChanged(data.userInput.config.NormalConfig.BitbucketUsername, repo.UnvalidatedConfig.NormalConfig.BitbucketUsername) &&
 		existsAndChanged(data.userInput.config.NormalConfig.BitbucketAppPassword, repo.UnvalidatedConfig.NormalConfig.BitbucketAppPassword)
 	if showScopeDialog {
 		oldTokenScope := determineScope(repo.ConfigSnapshot, configdomain.KeyBitbucketUsername, repo.UnvalidatedConfig.NormalConfig.BitbucketUsername)
-		tokenScope, aborted, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
+		tokenScope, exit, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
 	}
-	return aborted, tokenScope, err
+	return exit, tokenScope, err
 }
 
-func enterCodebergToken(data *setupData, repo execute.OpenRepoResult) (aborted dialogdomain.Aborted, tokenScope configdomain.ConfigScope, err error) {
-	data.userInput.config.NormalConfig.CodebergToken, aborted, err = dialog.CodebergToken(repo.UnvalidatedConfig.NormalConfig.CodebergToken, data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, err
+func enterCodebergToken(data *setupData, repo execute.OpenRepoResult) (exit dialogdomain.Exit, tokenScope configdomain.ConfigScope, err error) {
+	data.userInput.config.NormalConfig.CodebergToken, exit, err = dialog.CodebergToken(repo.UnvalidatedConfig.NormalConfig.CodebergToken, data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, err
 	}
 	showScopeDialog := existsAndChanged(data.userInput.config.NormalConfig.CodebergToken, repo.UnvalidatedConfig.NormalConfig.CodebergToken)
 	if showScopeDialog {
 		oldTokenScope := determineScope(repo.ConfigSnapshot, configdomain.KeyCodebergToken, repo.UnvalidatedConfig.NormalConfig.CodebergToken)
-		tokenScope, aborted, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
+		tokenScope, exit, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
 	}
-	return aborted, tokenScope, err
+	return exit, tokenScope, err
 }
 
-func enterGiteaToken(data *setupData, repo execute.OpenRepoResult) (aborted dialogdomain.Aborted, tokenScope configdomain.ConfigScope, err error) {
-	data.userInput.config.NormalConfig.GiteaToken, aborted, err = dialog.GiteaToken(repo.UnvalidatedConfig.NormalConfig.GiteaToken, data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, err
+func enterGiteaToken(data *setupData, repo execute.OpenRepoResult) (exit dialogdomain.Exit, tokenScope configdomain.ConfigScope, err error) {
+	data.userInput.config.NormalConfig.GiteaToken, exit, err = dialog.GiteaToken(repo.UnvalidatedConfig.NormalConfig.GiteaToken, data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, err
 	}
 	showScopeDialog := existsAndChanged(data.userInput.config.NormalConfig.GiteaToken, repo.UnvalidatedConfig.NormalConfig.GiteaToken)
 	if showScopeDialog {
 		oldTokenScope := determineScope(repo.ConfigSnapshot, configdomain.KeyGiteaToken, repo.UnvalidatedConfig.NormalConfig.GiteaToken)
-		tokenScope, aborted, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
+		tokenScope, exit, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
 	}
-	return aborted, tokenScope, err
+	return exit, tokenScope, err
 }
 
-func enterGithubToken(data *setupData, repo execute.OpenRepoResult) (aborted dialogdomain.Aborted, tokenScope configdomain.ConfigScope, err error) {
-	data.userInput.config.NormalConfig.GitHubToken, aborted, err = dialog.GitHubToken(repo.UnvalidatedConfig.NormalConfig.GitHubToken, data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, err
+func enterGithubToken(data *setupData, repo execute.OpenRepoResult) (exit dialogdomain.Exit, tokenScope configdomain.ConfigScope, err error) {
+	data.userInput.config.NormalConfig.GitHubToken, exit, err = dialog.GitHubToken(repo.UnvalidatedConfig.NormalConfig.GitHubToken, data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, err
 	}
 	showScopeDialog := existsAndChanged(data.userInput.config.NormalConfig.GitHubToken, repo.UnvalidatedConfig.NormalConfig.GitHubToken)
 	if showScopeDialog {
 		oldTokenScope := determineScope(repo.ConfigSnapshot, configdomain.KeyGithubToken, repo.UnvalidatedConfig.NormalConfig.GitHubToken)
-		tokenScope, aborted, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
+		tokenScope, exit, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
 	}
-	return aborted, tokenScope, err
+	return exit, tokenScope, err
 }
 
-func enterGitlabToken(data *setupData, repo execute.OpenRepoResult) (aborted dialogdomain.Aborted, tokenScope configdomain.ConfigScope, err error) {
-	data.userInput.config.NormalConfig.GitLabToken, aborted, err = dialog.GitLabToken(repo.UnvalidatedConfig.NormalConfig.GitLabToken, data.dialogInputs.Next())
-	if err != nil || aborted {
-		return aborted, tokenScope, err
+func enterGitlabToken(data *setupData, repo execute.OpenRepoResult) (exit dialogdomain.Exit, tokenScope configdomain.ConfigScope, err error) {
+	data.userInput.config.NormalConfig.GitLabToken, exit, err = dialog.GitLabToken(repo.UnvalidatedConfig.NormalConfig.GitLabToken, data.dialogInputs.Next())
+	if err != nil || exit {
+		return exit, tokenScope, err
 	}
 	showScopeDialog := existsAndChanged(data.userInput.config.NormalConfig.GitLabToken, repo.UnvalidatedConfig.NormalConfig.GitLabToken)
 	if showScopeDialog {
 		oldTokenScope := determineScope(repo.ConfigSnapshot, configdomain.KeyGitlabToken, repo.UnvalidatedConfig.NormalConfig.GitLabToken)
-		tokenScope, aborted, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
+		tokenScope, exit, err = dialog.TokenScope(oldTokenScope, data.dialogInputs.Next())
 	}
-	return aborted, tokenScope, err
+	return exit, tokenScope, err
 }
 
 func determineScope(configSnapshot undoconfig.ConfigSnapshot, key configdomain.Key, oldValue fmt.Stringer) configdomain.ConfigScope {
@@ -363,7 +364,7 @@ func existsAndChanged[T fmt.Stringer](input, existing T) bool {
 	return input.String() != "" && input.String() != existing.String()
 }
 
-func loadSetupData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data setupData, exit dialogdomain.Aborted, err error) {
+func loadSetupData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data setupData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/continue.go
+++ b/internal/cmd/continue.go
@@ -89,7 +89,7 @@ func executeContinue(verbose configdomain.Verbose) error {
 	})
 }
 
-func determineContinueData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data continueData, exit dialogdomain.Aborted, err error) {
+func determineContinueData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data continueData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {
@@ -170,7 +170,7 @@ type continueData struct {
 	stashSize        gitdomain.StashSize
 }
 
-func determineContinueRunstate(repo execute.OpenRepoResult) (runstate.RunState, dialogdomain.Aborted, error) {
+func determineContinueRunstate(repo execute.OpenRepoResult) (runstate.RunState, dialogdomain.Exit, error) {
 	runStateOpt, err := runstate.Load(repo.RootDir)
 	if err != nil {
 		return runstate.EmptyRunState(), true, fmt.Errorf(messages.RunstateLoadProblem, err)

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -165,7 +165,7 @@ type deleteData struct {
 	stashSize                gitdomain.StashSize
 }
 
-func determineDeleteData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data deleteData, exit dialogdomain.Aborted, err error) {
+func determineDeleteData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data deleteData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/detach.go
+++ b/internal/cmd/detach.go
@@ -176,7 +176,7 @@ type detachChildBranch struct {
 	proposal Option[forgedomain.Proposal]
 }
 
-func determineDetachData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data detachData, exit dialogdomain.Aborted, err error) {
+func determineDetachData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data detachData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/diff_parent.go
+++ b/internal/cmd/diff_parent.go
@@ -79,7 +79,7 @@ type diffParentData struct {
 }
 
 // Does not return error because "Ensure" functions will call exit directly.
-func determineDiffParentData(args []string, repo execute.OpenRepoResult, verbose configdomain.Verbose) (data diffParentData, exit dialogdomain.Aborted, err error) {
+func determineDiffParentData(args []string, repo execute.OpenRepoResult, verbose configdomain.Verbose) (data diffParentData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -238,7 +238,7 @@ type createFeatureBranchArgs struct {
 	verbose               configdomain.Verbose
 }
 
-func determineHackData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data hackData, exit dialogdomain.Aborted, err error) {
+func determineHackData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data hackData, exit dialogdomain.Exit, err error) {
 	preFetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -163,7 +163,7 @@ type mergeData struct {
 	stashSize          gitdomain.StashSize
 }
 
-func determineMergeData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (mergeData, dialogdomain.Aborted, error) {
+func determineMergeData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (mergeData, dialogdomain.Exit, error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -228,7 +228,7 @@ type prependData struct {
 	targetBranch        gitdomain.LocalBranchName
 }
 
-func determinePrependData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propasalBody gitdomain.ProposalBody, proposalTitle gitdomain.ProposalTitle, propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data prependData, exit dialogdomain.Aborted, err error) {
+func determinePrependData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propasalBody gitdomain.ProposalBody, proposalTitle gitdomain.ProposalTitle, propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data prependData, exit dialogdomain.Exit, err error) {
 	prefetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -184,7 +184,7 @@ type branchToProposeData struct {
 	syncStatus          gitdomain.SyncStatus
 }
 
-func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title gitdomain.ProposalTitle, body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile) (data proposeData, exit dialogdomain.Aborted, err error) {
+func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title gitdomain.ProposalTitle, body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile) (data proposeData, exit dialogdomain.Exit, err error) {
 	preFetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -141,7 +141,7 @@ type renameData struct {
 	stashSize                gitdomain.StashSize
 }
 
-func determineRenameData(args []string, force configdomain.Force, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data renameData, exit dialogdomain.Aborted, err error) {
+func determineRenameData(args []string, force configdomain.Force, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data renameData, exit dialogdomain.Exit, err error) {
 	previousBranch := repo.Git.PreviouslyCheckedOutBranch(repo.Backend)
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -118,8 +118,8 @@ func executeSetParent(args []string, verbose configdomain.Verbose) error {
 			return err
 		}
 	}
-	runProgram, aborted := setParentProgram(outcome, selectedBranch, data)
-	if aborted {
+	runProgram, exit := setParentProgram(outcome, selectedBranch, data)
+	if exit {
 		return nil
 	}
 	runState := runstate.RunState{
@@ -172,7 +172,7 @@ type setParentData struct {
 	stashSize          gitdomain.StashSize
 }
 
-func determineSetParentData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data setParentData, exit dialogdomain.Aborted, err error) {
+func determineSetParentData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data setParentData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {
@@ -261,7 +261,7 @@ func verifySetParentData(data setParentData) error {
 	return nil
 }
 
-func setParentProgram(dialogOutcome dialog.ParentOutcome, selectedBranch gitdomain.LocalBranchName, data setParentData) (prog program.Program, aborted dialogdomain.Aborted) {
+func setParentProgram(dialogOutcome dialog.ParentOutcome, selectedBranch gitdomain.LocalBranchName, data setParentData) (prog program.Program, exit dialogdomain.Exit) {
 	proposal, hasProposal := data.proposal.Get()
 	// update lineage
 	switch dialogOutcome {

--- a/internal/cmd/ship/shared.go
+++ b/internal/cmd/ship/shared.go
@@ -41,7 +41,7 @@ type sharedShipData struct {
 	targetBranchName         gitdomain.LocalBranchName
 }
 
-func determineSharedShipData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, shipStrategyOverride Option[configdomain.ShipStrategy], verbose configdomain.Verbose) (data sharedShipData, exit dialogdomain.Aborted, err error) {
+func determineSharedShipData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, shipStrategyOverride Option[configdomain.ShipStrategy], verbose configdomain.Verbose) (data sharedShipData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/swap.go
+++ b/internal/cmd/swap.go
@@ -173,7 +173,7 @@ type swapChildBranch struct {
 	proposal Option[forgedomain.Proposal]
 }
 
-func determineSwapData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data swapData, exit dialogdomain.Aborted, err error) {
+func determineSwapData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data swapData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/switch.go
+++ b/internal/cmd/switch.go
@@ -120,7 +120,7 @@ type switchData struct {
 	uncommittedChanges bool
 }
 
-func determineSwitchData(args []string, repo execute.OpenRepoResult, verbose configdomain.Verbose) (data switchData, exit dialogdomain.Aborted, err error) {
+func determineSwitchData(args []string, repo execute.OpenRepoResult, verbose configdomain.Verbose) (data switchData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/sync/cmd.go
+++ b/internal/cmd/sync/cmd.go
@@ -214,7 +214,7 @@ type syncData struct {
 	stashSize                gitdomain.StashSize
 }
 
-func determineSyncData(syncAllBranches configdomain.AllBranches, syncStack configdomain.FullStack, repo execute.OpenRepoResult, verbose configdomain.Verbose, detached configdomain.Detached) (data syncData, exit dialogdomain.Aborted, err error) {
+func determineSyncData(syncAllBranches configdomain.AllBranches, syncStack configdomain.FullStack, repo execute.OpenRepoResult, verbose configdomain.Verbose, detached configdomain.Detached) (data syncData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	preFetchBranchesSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {

--- a/internal/cmd/undo.go
+++ b/internal/cmd/undo.go
@@ -101,7 +101,7 @@ type undoData struct {
 	stashSize               gitdomain.StashSize
 }
 
-func determineUndoData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data undoData, exit dialogdomain.Aborted, err error) {
+func determineUndoData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data undoData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := components.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {

--- a/internal/cmd/walk.go
+++ b/internal/cmd/walk.go
@@ -168,7 +168,7 @@ type walkData struct {
 	stashSize          gitdomain.StashSize
 }
 
-func determineWalkData(all configdomain.AllBranches, dryRun configdomain.DryRun, stack configdomain.FullStack, verbose configdomain.Verbose) (walkData, dialogdomain.Aborted, error) {
+func determineWalkData(all configdomain.AllBranches, dryRun configdomain.DryRun, stack configdomain.FullStack, verbose configdomain.Verbose) (walkData, dialogdomain.Exit, error) {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		DryRun:           dryRun,
 		PrintBranchNames: true,

--- a/internal/execute/load_repo_snapshot.go
+++ b/internal/execute/load_repo_snapshot.go
@@ -17,7 +17,7 @@ import (
 )
 
 // LoadRepoSnapshot loads the initial snapshot of the Git repo.
-func LoadRepoSnapshot(args LoadRepoSnapshotArgs) (gitdomain.BranchesSnapshot, gitdomain.StashSize, Option[gitdomain.BranchInfos], dialogdomain.Aborted, error) {
+func LoadRepoSnapshot(args LoadRepoSnapshotArgs) (gitdomain.BranchesSnapshot, gitdomain.StashSize, Option[gitdomain.BranchInfos], dialogdomain.Exit, error) {
 	runStateOpt, err := runstate.Load(args.RootDir)
 	if err != nil {
 		return gitdomain.EmptyBranchesSnapshot(), 0, None[gitdomain.BranchInfos](), false, err

--- a/internal/validate/config.go
+++ b/internal/validate/config.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
-func Config(args ConfigArgs) (config.ValidatedConfig, dialogdomain.Aborted, error) {
+func Config(args ConfigArgs) (config.ValidatedConfig, dialogdomain.Exit, error) {
 	// check Git user data
 	gitUserEmail, gitUserName, err := GitUser(args.Unvalidated.Value.UnvalidatedConfig)
 	if err != nil {
@@ -22,7 +22,7 @@ func Config(args ConfigArgs) (config.ValidatedConfig, dialogdomain.Aborted, erro
 	// enter and save main and perennials
 	mainBranch, hasMain := args.Unvalidated.Value.UnvalidatedConfig.MainBranch.Get()
 	if !hasMain {
-		validatedMain, additionalPerennials, aborted, err := dialog.MainAndPerennials(dialog.MainAndPerennialsArgs{
+		validatedMain, additionalPerennials, exit, err := dialog.MainAndPerennials(dialog.MainAndPerennialsArgs{
 			Backend:               args.Backend,
 			DialogInputs:          args.TestInputs,
 			GetDefaultBranch:      args.Git.DefaultBranch,
@@ -31,8 +31,8 @@ func Config(args ConfigArgs) (config.ValidatedConfig, dialogdomain.Aborted, erro
 			UnvalidatedMain:       args.Unvalidated.Value.UnvalidatedConfig.MainBranch,
 			UnvalidatedPerennials: args.Unvalidated.Value.NormalConfig.PerennialBranches,
 		})
-		if err != nil || aborted {
-			return config.EmptyValidatedConfig(), aborted, err
+		if err != nil || exit {
+			return config.EmptyValidatedConfig(), exit, err
 		}
 		mainBranch = validatedMain
 		args.BranchesAndTypes[validatedMain] = configdomain.BranchTypeMainBranch

--- a/internal/vm/opcodes/merge_squash_program.go
+++ b/internal/vm/opcodes/merge_squash_program.go
@@ -21,11 +21,11 @@ type MergeSquashProgram struct {
 }
 
 func (self *MergeSquashProgram) Run(args shared.RunArgs) error {
-	author, aborted, err := dialog.SelectSquashCommitAuthor(self.Branch, self.Authors, args.DialogTestInputs.Next())
+	author, exit, err := dialog.SelectSquashCommitAuthor(self.Branch, self.Authors, args.DialogTestInputs.Next())
 	if err != nil {
 		return fmt.Errorf(messages.SquashCommitAuthorProblem, err)
 	}
-	if aborted {
+	if exit {
 		return errors.New("aborted by user")
 	}
 	repoAuthor := args.Config.Value.ValidatedConfigData.Author()


### PR DESCRIPTION
Right now we have two conventions for variables that indicate the user wants to abort: "abort" and "exit". Exit is shorter, so let's go with that one.