### PR TITLE
Dry up redundant code

### DIFF
--- a/internal/forge/gh/connector.go
+++ b/internal/forge/gh/connector.go
@@ -93,30 +93,7 @@ func (self Connector) findProposal(branch, target gitdomain.LocalBranchName) (Op
 	if len(parsed) > 1 {
 		return None[forgedomain.Proposal](), fmt.Errorf(messages.ProposalMultipleFromToFound, len(parsed), branch, target)
 	}
-	pr := parsed[0]
-	proposal := forgedomain.Proposal{
-		Data: forgedomain.ProposalData{
-			Body:         NewOption(pr.Body),
-			MergeWithAPI: pr.Mergeable == "MERGEABLE",
-			Number:       pr.Number,
-			Source:       gitdomain.NewLocalBranchName(pr.HeadRefName),
-			Target:       gitdomain.NewLocalBranchName(pr.BaseRefName),
-			Title:        pr.Title,
-			URL:          pr.URL,
-		},
-		ForgeType: forgedomain.ForgeTypeGitHub,
-	}
-	return Some(proposal), nil
-}
-
-type ghData struct {
-	BaseRefName string `json:"baseRefName"`
-	Body        string `json:"body"`
-	HeadRefName string `json:"headRefName"`
-	Mergeable   string `json:"mergeable"`
-	Number      int    `json:"number"`
-	Title       string `json:"title"`
-	URL         string `json:"url"`
+	return Some(parsed[0].ToProposal()), nil
 }
 
 func (self Connector) searchProposal(branch gitdomain.LocalBranchName) (Option[forgedomain.Proposal], error) {
@@ -132,20 +109,7 @@ func (self Connector) searchProposal(branch gitdomain.LocalBranchName) (Option[f
 	if len(parsed) > 1 {
 		return None[forgedomain.Proposal](), fmt.Errorf("found more than one pull request: %d", len(parsed))
 	}
-	pr := parsed[0]
-	proposal := forgedomain.Proposal{
-		Data: forgedomain.ProposalData{
-			Body:         NewOption(pr.Body),
-			MergeWithAPI: pr.Mergeable == "MERGEABLE",
-			Number:       pr.Number,
-			Source:       gitdomain.NewLocalBranchName(pr.HeadRefName),
-			Target:       gitdomain.NewLocalBranchName(pr.BaseRefName),
-			Title:        pr.Title,
-			URL:          pr.URL,
-		},
-		ForgeType: forgedomain.ForgeTypeGitHub,
-	}
-	return Some(proposal), nil
+	return Some(parsed[0].ToProposal()), nil
 }
 
 func (self Connector) squashMergeProposal(number int, message gitdomain.CommitMessage) (err error) {
@@ -186,4 +150,29 @@ func ParsePermissionsOutput(output string) forgedomain.VerifyConnectionResult {
 		}
 	}
 	return result
+}
+
+type ghData struct {
+	BaseRefName string `json:"baseRefName"`
+	Body        string `json:"body"`
+	HeadRefName string `json:"headRefName"`
+	Mergeable   string `json:"mergeable"`
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+}
+
+func (data ghData) ToProposal() forgedomain.Proposal {
+	return forgedomain.Proposal{
+		Data: forgedomain.ProposalData{
+			Body:         NewOption(data.Body),
+			MergeWithAPI: data.Mergeable == "MERGEABLE",
+			Number:       data.Number,
+			Source:       gitdomain.NewLocalBranchName(data.HeadRefName),
+			Target:       gitdomain.NewLocalBranchName(data.BaseRefName),
+			Title:        data.Title,
+			URL:          data.URL,
+		},
+		ForgeType: forgedomain.ForgeTypeGitHub,
+	}
 }


### PR DESCRIPTION
This code exists twice, extract it into a method on the parsed JSON data.
