### PR TITLE
setup assistant: ask for observed regex

### DIFF
--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -13,6 +13,7 @@ Feature: override an existing Git alias
       | perennial regex             | enter   |
       | feature regex               | enter   |
       | contribution regex          | enter   |
+      | observed regex              | enter   |
       | unknown branch type         | enter   |
       | dev-remote                  | enter   |
       | origin hostname             | enter   |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -18,16 +18,16 @@ Feature: change existing information in Git metadata
       | add all aliases                           | a enter                |
       | accept the already configured main branch | enter                  |
       | change the perennial branches             | space down space enter |
-      | enter a perennial regex                   |          3 3 6 6 enter |
+      | enter a perennial regex                   | 3 3 6 6 enter          |
       | feature regex                             | u s e r enter          |
-      | contribution regex                        |          1 1 1 1 enter |
-      | observed regex                            |          2 2 2 2 enter |
+      | contribution regex                        | 1 1 1 1 enter          |
+      | observed regex                            | 2 2 2 2 enter          |
       | unknown branch type                       | down enter             |
       | dev-remote                                | enter                  |
       | origin hostname                           | c o d e enter          |
       | set forge type to "github"                | up up enter            |
       | set github forge type to "API"            | enter                  |
-      | github token                              |      1 2 3 4 5 6 enter |
+      | github token                              | 1 2 3 4 5 6 enter      |
       | token scope                               | enter                  |
       | sync-feature-strategy                     | down enter             |
       | sync-perennial-strategy                   | down enter             |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -18,15 +18,16 @@ Feature: change existing information in Git metadata
       | add all aliases                           | a enter                |
       | accept the already configured main branch | enter                  |
       | change the perennial branches             | space down space enter |
-      | enter a perennial regex                   | 3 3 6 6 enter          |
+      | enter a perennial regex                   |          3 3 6 6 enter |
       | feature regex                             | u s e r enter          |
-      | contribution regex                        | 1 1 1 1 enter          |
+      | contribution regex                        |          1 1 1 1 enter |
+      | observed regex                            |          2 2 2 2 enter |
       | unknown branch type                       | down enter             |
       | dev-remote                                | enter                  |
       | origin hostname                           | c o d e enter          |
       | set forge type to "github"                | up up enter            |
       | set github forge type to "API"            | enter                  |
-      | github token                              | 1 2 3 4 5 6 enter      |
+      | github token                              |      1 2 3 4 5 6 enter |
       | token scope                               | enter                  |
       | sync-feature-strategy                     | down enter             |
       | sync-perennial-strategy                   | down enter             |
@@ -68,6 +69,7 @@ Feature: change existing information in Git metadata
       | git config git-town.unknown-branch-type observed         |
       | git config git-town.feature-regex user                   |
       | git config git-town.contribution-regex 1111              |
+      | git config git-town.observed-regex 2222                  |
       | git config git-town.push-hook true                       |
       | git config git-town.share-new-branches push              |
       | git config git-town.ship-strategy fast-forward           |
@@ -103,6 +105,7 @@ Feature: change existing information in Git metadata
     And local Git setting "git-town.perennial-regex" is now "3366"
     And local Git setting "git-town.feature-regex" is now "user"
     And local Git setting "git-town.contribution-regex" is now "1111"
+    And local Git setting "git-town.observed-regex" is now "2222"
     And local Git setting "git-town.unknown-branch-type" is now "observed"
     And local Git setting "git-town.share-new-branches" is now "push"
     And local Git setting "git-town.push-hook" is now "true"
@@ -135,6 +138,7 @@ Feature: change existing information in Git metadata
     And local Git setting "git-town.perennial-regex" now doesn't exist
     And local Git setting "git-town.feature-regex" now doesn't exist
     And local Git setting "git-town.contribution-regex" now doesn't exist
+    And local Git setting "git-town.observed-regex" now doesn't exist
     And local Git setting "git-town.unknown-branch-type" now doesn't exist
     And local Git setting "git-town.share-new-branches" is now "no"
     And local Git setting "git-town.push-hook" is now "false"

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -15,6 +15,7 @@ Feature: enter the Codeberg API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -49,11 +50,12 @@ Feature: enter the Codeberg API token
       | perennial regex             | enter                |                                             |
       | feature regex               | enter                |                                             |
       | contribution regex          | enter                |                                             |
