### PR TITLE
Extract CliConfig

### DIFF
--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -12,6 +12,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/forge"
@@ -81,7 +82,11 @@ func compressCmd() *cobra.Command {
 			if err := cmp.Or(err1, err2, err3, err4, err5); err != nil {
 				return err
 			}
-			return executeCompress(dryRun, verbose, message, commitHook, stack)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  dryRun,
+				Verbose: verbose,
+			}
+			return executeCompress(cliConfig, message, commitHook, stack)
 		},
 	}
 	addDryRunFlag(&cmd)
@@ -92,19 +97,18 @@ func compressCmd() *cobra.Command {
 	return &cmd
 }
 
-func executeCompress(dryRun configdomain.DryRun, verbose configdomain.Verbose, message Option[gitdomain.CommitMessage], commitHook configdomain.CommitHook, compressEntireStack configdomain.FullStack) error {
+func executeCompress(cliConfig cliconfig.CliConfig, message Option[gitdomain.CommitMessage], commitHook configdomain.CommitHook, compressEntireStack configdomain.FullStack) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           dryRun,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
 	}
-	data, exit, err := determineCompressBranchesData(repo, dryRun, verbose, message, compressEntireStack)
+	data, exit, err := determineCompressBranchesData(repo, cliConfig, message, compressEntireStack)
 	if err != nil || exit {
 		return err
 	}
@@ -118,7 +122,7 @@ func executeCompress(dryRun configdomain.DryRun, verbose configdomain.Verbose, m
 		BeginConfigSnapshot:   repo.ConfigSnapshot,
 		BeginStashSize:        data.stashSize,
 		Command:               compressCommand,
-		DryRun:                dryRun,
+		DryRun:                cliConfig.DryRun,
 		EndBranchesSnapshot:   None[gitdomain.BranchesSnapshot](),
 		EndConfigSnapshot:     None[undoconfig.ConfigSnapshot](),
 		EndStashSize:          None[gitdomain.StashSize](),
@@ -145,7 +149,7 @@ func executeCompress(dryRun configdomain.DryRun, verbose configdomain.Verbose, m
 		PendingCommand:          None[string](),
 		RootDir:                 repo.RootDir,
 		RunState:                runState,
-		Verbose:                 verbose,
+		Verbose:                 cliConfig.Verbose,
 	})
 }
 
@@ -171,7 +175,7 @@ type compressBranchData struct {
 	parentBranch     gitdomain.LocalBranchName
 }
 
