### PR TITLE
Merge the two connection verification methods

### DIFF
--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -347,8 +347,8 @@ func testForgeAuth(data *setupData, forgeTypeOpt Option[forgedomain.ForgeType]) 
 	if verifyResult.AuthenticationError != nil {
 		return dialog.CredentialsNoAccess(verifyResult.AuthenticationError, data.dialogInputs.Next())
 	}
-	if len(verifyResult.AuthenticatedUser) > 0 {
-		fmt.Printf(messages.CredentialsForgeUserName, components.FormattedSelection(verifyResult.AuthenticatedUser, exit))
+	if user, hasUser := verifyResult.AuthenticatedUser.Get(); hasUser {
+		fmt.Printf(messages.CredentialsForgeUserName, components.FormattedSelection(user, exit))
 	}
 	if verifyResult.AuthorizationError != nil {
 		return dialog.CredentialsNoProposalAccess(verifyResult.AuthorizationError, data.dialogInputs.Next())

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -344,14 +344,14 @@ func testForgeAuth(data *setupData, forgeTypeOpt Option[forgedomain.ForgeType]) 
 		return false, false, nil
 	}
 	verifyResult := connector.VerifyConnection()
-	if verifyResult.LoginError != nil {
-		return dialog.CredentialsNoAccess(verifyResult.LoginError, data.dialogInputs.Next())
+	if verifyResult.AuthenticationError != nil {
+		return dialog.CredentialsNoAccess(verifyResult.AuthenticationError, data.dialogInputs.Next())
 	}
-	if len(verifyResult.Username) > 0 {
-		fmt.Printf(messages.CredentialsForgeUserName, components.FormattedSelection(verifyResult.Username, exit))
+	if len(verifyResult.AuthenticatedUser) > 0 {
+		fmt.Printf(messages.CredentialsForgeUserName, components.FormattedSelection(verifyResult.AuthenticatedUser, exit))
 	}
-	if verifyResult.PermissionsError != nil {
-		return dialog.CredentialsNoProposalAccess(verifyResult.PermissionsError, data.dialogInputs.Next())
+	if verifyResult.AuthorizationError != nil {
+		return dialog.CredentialsNoProposalAccess(verifyResult.AuthorizationError, data.dialogInputs.Next())
 	}
 	fmt.Println(messages.CredentialsAccess)
 	return false, false, nil

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -343,11 +343,11 @@ func testForgeAuth(data *setupData, forgeTypeOpt Option[forgedomain.ForgeType]) 
 	if _, inTest := os.LookupEnv(subshell.TestToken); inTest {
 		return false, false, nil
 	}
-	userName, err := connector.VerifyConnection()
+	authInfo, err := connector.VerifyConnection()
 	if err != nil {
 		return dialog.CredentialsNoAccess(err, data.dialogInputs.Next())
 	}
-	if len(userName) > 0 {
+	if len(authInfo.Username) > 0 {
 		fmt.Printf(messages.CredentialsForgeUserName, components.FormattedSelection(userName, exit))
 	}
 	err = connector.VerifyReadProposalPermission()

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -343,16 +343,15 @@ func testForgeAuth(data *setupData, forgeTypeOpt Option[forgedomain.ForgeType]) 
 	if _, inTest := os.LookupEnv(subshell.TestToken); inTest {
 		return false, false, nil
 	}
-	authInfo, err := connector.VerifyConnection()
-	if err != nil {
-		return dialog.CredentialsNoAccess(err, data.dialogInputs.Next())
+	verifyResult := connector.VerifyConnection()
+	if verifyResult.LoginError != nil {
+		return dialog.CredentialsNoAccess(verifyResult.LoginError, data.dialogInputs.Next())
 	}
-	if len(authInfo.Username) > 0 {
-		fmt.Printf(messages.CredentialsForgeUserName, components.FormattedSelection(userName, exit))
+	if len(verifyResult.Username) > 0 {
+		fmt.Printf(messages.CredentialsForgeUserName, components.FormattedSelection(verifyResult.Username, exit))
 	}
-	err = connector.VerifyReadProposalPermission()
-	if err != nil {
-		return dialog.CredentialsNoProposalAccess(err, data.dialogInputs.Next())
+	if verifyResult.PermissionsError != nil {
+		return dialog.CredentialsNoProposalAccess(verifyResult.PermissionsError, data.dialogInputs.Next())
 	}
 	fmt.Println(messages.CredentialsAccess)
 	return false, false, nil

--- a/internal/forge/bitbucketcloud/connector.go
+++ b/internal/forge/bitbucketcloud/connector.go
@@ -101,22 +101,21 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return Some(self.updateProposalTarget)
 }
 
-func (self Connector) VerifyConnection() (string, error) {
+func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, err error) {
 	user, err := self.client.User.Profile()
 	if err != nil {
-		return "", err
+		return info, err
 	}
-	return user.Username, nil
-}
-
-func (self Connector) VerifyReadProposalPermission() error {
-	_, err := self.client.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{
+	_, err = self.client.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{
 		Owner:    self.Organization,
 		RepoSlug: self.Repository,
 		Query:    "",
 		States:   []string{},
 	})
-	return err
+	return forgedomain.AuthenticationInfo{
+		Username:         user.Username,
+		CanReadProposals: err != nil,
+	}, err
 }
 
 func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {

--- a/internal/forge/bitbucketcloud/connector.go
+++ b/internal/forge/bitbucketcloud/connector.go
@@ -105,7 +105,7 @@ func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResul
 	user, err := self.client.User.Profile()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    "",
+			AuthenticatedUser:    None[string](),
 			AuthenticationError:  err,
 			AuthorizationSuccess: false,
 			AuthorizationError:   nil,
@@ -118,7 +118,7 @@ func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResul
 		States:   []string{},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    user.Username,
+		AuthenticatedUser:    Some(user.Username),
 		AuthenticationError:  nil,
 		AuthorizationSuccess: err == nil,
 		AuthorizationError:   err,

--- a/internal/forge/bitbucketcloud/connector.go
+++ b/internal/forge/bitbucketcloud/connector.go
@@ -101,7 +101,7 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return Some(self.updateProposalTarget)
 }
 
-func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResult) {
+func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, err := self.client.User.Profile()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{

--- a/internal/forge/bitbucketcloud/connector.go
+++ b/internal/forge/bitbucketcloud/connector.go
@@ -105,10 +105,10 @@ func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResul
 	user, err := self.client.User.Profile()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			Username:         "",
-			LoginError:       err,
-			CanReadProposals: false,
-			PermissionsError: nil,
+			AuthenticatedUser:    "",
+			AuthenticationError:  err,
+			AuthorizationSuccess: false,
+			AuthorizationError:   nil,
 		}
 	}
 	_, err = self.client.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{
@@ -118,10 +118,10 @@ func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResul
 		States:   []string{},
 	})
 	return forgedomain.VerifyConnectionResult{
-		Username:         user.Username,
-		LoginError:       nil,
-		CanReadProposals: err == nil,
-		PermissionsError: err,
+		AuthenticatedUser:    user.Username,
+		AuthenticationError:  nil,
+		AuthorizationSuccess: err == nil,
+		AuthorizationError:   err,
 	}
 }
 

--- a/internal/forge/bitbucketcloud/connector.go
+++ b/internal/forge/bitbucketcloud/connector.go
@@ -117,7 +117,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		States:   []string{},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:   Some(user.Username),
+		AuthenticatedUser:   NewOption(user.Username),
 		AuthenticationError: nil,
 		AuthorizationError:  err,
 	}

--- a/internal/forge/bitbucketcloud/connector.go
+++ b/internal/forge/bitbucketcloud/connector.go
@@ -105,10 +105,9 @@ func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResul
 	user, err := self.client.User.Profile()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    None[string](),
-			AuthenticationError:  err,
-			AuthorizationSuccess: false,
-			AuthorizationError:   nil,
+			AuthenticatedUser:   None[string](),
+			AuthenticationError: err,
+			AuthorizationError:  nil,
 		}
 	}
 	_, err = self.client.Repositories.PullRequests.Gets(&bitbucket.PullRequestsOptions{
@@ -118,10 +117,9 @@ func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResul
 		States:   []string{},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    Some(user.Username),
-		AuthenticationError:  nil,
-		AuthorizationSuccess: err == nil,
-		AuthorizationError:   err,
+		AuthenticatedUser:   Some(user.Username),
+		AuthenticationError: nil,
+		AuthorizationError:  err,
 	}
 }
 

--- a/internal/forge/bitbucketdatacenter/connector.go
+++ b/internal/forge/bitbucketdatacenter/connector.go
@@ -101,10 +101,10 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 
 func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	return forgedomain.VerifyConnectionResult{
-		Username:         "",
-		LoginError:       nil,
-		CanReadProposals: true,
-		PermissionsError: nil,
+		AuthenticatedUser:    "",
+		AuthenticationError:  nil,
+		AuthorizationSuccess: true,
+		AuthorizationError:   nil,
 	}
 }
 

