### PR TITLE
Move code that performs work out of configdomain

### DIFF
--- a/internal/config/configdomain/branch_type_overrides.go
+++ b/internal/config/configdomain/branch_type_overrides.go
@@ -1,12 +1,7 @@
 package configdomain
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/git-town/git-town/v21/internal/cli/colors"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
-	"github.com/git-town/git-town/v21/internal/messages"
 )
 
 // BranchTypeOverrides contains all configured branch type overrides.
@@ -23,37 +18,4 @@ func (self BranchTypeOverrides) Concat(other BranchTypeOverrides) BranchTypeOver
 		result[key] = value
 	}
 	return result
-}
-
-// provides the branch type overrides stored in the given Git metadata snapshot
-func NewBranchTypeOverridesInSnapshot(snapshot SingleSnapshot, gitCommands configRemover) (BranchTypeOverrides, error) {
-	result := BranchTypeOverrides{}
-	for key, value := range snapshot.BranchTypeOverrideEntries() {
-		branch := key.Branch()
-		if branch == "" {
-			// empty branch name --> delete it
-			fmt.Println(colors.Cyan().Styled(messages.ConfigBranchTypeOverrideEmpty))
-			_ = gitCommands.RemoveConfigValue(ConfigScopeLocal, key.Key)
-			continue
-		}
-		value = strings.TrimSpace(value)
-		if value == "" {
-			// empty branch type values are invalid --> delete it
-			fmt.Println(colors.Cyan().Styled(messages.ConfigBranchTypeOverrideEmpty))
-			_ = gitCommands.RemoveConfigValue(ConfigScopeLocal, key.Key)
-			continue
-		}
-		branchTypeOpt, err := ParseBranchType(value)
-		if err != nil {
-			return result, err
-		}
-		if branchType, hasBranchType := branchTypeOpt.Get(); hasBranchType {
-			result[branch] = branchType
-		}
-	}
-	return result, nil
-}
-
-type configRemover interface {
-	RemoveConfigValue(ConfigScope, Key) error
 }

--- a/internal/config/configdomain/branch_type_overrides_test.go
+++ b/internal/config/configdomain/branch_type_overrides_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
-	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/shoenig/test/must"
 )
 
@@ -30,21 +29,4 @@ func TestBranchTypeOverrides(t *testing.T) {
 		must.Eq(t, want, have)
 	})
 
-	t.Run("NewBranchTypeOverridesFromSnapshot", func(t *testing.T) {
-		t.Parallel()
-		snapshot := configdomain.SingleSnapshot{
-			"git-town-branch.branch-1.branchtype": "feature",
-			"git-town-branch.branch-2.branchtype": "observed",
-			"git-town-branch.branch-3.parent":     "main",
-			"git-town.prototype-branches":         "foo",
-		}
-		gitIO := gitconfig.IO{Shell: nil}
-		have, err := configdomain.NewBranchTypeOverridesInSnapshot(snapshot, &gitIO)
-		must.NoError(t, err)
-		want := configdomain.BranchTypeOverrides{
-			"branch-1": configdomain.BranchTypeFeatureBranch,
-			"branch-2": configdomain.BranchTypeObservedBranch,
-		}
-		must.Eq(t, want, have)
-	})
 }

--- a/internal/config/configdomain/branch_type_overrides_test.go
+++ b/internal/config/configdomain/branch_type_overrides_test.go
@@ -28,5 +28,4 @@ func TestBranchTypeOverrides(t *testing.T) {
 		}
 		must.Eq(t, want, have)
 	})
-
 }

