### PR TITLE
Replace shelling out to which to determine paths with Go's built-in solution

### DIFF
--- a/features/hack/give_non_existing_branch/propose/without_message.feature
+++ b/features/hack/give_non_existing_branch/propose/without_message.feature
@@ -10,10 +10,10 @@ Feature: proposing uncommitted changes via a separate top-level branch, let Git 
       | main     | origin   | main commit     |
       | existing | local    | existing commit |
     And the current branch is "existing"
-    And the origin is "git@github.com:git-town/git-town.git"
-    And tool "open" is installed
     And an uncommitted file with name "new_file" and content "new content"
     And I ran "git add new_file"
+    And the origin is "git@github.com:git-town/git-town.git"
+    And tool "open" is installed
     When I run "git-town hack new --propose" and enter "unrelated idea" for the commit message
 
   @this

--- a/features/hack/give_non_existing_branch/propose/without_message.feature
+++ b/features/hack/give_non_existing_branch/propose/without_message.feature
@@ -16,6 +16,7 @@ Feature: proposing uncommitted changes via a separate top-level branch, let Git 
     And I ran "git add new_file"
     When I run "git-town hack new --propose" and enter "unrelated idea" for the commit message
 
+  @this
   Scenario: result
     Then Git Town runs the commands
       | BRANCH   | COMMAND                                                        |

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -4,6 +4,7 @@ package browser
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 
 	"github.com/git-town/git-town/v21/internal/messages"