--- a/internal/forge/bitbucketdatacenter/connector.go
+++ b/internal/forge/bitbucketdatacenter/connector.go
@@ -101,7 +101,7 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 
 func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    "",
+		AuthenticatedUser:    None[string](),
 		AuthenticationError:  nil,
 		AuthorizationSuccess: true,
 		AuthorizationError:   nil,

--- a/internal/forge/bitbucketdatacenter/connector.go
+++ b/internal/forge/bitbucketdatacenter/connector.go
@@ -101,10 +101,9 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 
 func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    None[string](),
-		AuthenticationError:  nil,
-		AuthorizationSuccess: true,
-		AuthorizationError:   nil,
+		AuthenticatedUser:   None[string](),
+		AuthenticationError: nil,
+		AuthorizationError:  nil,
 	}
 }
 

--- a/internal/forge/bitbucketdatacenter/connector.go
+++ b/internal/forge/bitbucketdatacenter/connector.go
@@ -99,11 +99,13 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return None[func(forgedomain.ProposalInterface, gitdomain.LocalBranchName, stringslice.Collector) error]()
 }
 
-func (self Connector) VerifyConnection() (forgedomain.AuthenticationInfo, error) {
-	return forgedomain.AuthenticationInfo{
+func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
+	return forgedomain.VerifyConnectionResult{
 		Username:         "",
+		LoginError:       nil,
 		CanReadProposals: true,
-	}, nil
+		PermissionsError: nil,
+	}
 }
 
 func (self Connector) apiBaseURL() string {

--- a/internal/forge/bitbucketdatacenter/connector.go
+++ b/internal/forge/bitbucketdatacenter/connector.go
@@ -99,12 +99,11 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return None[func(forgedomain.ProposalInterface, gitdomain.LocalBranchName, stringslice.Collector) error]()
 }
 