--- a/internal/config/configdomain/lineage.go
+++ b/internal/config/configdomain/lineage.go
@@ -2,16 +2,12 @@ package configdomain
 
 import (
 	"cmp"
-	"fmt"
 	"maps"
 	"slices"
-	"strings"
 
-	"github.com/git-town/git-town/v21/internal/cli/colors"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/gohacks/mapstools"
 	"github.com/git-town/git-town/v21/internal/gohacks/slice"
-	"github.com/git-town/git-town/v21/internal/messages"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
@@ -28,33 +24,6 @@ func NewLineage() Lineage {
 	return Lineage{
 		data: make(LineageData),
 	}
-}
-
-func NewLineageFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, gitCommands configRemover) (Lineage, error) {
-	result := NewLineage()
-	for key, value := range snapshot.LineageEntries() {
-		child := key.ChildBranch()
-		if child == "" {
-			// empty lineage entries are invalid --> delete it
-			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))
-			_ = gitCommands.RemoveConfigValue(ConfigScopeLocal, key.Key)
-			continue
-		}
-		value = strings.TrimSpace(value)
-		if value == "" {
-			// empty lineage entries are invalid --> delete it
-			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))
-			_ = gitCommands.RemoveConfigValue(ConfigScopeLocal, key.Key)
-			continue
-		}
-		if updateOutdated && child.String() == value {
-			fmt.Println(colors.Cyan().Styled(fmt.Sprintf(messages.ConfigLineageParentIsChild, child)))
-			_ = gitCommands.RemoveConfigValue(ConfigScopeLocal, key.Key)
-		}
-		parent := gitdomain.NewLocalBranchName(value)
-		result = result.Set(child, parent)
-	}
-	return result, nil
 }
 
 func NewLineageWith(data LineageData) Lineage {

--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -1,8 +1,6 @@
 package configdomain
 
 import (
-	"cmp"
-
 	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/gohacks/mapstools"
@@ -52,67 +50,6 @@ func EmptyPartialConfig() PartialConfig {
 		Aliases: Aliases{},
 		Lineage: NewLineage(),
 	} //exhaustruct:ignore
-}
-
-func NewPartialConfigFromSnapshot(snapshot SingleSnapshot, updateOutdated bool, gitCommands configRemover) (PartialConfig, error) {
-	aliases := snapshot.Aliases()
-	branchTypeOverrides, err1 := NewBranchTypeOverridesInSnapshot(snapshot, gitCommands)
-	contributionRegex, err2 := ParseContributionRegex(snapshot[KeyContributionRegex])
-	featureRegex, err3 := ParseFeatureRegex(snapshot[KeyFeatureRegex])
-	forgeType, err4 := forgedomain.ParseForgeType(snapshot[KeyForgeType])
-	githubConnectorType, err5 := forgedomain.ParseGitHubConnectorType(snapshot[KeyGitHubConnectorType])
-	gitlabConnectorType, err6 := forgedomain.ParseGitLabConnectorType(snapshot[KeyGitLabConnectorType])
-	lineage, err7 := NewLineageFromSnapshot(snapshot, updateOutdated, gitCommands)
-	newBranchType, err8 := ParseBranchType(snapshot[KeyNewBranchType])
-	observedRegex, err9 := ParseObservedRegex(snapshot[KeyObservedRegex])
-	offline, err10 := ParseOffline(snapshot[KeyOffline], KeyOffline)
-	perennialRegex, err11 := ParsePerennialRegex(snapshot[KeyPerennialRegex])
-	pushHook, err12 := ParsePushHook(snapshot[KeyPushHook], KeyPushHook)
-	shareNewBranches, err13 := ParseShareNewBranches(snapshot[KeyShareNewBranches], KeyShareNewBranches)
-	shipDeleteTrackingBranch, err14 := ParseShipDeleteTrackingBranch(snapshot[KeyShipDeleteTrackingBranch], KeyShipDeleteTrackingBranch)
-	shipStrategy, err15 := ParseShipStrategy(snapshot[KeyShipStrategy])
-	syncFeatureStrategy, err16 := ParseSyncFeatureStrategy(snapshot[KeySyncFeatureStrategy])
-	syncPerennialStrategy, err17 := ParseSyncPerennialStrategy(snapshot[KeySyncPerennialStrategy])
-	syncPrototypeStrategy, err18 := ParseSyncPrototypeStrategy(snapshot[KeySyncPrototypeStrategy])
-	syncTags, err19 := ParseSyncTags(snapshot[KeySyncTags], KeySyncTags)
-	syncUpstream, err20 := ParseSyncUpstream(snapshot[KeySyncUpstream], KeySyncUpstream)
-	unknownBranchType, err21 := ParseBranchType(snapshot[KeyUnknownBranchType])
-	return PartialConfig{
-		Aliases:                  aliases,
-		BitbucketAppPassword:     forgedomain.ParseBitbucketAppPassword(snapshot[KeyBitbucketAppPassword]),
-		BitbucketUsername:        forgedomain.ParseBitbucketUsername(snapshot[KeyBitbucketUsername]),
-		BranchTypeOverrides:      branchTypeOverrides,
-		CodebergToken:            forgedomain.ParseCodebergToken(snapshot[KeyCodebergToken]),
-		ContributionRegex:        contributionRegex,
-		DevRemote:                gitdomain.NewRemote(snapshot[KeyDevRemote]),
-		FeatureRegex:             featureRegex,
-		ForgeType:                forgeType,
-		GitHubConnectorType:      githubConnectorType,
-		GitHubToken:              forgedomain.ParseGitHubToken(snapshot[KeyGitHubToken]),
-		GitLabConnectorType:      gitlabConnectorType,
-		GitLabToken:              forgedomain.ParseGitLabToken(snapshot[KeyGitLabToken]),
-		GitUserEmail:             gitdomain.ParseGitUserEmail(snapshot[KeyGitUserEmail]),
-		GitUserName:              gitdomain.ParseGitUserName(snapshot[KeyGitUserName]),
-		GiteaToken:               forgedomain.ParseGiteaToken(snapshot[KeyGiteaToken]),
-		HostingOriginHostname:    ParseHostingOriginHostname(snapshot[KeyHostingOriginHostname]),
-		Lineage:                  lineage,
-		MainBranch:               gitdomain.NewLocalBranchNameOption(snapshot[KeyMainBranch]),
-		NewBranchType:            newBranchType,
-		ObservedRegex:            observedRegex,
-		Offline:                  offline,
-		PerennialBranches:        gitdomain.ParseLocalBranchNames(snapshot[KeyPerennialBranches]),
-		PerennialRegex:           perennialRegex,
-		PushHook:                 pushHook,
-		ShareNewBranches:         shareNewBranches,
-		ShipDeleteTrackingBranch: shipDeleteTrackingBranch,
-		ShipStrategy:             shipStrategy,
-		SyncFeatureStrategy:      syncFeatureStrategy,
-		SyncPerennialStrategy:    syncPerennialStrategy,
-		SyncPrototypeStrategy:    syncPrototypeStrategy,
-		SyncTags:                 syncTags,
-		SyncUpstream:             syncUpstream,
-		UnknownBranchType:        unknownBranchType,
-	}, cmp.Or(err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21)
 }
 
 // Merges the given PartialConfig into this configuration object.

--- a/internal/config/parse_snapshot.go
+++ b/internal/config/parse_snapshot.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"cmp"
+	"fmt"
+	"strings"
+
+	"github.com/git-town/git-town/v21/internal/cli/colors"
+	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	"github.com/git-town/git-town/v21/internal/messages"
+)
+
+// provides the branch type overrides stored in the given Git metadata snapshot
+func NewBranchTypeOverridesInSnapshot(snapshot configdomain.SingleSnapshot, gitCommands configRemover) (configdomain.BranchTypeOverrides, error) {
+	result := configdomain.BranchTypeOverrides{}
+	for key, value := range snapshot.BranchTypeOverrideEntries() {
+		branch := key.Branch()
+		if branch == "" {
+			// empty branch name --> delete it
+			fmt.Println(colors.Cyan().Styled(messages.ConfigBranchTypeOverrideEmpty))
+			_ = gitCommands.RemoveConfigValue(configdomain.ConfigScopeLocal, key.Key)
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			// empty branch type values are invalid --> delete it
+			fmt.Println(colors.Cyan().Styled(messages.ConfigBranchTypeOverrideEmpty))
+			_ = gitCommands.RemoveConfigValue(configdomain.ConfigScopeLocal, key.Key)
+			continue
+		}
+		branchTypeOpt, err := configdomain.ParseBranchType(value)
+		if err != nil {
+			return result, err
+		}
+		if branchType, hasBranchType := branchTypeOpt.Get(); hasBranchType {
+			result[branch] = branchType
+		}
+	}
+	return result, nil
+}
+
+type configRemover interface {
+	RemoveConfigValue(configdomain.ConfigScope, configdomain.Key) error
+}
+
+func NewLineageFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated bool, gitCommands configRemover) (configdomain.Lineage, error) {
+	result := configdomain.NewLineage()
+	for key, value := range snapshot.LineageEntries() {
+		child := key.ChildBranch()
+		if child == "" {
+			// empty lineage entries are invalid --> delete it
+			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))
+			_ = gitCommands.RemoveConfigValue(configdomain.ConfigScopeLocal, key.Key)
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			// empty lineage entries are invalid --> delete it
+			fmt.Println(colors.Cyan().Styled(messages.ConfigLineageEmptyChild))
+			_ = gitCommands.RemoveConfigValue(configdomain.ConfigScopeLocal, key.Key)
+			continue
+		}
+		if updateOutdated && child.String() == value {
+			fmt.Println(colors.Cyan().Styled(fmt.Sprintf(messages.ConfigLineageParentIsChild, child)))
+			_ = gitCommands.RemoveConfigValue(configdomain.ConfigScopeLocal, key.Key)
+		}
+		parent := gitdomain.NewLocalBranchName(value)
+		result = result.Set(child, parent)
+	}
+	return result, nil
+}
+
+func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated bool, gitCommands configRemover) (configdomain.PartialConfig, error) {
+	aliases := snapshot.Aliases()
+	branchTypeOverrides, err1 := NewBranchTypeOverridesInSnapshot(snapshot, gitCommands)
+	contributionRegex, err2 := configdomain.ParseContributionRegex(snapshot[configdomain.KeyContributionRegex])
+	featureRegex, err3 := configdomain.ParseFeatureRegex(snapshot[configdomain.KeyFeatureRegex])
+	forgeType, err4 := forgedomain.ParseForgeType(snapshot[configdomain.KeyForgeType])
+	githubConnectorType, err5 := forgedomain.ParseGitHubConnectorType(snapshot[configdomain.KeyGitHubConnectorType])
+	gitlabConnectorType, err6 := forgedomain.ParseGitLabConnectorType(snapshot[configdomain.KeyGitLabConnectorType])
+	lineage, err7 := NewLineageFromSnapshot(snapshot, updateOutdated, gitCommands)
+	newBranchType, err8 := configdomain.ParseBranchType(snapshot[configdomain.KeyNewBranchType])
+	observedRegex, err9 := configdomain.ParseObservedRegex(snapshot[configdomain.KeyObservedRegex])
+	offline, err10 := configdomain.ParseOffline(snapshot[configdomain.KeyOffline], configdomain.KeyOffline)
+	perennialRegex, err11 := configdomain.ParsePerennialRegex(snapshot[configdomain.KeyPerennialRegex])
+	pushHook, err12 := configdomain.ParsePushHook(snapshot[configdomain.KeyPushHook], configdomain.KeyPushHook)
+	shareNewBranches, err13 := configdomain.ParseShareNewBranches(snapshot[configdomain.KeyShareNewBranches], configdomain.KeyShareNewBranches)
+	shipDeleteTrackingBranch, err14 := configdomain.ParseShipDeleteTrackingBranch(snapshot[configdomain.KeyShipDeleteTrackingBranch], configdomain.KeyShipDeleteTrackingBranch)
+	shipStrategy, err15 := configdomain.ParseShipStrategy(snapshot[configdomain.KeyShipStrategy])
+	syncFeatureStrategy, err16 := configdomain.ParseSyncFeatureStrategy(snapshot[configdomain.KeySyncFeatureStrategy])
+	syncPerennialStrategy, err17 := configdomain.ParseSyncPerennialStrategy(snapshot[configdomain.KeySyncPerennialStrategy])
+	syncPrototypeStrategy, err18 := configdomain.ParseSyncPrototypeStrategy(snapshot[configdomain.KeySyncPrototypeStrategy])
+	syncTags, err19 := configdomain.ParseSyncTags(snapshot[configdomain.KeySyncTags], configdomain.KeySyncTags)
+	syncUpstream, err20 := configdomain.ParseSyncUpstream(snapshot[configdomain.KeySyncUpstream], configdomain.KeySyncUpstream)
+	unknownBranchType, err21 := configdomain.ParseBranchType(snapshot[configdomain.KeyUnknownBranchType])
+	return configdomain.PartialConfig{
+		Aliases:                  aliases,
+		BitbucketAppPassword:     forgedomain.ParseBitbucketAppPassword(snapshot[configdomain.KeyBitbucketAppPassword]),
+		BitbucketUsername:        forgedomain.ParseBitbucketUsername(snapshot[configdomain.KeyBitbucketUsername]),
+		BranchTypeOverrides:      branchTypeOverrides,
+		CodebergToken:            forgedomain.ParseCodebergToken(snapshot[configdomain.KeyCodebergToken]),
+		ContributionRegex:        contributionRegex,
+		DevRemote:                gitdomain.NewRemote(snapshot[configdomain.KeyDevRemote]),
+		FeatureRegex:             featureRegex,
+		ForgeType:                forgeType,
+		GitHubConnectorType:      githubConnectorType,
+		GitHubToken:              forgedomain.ParseGitHubToken(snapshot[configdomain.KeyGitHubToken]),
+		GitLabConnectorType:      gitlabConnectorType,
+		GitLabToken:              forgedomain.ParseGitLabToken(snapshot[configdomain.KeyGitLabToken]),
+		GitUserEmail:             gitdomain.ParseGitUserEmail(snapshot[configdomain.KeyGitUserEmail]),
+		GitUserName:              gitdomain.ParseGitUserName(snapshot[configdomain.KeyGitUserName]),
+		GiteaToken:               forgedomain.ParseGiteaToken(snapshot[configdomain.KeyGiteaToken]),
+		HostingOriginHostname:    configdomain.ParseHostingOriginHostname(snapshot[configdomain.KeyHostingOriginHostname]),
+		Lineage:                  lineage,
+		MainBranch:               gitdomain.NewLocalBranchNameOption(snapshot[configdomain.KeyMainBranch]),
+		NewBranchType:            newBranchType,
+		ObservedRegex:            observedRegex,
+		Offline:                  offline,
+		PerennialBranches:        gitdomain.ParseLocalBranchNames(snapshot[configdomain.KeyPerennialBranches]),
+		PerennialRegex:           perennialRegex,
+		PushHook:                 pushHook,
+		ShareNewBranches:         shareNewBranches,
+		ShipDeleteTrackingBranch: shipDeleteTrackingBranch,
+		ShipStrategy:             shipStrategy,
+		SyncFeatureStrategy:      syncFeatureStrategy,
+		SyncPerennialStrategy:    syncPerennialStrategy,
+		SyncPrototypeStrategy:    syncPrototypeStrategy,
+		SyncTags:                 syncTags,
+		SyncUpstream:             syncUpstream,
+		UnknownBranchType:        unknownBranchType,
+	}, cmp.Or(err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21)
+}