-func determineCompressBranchesData(repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose, message Option[gitdomain.CommitMessage], compressEntireStack configdomain.FullStack) (data compressBranchesData, exit dialogdomain.Exit, err error) {
+func determineCompressBranchesData(repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig, message Option[gitdomain.CommitMessage], compressEntireStack configdomain.FullStack) (data compressBranchesData, exit dialogdomain.Exit, err error) {
 	previousBranch := repo.Git.PreviouslyCheckedOutBranch(repo.Backend)
 	dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
@@ -214,7 +218,7 @@ func determineCompressBranchesData(repo execute.OpenRepoResult, dryRun configdom
 		RootDir:               repo.RootDir,
 		UnvalidatedConfig:     repo.UnvalidatedConfig,
 		ValidateNoOpenChanges: false,
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 	if err != nil || exit {
 		return data, exit, err
@@ -306,7 +310,7 @@ func determineCompressBranchesData(repo execute.OpenRepoResult, dryRun configdom
 		branchesToCompress: branchesToCompress,
 		config:             validatedConfig,
 		dialogTestInputs:   dialogTestInputs,
-		dryRun:             dryRun,
+		dryRun:             cliConfig.DryRun,
 		hasOpenChanges:     repoStatus.OpenChanges,
 		initialBranch:      initialBranch,
 		previousBranch:     previousBranch,

--- a/internal/cmd/config/get_parent.go
+++ b/internal/cmd/config/get_parent.go
@@ -6,7 +6,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
-	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/spf13/cobra"
@@ -26,21 +26,24 @@ func getParentCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeGetParent(args, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeGetParent(args, cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeGetParent(args []string, verbose configdomain.Verbose) error {
+func executeGetParent(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    false,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -58,6 +61,6 @@ func executeGetParent(args []string, verbose configdomain.Verbose) error {
 	if parent, hasParent := parentOpt.Get(); hasParent {
 		fmt.Print(parent)
 	}
-	print.Footer(verbose, repo.CommandsCounter.Immutable(), repo.FinalMessages.Result())
+	print.Footer(cliConfig.Verbose, repo.CommandsCounter.Immutable(), repo.FinalMessages.Result())
 	return nil
 }

--- a/internal/cmd/config/remove.go
+++ b/internal/cmd/config/remove.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
-	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/spf13/cobra"
@@ -27,21 +27,24 @@ func removeConfigCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeRemoveConfig(verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeRemoveConfig(cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeRemoveConfig(verbose configdomain.Verbose) error {
+func executeRemoveConfig(cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/config/root.go
+++ b/internal/cmd/config/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/spf13/cobra"
@@ -29,7 +30,11 @@ func RootCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeDisplayConfig(verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeDisplayConfig(cliConfig)
 		},
 	}
 	addVerboseFlag(&configCmd)
@@ -39,14 +44,13 @@ func RootCmd() *cobra.Command {
 	return &configCmd
 }
 
-func executeDisplayConfig(verbose configdomain.Verbose) error {
+func executeDisplayConfig(cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/configfile"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
@@ -44,7 +45,11 @@ func SetupCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeConfigSetup(verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeConfigSetup(cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
@@ -59,19 +64,18 @@ func defaultUserInput(gitVersion git.Version) userInput {
 	}
 }
 
-func executeConfigSetup(verbose configdomain.Verbose) error {
+func executeConfigSetup(cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
 	}
-	data, exit, err := loadSetupData(repo, verbose)
+	data, exit, err := loadSetupData(repo, cliConfig)
 	if err != nil || exit {
 		return err
 	}
@@ -92,7 +96,7 @@ func executeConfigSetup(verbose configdomain.Verbose) error {
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
 		TouchedBranches:       []gitdomain.BranchName{},
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 }
 
@@ -471,7 +475,7 @@ func existsAndChanged[T fmt.Stringer](input, existing T) bool {
 	return input.String() != "" && input.String() != existing.String()
 }
 
-func loadSetupData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (data setupData, exit dialogdomain.Exit, err error) {
+func loadSetupData(repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig) (data setupData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {
@@ -494,7 +498,7 @@ func loadSetupData(repo execute.OpenRepoResult, verbose configdomain.Verbose) (d
 		RootDir:               repo.RootDir,
 		UnvalidatedConfig:     repo.UnvalidatedConfig,
 		ValidateNoOpenChanges: false,
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 	if err != nil {
 		return data, exit, err

--- a/internal/cmd/contribute.go
+++ b/internal/cmd/contribute.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
@@ -48,21 +49,24 @@ func contributeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeContribute(args, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeContribute(args, cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeContribute(args []string, verbose configdomain.Verbose) error {
+func executeContribute(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -94,7 +98,7 @@ func executeContribute(args []string, verbose configdomain.Verbose) error {
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
 		TouchedBranches:       data.branchesToMark.Keys().BranchNames(),
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 }
 

--- a/internal/cmd/debug/enter_commits_to_beam.go
+++ b/internal/cmd/debug/enter_commits_to_beam.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/pkg/asserts"
@@ -18,13 +19,16 @@ func enterCommitsToBeam() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			amount := asserts.NoError1(strconv.ParseInt(args[0], 10, 64))
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: false,
+			}
 			repo := asserts.NoError1(execute.OpenRepo(execute.OpenRepoArgs{
-				DryRun:           false,
+				CliConfig:        cliConfig,
 				PrintBranchNames: true,
 				PrintCommands:    true,
 				ValidateGitRepo:  true,
 				ValidateIsOnline: false,
-				Verbose:          false,
 			}))
 			allCommits := asserts.NoError1(repo.Git.CommitsInPerennialBranch(repo.Backend))
 			commits := make([]gitdomain.Commit, amount)

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cmd/ship"
 	"github.com/git-town/git-town/v21/internal/cmd/sync"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/forge"
@@ -79,7 +80,11 @@ func deleteCommand() *cobra.Command {
 			if err := cmp.Or(err1, err2); err != nil {
 				return err
 			}
-			return executeDelete(args, dryRun, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  dryRun,
+				Verbose: verbose,
+			}
+			return executeDelete(args, cliConfig)
 		},
 	}
 	addDryRunFlag(&cmd)
@@ -87,19 +92,18 @@ func deleteCommand() *cobra.Command {
 	return &cmd
 }
 
-func executeDelete(args []string, dryRun configdomain.DryRun, verbose configdomain.Verbose) error {
+func executeDelete(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           dryRun,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
 	}
-	data, exit, err := determineDeleteData(args, repo, dryRun, verbose)
+	data, exit, err := determineDeleteData(args, repo, cliConfig)
 	if err != nil || exit {
 		return err
 	}
@@ -113,7 +117,7 @@ func executeDelete(args []string, dryRun configdomain.DryRun, verbose configdoma
 		BeginConfigSnapshot:   repo.ConfigSnapshot,
 		BeginStashSize:        data.stashSize,
 		Command:               "delete",
-		DryRun:                dryRun,
+		DryRun:                cliConfig.DryRun,
 		EndBranchesSnapshot:   None[gitdomain.BranchesSnapshot](),
 		EndConfigSnapshot:     None[undoconfig.ConfigSnapshot](),
 		EndStashSize:          None[gitdomain.StashSize](),
@@ -141,7 +145,7 @@ func executeDelete(args []string, dryRun configdomain.DryRun, verbose configdoma
 		PendingCommand:          None[string](),
 		RootDir:                 repo.RootDir,
 		RunState:                runState,
-		Verbose:                 verbose,
+		Verbose:                 cliConfig.Verbose,
 	})
 }
 
@@ -163,7 +167,7 @@ type deleteData struct {
 	stashSize                gitdomain.StashSize
 }
 
-func determineDeleteData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, verbose configdomain.Verbose) (data deleteData, exit dialogdomain.Exit, err error) {
+func determineDeleteData(args []string, repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig) (data deleteData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {
@@ -205,7 +209,7 @@ func determineDeleteData(args []string, repo execute.OpenRepoResult, dryRun conf
 		RootDir:               repo.RootDir,
 		UnvalidatedConfig:     repo.UnvalidatedConfig,
 		ValidateNoOpenChanges: false,
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 	if err != nil || exit {
 		return data, exit, err
@@ -268,7 +272,7 @@ func determineDeleteData(args []string, repo execute.OpenRepoResult, dryRun conf
 		config:                   validatedConfig,
 		connector:                connector,
 		dialogTestInputs:         dialogTestInputs,
-		dryRun:                   dryRun,
+		dryRun:                   cliConfig.DryRun,
 		hasOpenChanges:           repoStatus.OpenChanges,
 		initialBranch:            initialBranch,
 		nonExistingBranches:      nonExistingBranches,

--- a/internal/cmd/kill.go
+++ b/internal/cmd/kill.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/messages"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +28,11 @@ func killCommand() *cobra.Command {
 			if err := cmp.Or(err1, err2); err != nil {
 				return err
 			}
-			result := executeDelete(args, dryRun, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  dryRun,
+				Verbose: verbose,
+			}
+			result := executeDelete(args, cliConfig)
 			printKillDeprecationNotice()
 			return result
 		},

--- a/internal/cmd/observe.go
+++ b/internal/cmd/observe.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
@@ -47,21 +48,24 @@ func observeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeObserve(args, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeObserve(args, cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeObserve(args []string, verbose configdomain.Verbose) error {
+func executeObserve(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -93,7 +97,7 @@ func executeObserve(args []string, verbose configdomain.Verbose) error {
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
 		TouchedBranches:       branchNames.BranchNames(),
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 }
 

--- a/internal/cmd/offline.go
+++ b/internal/cmd/offline.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/format"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
@@ -38,21 +39,24 @@ func offlineCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeOffline(args, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeOffline(args, cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeOffline(args []string, verbose configdomain.Verbose) error {
+func executeOffline(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    true,
 		ValidateGitRepo:  false,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -76,7 +80,7 @@ func executeOffline(args []string, verbose configdomain.Verbose) error {
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
 		TouchedBranches:       []gitdomain.BranchName{},
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 }
 

--- a/internal/cmd/park.go
+++ b/internal/cmd/park.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
@@ -41,21 +42,24 @@ func parkCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executePark(args, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executePark(args, cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executePark(args []string, verbose configdomain.Verbose) error {
+func executePark(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: false,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -87,7 +91,7 @@ func executePark(args []string, verbose configdomain.Verbose) error {
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
 		TouchedBranches:       branchNames.BranchNames(),
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 }
 

--- a/internal/cmd/prototype.go
+++ b/internal/cmd/prototype.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
@@ -44,21 +45,24 @@ func prototypeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executePrototype(args, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executePrototype(args, cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executePrototype(args []string, verbose configdomain.Verbose) error {
+func executePrototype(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -90,7 +94,7 @@ func executePrototype(args []string, verbose configdomain.Verbose) error {
 		Git:                   repo.Git,
 		RootDir:               repo.RootDir,
 		TouchedBranches:       branchNames.BranchNames(),
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 }
 

--- a/internal/cmd/repo.go
+++ b/internal/cmd/repo.go
@@ -6,6 +6,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/forge"
@@ -42,21 +43,24 @@ func repoCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeRepo(args, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeRepo(args, cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeRepo(args []string, verbose configdomain.Verbose) error {
+func executeRepo(args []string, cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: true,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -66,7 +70,7 @@ func executeRepo(args []string, verbose configdomain.Verbose) error {
 		return err
 	}
 	err = data.connector.OpenRepository(repo.Frontend)
-	print.Footer(verbose, repo.CommandsCounter.Immutable(), repo.FinalMessages.Result())
+	print.Footer(cliConfig.Verbose, repo.CommandsCounter.Immutable(), repo.FinalMessages.Result())
 	return err
 }
 

--- a/internal/cmd/runlog.go
+++ b/internal/cmd/runlog.go
@@ -7,7 +7,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
-	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/messages"
@@ -41,21 +41,24 @@ func runLogCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeRunLog(verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeRunLog(cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeRunLog(verbose configdomain.Verbose) error {
+func executeRunLog(cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -67,7 +70,7 @@ func executeRunLog(verbose configdomain.Verbose) error {
 	if err = showRunLog(data); err != nil {
 		return err
 	}
-	print.Footer(verbose, *repo.CommandsCounter.Value, []string{})
+	print.Footer(cliConfig.Verbose, *repo.CommandsCounter.Value, []string{})
 	return nil
 }
 

--- a/internal/cmd/ship/shared.go
+++ b/internal/cmd/ship/shared.go
@@ -9,6 +9,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/forge"
@@ -41,7 +42,7 @@ type sharedShipData struct {
 	targetBranchName         gitdomain.LocalBranchName
 }
 
-func determineSharedShipData(args []string, repo execute.OpenRepoResult, dryRun configdomain.DryRun, shipStrategyOverride Option[configdomain.ShipStrategy], verbose configdomain.Verbose) (data sharedShipData, exit dialogdomain.Exit, err error) {
+func determineSharedShipData(args []string, repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig, shipStrategyOverride Option[configdomain.ShipStrategy]) (data sharedShipData, exit dialogdomain.Exit, err error) {
 	dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
 	repoStatus, err := repo.Git.RepoStatus(repo.Backend)
 	if err != nil {
@@ -83,7 +84,7 @@ func determineSharedShipData(args []string, repo execute.OpenRepoResult, dryRun 
 		RootDir:               repo.RootDir,
 		UnvalidatedConfig:     repo.UnvalidatedConfig,
 		ValidateNoOpenChanges: len(args) == 0,
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 	if err != nil || exit {
 		return data, exit, err
@@ -162,7 +163,7 @@ func determineSharedShipData(args []string, repo execute.OpenRepoResult, dryRun 
 		config:                   validatedConfig,
 		connector:                connector,
 		dialogTestInputs:         dialogTestInputs,
-		dryRun:                   dryRun,
+		dryRun:                   cliConfig.DryRun,
 		hasOpenChanges:           repoStatus.OpenChanges,
 		initialBranch:            initialBranch,
 		isShippingInitialBranch:  isShippingInitialBranch,

--- a/internal/cmd/skip.go
+++ b/internal/cmd/skip.go
@@ -9,7 +9,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
-	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/forge"
 	"github.com/git-town/git-town/v21/internal/messages"
@@ -35,21 +35,24 @@ func skipCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeSkip(verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeSkip(cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeSkip(verbose configdomain.Verbose) error {
+func executeSkip(cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -95,7 +98,7 @@ func executeSkip(verbose configdomain.Verbose) error {
 		RootDir:               repo.RootDir,
 		UnvalidatedConfig:     repo.UnvalidatedConfig,
 		ValidateNoOpenChanges: false,
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 	if err != nil || exit {
 		return err
@@ -153,6 +156,6 @@ func executeSkip(verbose configdomain.Verbose) error {
 		RootDir:         repo.RootDir,
 		RunState:        runState,
 		TestInputs:      dialogTestInputs,
-		Verbose:         verbose,
+		Verbose:         cliConfig.Verbose,
 	})
 }

--- a/internal/cmd/status/show.go
+++ b/internal/cmd/status/show.go
@@ -6,7 +6,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/flags"
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
-	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/spf13/cobra"
 )
@@ -25,21 +25,24 @@ func showRunstateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeStatusShow(verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  false,
+				Verbose: verbose,
+			}
+			return executeStatusShow(cliConfig)
 		},
 	}
 	addVerboseFlag(&cmd)
 	return &cmd
 }
 
-func executeStatusShow(verbose configdomain.Verbose) error {
+func executeStatusShow(cliConfig cliconfig.CliConfig) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           false,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return err
@@ -49,7 +52,7 @@ func executeStatusShow(verbose configdomain.Verbose) error {
 		return err
 	}
 	showStatus(data)
-	print.Footer(verbose, *repo.CommandsCounter.Value, []string{})
+	print.Footer(cliConfig.Verbose, *repo.CommandsCounter.Value, []string{})
 	return nil
 }
 

--- a/internal/cmd/walk.go
+++ b/internal/cmd/walk.go
@@ -11,6 +11,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/forge"
@@ -87,7 +88,11 @@ func walkCommand() *cobra.Command {
 			if err := cmp.Or(err1, err2, err3, err4); err != nil {
 				return err
 			}
-			return executeWalk(args, dryRun, allBranches, stack, verbose)
+			cliConfig := cliconfig.CliConfig{
+				DryRun:  dryRun,
+				Verbose: verbose,
+			}
+			return executeWalk(args, cliConfig, allBranches, stack)
 		},
 	}
 	addAllFlag(&cmd)
@@ -97,25 +102,25 @@ func walkCommand() *cobra.Command {
 	return &cmd
 }
 
-func executeWalk(args []string, dryRun configdomain.DryRun, allBranches configdomain.AllBranches, fullStack configdomain.FullStack, verbose configdomain.Verbose) error {
-	if len(args) == 0 && dryRun {
+func executeWalk(args []string, cliConfig cliconfig.CliConfig, allBranches configdomain.AllBranches, fullStack configdomain.FullStack) error {
+	if len(args) == 0 && cliConfig.DryRun {
 		return errors.New(messages.WalkNoDryRun)
 	}
 	if err := validateArgs(allBranches, fullStack); err != nil {
 		return err
 	}
-	data, exit, err := determineWalkData(allBranches, dryRun, fullStack, verbose)
+	data, exit, err := determineWalkData(cliConfig, allBranches, fullStack)
 	if err != nil || exit {
 		return err
 	}
-	runProgram := walkProgram(args, data, dryRun)
+	runProgram := walkProgram(args, data, cliConfig.DryRun)
 	runState := runstate.RunState{
 		BeginBranchesSnapshot: data.branchesSnapshot,
 		BeginConfigSnapshot:   data.repo.ConfigSnapshot,
 		BeginStashSize:        data.stashSize,
 		BranchInfosLastRun:    data.branchInfosLastRun,
 		Command:               walkCmd,
-		DryRun:                dryRun,
+		DryRun:                cliConfig.DryRun,
 		EndBranchesSnapshot:   None[gitdomain.BranchesSnapshot](),
 		EndConfigSnapshot:     None[undoconfig.ConfigSnapshot](),
 		EndStashSize:          None[gitdomain.StashSize](),
@@ -141,7 +146,7 @@ func executeWalk(args []string, dryRun configdomain.DryRun, allBranches configdo
 		PendingCommand:          None[string](),
 		RootDir:                 data.repo.RootDir,
 		RunState:                runState,
-		Verbose:                 verbose,
+		Verbose:                 cliConfig.Verbose,
 	})
 }
 
@@ -159,14 +164,13 @@ type walkData struct {
 	stashSize          gitdomain.StashSize
 }
 
-func determineWalkData(all configdomain.AllBranches, dryRun configdomain.DryRun, stack configdomain.FullStack, verbose configdomain.Verbose) (walkData, dialogdomain.Exit, error) {
+func determineWalkData(cliConfig cliconfig.CliConfig, all configdomain.AllBranches, stack configdomain.FullStack) (walkData, dialogdomain.Exit, error) {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
-		DryRun:           dryRun,
+		CliConfig:        cliConfig,
 		PrintBranchNames: true,
 		PrintCommands:    true,
 		ValidateGitRepo:  true,
 		ValidateIsOnline: false,
-		Verbose:          verbose,
 	})
 	if err != nil {
 		return walkData{}, false, err
@@ -212,7 +216,7 @@ func determineWalkData(all configdomain.AllBranches, dryRun configdomain.DryRun,
 		RootDir:               repo.RootDir,
 		UnvalidatedConfig:     repo.UnvalidatedConfig,
 		ValidateNoOpenChanges: false,
-		Verbose:               verbose,
+		Verbose:               cliConfig.Verbose,
 	})
 	if err != nil || exit {
 		return walkData{}, exit, err

--- a/internal/config/cliconfig/cli_config.go
+++ b/internal/config/cliconfig/cli_config.go
@@ -1,0 +1,8 @@
+package cliconfig
+
+import "github.com/git-town/git-town/v21/internal/config/configdomain"
+
+type CliConfig struct {
+	DryRun  configdomain.DryRun
+	Verbose configdomain.Verbose
+}

--- a/internal/config/cliconfig/doc.go
+++ b/internal/config/cliconfig/doc.go
@@ -1,0 +1,2 @@
+// Package cliconfig reads configuration information from the CLI
+package cliconfig

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -43,6 +43,7 @@ type NormalConfigData struct {
 	SyncTags                 SyncTags
 	SyncUpstream             SyncUpstream
 	UnknownBranchType        BranchType
+	Verbose                  Verbose
 }
 
 func (self *NormalConfigData) NoPushHook() NoPushHook {

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -106,6 +106,7 @@ func DefaultNormalConfig() NormalConfigData {
 		CodebergToken:            None[forgedomain.CodebergToken](),
 		ContributionRegex:        None[ContributionRegex](),
 		DevRemote:                gitdomain.RemoteOrigin,
+		DryRun:                   false,
 		FeatureRegex:             None[FeatureRegex](),
 		ForgeType:                None[forgedomain.ForgeType](),
 		GitHubConnectorType:      None[forgedomain.GitHubConnectorType](),
@@ -130,5 +131,6 @@ func DefaultNormalConfig() NormalConfigData {
 		SyncTags:                 true,
 		SyncUpstream:             true,
 		UnknownBranchType:        BranchTypeFeatureBranch,
+		Verbose:                  false,
 	}
 }

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -18,6 +18,7 @@ type NormalConfigData struct {
 	CodebergToken            Option[forgedomain.CodebergToken]
 	ContributionRegex        Option[ContributionRegex]
 	DevRemote                gitdomain.Remote
+	DryRun                   DryRun // whether to only print the Git commands but not execute them
 	FeatureRegex             Option[FeatureRegex]
 	ForgeType                Option[forgedomain.ForgeType] // None = auto-detect
 	GitHubConnectorType      Option[forgedomain.GitHubConnectorType]

--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -64,6 +64,7 @@ func (self PartialConfig) Merge(other PartialConfig) PartialConfig {
 		CodebergToken:            other.CodebergToken.Or(self.CodebergToken),
 		ContributionRegex:        other.ContributionRegex.Or(self.ContributionRegex),
 		DevRemote:                other.DevRemote.Or(self.DevRemote),
+		DryRun:                   other.DryRun.Or(self.DryRun),
 		FeatureRegex:             other.FeatureRegex.Or(self.FeatureRegex),
 		ForgeType:                other.ForgeType.Or(self.ForgeType),
 		GitHubConnectorType:      other.GitHubConnectorType.Or(self.GitHubConnectorType),
@@ -91,6 +92,7 @@ func (self PartialConfig) Merge(other PartialConfig) PartialConfig {
 		SyncTags:                 other.SyncTags.Or(self.SyncTags),
 		SyncUpstream:             other.SyncUpstream.Or(self.SyncUpstream),
 		UnknownBranchType:        other.UnknownBranchType.Or(self.UnknownBranchType),
+		Verbose:                  other.Verbose.Or(self.Verbose),
 	}
 }
 
@@ -104,6 +106,7 @@ func (self PartialConfig) ToNormalConfig(defaults NormalConfigData) NormalConfig
 		CodebergToken:            self.CodebergToken,
 		ContributionRegex:        self.ContributionRegex,
 		DevRemote:                self.DevRemote.GetOrElse(defaults.DevRemote),
+		DryRun:                   self.DryRun.GetOrDefault(),
 		FeatureRegex:             self.FeatureRegex,
 		ForgeType:                self.ForgeType,
 		GitHubConnectorType:      self.GitHubConnectorType,
@@ -128,6 +131,7 @@ func (self PartialConfig) ToNormalConfig(defaults NormalConfigData) NormalConfig
 		SyncTags:                 self.SyncTags.GetOrElse(defaults.SyncTags),
 		SyncUpstream:             self.SyncUpstream.GetOrElse(defaults.SyncUpstream),
 		UnknownBranchType:        self.UnknownBranchType.GetOrElse(BranchTypeFeatureBranch),
+		Verbose:                  self.Verbose.GetOrDefault(),
 	}
 }
 

--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -16,6 +16,7 @@ type PartialConfig struct {
 	CodebergToken            Option[forgedomain.CodebergToken]
 	ContributionRegex        Option[ContributionRegex]
 	DevRemote                Option[gitdomain.Remote]
+	DryRun                   Option[DryRun]
 	FeatureRegex             Option[FeatureRegex]
 	ForgeType                Option[forgedomain.ForgeType]
 	GitHubConnectorType      Option[forgedomain.GitHubConnectorType]
@@ -43,6 +44,7 @@ type PartialConfig struct {
 	SyncTags                 Option[SyncTags]
 	SyncUpstream             Option[SyncUpstream]
 	UnknownBranchType        Option[BranchType]
+	Verbose                  Option[Verbose]
 }
 
 func EmptyPartialConfig() PartialConfig {

--- a/internal/config/configfile/load.go
+++ b/internal/config/configfile/load.go
@@ -222,6 +222,7 @@ func Validate(data Data, finalMessages stringslice.Collector) (configdomain.Part
 		BranchTypeOverrides:      configdomain.BranchTypeOverrides{},
 		CodebergToken:            None[forgedomain.CodebergToken](),
 		ContributionRegex:        contributionRegex,
+		DryRun:                   None[configdomain.DryRun](),
 		UnknownBranchType:        unknownBranchType,
 		DevRemote:                devRemote,
 		FeatureRegex:             featureRegex,
@@ -250,5 +251,6 @@ func Validate(data Data, finalMessages stringslice.Collector) (configdomain.Part
 		SyncPrototypeStrategy:    syncPrototypeStrategy,
 		SyncTags:                 syncTags,
 		SyncUpstream:             syncUpstream,
+		Verbose:                  None[configdomain.Verbose](),
 	}, ec.Err
 }

--- a/internal/config/envconfig/load.go
+++ b/internal/config/envconfig/load.go
@@ -1,8 +1,6 @@
 package envconfig
 
-import (
-	"github.com/git-town/git-town/v21/internal/config/configdomain"
-)
+import "github.com/git-town/git-town/v21/internal/config/configdomain"
 
 func Load() configdomain.PartialConfig {
 	partialConfig := configdomain.EmptyPartialConfig()

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -18,7 +18,6 @@ import (
 
 type NormalConfig struct {
 	configdomain.NormalConfigData
-	DryRun     configdomain.DryRun                // whether to only print the Git commands but not execute them
 	Env        configdomain.PartialConfig         // configuration data taken from environment variables
 	File       Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
 	Git        configdomain.PartialConfig         // configuration data taken from Git metadata, in particular the unscoped Git metadata

--- a/internal/config/parse_snapshot.go
+++ b/internal/config/parse_snapshot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/messages"
 	"github.com/git-town/git-town/v21/internal/subshell/subshelldomain"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
 // provides the branch type overrides stored in the given Git metadata snapshot
@@ -101,6 +102,7 @@ func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOu
 		CodebergToken:            forgedomain.ParseCodebergToken(snapshot[configdomain.KeyCodebergToken]),
 		ContributionRegex:        contributionRegex,
 		DevRemote:                gitdomain.NewRemote(snapshot[configdomain.KeyDevRemote]),
+		DryRun:                   None[configdomain.DryRun](),
 		FeatureRegex:             featureRegex,
 		ForgeType:                forgeType,
 		GitHubConnectorType:      githubConnectorType,
@@ -128,5 +130,6 @@ func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOu
 		SyncTags:                 syncTags,
 		SyncUpstream:             syncUpstream,
 		UnknownBranchType:        unknownBranchType,
+		Verbose:                  None[configdomain.Verbose](),
 	}, cmp.Or(err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21)
 }

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -42,6 +42,10 @@ func (self *UnvalidatedConfig) Reload(backend subshelldomain.RunnerQuerier) (glo
 	unscopedGitConfig, _ := NewPartialConfigFromSnapshot(unscopedSnapshot, false, nil)
 	envConfig := envconfig.Load()
 	unvalidatedConfig, normalConfig := mergeConfigs(mergeConfigsArgs{
+		cli: cliconfig.CliConfig{
+			DryRun:  false,
+			Verbose: false,
+		},
 		env:  envConfig,
 		file: self.NormalConfig.File,
 		git:  unscopedGitConfig,

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -95,7 +95,6 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	}
 	unvalidatedConfig := config.NewUnvalidatedConfig(config.NewUnvalidatedConfigArgs{
 		ConfigFile:    configFile,
-		DryRun:        args.CliConfig.DryRun,
 		EnvConfig:     envconfig.Load(),
 		FinalMessages: finalMessages,
 		GitConfig:     unscopedConfig,

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/configfile"
 	"github.com/git-town/git-town/v21/internal/config/envconfig"
@@ -26,7 +27,7 @@ import (
 
 func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	commandsCounter := NewMutable(new(gohacks.Counter))
-	if args.Verbose {
+	if args.CliConfig.Verbose {
 		fmt.Println("Git Town " + config.GitTownVersion)
 		fmt.Println("OS:", runtime.GOOS)
 		var cmd *exec.Cmd
@@ -42,7 +43,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	backendRunner := subshell.BackendRunner{
 		Dir:             None[string](),
 		CommandsCounter: commandsCounter,
-		Verbose:         args.Verbose,
+		Verbose:         args.CliConfig.Verbose,
 	}
 	gitCommands := git.Commands{
 		CurrentBranchCache: &cache.WithPrevious[gitdomain.LocalBranchName]{},
@@ -94,7 +95,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	}
 	unvalidatedConfig := config.NewUnvalidatedConfig(config.NewUnvalidatedConfigArgs{
 		ConfigFile:    configFile,
-		DryRun:        args.DryRun,
+		DryRun:        args.CliConfig.DryRun,
 		EnvConfig:     envconfig.Load(),
 		FinalMessages: finalMessages,
 		GitConfig:     unscopedConfig,
@@ -103,7 +104,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	frontEndRunner := newFrontendRunner(newFrontendRunnerArgs{
 		backend:          backendRunner,
 		counter:          commandsCounter,
-		dryRun:           args.DryRun,
+		dryRun:           args.CliConfig.DryRun,
 		getCurrentBranch: gitCommands.CurrentBranch,
 		printBranchNames: args.PrintBranchNames,
 		printCommands:    args.PrintCommands,
@@ -136,12 +137,11 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 }
 
 type OpenRepoArgs struct {
-	DryRun           configdomain.DryRun
+	CliConfig        cliconfig.CliConfig
 	PrintBranchNames bool
 	PrintCommands    bool
 	ValidateGitRepo  bool
 	ValidateIsOnline bool
-	Verbose          configdomain.Verbose
 }
 
 type OpenRepoResult struct {

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -94,6 +94,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 		}
 	}
 	unvalidatedConfig := config.NewUnvalidatedConfig(config.NewUnvalidatedConfigArgs{
+		CliConfig:     args.CliConfig,
 		ConfigFile:    configFile,
 		EnvConfig:     envconfig.Load(),
 		FinalMessages: finalMessages,

--- a/internal/test/testruntime/test_runtime.go
+++ b/internal/test/testruntime/test_runtime.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v21/internal/config"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/git"
@@ -93,8 +94,11 @@ func New(workingDir, homeDir, binDir string) commands.TestCommands {
 		RemotesCache:       &cache.Cache[gitdomain.Remotes]{},
 	}
 	unvalidatedConfig := config.NewUnvalidatedConfig(config.NewUnvalidatedConfigArgs{
+		CliConfig: cliconfig.CliConfig{
+			DryRun:  false,
+			Verbose: false,
+		},
 		ConfigFile:    None[configdomain.PartialConfig](),
-		DryRun:        false,
 		EnvConfig:     configdomain.EmptyPartialConfig(),
 		FinalMessages: stringslice.NewCollector(),
 		GitConfig:     configdomain.EmptyPartialConfig(),

--- a/tools/print_config_exhaustive/lint.go
+++ b/tools/print_config_exhaustive/lint.go
@@ -17,6 +17,8 @@ const (
 var whiteList = []string{
 	"Aliases",
 	"BranchTypeOverrides",
+	"DryRun",
+	"Verbose",
 }
 
 func main() {


### PR DESCRIPTION
In preparation to allowing more config overrides via CLI, this PR extracts a struct for the configuration received via CLI arguments. It is merged together with the other configurations taken from environment variables, Git metadata, and config file.