+      | observed regex              | enter                |                                             |
       | unknown branch type         | enter                |                                             |
       | dev-remote                  | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
+      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                |                                             |
       | sync-feature-strategy       | enter                |                                             |
       | sync-perennial-strategy     | enter                |                                             |
@@ -85,6 +87,7 @@ Feature: enter the Codeberg API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -120,6 +123,7 @@ Feature: enter the Codeberg API token
       | perennial regex             | enter                                     |                                             |
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
+      | observed regex              | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | dev-remote                  | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -55,7 +55,7 @@ Feature: enter the Codeberg API token
       | dev-remote                  | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
+      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
       | token scope                 | enter                |                                             |
       | sync-feature-strategy       | enter                |                                             |
       | sync-perennial-strategy     | enter                |                                             |

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -18,6 +18,7 @@ Feature: Accepting all default values leads to a working setup
       | perennial regex             | enter |
       | feature regex               | enter |
       | contribution regex          | enter |
+      | observed regex              | enter |
       | unknown branch type         | enter |
       | dev-remote                  | enter |
       | origin hostname             | enter |
@@ -45,6 +46,7 @@ Feature: Accepting all default values leads to a working setup
     And local Git setting "git-town.unknown-branch-type" still doesn't exist
     And local Git setting "git-town.feature-regex" still doesn't exist
     And local Git setting "git-town.contribution-regex" still doesn't exist
+    And local Git setting "git-town.observed-regex" still doesn't exist
     And local Git setting "git-town.forge-type" still doesn't exist
     And local Git setting "git-town.share-new-branches" still doesn't exist
     And local Git setting "git-town.push-hook" still doesn't exist
@@ -57,23 +59,23 @@ Feature: Accepting all default values leads to a working setup
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
       perennials = []
       perennial-regex = ""
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
@@ -105,6 +107,7 @@ Feature: Accepting all default values leads to a working setup
     And local Git setting "git-town.hosting-origin-hostname" still doesn't exist
     And local Git setting "git-town.feature-regex" now doesn't exist
     And local Git setting "git-town.contribution-regex" now doesn't exist
+    And local Git setting "git-town.observed-regex" now doesn't exist
     And local Git setting "git-town.sync-feature-strategy" still doesn't exist
     And local Git setting "git-town.sync-perennial-strategy" still doesn't exist
     And local Git setting "git-town.sync-upstream" still doesn't exist

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -59,23 +59,23 @@ Feature: Accepting all default values leads to a working setup
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
       perennials = []
       perennial-regex = ""
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "origin"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -53,23 +53,23 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "initial"
       perennials = []
       perennial-regex = ""
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "origin"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -12,6 +12,7 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       | perennial regex             | enter |
       | feature regex               | enter |
       | contribution regex          | enter |
+      | observed regex              | enter |
       | unknown branch type         | enter |
       | dev-remote                  | enter |
       | origin hostname             | enter |
@@ -39,6 +40,7 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And local Git setting "git-town.unknown-branch-type" still doesn't exist
     And local Git setting "git-town.feature-regex" still doesn't exist
     And local Git setting "git-town.contribution-regex" still doesn't exist
+    And local Git setting "git-town.observed-regex" still doesn't exist
     And local Git setting "git-town.forge-type" still doesn't exist
     And local Git setting "git-town.share-new-branches" still doesn't exist
     And local Git setting "git-town.push-hook" still doesn't exist
@@ -51,23 +53,23 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "initial"
       perennials = []
       perennial-regex = ""
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
@@ -99,6 +101,7 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And local Git setting "git-town.hosting-origin-hostname" still doesn't exist
     And local Git setting "git-town.feature-regex" now doesn't exist
     And local Git setting "git-town.contribution-regex" now doesn't exist
+    And local Git setting "git-town.observed-regex" now doesn't exist
     And local Git setting "git-town.sync-feature-strategy" still doesn't exist
     And local Git setting "git-town.sync-perennial-strategy" still doesn't exist
     And local Git setting "git-town.sync-upstream" still doesn't exist

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -55,7 +55,7 @@ Feature: enter the Gitea API token
       | dev-remote                  | enter                     |                                             |
       | origin hostname             | enter                     |                                             |
       | forge type                  | down down down down enter |                                             |
