### PR TITLE
Fix tagliatelle configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
     tagliatelle:
       case:
         rules:
-          json: pascal
+          json: camel
         use-field-name: true
 
   exclusions:

--- a/internal/forge/bitbucketdatacenter/types.go
+++ b/internal/forge/bitbucketdatacenter/types.go
@@ -1,4 +1,3 @@
-//nolint:tagliatelle // we integrate with remote APIs only
 package bitbucketdatacenter
 
 type PullRequestResponse struct {


### PR DESCRIPTION
The tagliatelle linter was set to Pascal case, but in JSON we want to use camelcase fields.