-func (self Connector) VerifyConnection() (string, error) {
-	return "", nil
-}
-
-func (self Connector) VerifyReadProposalPermission() error {
-	return nil
+func (self Connector) VerifyConnection() (forgedomain.AuthenticationInfo, error) {
+	return forgedomain.AuthenticationInfo{
+		Username:         "",
+		CanReadProposals: true,
+	}, nil
 }
 
 func (self Connector) apiBaseURL() string {

--- a/internal/forge/codeberg/connector.go
+++ b/internal/forge/codeberg/connector.go
@@ -84,21 +84,20 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return None[func(forgedomain.ProposalInterface, gitdomain.LocalBranchName, stringslice.Collector) error]()
 }
 
-func (self Connector) VerifyConnection() (string, error) {
+func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, err error) {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
-		return "", err
+		return info, err
 	}
-	return user.UserName, nil
-}
-
-func (self Connector) VerifyReadProposalPermission() error {
-	_, _, err := self.client.ListRepoPullRequests(self.Organization, self.Repository, forgejo.ListPullRequestsOptions{
+	_, _, err = self.client.ListRepoPullRequests(self.Organization, self.Repository, forgejo.ListPullRequestsOptions{
 		ListOptions: forgejo.ListOptions{
 			PageSize: 1,
 		},
 	})
-	return err
+	return forgedomain.AuthenticationInfo{
+		Username:         user.UserName,
+		CanReadProposals: err != nil,
+	}, err
 }
 
 func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {

--- a/internal/forge/codeberg/connector.go
+++ b/internal/forge/codeberg/connector.go
@@ -99,7 +99,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:   Some(user.UserName),
+		AuthenticatedUser:   NewOption(user.UserName),
 		AuthenticationError: nil,
 		AuthorizationError:  err,
 	}

--- a/internal/forge/codeberg/connector.go
+++ b/internal/forge/codeberg/connector.go
@@ -88,10 +88,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    None[string](),
-			AuthenticationError:  err,
-			AuthorizationSuccess: false,
-			AuthorizationError:   nil,
+			AuthenticatedUser:   None[string](),
+			AuthenticationError: err,
+			AuthorizationError:  nil,
 		}
 	}
 	_, _, err = self.client.ListRepoPullRequests(self.Organization, self.Repository, forgejo.ListPullRequestsOptions{
@@ -100,10 +99,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    Some(user.UserName),
-		AuthenticationError:  nil,
-		AuthorizationSuccess: err == nil,
-		AuthorizationError:   err,
+		AuthenticatedUser:   Some(user.UserName),
+		AuthenticationError: nil,
+		AuthorizationError:  err,
 	}
 }
 