-      | gitea token                 |         1 2 3 4 5 6 enter |                                             |
+      | gitea token                 | 1 2 3 4 5 6 enter         |                                             |
       | token scope                 | enter                     |                                             |
       | sync-feature-strategy       | enter                     |                                             |
       | sync-perennial-strategy     | enter                     |                                             |

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -15,6 +15,7 @@ Feature: enter the Gitea API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -49,11 +50,12 @@ Feature: enter the Gitea API token
       | perennial regex             | enter                     |                                             |
       | feature regex               | enter                     |                                             |
       | contribution regex          | enter                     |                                             |
+      | observed regex              | enter                     |                                             |
       | unknown branch type         | enter                     |                                             |
       | dev-remote                  | enter                     |                                             |
       | origin hostname             | enter                     |                                             |
       | forge type                  | down down down down enter |                                             |
-      | gitea token                 | 1 2 3 4 5 6 enter         |                                             |
+      | gitea token                 |         1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                     |                                             |
       | sync-feature-strategy       | enter                     |                                             |
       | sync-perennial-strategy     | enter                     |                                             |
@@ -85,6 +87,7 @@ Feature: enter the Gitea API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -120,6 +123,7 @@ Feature: enter the Gitea API token
       | perennial regex             | enter                                     |                                             |
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
+      | observed regex              | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | dev-remote                  | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -58,7 +58,7 @@ Feature: enter the GitHub API token
       | origin hostname             | enter                          |                                             |
       | forge type                  | down down down down down enter |                                             |
       | github connector type: API  | enter                          |                                             |
-      | github token                |              1 2 3 4 5 6 enter |                                             |
+      | github token                | 1 2 3 4 5 6 enter              |                                             |
       | token scope                 | enter                          |                                             |
       | sync-feature-strategy       | enter                          |                                             |
       | sync-perennial-strategy     | enter                          |                                             |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -15,6 +15,7 @@ Feature: enter the GitHub API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -51,12 +52,13 @@ Feature: enter the GitHub API token
       | perennial regex             | enter                          |                                             |
       | feature regex               | enter                          |                                             |
       | contribution regex          | enter                          |                                             |
+      | observed regex              | enter                          |                                             |
       | unknown branch type         | enter                          |                                             |
       | dev-remote                  | enter                          |                                             |
       | origin hostname             | enter                          |                                             |
       | forge type                  | down down down down down enter |                                             |
       | github connector type: API  | enter                          |                                             |
-      | github token                | 1 2 3 4 5 6 enter              |                                             |
+      | github token                |              1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                          |                                             |
       | sync-feature-strategy       | enter                          |                                             |
       | sync-perennial-strategy     | enter                          |                                             |
@@ -90,6 +92,7 @@ Feature: enter the GitHub API token
       | perennial regex             | enter                               |                                             |
       | feature regex               | enter                               |                                             |
       | contribution regex          | enter                               |                                             |
+      | observed regex              | enter                               |                                             |
       | unknown branch type         | enter                               |                                             |
       | dev-remote                  | enter                               |                                             |
       | origin hostname             | enter                               |                                             |
@@ -126,6 +129,7 @@ Feature: enter the GitHub API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -163,6 +167,7 @@ Feature: enter the GitHub API token
       | perennial regex             | enter                                     |                                             |
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
+      | observed regex              | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | dev-remote                  | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -15,6 +15,7 @@ Feature: enter the GitLab API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -50,6 +51,7 @@ Feature: enter the GitLab API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -88,6 +90,7 @@ Feature: enter the GitLab API token
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -125,6 +128,7 @@ Feature: enter the GitLab API token
       | perennial regex             | enter                                     |                                             |
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
+      | observed regex              | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | dev-remote                  | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -14,6 +14,7 @@ Feature: a global API token of another forge exists
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
+      | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | dev-remote                  | enter             |                                             |
       | origin hostname             | enter             |                                             |

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -8,6 +8,7 @@ Feature: migrate existing configuration in Git metadata to a config file
     And local Git setting "git-town.perennial-branches" is "qa"
     And local Git setting "git-town.feature-regex" is "user-.*"
     And local Git setting "git-town.contribution-regex" is "coworker-.*"
