### PR TITLE
Use `--merge-base` in diff-parent

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -486,7 +486,7 @@ func (self *Commands) DeleteTrackingBranch(runner gitdomain.Runner, name gitdoma
 
 // DiffParent displays the diff between the given branch and its given parent branch.
 func (self *Commands) DiffParent(runner gitdomain.Runner, branch, parentBranch gitdomain.LocalBranchName) error {
-	return runner.Run("git", "diff", parentBranch.String(), branch.String())
+	return runner.Run("git", "diff", "--merge-base", parentBranch.String(), branch.String())
 }
 
 func (self *Commands) DiscardOpenChanges(runner gitdomain.Runner) error {


### PR DESCRIPTION
I have a parked branch that hasn't been updated for a while. I wanted to see what changes are in that branch. When I used the diff-parent command, it showed me all the differences between the up-to-date parent and the parked child, which is 99% unrelated to the changes I made in that branch.

This PR changes the diff-parent command to use the `--merge-base` flag when calling git-diff:

[`git diff --merge-base <parent> <child>`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-codegitdiffltoptionsgt--merge-baseltcommitgtltcommitgt--ltpathgtcode)

which is equivalent to

`git diff $(git merge-base <parent> <child>) <child>`.