--- a/internal/forge/codeberg/connector.go
+++ b/internal/forge/codeberg/connector.go
@@ -88,10 +88,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			Username:         "",
-			LoginError:       err,
-			CanReadProposals: false,
-			PermissionsError: nil,
+			AuthenticatedUser:    "",
+			AuthenticationError:  err,
+			AuthorizationSuccess: false,
+			AuthorizationError:   nil,
 		}
 	}
 	_, _, err = self.client.ListRepoPullRequests(self.Organization, self.Repository, forgejo.ListPullRequestsOptions{
@@ -100,10 +100,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		Username:         user.UserName,
-		LoginError:       nil,
-		CanReadProposals: err == nil,
-		PermissionsError: err,
+		AuthenticatedUser:    user.UserName,
+		AuthenticationError:  nil,
+		AuthorizationSuccess: err == nil,
+		AuthorizationError:   err,
 	}
 }
 

--- a/internal/forge/codeberg/connector.go
+++ b/internal/forge/codeberg/connector.go
@@ -88,7 +88,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    "",
+			AuthenticatedUser:    None[string](),
 			AuthenticationError:  err,
 			AuthorizationSuccess: false,
 			AuthorizationError:   nil,
@@ -100,7 +100,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    user.UserName,
+		AuthenticatedUser:    Some(user.UserName),
 		AuthenticationError:  nil,
 		AuthorizationSuccess: err == nil,
 		AuthorizationError:   err,

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -54,10 +54,12 @@ type Connector interface {
 	UpdateProposalTargetFn() Option[func(proposal ProposalInterface, newTarget gitdomain.LocalBranchName, finalMessages stringslice.Collector) error]
 
 	// VerifyConnection checks whether this connector can make successful requests to the forge.
-	VerifyConnection() (userName string, err error)
+	VerifyConnection() (AuthenticationInfo, error)
+}
 
