### PR TITLE
Make CLI argument data options

### DIFF
--- a/internal/cli/flags/proposal_body.go
+++ b/internal/cli/flags/proposal_body.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/spf13/cobra"
 )
 
@@ -14,12 +15,12 @@ func ProposalBody(short string) (AddFunc, ReadProposalBodyFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
 		cmd.Flags().StringP(bodyLong, short, "", "provide a body for the proposal")
 	}
-	readFlag := func(cmd *cobra.Command) (gitdomain.ProposalBody, error) {
+	readFlag := func(cmd *cobra.Command) (Option[gitdomain.ProposalBody], error) {
 		value, err := cmd.Flags().GetString(bodyLong)
-		return gitdomain.ProposalBody(value), err
+		return NewOption(gitdomain.ProposalBody(value)), err
 	}
 	return addFlag, readFlag
 }
 
 // ReadCommitMessageFlagFunc defines the type signature for helper functions that provide the value a string CLI flag associated with a Cobra command.
-type ReadProposalBodyFlagFunc func(*cobra.Command) (gitdomain.ProposalBody, error)
+type ReadProposalBodyFlagFunc func(*cobra.Command) (Option[gitdomain.ProposalBody], error)

--- a/internal/cli/flags/proposal_body_file.go
+++ b/internal/cli/flags/proposal_body_file.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/spf13/cobra"
 )
 
@@ -15,12 +16,12 @@ func ProposalBodyFile() (AddFunc, ReadProposalBodyFileFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
 		cmd.Flags().StringP(bodyFileLong, bodyFileShort, "", "Read the proposal body from the given file (use \"-\" to read from STDIN)")
 	}
-	readFlag := func(cmd *cobra.Command) (gitdomain.ProposalBodyFile, error) {
+	readFlag := func(cmd *cobra.Command) (Option[gitdomain.ProposalBodyFile], error) {
 		value, err := cmd.Flags().GetString(bodyFileLong)
-		return gitdomain.ProposalBodyFile(value), err
+		return NewOption(gitdomain.ProposalBodyFile(value)), err
 	}
 	return addFlag, readFlag
 }
 
 // ReadProposalBodyFileFlagFunc reads gitdomain.ProposalBodyFile from the CLI args.
-type ReadProposalBodyFileFlagFunc func(*cobra.Command) (gitdomain.ProposalBodyFile, error)
+type ReadProposalBodyFileFlagFunc func(*cobra.Command) (Option[gitdomain.ProposalBodyFile], error)

--- a/internal/cli/flags/proposal_title.go
+++ b/internal/cli/flags/proposal_title.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/spf13/cobra"
 )
 
@@ -15,12 +16,12 @@ func ProposalTitle() (AddFunc, ReadProposalTitleFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
 		cmd.Flags().StringP(titleLong, titleShort, "", "provide a title for the proposal")
 	}
-	readFlag := func(cmd *cobra.Command) (gitdomain.ProposalTitle, error) {
+	readFlag := func(cmd *cobra.Command) (Option[gitdomain.ProposalTitle], error) {
 		value, err := cmd.Flags().GetString(titleLong)
-		return gitdomain.ProposalTitle(value), err
+		return NewOption(gitdomain.ProposalTitle(value)), err
 	}
 	return addFlag, readFlag
 }
 
 // ReadCommitMessageFlagFunc defines the type signature for helper functions that provide the value a string CLI flag associated with a Cobra command.