+    And local Git setting "git-town.observed-regex" is "other-.*"
     And local Git setting "git-town.dev-remote" is "fork"
     And local Git setting "git-town.share-new-branches" is "no"
     And local Git setting "git-town.push-hook" is "true"
@@ -28,6 +29,7 @@ Feature: migrate existing configuration in Git metadata to a config file
       | perennial regex                           | enter |
       | feature regex                             | enter |
       | contribution regex                        | enter |
+      | observed regex                            | enter |
       | unknown branch type                       | enter |
       | dev-remote                                | enter |
       | origin hostname                           | enter |
@@ -71,6 +73,7 @@ Feature: migrate existing configuration in Git metadata to a config file
     And local Git setting "git-town.perennial-regex" now doesn't exist
     And local Git setting "git-town.feature-regex" is still "user-.*"
     And local Git setting "git-town.contribution-regex" is still "coworker-.*"
+    And local Git setting "git-town.observed-regex" is still "other-.*"
     And local Git setting "git-town.unknown-branch-type" is still "observed"
     And local Git setting "git-town.share-new-branches" now doesn't exist
     And local Git setting "git-town.push-hook" now doesn't exist
@@ -80,23 +83,23 @@ Feature: migrate existing configuration in Git metadata to a config file
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
       perennials = ["qa"]
       perennial-regex = "release-.*"
-
+      
       [create]
       new-branch-type = "prototype"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = false
       strategy = "squash-merge"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
@@ -114,6 +117,7 @@ Feature: migrate existing configuration in Git metadata to a config file
     And local Git setting "git-town.perennial-regex" is now "release-.*"
     And local Git setting "git-town.feature-regex" is now "user-.*"
     And local Git setting "git-town.contribution-regex" is now "coworker-.*"
+    And local Git setting "git-town.observed-regex" is now "other-.*"
     And local Git setting "git-town.unknown-branch-type" is now "observed"
     And local Git setting "git-town.share-new-branches" is now "no"
     And local Git setting "git-town.push-hook" is now "true"

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -83,23 +83,23 @@ Feature: migrate existing configuration in Git metadata to a config file
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
       perennials = ["qa"]
       perennial-regex = "release-.*"
-      
+
       [create]
       new-branch-type = "prototype"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "origin"
-      
+
       [ship]
       delete-tracking-branch = false
       strategy = "squash-merge"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -37,23 +37,23 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
       perennials = []
       perennial-regex = ""
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "fork"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -13,6 +13,7 @@ Feature: Configure a different development remote
       | perennial regex             | enter    |
       | feature regex               | enter    |
       | contribution regex          | enter    |
+      | observed regex              | enter    |
       | unknown branch type         | enter    |
       | dev-remote                  | up enter |
       | origin hostname             | enter    |
@@ -36,23 +37,23 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
       perennials = []
       perennial-regex = ""
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -25,6 +25,7 @@ Feature: remove existing configuration in Git metadata
     And local Git setting "git-town.perennial-regex" is "qa.*"
     And local Git setting "git-town.feature-regex" is "user.*"
     And local Git setting "git-town.contribution-regex" is "other.*"
+    And local Git setting "git-town.observed-regex" is "obs.*"
     And local Git setting "git-town.unknown-branch-type" is "observed"
     And local Git setting "git-town.dev-remote" is "fork"
     And local Git setting "git-town.push-hook" is "false"
@@ -48,6 +49,7 @@ Feature: remove existing configuration in Git metadata
       | remove the perennial regex              | backspace backspace backspace backspace enter                               |
       | feature regex                           | backspace backspace backspace backspace backspace backspace enter           |
       | contribution regex                      | backspace backspace backspace backspace backspace backspace backspace enter |
+      | observed regex                          | backspace backspace backspace backspace backspace enter                     |
       | unknown branch type                     | up enter                                                                    |
       | dev-remote                              | enter                                                                       |
       | remove origin hostname                  | backspace backspace backspace backspace enter                               |
@@ -86,6 +88,7 @@ Feature: remove existing configuration in Git metadata
       | git config git-town.unknown-branch-type feature      |
       | git config --unset git-town.feature-regex            |
       | git config --unset git-town.contribution-regex       |