-	// VerifyProposalAccess checks whether this connector has authorization to read proposals at the forge.
-	VerifyReadProposalPermission() error
+type AuthenticationInfo struct {
+	Username         string
+	CanReadProposals bool
 }
 
 type CreateProposalArgs struct {

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -64,10 +64,6 @@ type VerifyConnectionResult struct {
 	PermissionsError error
 }
 
-func EmptyAuthenticationInfo() VerifyConnectionResult {
-	return VerifyConnectionResult{}
-}
-
 type CreateProposalArgs struct {
 	Branch         gitdomain.LocalBranchName
 	FrontendRunner subshelldomain.Runner

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -58,10 +58,10 @@ type Connector interface {
 }
 
 type VerifyConnectionResult struct {
-	Username         string
-	LoginError       error
-	CanReadProposals bool
-	PermissionsError error
+	AuthenticatedUser    string // the authenticated username
+	AuthenticationError  error  // error while verifying to verify authentication
+	AuthorizationError   error  // error while verifying authorization
+	AuthorizationSuccess bool   // whether the connection provides proper authorization
 }
 
 type CreateProposalArgs struct {

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -58,10 +58,9 @@ type Connector interface {
 }
 
 type VerifyConnectionResult struct {
-	AuthenticatedUser    Option[string] // the authenticated username
-	AuthenticationError  error          // error while verifying to verify authentication
-	AuthorizationError   error          // error while verifying authorization
-	AuthorizationSuccess bool           // whether the connection provides proper authorization
+	AuthenticatedUser   Option[string] // the authenticated username
+	AuthenticationError error          // error while verifying to verify authentication
+	AuthorizationError  error          // error while verifying authorization, nil == user is authenticated
 }
 
 type CreateProposalArgs struct {

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -58,10 +58,10 @@ type Connector interface {
 }
 
 type VerifyConnectionResult struct {
-	AuthenticatedUser    string // the authenticated username
-	AuthenticationError  error  // error while verifying to verify authentication
-	AuthorizationError   error  // error while verifying authorization
-	AuthorizationSuccess bool   // whether the connection provides proper authorization
+	AuthenticatedUser    Option[string] // the authenticated username
+	AuthenticationError  error          // error while verifying to verify authentication
+	AuthorizationError   error          // error while verifying authorization
+	AuthorizationSuccess bool           // whether the connection provides proper authorization
 }
 
 type CreateProposalArgs struct {

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -62,6 +62,10 @@ type AuthenticationInfo struct {
 	CanReadProposals bool
 }
 
+func EmptyAuthenticationInfo() AuthenticationInfo {
+	return AuthenticationInfo{}
+}
+
 type CreateProposalArgs struct {
 	Branch         gitdomain.LocalBranchName
 	FrontendRunner subshelldomain.Runner

--- a/internal/forge/forgedomain/connector.go
+++ b/internal/forge/forgedomain/connector.go
@@ -54,16 +54,18 @@ type Connector interface {
 	UpdateProposalTargetFn() Option[func(proposal ProposalInterface, newTarget gitdomain.LocalBranchName, finalMessages stringslice.Collector) error]
 
 	// VerifyConnection checks whether this connector can make successful requests to the forge.
-	VerifyConnection() (AuthenticationInfo, error)
+	VerifyConnection() VerifyConnectionResult
 }
 
-type AuthenticationInfo struct {
+type VerifyConnectionResult struct {
 	Username         string
+	LoginError       error
 	CanReadProposals bool
+	PermissionsError error
 }
 
-func EmptyAuthenticationInfo() AuthenticationInfo {
-	return AuthenticationInfo{}
+func EmptyAuthenticationInfo() VerifyConnectionResult {
+	return VerifyConnectionResult{}
 }
 
 type CreateProposalArgs struct {

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -84,7 +84,7 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return None[func(forgedomain.ProposalInterface, gitdomain.LocalBranchName, stringslice.Collector) error]()
 }
 
-func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, err error) {
+func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResult, err error) {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
 		return info, err
@@ -94,7 +94,7 @@ func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, e
 			PageSize: 1,
 		},
 	})
-	return forgedomain.AuthenticationInfo{
+	return forgedomain.VerifyConnectionResult{
 		Username:         user.UserName,
 		CanReadProposals: err != nil,
 	}, err

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -88,10 +88,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    None[string](),
-			AuthenticationError:  err,
-			AuthorizationSuccess: false,
-			AuthorizationError:   nil,
+			AuthenticatedUser:   None[string](),
+			AuthenticationError: err,
+			AuthorizationError:  nil,
 		}
 	}
 	_, _, err = self.client.ListRepoPullRequests(self.Organization, self.Repository, gitea.ListPullRequestsOptions{
@@ -100,10 +99,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    Some(user.UserName),
-		AuthenticationError:  err,
-		AuthorizationSuccess: err == nil,
-		AuthorizationError:   err,
+		AuthenticatedUser:   Some(user.UserName),
+		AuthenticationError: err,
+		AuthorizationError:  err,
 	}
 }
 

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -100,7 +100,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	})
 	return forgedomain.VerifyConnectionResult{
 		AuthenticatedUser:   Some(user.UserName),
-		AuthenticationError: err,
+		AuthenticationError: nil,
 		AuthorizationError:  err,
 	}
 }

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -99,7 +99,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:   Some(user.UserName),
+		AuthenticatedUser:   NewOption(user.UserName),
 		AuthenticationError: nil,
 		AuthorizationError:  err,
 	}

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -84,21 +84,20 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return None[func(forgedomain.ProposalInterface, gitdomain.LocalBranchName, stringslice.Collector) error]()
 }
 