-type ReadProposalTitleFlagFunc func(*cobra.Command) (gitdomain.ProposalTitle, error)
+type ReadProposalTitleFlagFunc func(*cobra.Command) (Option[gitdomain.ProposalTitle], error)

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -399,7 +399,7 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector, 
 			&opcodes.ProposalCreate{
 				Branch:        data.targetBranch,
 				MainBranch:    data.config.ValidatedConfigData.MainBranch,
-				ProposalBody:  "",
+				ProposalBody:  None[gitdomain.ProposalBody](),
 				ProposalTitle: title,
 			},
 		)

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -388,6 +388,10 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector, 
 	}
 	moveCommitsToAppendedBranch(prog, data, beamCherryPick)
 	if data.propose {
+		title := None[gitdomain.ProposalTitle]()
+		if commitMessage, has := data.commitMessage.Get(); has {
+			title = Some(gitdomain.ProposalTitle(string(commitMessage)))
+		}
 		prog.Value.Add(
 			&opcodes.BranchTrackingCreate{
 				Branch: data.targetBranch,
@@ -396,7 +400,7 @@ func appendProgram(data appendFeatureData, finalMessages stringslice.Collector, 
 				Branch:        data.targetBranch,
 				MainBranch:    data.config.ValidatedConfigData.MainBranch,
 				ProposalBody:  "",
-				ProposalTitle: gitdomain.ProposalTitle(data.commitMessage.GetOrDefault()),
+				ProposalTitle: title,
 			},
 		)
 	}

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -144,7 +144,7 @@ func prependCommand() *cobra.Command {
 	return &cmd
 }
 
-func executePrepend(args []string, beam configdomain.Beam, proposalBody gitdomain.ProposalBody, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, proposalTitle gitdomain.ProposalTitle, verbose configdomain.Verbose) error {
+func executePrepend(args []string, beam configdomain.Beam, proposalBody gitdomain.ProposalBody, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, proposalTitle Option[gitdomain.ProposalTitle], verbose configdomain.Verbose) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		DryRun:           dryRun,
 		PrintBranchNames: true,
@@ -220,7 +220,7 @@ type prependData struct {
 	previousBranch      Option[gitdomain.LocalBranchName]
 	proposal            Option[forgedomain.Proposal]
 	proposalBody        gitdomain.ProposalBody
-	proposalTitle       gitdomain.ProposalTitle
+	proposalTitle       Option[gitdomain.ProposalTitle]
 	propose             configdomain.Propose
 	prototype           configdomain.Prototype
 	remotes             gitdomain.Remotes
@@ -228,7 +228,7 @@ type prependData struct {
 	targetBranch        gitdomain.LocalBranchName
 }
 
-func determinePrependData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propasalBody gitdomain.ProposalBody, proposalTitle gitdomain.ProposalTitle, propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data prependData, exit dialogdomain.Exit, err error) {
+func determinePrependData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propasalBody gitdomain.ProposalBody, proposalTitle Option[gitdomain.ProposalTitle], propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data prependData, exit dialogdomain.Exit, err error) {
 	prefetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -144,7 +144,7 @@ func prependCommand() *cobra.Command {
 	return &cmd
 }
 
-func executePrepend(args []string, beam configdomain.Beam, proposalBody gitdomain.ProposalBody, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, proposalTitle Option[gitdomain.ProposalTitle], verbose configdomain.Verbose) error {
+func executePrepend(args []string, beam configdomain.Beam, proposalBody Option[gitdomain.ProposalBody], commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propose configdomain.Propose, prototype configdomain.Prototype, proposalTitle Option[gitdomain.ProposalTitle], verbose configdomain.Verbose) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		DryRun:           dryRun,
 		PrintBranchNames: true,
@@ -219,7 +219,7 @@ type prependData struct {
 	preFetchBranchInfos gitdomain.BranchInfos
 	previousBranch      Option[gitdomain.LocalBranchName]
 	proposal            Option[forgedomain.Proposal]
-	proposalBody        gitdomain.ProposalBody
+	proposalBody        Option[gitdomain.ProposalBody]
 	proposalTitle       Option[gitdomain.ProposalTitle]
 	propose             configdomain.Propose
 	prototype           configdomain.Prototype
@@ -228,7 +228,7 @@ type prependData struct {
 	targetBranch        gitdomain.LocalBranchName
 }
 
-func determinePrependData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, propasalBody gitdomain.ProposalBody, proposalTitle Option[gitdomain.ProposalTitle], propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data prependData, exit dialogdomain.Exit, err error) {
+func determinePrependData(args []string, repo execute.OpenRepoResult, beam configdomain.Beam, commit configdomain.Commit, commitMessage Option[gitdomain.CommitMessage], detached configdomain.Detached, dryRun configdomain.DryRun, proposalBody Option[gitdomain.ProposalBody], proposalTitle Option[gitdomain.ProposalTitle], propose configdomain.Propose, prototype configdomain.Prototype, verbose configdomain.Verbose) (data prependData, exit dialogdomain.Exit, err error) {
 	prefetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err
@@ -356,7 +356,7 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, beam confi
 		preFetchBranchInfos: prefetchBranchSnapshot.Branches,
 		previousBranch:      previousBranch,
 		proposal:            proposalOpt,
-		proposalBody:        propasalBody,
+		proposalBody:        proposalBody,
 		proposalTitle:       proposalTitle,
 		propose:             propose,
 		prototype:           prototype,

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -312,13 +312,13 @@ func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRu
 			if err != nil {
 				return data, false, fmt.Errorf("cannot read STDIN: %w", err)
 			}
-			bodyText = Some(gitdomain.ProposalBody(content))
+			bodyText = NewOption(gitdomain.ProposalBody(content))
 		} else {
 			fileData, err := os.ReadFile(bodyFile.String())
 			if err != nil {
 				return data, false, err
 			}
-			bodyText = Some(gitdomain.ProposalBody(fileData))
+			bodyText = NewOption(gitdomain.ProposalBody(fileData))
 		}
 	}
 	return proposeData{

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -103,7 +103,7 @@ func proposeCommand() *cobra.Command {
 	return &cmd
 }
 
-func executePropose(dryRun configdomain.DryRun, verbose configdomain.Verbose, title gitdomain.ProposalTitle, body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile, fullStack configdomain.FullStack) error {
+func executePropose(dryRun configdomain.DryRun, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile, fullStack configdomain.FullStack) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		DryRun:           dryRun,
 		PrintBranchNames: true,
@@ -172,7 +172,7 @@ type proposeData struct {
 	preFetchBranchInfos gitdomain.BranchInfos
 	previousBranch      Option[gitdomain.LocalBranchName]
 	proposalBody        gitdomain.ProposalBody
-	proposalTitle       gitdomain.ProposalTitle
+	proposalTitle       Option[gitdomain.ProposalTitle]
 	remotes             gitdomain.Remotes
 	stashSize           gitdomain.StashSize
 }
@@ -184,7 +184,7 @@ type branchToProposeData struct {
 	syncStatus          gitdomain.SyncStatus
 }
 
-func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title gitdomain.ProposalTitle, body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile) (data proposeData, exit dialogdomain.Exit, err error) {
+func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile) (data proposeData, exit dialogdomain.Exit, err error) {
 	preFetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -103,7 +103,7 @@ func proposeCommand() *cobra.Command {
 	return &cmd
 }
 
-func executePropose(dryRun configdomain.DryRun, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body Option[gitdomain.ProposalBody], bodyFile gitdomain.ProposalBodyFile, fullStack configdomain.FullStack) error {
+func executePropose(dryRun configdomain.DryRun, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body Option[gitdomain.ProposalBody], bodyFile Option[gitdomain.ProposalBodyFile], fullStack configdomain.FullStack) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		DryRun:           dryRun,
 		PrintBranchNames: true,
@@ -184,7 +184,7 @@ type branchToProposeData struct {
 	syncStatus          gitdomain.SyncStatus
 }
 
-func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body Option[gitdomain.ProposalBody], bodyFile gitdomain.ProposalBodyFile) (data proposeData, exit dialogdomain.Exit, err error) {
+func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body Option[gitdomain.ProposalBody], bodyFileOpt Option[gitdomain.ProposalBodyFile]) (data proposeData, exit dialogdomain.Exit, err error) {
 	preFetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err
@@ -306,7 +306,7 @@ func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRu
 	var bodyText Option[gitdomain.ProposalBody]
 	if body.IsSome() {
 		bodyText = body
-	} else if len(bodyFile) > 0 {
+	} else if bodyFile, hasBodyFile := bodyFileOpt.Get(); hasBodyFile {
 		if bodyFile.ShouldReadStdin() {
 			content, err := io.ReadAll(os.Stdin)
 			if err != nil {

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -103,7 +103,7 @@ func proposeCommand() *cobra.Command {
 	return &cmd
 }
 
-func executePropose(dryRun configdomain.DryRun, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile, fullStack configdomain.FullStack) error {
+func executePropose(dryRun configdomain.DryRun, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body Option[gitdomain.ProposalBody], bodyFile gitdomain.ProposalBodyFile, fullStack configdomain.FullStack) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		DryRun:           dryRun,
 		PrintBranchNames: true,
@@ -171,7 +171,7 @@ type proposeData struct {
 	nonExistingBranches gitdomain.LocalBranchNames // branches that are listed in the lineage information, but don't exist in the repo, neither locally nor remotely
 	preFetchBranchInfos gitdomain.BranchInfos
 	previousBranch      Option[gitdomain.LocalBranchName]
-	proposalBody        gitdomain.ProposalBody
+	proposalBody        Option[gitdomain.ProposalBody]
 	proposalTitle       Option[gitdomain.ProposalTitle]
 	remotes             gitdomain.Remotes
 	stashSize           gitdomain.StashSize
@@ -184,7 +184,7 @@ type branchToProposeData struct {
 	syncStatus          gitdomain.SyncStatus
 }
 
-func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body gitdomain.ProposalBody, bodyFile gitdomain.ProposalBodyFile) (data proposeData, exit dialogdomain.Exit, err error) {
+func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, fullStack configdomain.FullStack, verbose configdomain.Verbose, title Option[gitdomain.ProposalTitle], body Option[gitdomain.ProposalBody], bodyFile gitdomain.ProposalBodyFile) (data proposeData, exit dialogdomain.Exit, err error) {
 	preFetchBranchSnapshot, err := repo.Git.BranchesSnapshot(repo.Backend)
 	if err != nil {
 		return data, false, err
@@ -303,8 +303,8 @@ func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRu
 	if err != nil {
 		return data, false, err
 	}
-	var bodyText gitdomain.ProposalBody
-	if len(body) > 0 {
+	var bodyText Option[gitdomain.ProposalBody]
+	if body.IsSome() {
 		bodyText = body
 	} else if len(bodyFile) > 0 {
 		if bodyFile.ShouldReadStdin() {
@@ -312,13 +312,13 @@ func determineProposeData(repo execute.OpenRepoResult, dryRun configdomain.DryRu
 			if err != nil {
 				return data, false, fmt.Errorf("cannot read STDIN: %w", err)
 			}
-			bodyText = gitdomain.ProposalBody(content)
+			bodyText = Some(gitdomain.ProposalBody(content))
 		} else {
 			fileData, err := os.ReadFile(bodyFile.String())
 			if err != nil {
 				return data, false, err
 			}
-			bodyText = gitdomain.ProposalBody(fileData)
+			bodyText = Some(gitdomain.ProposalBody(fileData))
 		}
 	}
 	return proposeData{

--- a/internal/forge/bitbucketcloud/connector_test.go
+++ b/internal/forge/bitbucketcloud/connector_test.go
@@ -62,7 +62,7 @@ func TestBitbucketConnector(t *testing.T) {
 			Branch:        "branch",
 			MainBranch:    "main",
 			ParentBranch:  "parent-branch",
-			ProposalBody:  "",
+			ProposalBody:  None[gitdomain.ProposalBody](),
 			ProposalTitle: None[gitdomain.ProposalTitle](),
 		})
 		want := "https://bitbucket.org/org/repo/pull-requests/new?source=branch&dest=org%2Frepo%3Aparent-branch"

--- a/internal/forge/bitbucketcloud/connector_test.go
+++ b/internal/forge/bitbucketcloud/connector_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/forge/bitbucketcloud"
 	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/git/giturl"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/shoenig/test/must"
@@ -62,7 +63,7 @@ func TestBitbucketConnector(t *testing.T) {
 			MainBranch:    "main",
 			ParentBranch:  "parent-branch",
 			ProposalBody:  "",
-			ProposalTitle: "",
+			ProposalTitle: None[gitdomain.ProposalTitle](),
 		})
 		want := "https://bitbucket.org/org/repo/pull-requests/new?source=branch&dest=org%2Frepo%3Aparent-branch"
 		must.EqOp(t, want, have)

--- a/internal/forge/bitbucketdatacenter/connector_test.go
+++ b/internal/forge/bitbucketdatacenter/connector_test.go
@@ -46,7 +46,7 @@ func TestBitbucketConnector(t *testing.T) {
 			Branch:        "branch",
 			MainBranch:    "main",
 			ParentBranch:  "parent-branch",
-			ProposalBody:  "",
+			ProposalBody:  None[gitdomain.ProposalBody](),
 			ProposalTitle: None[gitdomain.ProposalTitle](),
 		})
 		want := "https://custom-url.com/projects/git-town/repos/docs/pull-requests?create&sourceBranch=branch&targetBranch=parent-branch"

--- a/internal/forge/bitbucketdatacenter/connector_test.go
+++ b/internal/forge/bitbucketdatacenter/connector_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/forge/bitbucketdatacenter"
 	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/git/giturl"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/shoenig/test/must"
@@ -46,7 +47,7 @@ func TestBitbucketConnector(t *testing.T) {
 			MainBranch:    "main",
 			ParentBranch:  "parent-branch",
 			ProposalBody:  "",
-			ProposalTitle: "",
+			ProposalTitle: None[gitdomain.ProposalTitle](),
 		})
 		want := "https://custom-url.com/projects/git-town/repos/docs/pull-requests?create&sourceBranch=branch&targetBranch=parent-branch"
 		must.EqOp(t, want, have)

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -65,6 +65,6 @@ type CreateProposalArgs struct {
 	FrontendRunner subshelldomain.Runner
 	MainBranch     gitdomain.LocalBranchName
 	ParentBranch   gitdomain.LocalBranchName
-	ProposalBody   gitdomain.ProposalBody
+	ProposalBody   Option[gitdomain.ProposalBody]
 	ProposalTitle  Option[gitdomain.ProposalTitle]
 }

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -66,5 +66,5 @@ type CreateProposalArgs struct {
 	MainBranch     gitdomain.LocalBranchName
 	ParentBranch   gitdomain.LocalBranchName
 	ProposalBody   gitdomain.ProposalBody
-	ProposalTitle  gitdomain.ProposalTitle
+	ProposalTitle  Option[gitdomain.ProposalTitle]
 }

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -56,8 +56,8 @@ func (self Connector) NewProposalURL(data forgedomain.CreateProposalArgs) string
 		toCompare = data.ParentBranch.String() + "..." + data.Branch.String()
 	}
 	result := fmt.Sprintf("%s/compare/%s?expand=1", self.RepositoryURL(), url.PathEscape(toCompare))
-	if len(data.ProposalTitle) > 0 {
-		result += "&title=" + url.QueryEscape(data.ProposalTitle.String())
+	if title, hasTitle := data.ProposalTitle.Get(); hasTitle {
+		result += "&title=" + url.QueryEscape(title.String())
 	}
 	if len(data.ProposalBody) > 0 {
 		result += "&body=" + url.QueryEscape(data.ProposalBody.String())

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -59,8 +59,8 @@ func (self Connector) NewProposalURL(data forgedomain.CreateProposalArgs) string
 	if title, hasTitle := data.ProposalTitle.Get(); hasTitle {
 		result += "&title=" + url.QueryEscape(title.String())
 	}
-	if len(data.ProposalBody) > 0 {
-		result += "&body=" + url.QueryEscape(data.ProposalBody.String())
+	if body, hasBody := data.ProposalBody.Get(); hasBody {
+		result += "&body=" + url.QueryEscape(body.String())
 	}
 	return result
 }

--- a/internal/forge/github/connector_test.go
+++ b/internal/forge/github/connector_test.go
@@ -48,49 +48,49 @@ func TestConnector(t *testing.T) {
 		tests := map[string]struct {
 			branch gitdomain.LocalBranchName
 			parent gitdomain.LocalBranchName
-			title  gitdomain.ProposalTitle
+			title  Option[gitdomain.ProposalTitle]
 			body   gitdomain.ProposalBody
 			want   string
 		}{
 			"top-level branch": {
 				branch: "feature",
 				parent: "main",
-				title:  "",
+				title:  None[gitdomain.ProposalTitle](),
 				body:   "",
 				want:   "https://github.com/organization/repo/compare/feature?expand=1",
 			},
 			"stacked change": {
 				branch: "feature-3",
 				parent: "feature-2",
-				title:  "",
+				title:  None[gitdomain.ProposalTitle](),
 				body:   "",
 				want:   "https://github.com/organization/repo/compare/feature-2...feature-3?expand=1",
 			},
 			"special characters in branch name": {
 				branch: "feature-#",
 				parent: "main",
-				title:  "",
+				title:  None[gitdomain.ProposalTitle](),
 				body:   "",
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1",
 			},
 			"provide title and body": {
 				branch: "feature-#",
 				parent: "main",
-				title:  "my title",
+				title:  Some(gitdomain.ProposalTitle("my title")),
 				body:   "my body",
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1&title=my+title&body=my+body",
 			},
 			"provide title only": {
 				branch: "feature-#",
 				parent: "main",
-				title:  "my title",
+				title:  Some(gitdomain.ProposalTitle("my title")),
 				body:   "",
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1&title=my+title",
 			},
 			"provide body only": {
 				branch: "feature-#",
 				parent: "main",
-				title:  "",
+				title:  None[gitdomain.ProposalTitle](),
 				body:   "my body",
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1&body=my+body",
 			},

--- a/internal/forge/github/connector_test.go
+++ b/internal/forge/github/connector_test.go
@@ -49,49 +49,49 @@ func TestConnector(t *testing.T) {
 			branch gitdomain.LocalBranchName
 			parent gitdomain.LocalBranchName
 			title  Option[gitdomain.ProposalTitle]
-			body   gitdomain.ProposalBody
+			body   Option[gitdomain.ProposalBody]
 			want   string
 		}{
 			"top-level branch": {
 				branch: "feature",
 				parent: "main",
 				title:  None[gitdomain.ProposalTitle](),
-				body:   "",
+				body:   None[gitdomain.ProposalBody](),
 				want:   "https://github.com/organization/repo/compare/feature?expand=1",
 			},
 			"stacked change": {
 				branch: "feature-3",
 				parent: "feature-2",
 				title:  None[gitdomain.ProposalTitle](),
-				body:   "",
+				body:   None[gitdomain.ProposalBody](),
 				want:   "https://github.com/organization/repo/compare/feature-2...feature-3?expand=1",
 			},
 			"special characters in branch name": {
 				branch: "feature-#",
 				parent: "main",
 				title:  None[gitdomain.ProposalTitle](),
-				body:   "",
+				body:   None[gitdomain.ProposalBody](),
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1",
 			},
 			"provide title and body": {
 				branch: "feature-#",
 				parent: "main",
 				title:  Some(gitdomain.ProposalTitle("my title")),
-				body:   "my body",
+				body:   Some(gitdomain.ProposalBody("my body")),
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1&title=my+title&body=my+body",
 			},
 			"provide title only": {
 				branch: "feature-#",
 				parent: "main",
 				title:  Some(gitdomain.ProposalTitle("my title")),
-				body:   "",
+				body:   None[gitdomain.ProposalBody](),
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1&title=my+title",
 			},
 			"provide body only": {
 				branch: "feature-#",
 				parent: "main",
 				title:  None[gitdomain.ProposalTitle](),
-				body:   "my body",
+				body:   Some(gitdomain.ProposalBody("my body")),
 				want:   "https://github.com/organization/repo/compare/feature-%23?expand=1&body=my+body",
 			},
 		}

--- a/internal/forge/gitlab/connector_test.go
+++ b/internal/forge/gitlab/connector_test.go
@@ -83,7 +83,7 @@ func TestGitlabConnector(t *testing.T) {
 					Branch:        tt.branch,
 					MainBranch:    "main",
 					ParentBranch:  tt.parent,
-					ProposalBody:  "",
+					ProposalBody:  None[gitdomain.ProposalBody](),
 					ProposalTitle: None[gitdomain.ProposalTitle](),
 				})
 				must.EqOp(t, tt.want, have)

--- a/internal/forge/gitlab/connector_test.go
+++ b/internal/forge/gitlab/connector_test.go
@@ -84,7 +84,7 @@ func TestGitlabConnector(t *testing.T) {
 					MainBranch:    "main",
 					ParentBranch:  tt.parent,
 					ProposalBody:  "",
-					ProposalTitle: "",
+					ProposalTitle: None[gitdomain.ProposalTitle](),
 				})
 				must.EqOp(t, tt.want, have)
 			})

--- a/internal/state/runstate/save_load_test.go
+++ b/internal/state/runstate/save_load_test.go
@@ -565,7 +565,7 @@ func TestLoadSave(t *testing.T) {
         "Branch": "branch",
         "MainBranch": "main",
         "ProposalBody": "",
-        "ProposalTitle": ""
+        "ProposalTitle": null
       },
       "type": "ProposalCreate"
     },

--- a/internal/state/runstate/save_load_test.go
+++ b/internal/state/runstate/save_load_test.go
@@ -564,7 +564,7 @@ func TestLoadSave(t *testing.T) {
       "data": {
         "Branch": "branch",
         "MainBranch": "main",
-        "ProposalBody": "",
+        "ProposalBody": null,
         "ProposalTitle": null
       },
       "type": "ProposalCreate"

--- a/internal/vm/opcodes/proposal_create.go
+++ b/internal/vm/opcodes/proposal_create.go
@@ -14,7 +14,7 @@ import (
 type ProposalCreate struct {
 	Branch                  gitdomain.LocalBranchName
 	MainBranch              gitdomain.LocalBranchName
-	ProposalBody            gitdomain.ProposalBody
+	ProposalBody            Option[gitdomain.ProposalBody]
 	ProposalTitle           Option[gitdomain.ProposalTitle]
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }

--- a/internal/vm/opcodes/proposal_create.go
+++ b/internal/vm/opcodes/proposal_create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/messages"
 	"github.com/git-town/git-town/v21/internal/vm/shared"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
 // ProposalCreate creates a new proposal for the current branch.
@@ -14,7 +15,7 @@ type ProposalCreate struct {
 	Branch                  gitdomain.LocalBranchName
 	MainBranch              gitdomain.LocalBranchName
 	ProposalBody            gitdomain.ProposalBody
-	ProposalTitle           gitdomain.ProposalTitle
+	ProposalTitle           Option[gitdomain.ProposalTitle]
 	undeclaredOpcodeMethods `exhaustruct:"optional"`
 }
 


### PR DESCRIPTION
Data provided by CLI arguments is currently a string, with an empty string indicating that the user didn't provide this option. This PR converts these data fields to proper options so that they are guaranteed to be handled correctly.