@@ -12,8 +13,8 @@ import (
 
 // Open opens a new window/tab in the default browser with the given URL.
 // If no browser is found, it prints the URL.
-func Open(url string, frontend frontendRunner, backend backendRunner) {
-	command, hasCommand := OpenBrowserCommand(backend).Get()
+func Open(url string, frontend frontendRunner) {
+	command, hasCommand := OpenBrowserCommand().Get()
 	if !hasCommand {
 		fmt.Printf(messages.BrowserOpen, url)
 		return
@@ -25,7 +26,7 @@ func Open(url string, frontend frontendRunner, backend backendRunner) {
 }
 
 // OpenBrowserCommand provides the console command to open the default browser.
-func OpenBrowserCommand(runner backendRunner) Option[string] {
+func OpenBrowserCommand() Option[string] {
 	if runtime.GOOS == "windows" {
 		// NOTE: the "explorer" command cannot handle special characters like "?" and "=".
 		//       In particular, "?" can be escaped via "\", but "=" cannot.
@@ -49,8 +50,8 @@ func OpenBrowserCommand(runner backendRunner) Option[string] {
 		"netscape",
 	)
 	for _, browserCommand := range openBrowserCommands {
-		output, err := runner.Query("which", browserCommand)
-		if err == nil && len(output) > 0 {
+		executable, err := exec.LookPath(browserCommand)
+		if err == nil && len(executable) > 0 {
 			return Some(browserCommand)
 		}
 	}
@@ -59,8 +60,4 @@ func OpenBrowserCommand(runner backendRunner) Option[string] {
 
 type frontendRunner interface {
 	Run(executable string, args ...string) error
-}
-
-type backendRunner interface {
-	Query(executable string, args ...string) (string, error)
 }

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -34,10 +34,12 @@ func OpenBrowserCommand() Option[string] {
 		return Some("start")
 	}
 	openBrowserCommands := make([]string, 0, 11)
+	fmt.Println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 	if browser := os.Getenv("BROWSER"); browser != "" {
-		fmt.Println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+		fmt.Println("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
 		openBrowserCommands = append(openBrowserCommands, browser)
 	}
+	fmt.Println("CCCCCCCCCCCCCCCCCCCCCCCCC", openBrowserCommands)
 	openBrowserCommands = append(openBrowserCommands,
 		"wsl-open",           // for Windows Subsystem for Linux, see https://github.com/git-town/git-town/issues/1344
 		"garcon-url-handler", // opens links in the native browser from Crostini on ChromeOS

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -34,12 +34,9 @@ func OpenBrowserCommand() Option[string] {
 		return Some("start")
 	}
 	openBrowserCommands := make([]string, 0, 11)
-	fmt.Println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 	if browser := os.Getenv("BROWSER"); browser != "" {
-		fmt.Println("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
 		openBrowserCommands = append(openBrowserCommands, browser)
 	}
-	fmt.Println("CCCCCCCCCCCCCCCCCCCCCCCCC", openBrowserCommands)
 	openBrowserCommands = append(openBrowserCommands,
 		"wsl-open",           // for Windows Subsystem for Linux, see https://github.com/git-town/git-town/issues/1344
 		"garcon-url-handler", // opens links in the native browser from Crostini on ChromeOS

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -35,6 +35,7 @@ func OpenBrowserCommand() Option[string] {
 	}
 	openBrowserCommands := []string{}
 	if browser := os.Getenv("BROWSER"); browser != "" {
+		fmt.Println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 		openBrowserCommands = append(openBrowserCommands, browser)
 	}
 	openBrowserCommands = append(openBrowserCommands,

--- a/internal/cmd/repo.go
+++ b/internal/cmd/repo.go
@@ -66,7 +66,7 @@ func executeRepo(args []string, verbose configdomain.Verbose) error {
 	if err != nil {
 		return err
 	}
-	browser.Open(data.connector.RepositoryURL(), repo.Frontend, repo.Backend)
+	browser.Open(data.connector.RepositoryURL(), repo.Frontend)
 	print.Footer(verbose, repo.CommandsCounter.Immutable(), repo.FinalMessages.Result())
 	return nil
 }

--- a/internal/test/cucumber/scenario_state.go
+++ b/internal/test/cucumber/scenario_state.go
@@ -21,6 +21,9 @@ type ScenarioState struct {
 	// commits at the origin remote before the end-to-end test executed the most recent subshell command
 	beforeRunOriginSHAs Option[gitdomain.Commits]
 
+	// content of the $BROWSER variable in the subshell
+	browserVariable Option[string]
+
 	// the Fixture used in the current scenario
 	fixture fixture.Fixture
 

--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -818,7 +818,18 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state.CaptureState()
 		updateInitialSHAs(state)
 		devRepo.MockCommitMessage(message)
-		output, exitCode := devRepo.MustQueryStringCode(cmd)
+		output := ""
+		exitCode := 0
+		if browser, has := state.browserVariable.Get(); has {
+			envPath := os.Getenv("PATH")
+			env := []string{"PATH="}
+			env = append(env, "BROWSER="+browser)
+			output, exitCode = devRepo.MustQueryStringCodeWith(cmd, &subshell.Options{
+				Env: env,
+			})
+		} else {
+			output, exitCode = devRepo.MustQueryStringCode(cmd)
+		}
 		state.runOutput = Some(output)
 		state.runExitCode = Some(exitCode)
 		devRepo.Reload()

--- a/internal/test/subshell/test_runner.go
+++ b/internal/test/subshell/test_runner.go
@@ -63,9 +63,9 @@ func (self *TestRunner) MockBrokenCommand(name string) {
 }
 
 // MockCommand adds a mock for the command with the given name.
-func (self *TestRunner) MockCommand(name string) string {
+func (self *TestRunner) MockCommand(name string) {
 	content := fmt.Sprintf("#!/usr/bin/env bash\n\necho %s called with: \"$@\"\n", name)
-	return self.createMockBinary(name, content)
+	self.createMockBinary(name, content)
 }
 
 // MockCommitMessage sets up this runner with an editor that enters the given commit message.
@@ -293,12 +293,11 @@ func (self *TestRunner) createBinDir() {
 }
 
 // createMockBinary creates an executable with the given name and content in ms.binDir.
-func (self *TestRunner) createMockBinary(name string, content string) string {
+func (self *TestRunner) createMockBinary(name string, content string) {
 	self.createBinDir()
 	binaryPath := filepath.Join(self.BinDir, name)
 	//nolint:gosec // intentionally creating an executable here
 	asserts.NoError(os.WriteFile(binaryPath, []byte(content), 0o744))
-	return binaryPath
 }
 
 // Options defines optional arguments for ShellRunner.RunWith().

--- a/internal/test/subshell/test_runner.go
+++ b/internal/test/subshell/test_runner.go
@@ -63,13 +63,9 @@ func (self *TestRunner) MockBrokenCommand(name string) {
 }
 
 // MockCommand adds a mock for the command with the given name.
-func (self *TestRunner) MockCommand(name string) {
-	// write custom "which" command
-	content := fmt.Sprintf("#!/usr/bin/env bash\n\nif [ \"$1\" == %q ]; then\n  echo %q\nelse\n  exit 1\nfi", name, filepath.Join(self.BinDir, name))
-	self.createMockBinary("which", content)
-	// write custom command
-	content = fmt.Sprintf("#!/usr/bin/env bash\n\necho %s called with: \"$@\"\n", name)
-	self.createMockBinary(name, content)
+func (self *TestRunner) MockCommand(name string) string {
+	content := fmt.Sprintf("#!/usr/bin/env bash\n\necho %s called with: \"$@\"\n", name)
+	return self.createMockBinary(name, content)
 }
 
 // MockCommitMessage sets up this runner with an editor that enters the given commit message.
@@ -297,10 +293,12 @@ func (self *TestRunner) createBinDir() {
 }
 
 // createMockBinary creates an executable with the given name and content in ms.binDir.
-func (self *TestRunner) createMockBinary(name string, content string) {
+func (self *TestRunner) createMockBinary(name string, content string) string {
 	self.createBinDir()
+	binaryPath := filepath.Join(self.BinDir, name)
 	//nolint:gosec // intentionally creating an executable here
-	asserts.NoError(os.WriteFile(filepath.Join(self.BinDir, name), []byte(content), 0o744))
+	asserts.NoError(os.WriteFile(binaryPath, []byte(content), 0o744))
+	return binaryPath
 }
 
 // Options defines optional arguments for ShellRunner.RunWith().

--- a/internal/vm/opcodes/browser_open.go
+++ b/internal/vm/opcodes/browser_open.go
@@ -12,6 +12,6 @@ type BrowserOpen struct {
 }
 
 func (self *BrowserOpen) Run(args shared.RunArgs) error {
-	browser.Open(self.URL, args.Frontend, args.Backend)
+	browser.Open(self.URL, args.Frontend)
 	return nil
 }

--- a/internal/vm/opcodes/proposal_create.go
+++ b/internal/vm/opcodes/proposal_create.go
@@ -38,6 +38,6 @@ func (self *ProposalCreate) Run(args shared.RunArgs) error {
 	if err != nil {
 		return err
 	}
-	browser.Open(prURL, args.Frontend, args.Backend)
+	browser.Open(prURL, args.Frontend)
 	return nil
 }


### PR DESCRIPTION
Git Town currently calls `which` in a subshell to determine if a tool is installed. This PR replaces this mechanism with Go's built-in `exec.LookPath`. This removes one additional dependency and improves latency.