-func (self Connector) VerifyConnection() (string, error) {
+func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, err error) {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
-		return "", err
+		return info, err
 	}
-	return user.UserName, nil
-}
-
-func (self Connector) VerifyReadProposalPermission() error {
-	_, _, err := self.client.ListRepoPullRequests(self.Organization, self.Repository, gitea.ListPullRequestsOptions{
+	_, _, err = self.client.ListRepoPullRequests(self.Organization, self.Repository, gitea.ListPullRequestsOptions{
 		ListOptions: gitea.ListOptions{
 			PageSize: 1,
 		},
 	})
-	return err
+	return forgedomain.AuthenticationInfo{
+		Username:         user.UserName,
+		CanReadProposals: err != nil,
+	}, err
 }
 
 func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -88,10 +88,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			Username:         "",
-			LoginError:       err,
-			CanReadProposals: false,
-			PermissionsError: nil,
+			AuthenticatedUser:    "",
+			AuthenticationError:  err,
+			AuthorizationSuccess: false,
+			AuthorizationError:   nil,
 		}
 	}
 	_, _, err = self.client.ListRepoPullRequests(self.Organization, self.Repository, gitea.ListPullRequestsOptions{
@@ -100,10 +100,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		Username:         user.UserName,
-		LoginError:       err,
-		CanReadProposals: err == nil,
-		PermissionsError: err,
+		AuthenticatedUser:    user.UserName,
+		AuthenticationError:  err,
+		AuthorizationSuccess: err == nil,
+		AuthorizationError:   err,
 	}
 }
 

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -88,7 +88,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.GetMyUserInfo()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    "",
+			AuthenticatedUser:    None[string](),
 			AuthenticationError:  err,
 			AuthorizationSuccess: false,
 			AuthorizationError:   nil,
@@ -100,7 +100,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    user.UserName,
+		AuthenticatedUser:    Some(user.UserName),
 		AuthenticationError:  err,
 		AuthorizationSuccess: err == nil,
 		AuthorizationError:   err,

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -103,10 +103,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.Users.Get(context.Background(), "")
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			Username:         "",
-			LoginError:       err,
-			CanReadProposals: false,
-			PermissionsError: nil,
+			AuthenticatedUser:    "",
+			AuthenticationError:  err,
+			AuthorizationSuccess: false,
+			AuthorizationError:   nil,
 		}
 	}
 	_, _, err = self.client.PullRequests.List(context.Background(), self.Organization, self.Repository, &github.PullRequestListOptions{
@@ -115,10 +115,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		Username:         *user.Login,
-		LoginError:       nil,
-		CanReadProposals: err == nil,
-		PermissionsError: err,
+		AuthenticatedUser:    *user.Login,
+		AuthenticationError:  nil,
+		AuthorizationSuccess: err == nil,
+		AuthorizationError:   err,
 	}
 }
 

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -99,21 +99,20 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return Some(self.updateProposalTarget)
 }
 