--- a/internal/config/parse_snapshot.go
+++ b/internal/config/parse_snapshot.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/cli/colors"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/messages"
 )
 
 // provides the branch type overrides stored in the given Git metadata snapshot
-func NewBranchTypeOverridesInSnapshot(snapshot configdomain.SingleSnapshot, gitCommands configRemover) (configdomain.BranchTypeOverrides, error) {
+func NewBranchTypeOverridesInSnapshot(snapshot configdomain.SingleSnapshot, gitCommands gitconfig.IO) (configdomain.BranchTypeOverrides, error) {
 	result := configdomain.BranchTypeOverrides{}
 	for key, value := range snapshot.BranchTypeOverrideEntries() {
 		branch := key.Branch()
@@ -41,11 +42,7 @@ func NewBranchTypeOverridesInSnapshot(snapshot configdomain.SingleSnapshot, gitC
 	return result, nil
 }
 
-type configRemover interface {
-	RemoveConfigValue(configdomain.ConfigScope, configdomain.Key) error
-}
-
-func NewLineageFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated bool, gitCommands configRemover) (configdomain.Lineage, error) {
+func NewLineageFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated bool, gitCommands gitconfig.IO) (configdomain.Lineage, error) {
 	result := configdomain.NewLineage()
 	for key, value := range snapshot.LineageEntries() {
 		child := key.ChildBranch()
@@ -72,7 +69,7 @@ func NewLineageFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated
 	return result, nil
 }
 
-func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated bool, gitCommands configRemover) (configdomain.PartialConfig, error) {
+func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated bool, gitCommands gitconfig.IO) (configdomain.PartialConfig, error) {
 	aliases := snapshot.Aliases()
 	branchTypeOverrides, err1 := NewBranchTypeOverridesInSnapshot(snapshot, gitCommands)
 	contributionRegex, err2 := configdomain.ParseContributionRegex(snapshot[configdomain.KeyContributionRegex])

--- a/internal/config/parse_snapshot_test.go
+++ b/internal/config/parse_snapshot_test.go
@@ -1,0 +1,28 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/gitconfig"
+	"github.com/shoenig/test/must"
+)
+
+func TestNewBranchTypeOverridesFromSnapshot(t *testing.T) {
+	t.Parallel()
+	snapshot := configdomain.SingleSnapshot{
+		"git-town-branch.branch-1.branchtype": "feature",
+		"git-town-branch.branch-2.branchtype": "observed",
+		"git-town-branch.branch-3.parent":     "main",
+		"git-town.prototype-branches":         "foo",
+	}
+	gitIO := gitconfig.IO{Shell: nil}
+	have, err := config.NewBranchTypeOverridesInSnapshot(snapshot, &gitIO)
+	must.NoError(t, err)
+	want := configdomain.BranchTypeOverrides{
+		"branch-1": configdomain.BranchTypeFeatureBranch,
+		"branch-2": configdomain.BranchTypeObservedBranch,
+	}
+	must.Eq(t, want, have)
+}

--- a/internal/config/parse_snapshot_test.go
+++ b/internal/config/parse_snapshot_test.go
@@ -18,7 +18,7 @@ func TestNewBranchTypeOverridesFromSnapshot(t *testing.T) {
 		"git-town.prototype-branches":         "foo",
 	}
 	gitIO := gitconfig.IO{Shell: nil}
-	have, err := config.NewBranchTypeOverridesInSnapshot(snapshot, &gitIO)
+	have, err := config.NewBranchTypeOverridesInSnapshot(snapshot, gitIO)
 	must.NoError(t, err)
 	want := configdomain.BranchTypeOverrides{
 		"branch-1": configdomain.BranchTypeFeatureBranch,

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -37,7 +37,7 @@ func (self *UnvalidatedConfig) Reload() (globalSnapshot, localSnapshot, unscoped
 	globalSnapshot, _ = self.NormalConfig.GitIO.LoadSnapshot(Some(configdomain.ConfigScopeGlobal), configdomain.UpdateOutdatedNo) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	localSnapshot, _ = self.NormalConfig.GitIO.LoadSnapshot(Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedNo)   // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	unscopedSnapshot, _ = self.NormalConfig.GitIO.LoadSnapshot(None[configdomain.ConfigScope](), configdomain.UpdateOutdatedNo)   // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	unscopedGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(unscopedSnapshot, false, nil)
+	unscopedGitConfig, _ := NewPartialConfigFromSnapshot(unscopedSnapshot, false, nil)
 	envConfig := envconfig.Load()
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{
 		env:  envConfig,

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -37,7 +37,8 @@ func (self *UnvalidatedConfig) Reload() (globalSnapshot, localSnapshot, unscoped
 	globalSnapshot, _ = self.NormalConfig.GitIO.LoadSnapshot(Some(configdomain.ConfigScopeGlobal), configdomain.UpdateOutdatedNo) // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	localSnapshot, _ = self.NormalConfig.GitIO.LoadSnapshot(Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedNo)   // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
 	unscopedSnapshot, _ = self.NormalConfig.GitIO.LoadSnapshot(None[configdomain.ConfigScope](), configdomain.UpdateOutdatedNo)   // we ignore the Git cache here because reloading a config in the middle of a Git Town command doesn't change the cached initial state of the repo
-	unscopedGitConfig, _ := NewPartialConfigFromSnapshot(unscopedSnapshot, false, nil)
+	gitIO := gitconfig.IO{Shell: nil}
+	unscopedGitConfig, _ := NewPartialConfigFromSnapshot(unscopedSnapshot, false, gitIO)
 	envConfig := envconfig.Load()
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{
 		env:  envConfig,

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -74,7 +74,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
-	unscopedConfig, err := config.NewPartialConfigFromSnapshot(unscopedSnapshot, true, &gitIO)
+	unscopedConfig, err := config.NewPartialConfigFromSnapshot(unscopedSnapshot, true, gitIO)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -74,7 +74,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
-	unscopedConfig, err := configdomain.NewPartialConfigFromSnapshot(unscopedSnapshot, true, &gitIO)
+	unscopedConfig, err := config.NewPartialConfigFromSnapshot(unscopedSnapshot, true, &gitIO)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -350,7 +350,7 @@ func (self *TestCommands) LineageTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("BRANCH", "PARENT")
 	localSnapshot, _ := self.Config.NormalConfig.GitIO.LoadSnapshot(Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedNo)
-	localGitConfig, _ := configdomain.NewPartialConfigFromSnapshot(localSnapshot, false, nil)
+	localGitConfig, _ := config.NewPartialConfigFromSnapshot(localSnapshot, false, nil)
 	lineage := localGitConfig.Lineage
 	for _, entry := range lineage.Entries() {
 		result.AddRow(entry.Child.String(), entry.Parent.String())

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/config"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	prodgit "github.com/git-town/git-town/v21/internal/git"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/gohacks/slice"
@@ -350,7 +351,8 @@ func (self *TestCommands) LineageTable() datatable.DataTable {
 	result := datatable.DataTable{}
 	result.AddRow("BRANCH", "PARENT")
 	localSnapshot, _ := self.Config.NormalConfig.GitIO.LoadSnapshot(Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedNo)
-	localGitConfig, _ := config.NewPartialConfigFromSnapshot(localSnapshot, false, nil)
+	gitIO := gitconfig.IO{Shell: nil}
+	localGitConfig, _ := config.NewPartialConfigFromSnapshot(localSnapshot, false, gitIO)
 	lineage := localGitConfig.Lineage
 	for _, entry := range lineage.Entries() {
 		result.AddRow(entry.Child.String(), entry.Parent.String())


### PR DESCRIPTION
Code that performs work has dependencies on other domain packages, which increases the risk of circular dependencies.

This also removes a pointless interface that existed only to decouple packages that shouldn't have been coupled with each other in the first place.