+      | git config --unset git-town.observed-regex           |
       | git config git-town.push-hook true                   |
       | git config git-town.share-new-branches no            |
       | git config git-town.ship-strategy api                |
@@ -120,6 +123,7 @@ Feature: remove existing configuration in Git metadata
     And local Git setting "git-town.perennial-regex" now doesn't exist
     And local Git setting "git-town.feature-regex" now doesn't exist
     And local Git setting "git-town.contribution-regex" now doesn't exist
+    And local Git setting "git-town.observed-regex" now doesn't exist
     And local Git setting "git-town.unknown-branch-type" is now "feature"
     And local Git setting "git-town.share-new-branches" is now "no"
     And local Git setting "git-town.push-hook" is now "true"
@@ -147,6 +151,7 @@ Feature: remove existing configuration in Git metadata
     And local Git setting "git-town.perennial-regex" is now "qa.*"
     And local Git setting "git-town.feature-regex" is now "user.*"
     And local Git setting "git-town.contribution-regex" is now "other.*"
+    And local Git setting "git-town.observed-regex" is now "obs.*"
     And local Git setting "git-town.unknown-branch-type" is now "observed"
     And local Git setting "git-town.share-new-branches" is now "push"
     And local Git setting "git-town.push-hook" is now "false"

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -13,6 +13,7 @@ Feature: remove an existing forge type override
       | perennial regex             | enter                |                                             |
       | feature regex               | enter                |                                             |
       | contribution regex          | enter                |                                             |
+      | observed regex              | enter                |                                             |
       | unknown branch type         | enter                |                                             |
       | dev-remote                  | enter                |                                             |
       | origin hostname             | enter                |                                             |

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -13,6 +13,7 @@ Feature: don't ask for perennial branches if no branches that could be perennial
       | perennial regex             | enter      |                                             |
       | feature regex               | enter      |                                             |
       | contribution regex          | enter      |                                             |
+      | observed regex              | enter      |                                             |
       | unknown branch type         | enter      |                                             |
       | dev-remote                  | enter      |                                             |
       | origin hostname             | enter      |                                             |

--- a/internal/cli/dialog/observed_regex.go
+++ b/internal/cli/dialog/observed_regex.go
@@ -1,0 +1,39 @@
+package dialog
+
+import (
+	"fmt"
+
+	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
+	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
+	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/messages"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
+)
+
+const (
+	observedRegexTitle = `Observed branch regex`
+	observedRegexHelp  = `
+Branches matching this regular expression
+will be treated as observed branches.
+This setting only applies
+if the "unknown-branch-type"
+is set to something other than "observed".
+
+`
+)
+
+func ObservedRegex(existingValue Option[configdomain.ObservedRegex], inputs dialogcomponents.TestInput) (Option[configdomain.ObservedRegex], dialogdomain.Exit, error) {
+	value, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		ExistingValue: existingValue.String(),
+		Help:          observedRegexHelp,
+		Prompt:        "Observed regex: ",
+		TestInput:     inputs,
+		Title:         observedRegexTitle,
+	})
+	fmt.Printf(messages.ObservedRegex, dialogcomponents.FormattedSelection(value, exit))
+	if err != nil {
+		return None[configdomain.ObservedRegex](), exit, err
+	}
+	observedRegex, err := configdomain.ParseObservedRegex(value)
+	return observedRegex, false, err
+}

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -173,6 +173,13 @@ func enterData(repo execute.OpenRepoResult, data *setupData) (configdomain.Confi
 			return tokenScope, forgeType, exit, err
 		}
 	}
