### PR TITLE
Extract browser env var name into constant

### DIFF
--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/git-town/git-town/v21/internal/browser"
 	"github.com/git-town/git-town/v21/internal/messages"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
@@ -34,7 +33,7 @@ func OpenBrowserCommand(runner backendRunner) Option[string] {
 		return Some("start")
 	}
 	openBrowserCommands := make([]string, 0, 11)
-	if browser := os.Getenv(browser.ENVVAR); browser != "" {
+	if browser := os.Getenv(ENVVAR); browser != "" {
 		openBrowserCommands = append(openBrowserCommands, browser)
 	}
 	openBrowserCommands = append(openBrowserCommands,

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/git-town/git-town/v21/internal/browser"
 	"github.com/git-town/git-town/v21/internal/messages"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
@@ -33,7 +34,7 @@ func OpenBrowserCommand(runner backendRunner) Option[string] {
 		return Some("start")
 	}
 	openBrowserCommands := make([]string, 0, 11)
-	if browser := os.Getenv("BROWSER"); browser != "" {
+	if browser := os.Getenv(browser.ENVVAR); browser != "" {
 		openBrowserCommands = append(openBrowserCommands, browser)
 	}
 	openBrowserCommands = append(openBrowserCommands,

--- a/internal/browser/env.go
+++ b/internal/browser/env.go
@@ -1,0 +1,4 @@
+package browser
+
+// name of the environment variable that defines the browser to use
+const ENVVAR = "BROWSER"


### PR DESCRIPTION
In the future, we will use this env var in a lot more places, so it's better to extract its name into a constant.