-func (self Connector) VerifyConnection() (string, error) {
+func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, err error) {
 	user, _, err := self.client.Users.Get(context.Background(), "")
 	if err != nil {
-		return "", err
+		return info, err
 	}
-	return *user.Login, nil
-}
-
-func (self Connector) VerifyReadProposalPermission() error {
-	_, _, err := self.client.PullRequests.List(context.Background(), self.Organization, self.Repository, &github.PullRequestListOptions{
+	_, _, err = self.client.PullRequests.List(context.Background(), self.Organization, self.Repository, &github.PullRequestListOptions{
 		ListOptions: github.ListOptions{
 			PerPage: 1,
 		},
 	})
-	return err
+	return forgedomain.AuthenticationInfo{
+		Username:         *user.Login,
+		CanReadProposals: err != nil,
+	}, err
 }
 
 func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -103,10 +103,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.Users.Get(context.Background(), "")
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    None[string](),
-			AuthenticationError:  err,
-			AuthorizationSuccess: false,
-			AuthorizationError:   nil,
+			AuthenticatedUser:   None[string](),
+			AuthenticationError: err,
+			AuthorizationError:  nil,
 		}
 	}
 	_, _, err = self.client.PullRequests.List(context.Background(), self.Organization, self.Repository, &github.PullRequestListOptions{
@@ -115,10 +114,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    Some(*user.Login),
-		AuthenticationError:  nil,
-		AuthorizationSuccess: err == nil,
-		AuthorizationError:   err,
+		AuthenticatedUser:   Some(*user.Login),
+		AuthenticationError: nil,
+		AuthorizationError:  err,
 	}
 }
 

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -99,7 +99,7 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return Some(self.updateProposalTarget)
 }
 
-func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, err error) {
+func (self Connector) VerifyConnection() (info forgedomain.VerifyConnectionResult, err error) {
 	user, _, err := self.client.Users.Get(context.Background(), "")
 	if err != nil {
 		return info, err
@@ -109,7 +109,7 @@ func (self Connector) VerifyConnection() (info forgedomain.AuthenticationInfo, e
 			PerPage: 1,
 		},
 	})
-	return forgedomain.AuthenticationInfo{
+	return forgedomain.VerifyConnectionResult{
 		Username:         *user.Login,
 		CanReadProposals: err != nil,
 	}, err

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -114,7 +114,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:   Some(*user.Login),
+		AuthenticatedUser:   NewOption(*user.Login),
 		AuthenticationError: nil,
 		AuthorizationError:  err,
 	}

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -103,7 +103,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.Users.Get(context.Background(), "")
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    "",
+			AuthenticatedUser:    None[string](),
 			AuthenticationError:  err,
 			AuthorizationSuccess: false,
 			AuthorizationError:   nil,
@@ -115,7 +115,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    *user.Login,
+		AuthenticatedUser:    Some(*user.Login),
 		AuthenticationError:  nil,
 		AuthorizationSuccess: err == nil,
 		AuthorizationError:   err,

--- a/internal/forge/gitlab/connector.go
+++ b/internal/forge/gitlab/connector.go
@@ -76,10 +76,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.Users.CurrentUser()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    None[string](),
-			AuthenticationError:  err,
-			AuthorizationSuccess: false,
-			AuthorizationError:   nil,
+			AuthenticatedUser:   None[string](),
+			AuthenticationError: err,
+			AuthorizationError:  nil,
 		}
 	}
 	_, _, err = self.client.MergeRequests.ListMergeRequests(&gitlab.ListMergeRequestsOptions{
@@ -88,10 +87,9 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    Some(user.Username),
-		AuthenticationError:  nil,
-		AuthorizationSuccess: err == nil,
-		AuthorizationError:   err,
+		AuthenticatedUser:   Some(user.Username),
+		AuthenticationError: nil,
+		AuthorizationError:  err,
 	}
 }
 

--- a/internal/forge/gitlab/connector.go
+++ b/internal/forge/gitlab/connector.go
@@ -87,7 +87,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:   Some(user.Username),
+		AuthenticatedUser:   NewOption(user.Username),
 		AuthenticationError: nil,
 		AuthorizationError:  err,
 	}

--- a/internal/forge/gitlab/connector.go
+++ b/internal/forge/gitlab/connector.go
@@ -72,21 +72,20 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return Some(self.updateProposalTarget)
 }
 