+	observedRegex := None[configdomain.ObservedRegex]()
+	if configFile.ObservedRegex.IsNone() {
+		observedRegex, exit, err = dialog.ObservedRegex(repo.UnvalidatedConfig.NormalConfig.ObservedRegex, data.dialogInputs.Next())
+		if err != nil || exit {
+			return tokenScope, forgeType, exit, err
+		}
+	}
 	if configFile.UnknownBranchType.IsNone() {
 		data.userInput.config.NormalConfig.UnknownBranchType, exit, err = dialog.UnknownBranchType(repo.UnvalidatedConfig.NormalConfig.UnknownBranchType, data.dialogInputs.Next())
 		if err != nil || exit {

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -173,9 +173,8 @@ func enterData(repo execute.OpenRepoResult, data *setupData) (configdomain.Confi
 			return tokenScope, forgeType, exit, err
 		}
 	}
-	observedRegex := None[configdomain.ObservedRegex]()
 	if configFile.ObservedRegex.IsNone() {
-		observedRegex, exit, err = dialog.ObservedRegex(repo.UnvalidatedConfig.NormalConfig.ObservedRegex, data.dialogInputs.Next())
+		data.userInput.config.NormalConfig.ObservedRegex, exit, err = dialog.ObservedRegex(repo.UnvalidatedConfig.NormalConfig.ObservedRegex, data.dialogInputs.Next())
 		if err != nil || exit {
 			return tokenScope, forgeType, exit, err
 		}
@@ -624,6 +623,11 @@ func saveToGit(userInput userInput, oldConfig config.UnvalidatedConfig, configFi
 			saveContributionRegex(userInput.config.NormalConfig.ContributionRegex, oldConfig.NormalConfig, frontend),
 		)
 	}
+	if configFile.ObservedRegex.IsNone() {
+		fc.Check(
+			saveObservedRegex(userInput.config.NormalConfig.ObservedRegex, oldConfig.NormalConfig, frontend),
+		)
+	}
 	if configFile.PushHook.IsNone() {
 		fc.Check(
 			savePushHook(userInput.config.NormalConfig.PushHook, oldConfig.NormalConfig, frontend),
@@ -753,6 +757,17 @@ func saveContributionRegex(value Option[configdomain.ContributionRegex], config 
 		return gitconfig.SetContributionRegex(runner, value)
 	}
 	_ = gitconfig.RemoveContributionRegex(runner)
+	return nil
+}
+
+func saveObservedRegex(value Option[configdomain.ObservedRegex], config config.NormalConfig, runner subshelldomain.Runner) error {
+	if value.Equal(config.ObservedRegex) {
+		return nil
+	}
+	if value, has := value.Get(); has {
+		return gitconfig.SetObservedRegex(runner, value)
+	}
+	_ = gitconfig.RemoveObservedRegex(runner)
 	return nil
 }
 

--- a/internal/config/gitconfig/high_level.go
+++ b/internal/config/gitconfig/high_level.go
@@ -100,6 +100,10 @@ func RemoveNewBranchType(runner subshelldomain.Runner) error {
 	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyNewBranchType)
 }
 
+func RemoveObservedRegex(runner subshelldomain.Runner) error {
+	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyObservedRegex)
+}
+
 func RemoveOriginHostname(runner subshelldomain.Runner) error {
 	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyHostingOriginHostname)
 }
@@ -219,6 +223,10 @@ func SetMainBranch(runner subshelldomain.Runner, value gitdomain.LocalBranchName
 
 func SetNewBranchType(runner subshelldomain.Runner, value configdomain.BranchType) error {
 	return SetConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyNewBranchType, value.String())
+}
+
+func SetObservedRegex(runner subshelldomain.Runner, regex configdomain.ObservedRegex) error {
+	return SetConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyObservedRegex, regex.String())
 }
 
 func SetOffline(runner subshelldomain.Runner, value configdomain.Offline) error {

--- a/internal/messages/en.go
+++ b/internal/messages/en.go
@@ -168,6 +168,7 @@ Please upgrade to the new format: create.new-branch-type = "prototype"`
 	ObservedBranchCannotShip              = "cannot ship observed branches"
 	ObserveBranchIsLocal                  = "branch %q is local only - branches you want to observe must have a remote branch because they are per definition other people's branches"
 	ObservedBranchIsNowObserved           = "branch %q is now an observed branch\n"
+	ObservedRegex                         = "Observed regex: %s\n"
 	OfflineNotAllowed                     = "this command requires an active internet connection"
 	OpcodeUnknown                         = "unknown opcode: %q, run \"git town status reset\" to reset it"
 	OpenChangesProblem                    = "cannot determine open changes: %w"


### PR DESCRIPTION
The setup assistant didn't ask for the observed regex. This PR adds the missing dialog.
