### PR TITLE
Remove redundant dry-run check

### DIFF
--- a/internal/cmd/ship/always_merge.go
+++ b/internal/cmd/ship/always_merge.go
@@ -20,9 +20,7 @@ func shipProgramAlwaysMerge(prog Mutable[program.Program], sharedData sharedShip
 	if mergeData.remotes.HasRemote(sharedData.config.NormalConfig.DevRemote) && sharedData.config.NormalConfig.Offline.IsOnline() {
 		prog.Value.Add(&opcodes.PushCurrentBranchIfNeeded{CurrentBranch: sharedData.targetBranchName})
 	}
-	if !sharedData.dryRun {
-		prog.Value.Add(&opcodes.LineageParentRemove{Branch: sharedData.branchNameToShip})
-	}
+	prog.Value.Add(&opcodes.LineageParentRemove{Branch: sharedData.branchNameToShip})
 	if branchToShipRemoteName, hasRemoteName := sharedData.branchToShip.RemoteName.Get(); hasRemoteName {
 		if sharedData.config.NormalConfig.Offline.IsOnline() {
 			if sharedData.config.NormalConfig.ShipDeleteTrackingBranch {


### PR DESCRIPTION
Opcodes already check for dryrun, so no need to check again when creating the program.