-func (self Connector) VerifyConnection() (string, error) {
+func (self Connector) VerifyConnection() (forgedomain.AuthenticationInfo, error) {
 	user, _, err := self.client.Users.CurrentUser()
 	if err != nil {
-		return "", err
+		return forgedomain.EmptyAuthenticationInfo(), err
 	}
-	return user.Username, nil
-}
-
-func (self Connector) VerifyReadProposalPermission() error {
-	_, _, err := self.client.MergeRequests.ListMergeRequests(&gitlab.ListMergeRequestsOptions{
+	_, _, err = self.client.MergeRequests.ListMergeRequests(&gitlab.ListMergeRequestsOptions{
 		ListOptions: gitlab.ListOptions{
 			PerPage: 1,
 		},
 	})
-	return err
+	return forgedomain.AuthenticationInfo{
+		Username:         user.Username,
+		CanReadProposals: err != nil,
+	}, err
 }
 
 func (self Connector) findProposalViaAPI(branch, target gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {

--- a/internal/forge/gitlab/connector.go
+++ b/internal/forge/gitlab/connector.go
@@ -76,10 +76,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.Users.CurrentUser()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			Username:         "",
-			LoginError:       err,
-			CanReadProposals: false,
-			PermissionsError: nil,
+			AuthenticatedUser:    "",
+			AuthenticationError:  err,
+			AuthorizationSuccess: false,
+			AuthorizationError:   nil,
 		}
 	}
 	_, _, err = self.client.MergeRequests.ListMergeRequests(&gitlab.ListMergeRequestsOptions{
@@ -88,10 +88,10 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		Username:         user.Username,
-		LoginError:       nil,
-		CanReadProposals: err == nil,
-		PermissionsError: err,
+		AuthenticatedUser:    user.Username,
+		AuthenticationError:  nil,
+		AuthorizationSuccess: err == nil,
+		AuthorizationError:   err,
 	}
 }
 

--- a/internal/forge/gitlab/connector.go
+++ b/internal/forge/gitlab/connector.go
@@ -76,7 +76,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 	user, _, err := self.client.Users.CurrentUser()
 	if err != nil {
 		return forgedomain.VerifyConnectionResult{
-			AuthenticatedUser:    "",
+			AuthenticatedUser:    None[string](),
 			AuthenticationError:  err,
 			AuthorizationSuccess: false,
 			AuthorizationError:   nil,
@@ -88,7 +88,7 @@ func (self Connector) VerifyConnection() forgedomain.VerifyConnectionResult {
 		},
 	})
 	return forgedomain.VerifyConnectionResult{
-		AuthenticatedUser:    user.Username,
+		AuthenticatedUser:    Some(user.Username),
 		AuthenticationError:  nil,
 		AuthorizationSuccess: err == nil,
 		AuthorizationError:   err,

--- a/internal/forge/gitlab/connector.go
+++ b/internal/forge/gitlab/connector.go
@@ -72,7 +72,7 @@ func (self Connector) UpdateProposalTargetFn() Option[func(forgedomain.ProposalI
 	return Some(self.updateProposalTarget)
 }
 
-func (self Connector) VerifyConnection() (forgedomain.AuthenticationInfo, error) {
+func (self Connector) VerifyConnection() (forgedomain.VerifyConnectionResult, error) {
 	user, _, err := self.client.Users.CurrentUser()
 	if err != nil {
 		return forgedomain.EmptyAuthenticationInfo(), err
@@ -82,7 +82,7 @@ func (self Connector) VerifyConnection() (forgedomain.AuthenticationInfo, error)
 			PerPage: 1,
 		},
 	})
-	return forgedomain.AuthenticationInfo{
+	return forgedomain.VerifyConnectionResult{
 		Username:         user.Username,
 		CanReadProposals: err != nil,
 	}, err


### PR DESCRIPTION
Connectors implement two separate methods to verify authentication and authorization. This PR merges them into one method. This is necessary now because the upcoming `gh` connector verifies both with one subshell call.

part of #1639