### PR TITLE
Convert print_config_exhaustive linter to Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tools/golangci_lint*
 tools/lint_steps/lint_steps
 tools/messy_output/messy_output
 tools/optioncompare/optioncompare
+tools/print_config_exhaustive/print_config_exhaustive
 tools/stats_release/stats_release
 tools/structs_sorted/structs_sorted
 tools/tests_sorted/tests_sorted

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ lint-messy-output:
 	@(cd tools/messy_output && go build) && ./tools/messy_output/messy_output
 
 lint-print-config:
-	@tools/rta node tools/print_config_exhaustive/lint.js
+	@(cd tools/print_config_exhaustive && go build) && ./tools/print_config_exhaustive/print_config_exhaustive
 
 lint-optioncompare:
 	@(cd tools/optioncompare && go build) && ./tools/optioncompare/optioncompare github.com/git-town/git-town/v21/...

--- a/go.work
+++ b/go.work
@@ -7,6 +7,7 @@ use (
 	./tools/lint_steps
 	./tools/messy_output
 	./tools/optioncompare
+	./tools/print_config_exhaustive
 	./tools/stats_release
 	./tools/structs_sorted
 	./tools/tests_sorted

--- a/tools/print_config_exhaustive/Makefile
+++ b/tools/print_config_exhaustive/Makefile
@@ -1,0 +1,23 @@
+.DEFAULT_GOAL := help
+
+fix:  # runs all linters and auto-fixes
+	../rta gofumpt -l -w .
+	go run ../format_unittests/format_unittests.go
+	go run ../format_self/format_self.go
+
+help:  # prints all available targets
+	@grep -h -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?# "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+lint:  # runs all linters
+	../rta golangci-lint run
+	../rta deadcode github.com/git-town/git-town/tools/structs_sorted
+	@../rta --available alphavet && go vet "-vettool=$(shell ../rta --which alphavet)" $(shell go list ./...)
+	(cd ../structs_sorted && go build) && ../structs_sorted/structs_sorted
+	../ensure_no_files_with_dashes.sh
+	../rta golangci-lint cache clean
+	../rta golangci-lint run
+
+test: unit lint  # runs all tests
+
+unit:  # runs only the unit tests
+	go test ./...

--- a/tools/print_config_exhaustive/go.mod
+++ b/tools/print_config_exhaustive/go.mod
@@ -1,0 +1,3 @@
+module github.com/git-town/git-town/tools/print_config_exhaustive
+
+go 1.23.10

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -26,7 +26,7 @@ func main() {
 
 	// read and parse print file
 	printText := readFile(printConfigPath)
-	printBody := parsePrintFile(printText)
+	printBody := ParsePrintFile(printText)
 
 	// find fields that are in the definition file but not the print file
 	unprinted := findUnprinted(definitionFields, printBody, whiteList)
@@ -68,7 +68,7 @@ func DefinitionFields(text string) []string {
 	return result
 }
 
-func parsePrintFile(text string) string {
+func ParsePrintFile(text string) string {
 	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
 	match := functionContentRE.FindStringSubmatch(string(text))
 	if len(match) < 2 {

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -30,14 +30,10 @@ func main() {
 
 	// find fields that are in the definition file but not the print file
 	unprinted := FindUnprinted(definitionFields, printBody, whiteList)
-	if len(unprinted) == 0 {
-		return
+	if len(unprinted) > 0 {
+		printMissingFields(unprinted)
+		os.Exit(1)
 	}
-	fmt.Println("Missing fields in printConfig function:")
-	for _, field := range unprinted {
-		fmt.Println(field)
-	}
-	os.Exit(1)
 }
 
 func readFile(path string) string {
@@ -93,4 +89,11 @@ func FindUnprinted(fields []string, text string, whiteList []string) []string {
 
 func isWhitelisted(field string, whitelist []string) bool {
 	return slices.Contains(whitelist, field)
+}
+
+func printMissingFields(unprinted []string) {
+	fmt.Println("Missing fields in printConfig function:")
+	for _, field := range unprinted {
+		fmt.Println(field)
+	}
 }

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -36,14 +36,6 @@ func main() {
 	}
 }
 
-func readFile(path string) string {
-	result, err := os.ReadFile(path)
-	if err != nil {
-		log.Fatalf("Error reading %s: %v\n", path, err)
-	}
-	return string(result)
-}
-
 func DefinitionFields(text string) []string {
 	structRE := regexp.MustCompile(`type NormalConfigData struct {([^}]*)}`)
 	match := structRE.FindStringSubmatch(text)
@@ -64,15 +56,6 @@ func DefinitionFields(text string) []string {
 	return result
 }
 
-func ParsePrintFile(text string) string {
-	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
-	match := functionContentRE.FindStringSubmatch(text)
-	if len(match) < 2 {
-		log.Fatalf("Error: Failed to find printConfig function")
-	}
-	return match[1]
-}
-
 func FindUnprinted(fields []string, text string, whiteList []string) []string {
 	result := []string{}
 	for _, field := range fields {
@@ -87,6 +70,15 @@ func FindUnprinted(fields []string, text string, whiteList []string) []string {
 	return result
 }
 
+func ParsePrintFile(text string) string {
+	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
+	match := functionContentRE.FindStringSubmatch(text)
+	if len(match) < 2 {
+		log.Fatalf("Error: Failed to find printConfig function")
+	}
+	return match[1]
+}
+
 func isWhitelisted(field string, whitelist []string) bool {
 	return slices.Contains(whitelist, field)
 }
@@ -96,4 +88,12 @@ func printMissingFields(unprinted []string) {
 	for _, field := range unprinted {
 		fmt.Println(field)
 	}
+}
+
+func readFile(path string) string {
+	result, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("Error reading %s: %v\n", path, err)
+	}
+	return string(result)
 }

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -20,16 +20,9 @@ var whiteList = []string{
 }
 
 func main() {
-	// read and parse definition file
-	definitionText := readFile(normalConfigDataPath)
-	definitionFields := DefinitionFields(definitionText)
-
-	// read and parse print file
-	printText := readFile(printConfigPath)
-	printBody := ParsePrintFile(printText)
-
-	// find fields that are in the definition file but not the print file
-	unprinted := FindUnprinted(definitionFields, printBody, whiteList)
+	definedFields := DefinitionFields(readFile(normalConfigDataPath))
+	printFunction := ParsePrintFile(readFile(printConfigPath))
+	unprinted := FindUnprinted(definedFields, printFunction, whiteList)
 	if len(unprinted) > 0 {
 		printMissingFields(unprinted)
 		os.Exit(1)

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -49,6 +49,15 @@ func FindDefinedFields(text string) []string {
 	return result
 }
 
+func FindPrintFunc(text string) string {
+	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
+	match := functionContentRE.FindStringSubmatch(text)
+	if len(match) < 2 {
+		log.Fatalf("Error: Failed to find printConfig function")
+	}
+	return match[1]
+}
+
 func FindUnprintedFields(fields []string, text string, whiteList []string) []string {
 	result := []string{}
 	for _, field := range fields {
@@ -57,15 +66,6 @@ func FindUnprintedFields(fields []string, text string, whiteList []string) []str
 		}
 	}
 	return result
-}
-
-func FindPrintFunc(text string) string {
-	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
-	match := functionContentRE.FindStringSubmatch(text)
-	if len(match) < 2 {
-		log.Fatalf("Error: Failed to find printConfig function")
-	}
-	return match[1]
 }
 
 func isPrinted(field, text string) bool {

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -46,7 +46,7 @@ func readFile(path string) string {
 
 func DefinitionFields(text string) []string {
 	structRE := regexp.MustCompile(`type NormalConfigData struct {([^}]*)}`)
-	match := structRE.FindStringSubmatch(string(text))
+	match := structRE.FindStringSubmatch(text)
 	if len(match) < 2 {
 		log.Fatalf("Error: Failed to find NormalConfigData struct")
 	}
@@ -66,7 +66,7 @@ func DefinitionFields(text string) []string {
 
 func ParsePrintFile(text string) string {
 	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
-	match := functionContentRE.FindStringSubmatch(string(text))
+	match := functionContentRE.FindStringSubmatch(text)
 	if len(match) < 2 {
 		log.Fatalf("Error: Failed to find printConfig function")
 	}

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -50,8 +50,8 @@ func FindDefinedFields(text string) []string {
 }
 
 func FindPrintFunc(text string) string {
-	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
-	match := functionContentRE.FindStringSubmatch(text)
+	funcBodyRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
+	match := funcBodyRE.FindStringSubmatch(text)
 	if len(match) < 2 {
 		log.Fatalf("Error: Failed to find printConfig function")
 	}

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -22,7 +22,7 @@ var whiteList = []string{
 func main() {
 	// read and parse definition file
 	definitionText := readFile(normalConfigDataPath)
-	definitionFields := definitionFields(definitionText)
+	definitionFields := DefinitionFields(definitionText)
 
 	// read and parse print file
 	printText := readFile(printConfigPath)
@@ -48,7 +48,7 @@ func readFile(path string) string {
 	return string(result)
 }
 
-func definitionFields(text string) []string {
+func DefinitionFields(text string) []string {
 	structRE := regexp.MustCompile(`type NormalConfigData struct {([^}]*)}`)
 	match := structRE.FindStringSubmatch(string(text))
 	if len(match) < 2 {

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -29,7 +29,7 @@ func main() {
 	printBody := ParsePrintFile(printText)
 
 	// find fields that are in the definition file but not the print file
-	unprinted := findUnprinted(definitionFields, printBody, whiteList)
+	unprinted := FindUnprinted(definitionFields, printBody, whiteList)
 	if len(unprinted) == 0 {
 		return
 	}
@@ -77,7 +77,7 @@ func ParsePrintFile(text string) string {
 	return match[1]
 }
 
-func findUnprinted(fields []string, text string, whiteList []string) []string {
+func FindUnprinted(fields []string, text string, whiteList []string) []string {
 	result := []string{}
 	for _, field := range fields {
 		if strings.Contains(text, field) {

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+const (
+	normalConfigDataPath = "internal/config/configdomain/normal_config_data.go"
+	printConfigPath      = "internal/cmd/config/root.go"
+)
+
+var whiteList = []string{
+	"Aliases",
+	"BranchTypeOverrides",
+}
+
+func main() {
+	// read and parse definition file
+	definitionText := readFile(normalConfigDataPath)
+	definitionFields := definitionFields(definitionText)
+
+	// read and parse print file
+	printText := readFile(printConfigPath)
+	printBody := parsePrintFile(printText)
+
+	// find fields that are in the definition file but not the print file
+	unprinted := findUnprinted(definitionFields, printBody, whiteList)
+	if len(unprinted) == 0 {
+		return
+	}
+	fmt.Println("Missing fields in printConfig function:")
+	for _, field := range unprinted {
+		fmt.Println(field)
+	}
+	os.Exit(1)
+}
+
+func readFile(path string) string {
+	result, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("Error reading %s: %v\n", path, err)
+	}
+	return string(result)
+}
+
+func definitionFields(text string) []string {
+	structRE := regexp.MustCompile(`type NormalConfigData struct {([^}]*)}`)
+	match := structRE.FindStringSubmatch(string(text))
+	if len(match) < 2 {
+		log.Fatalf("Error: Failed to find NormalConfigData struct")
+	}
+	result := []string{}
+	for _, line := range strings.Split(strings.TrimSpace(match[1]), "\n") {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "//") {
+			continue // skip comments
+		}
+		parts := strings.Fields(trimmedLine)
+		if len(parts) > 0 {
+			result = append(result, parts[0])
+		}
+	}
+	return result
+}
+
+func parsePrintFile(text string) string {
+	functionContentRE := regexp.MustCompile(`func printConfig\(.*?\) {([^}]*)}`)
+	match := functionContentRE.FindStringSubmatch(string(text))
+	if len(match) < 2 {
+		log.Fatalf("Error: Failed to find printConfig function")
+	}
+	return match[1]
+}
+
+func findUnprinted(fields []string, text string, whiteList []string) []string {
+	result := []string{}
+	for _, field := range fields {
+		if strings.Contains(text, field) {
+			continue
+		}
+		if isWhitelisted(field, whiteList) {
+			continue
+		}
+		result = append(result, field)
+	}
+	return result
+}
+
+func isWhitelisted(field string, whitelist []string) bool {
+	return slices.Contains(whitelist, field)
+}

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -10,6 +10,7 @@ import (
 func TestDefinitionFields(t *testing.T) {
 	t.Parallel()
 
+	//nolint:dupword
 	give := `
 	package configdomain
 

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -1,0 +1,99 @@
+package main_test
+
+import (
+	"testing"
+
+	main "github.com/git-town/git-town/tools/print_config_exhaustive"
+	"github.com/shoenig/test/must"
+)
+
+func TestDefinitionFields(t *testing.T) {
+	t.Parallel()
+
+	give := `
+	package configdomain
+
+import (
+	"slices"
+
+	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
+	"github.com/git-town/git-town/v21/pkg/set"
+)
+
+// configuration settings that exist in both UnvalidatedConfig and ValidatedConfig
+type NormalConfigData struct {
+	Aliases                  Aliases
+	BitbucketAppPassword     Option[forgedomain.BitbucketAppPassword]
+	BitbucketUsername        Option[forgedomain.BitbucketUsername]
+	BranchTypeOverrides      BranchTypeOverrides
+	CodebergToken            Option[forgedomain.CodebergToken]
+	ContributionRegex        Option[ContributionRegex]
+	DevRemote                gitdomain.Remote
+	FeatureRegex             Option[FeatureRegex]
+	ForgeType                Option[forgedomain.ForgeType] // None = auto-detect
+	GitHubConnectorType      Option[forgedomain.GitHubConnectorType]
+	GitHubToken              Option[forgedomain.GitHubToken]
+	GitLabConnectorType      Option[forgedomain.GitLabConnectorType]
+	GitLabToken              Option[forgedomain.GitLabToken]
+	GiteaToken               Option[forgedomain.GiteaToken]
+	HostingOriginHostname    Option[HostingOriginHostname]
+	Lineage                  Lineage
+	NewBranchType            Option[BranchType]
+	ObservedRegex            Option[ObservedRegex]
+	Offline                  Offline
+	PerennialBranches        gitdomain.LocalBranchNames
+	PerennialRegex           Option[PerennialRegex]
+	PushHook                 PushHook
+	ShareNewBranches         ShareNewBranches
+	ShipDeleteTrackingBranch ShipDeleteTrackingBranch
+	ShipStrategy             ShipStrategy
+	SyncFeatureStrategy      SyncFeatureStrategy
+	SyncPerennialStrategy    SyncPerennialStrategy
+	SyncPrototypeStrategy    SyncPrototypeStrategy
+	SyncTags                 SyncTags
+	SyncUpstream             SyncUpstream
+	UnknownBranchType        BranchType
+}
+
+func (self *NormalConfigData) NoPushHook() NoPushHook {
+	return self.PushHook.Negate()
+}
+`
+	have := main.DefinitionFields(give)
+	want := []string{
+		"Aliases",
+		"BitbucketAppPassword",
+		"BitbucketUsername",
+		"BranchTypeOverrides",
+		"CodebergToken",
+		"ContributionRegex",
+		"DevRemote",
+		"FeatureRegex",
+		"ForgeType",
+		"GitHubConnectorType",
+		"GitHubToken",
+		"GitLabConnectorType",
+		"GitLabToken",
+		"GiteaToken",
+		"HostingOriginHostname",
+		"Lineage",
+		"NewBranchType",
+		"ObservedRegex",
+		"Offline",
+		"PerennialBranches",
+		"PerennialRegex",
+		"PushHook",
+		"ShareNewBranches",
+		"ShipDeleteTrackingBranch",
+		"ShipStrategy",
+		"SyncFeatureStrategy",
+		"SyncPerennialStrategy",
+		"SyncPrototypeStrategy",
+		"SyncTags",
+		"SyncUpstream",
+		"UnknownBranchType",
+	}
+	must.Eq(t, want, have)
+}

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -164,14 +164,6 @@ func printConfig(config config.UnvalidatedConfig) {
 	print.Entry("contribution branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeContributionBranch)))
 	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
 	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
-	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
-	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
-	print.Entry("observed regex", format.OptionalStringerSetting(config.NormalConfig.ObservedRegex))
-	print.Entry("parked branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeParkedBranch)))
-	print.Entry("perennial branches", format.StringsSetting(config.NormalConfig.PerennialBranches.Join(", ")))
-	print.Entry("perennial regex", format.OptionalStringerSetting(config.NormalConfig.PerennialRegex))
-	print.Entry("prototype branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypePrototypeBranch)))
-	print.Entry("unknown branch type", config.NormalConfig.UnknownBranchType.String())
 	fmt.Println()
 	if config.NormalConfig.Lineage.Len() > 0 {
 		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
@@ -185,17 +177,35 @@ func printConfig(config config.UnvalidatedConfig) {
 	print.Entry("contribution branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeContributionBranch)))
 	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
 	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
-	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
-	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
-	print.Entry("observed regex", format.OptionalStringerSetting(config.NormalConfig.ObservedRegex))
-	print.Entry("parked branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeParkedBranch)))
-	print.Entry("perennial branches", format.StringsSetting(config.NormalConfig.PerennialBranches.Join(", ")))
-	print.Entry("perennial regex", format.OptionalStringerSetting(config.NormalConfig.PerennialRegex))
-	print.Entry("prototype branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypePrototypeBranch)))
-	print.Entry("unknown branch type", config.NormalConfig.UnknownBranchType.String())
 	fmt.Println()
 	if config.NormalConfig.Lineage.Len() > 0 {
 		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
 	`
 	must.EqOp(t, want, have)
+}
+
+func TestFindUnprinted(t *testing.T) {
+	t.Parallel()
+	fields := []string{
+		"ContributionRegex",
+		"FeatureRegex",
+		"MainBranch",
+		"ObservedRegex",
+		"ForgeType",
+	}
+	whiteList := []string{
+		"ParkedBranch",
+	}
+	printText := `
+	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
+	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
+	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
+	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
+	`
+	have := main.FindUnprinted(fields, printText, whiteList)
+	want := []string{
+		"ObservedRegex",
+		"ForgeType",
+	}
+	must.Eq(t, want, have)
 }

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -62,7 +62,7 @@ func (self *NormalConfigData) NoPushHook() NoPushHook {
 	return self.PushHook.Negate()
 }
 `
-	have := main.DefinitionFields(give)
+	have := main.FindDefinedFields(give)
 	want := []string{
 		"Aliases",
 		"BitbucketAppPassword",
@@ -117,7 +117,7 @@ func TestFindUnprinted(t *testing.T) {
 	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
 	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
 	`
-	have := main.FindUnprinted(fields, printText, whiteList)
+	have := main.FindUnprintedFields(fields, printText, whiteList)
 	want := []string{
 		"ObservedRegex",
 		"ForgeType",
@@ -197,7 +197,7 @@ func printConfig(config config.UnvalidatedConfig) {
 	}
 }
 `
-	have := main.ParsePrintFile(give)
+	have := main.FindPrintFunction(give)
 	want := `
 	fmt.Println()
 	print.Header("Branches")

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -197,7 +197,7 @@ func printConfig(config config.UnvalidatedConfig) {
 	}
 }
 `
-	have := main.FindPrintFunction(give)
+	have := main.FindPrintFunc(give)
 	want := `
 	fmt.Println()
 	print.Header("Branches")

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -99,6 +99,32 @@ func (self *NormalConfigData) NoPushHook() NoPushHook {
 	must.Eq(t, want, have)
 }
 
+func TestFindUnprinted(t *testing.T) {
+	t.Parallel()
+	fields := []string{
+		"ContributionRegex",
+		"FeatureRegex",
+		"MainBranch",
+		"ObservedRegex",
+		"ForgeType",
+	}
+	whiteList := []string{
+		"ParkedBranch",
+	}
+	printText := `
+	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
+	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
+	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
+	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
+	`
+	have := main.FindUnprinted(fields, printText, whiteList)
+	want := []string{
+		"ObservedRegex",
+		"ForgeType",
+	}
+	must.Eq(t, want, have)
+}
+
 func TestParsePrintFile(t *testing.T) {
 	t.Parallel()
 	give := `
@@ -183,30 +209,4 @@ func printConfig(config config.UnvalidatedConfig) {
 		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
 	`
 	must.EqOp(t, want, have)
-}
-
-func TestFindUnprinted(t *testing.T) {
-	t.Parallel()
-	fields := []string{
-		"ContributionRegex",
-		"FeatureRegex",
-		"MainBranch",
-		"ObservedRegex",
-		"ForgeType",
-	}
-	whiteList := []string{
-		"ParkedBranch",
-	}
-	printText := `
-	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
-	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
-	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
-	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
-	`
-	have := main.FindUnprinted(fields, printText, whiteList)
-	want := []string{
-		"ObservedRegex",
-		"ForgeType",
-	}
-	must.Eq(t, want, have)
 }

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -97,3 +97,105 @@ func (self *NormalConfigData) NoPushHook() NoPushHook {
 	}
 	must.Eq(t, want, have)
 }
+
+func TestParsePrintFile(t *testing.T) {
+	t.Parallel()
+	give := `
+// Package config implements Git Town's "config" command.
+package config
+
+import (
+	"fmt"
+
+	"github.com/git-town/git-town/v21/internal/cli/flags"
+	"github.com/git-town/git-town/v21/internal/cli/format"
+	"github.com/git-town/git-town/v21/internal/cli/print"
+	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
+	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/execute"
+	"github.com/spf13/cobra"
+)
+
+const configDesc = "Display your Git Town configuration"
+
+func RootCmd() *cobra.Command {
+	addVerboseFlag, readVerboseFlag := flags.Verbose()
+	configCmd := cobra.Command{
+		Use:     "config",
+		GroupID: cmdhelpers.GroupIDSetup,
+		Args:    cobra.NoArgs,
+		Short:   configDesc,
+		Long:    cmdhelpers.Long(configDesc),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			verbose, err := readVerboseFlag(cmd)
+			if err != nil {
+				return err
+			}
+			return executeDisplayConfig(verbose)
+		},
+	}
+	addVerboseFlag(&configCmd)
+	configCmd.AddCommand(getParentCommand())
+	configCmd.AddCommand(removeConfigCommand())
+	configCmd.AddCommand(SetupCommand())
+	return &configCmd
+}
+
+func executeDisplayConfig(verbose configdomain.Verbose) error {
+	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
+		DryRun:           false,
+		PrintBranchNames: false,
+		PrintCommands:    true,
+		ValidateGitRepo:  true,
+		ValidateIsOnline: false,
+		Verbose:          verbose,
+	})
+	if err != nil {
+		return err
+	}
+	printConfig(repo.UnvalidatedConfig)
+	return nil
+}
+
+func printConfig(config config.UnvalidatedConfig) {
+	fmt.Println()
+	print.Header("Branches")
+	print.Entry("contribution branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeContributionBranch)))
+	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
+	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
+	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
+	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
+	print.Entry("observed regex", format.OptionalStringerSetting(config.NormalConfig.ObservedRegex))
+	print.Entry("parked branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeParkedBranch)))
+	print.Entry("perennial branches", format.StringsSetting(config.NormalConfig.PerennialBranches.Join(", ")))
+	print.Entry("perennial regex", format.OptionalStringerSetting(config.NormalConfig.PerennialRegex))
+	print.Entry("prototype branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypePrototypeBranch)))
+	print.Entry("unknown branch type", config.NormalConfig.UnknownBranchType.String())
+	fmt.Println()
+	if config.NormalConfig.Lineage.Len() > 0 {
+		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
+	}
+}
+`
+	have := main.ParsePrintFile(give)
+	want := `
+	fmt.Println()
+	print.Header("Branches")
+	print.Entry("contribution branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeContributionBranch)))
+	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
+	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
+	print.Entry("main branch", format.OptionalStringerSetting(config.UnvalidatedConfig.MainBranch))
+	print.Entry("observed branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeObservedBranch)))
+	print.Entry("observed regex", format.OptionalStringerSetting(config.NormalConfig.ObservedRegex))
+	print.Entry("parked branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypeParkedBranch)))
+	print.Entry("perennial branches", format.StringsSetting(config.NormalConfig.PerennialBranches.Join(", ")))
+	print.Entry("perennial regex", format.OptionalStringerSetting(config.NormalConfig.PerennialRegex))
+	print.Entry("prototype branches", format.BranchNames(config.NormalConfig.PartialBranchesOfType(configdomain.BranchTypePrototypeBranch)))
+	print.Entry("unknown branch type", config.NormalConfig.UnknownBranchType.String())
+	fmt.Println()
+	if config.NormalConfig.Lineage.Len() > 0 {
+		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
+	`
+	must.EqOp(t, want, have)
+}


### PR DESCRIPTION
This linter is a community contribution. It's currently written in JS. I had Gemini transcribe it to Go, for the sake of consistency, and added unit tests.