### PR TITLE
setup assistant: allow modifying existing perennial branches from Git config

### DIFF
--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -20,16 +20,16 @@ Feature: change existing information in Git metadata
       | add all aliases                           | a enter                |
       | accept the already configured main branch | enter                  |
       | change the perennial branches             | space down space enter |
-      | enter a perennial regex                   |          3 3 6 6 enter |
+      | enter a perennial regex                   | 3 3 6 6 enter          |
       | feature regex                             | u s e r enter          |
-      | contribution regex                        |          1 1 1 1 enter |
-      | observed regex                            |          2 2 2 2 enter |
+      | contribution regex                        | 1 1 1 1 enter          |
+      | observed regex                            | 2 2 2 2 enter          |
       | unknown branch type                       | down enter             |
       | dev-remote                                | enter                  |
       | origin hostname                           | c o d e enter          |
       | set forge type to "github"                | up up enter            |
       | set github forge type to "API"            | enter                  |
-      | github token                              |      1 2 3 4 5 6 enter |
+      | github token                              | 1 2 3 4 5 6 enter      |
       | token scope                               | enter                  |
       | sync-feature-strategy                     | down enter             |
       | sync-perennial-strategy                   | down enter             |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -13,22 +13,23 @@ Feature: change existing information in Git metadata
     And local Git setting "git-town.push-hook" is "false"
     And local Git setting "git-town.sync-tags" is "false"
     And local Git setting "git-town.ship-delete-tracking-branch" is "false"
+    And inspect the repo
     When I run "git-town config setup" and enter into the dialogs:
       | DESCRIPTION                               | KEYS                   |
       | welcome                                   | enter                  |
       | add all aliases                           | a enter                |
       | accept the already configured main branch | enter                  |
       | change the perennial branches             | space down space enter |
-      | enter a perennial regex                   | 3 3 6 6 enter          |
+      | enter a perennial regex                   |          3 3 6 6 enter |
       | feature regex                             | u s e r enter          |
-      | contribution regex                        | 1 1 1 1 enter          |
-      | observed regex                            | 2 2 2 2 enter          |
+      | contribution regex                        |          1 1 1 1 enter |
+      | observed regex                            |          2 2 2 2 enter |
       | unknown branch type                       | down enter             |
       | dev-remote                                | enter                  |
       | origin hostname                           | c o d e enter          |
       | set forge type to "github"                | up up enter            |
       | set github forge type to "API"            | enter                  |
-      | github token                              | 1 2 3 4 5 6 enter      |
+      | github token                              |      1 2 3 4 5 6 enter |
       | token scope                               | enter                  |
       | sync-feature-strategy                     | down enter             |
       | sync-perennial-strategy                   | down enter             |
@@ -42,6 +43,7 @@ Feature: change existing information in Git metadata
       | disable ship-delete-tracking-branch       | down enter             |
       | save config to Git metadata               | down enter             |
 
+  @debug @this
   Scenario: result
     Then Git Town runs the commands
       | COMMAND                                                  |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -43,7 +43,6 @@ Feature: change existing information in Git metadata
       | disable ship-delete-tracking-branch       | down enter             |
       | save config to Git metadata               | down enter             |
 
-  @debug @this
   Scenario: result
     Then Git Town runs the commands
       | COMMAND                                                  |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -13,7 +13,7 @@ Feature: change existing information in Git metadata
     And local Git setting "git-town.push-hook" is "false"
     And local Git setting "git-town.sync-tags" is "false"
     And local Git setting "git-town.ship-delete-tracking-branch" is "false"
-    And inspect the repo
+    # And inspect the repo
     When I run "git-town config setup" and enter into the dialogs:
       | DESCRIPTION                               | KEYS                   |
       | welcome                                   | enter                  |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -55,7 +55,7 @@ Feature: enter the Codeberg API token
       | dev-remote                  | enter                |
       | origin hostname             | enter                |
       | forge type                  | down down down enter |
-      | codeberg token              |    1 2 3 4 5 6 enter |
+      | codeberg token              | 1 2 3 4 5 6 enter    |
       | token scope                 | enter                |
       | sync-feature-strategy       | enter                |
       | sync-perennial-strategy     | enter                |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -7,32 +7,32 @@ Feature: enter the Codeberg API token
   Scenario: auto-detected Codeberg platform
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | dev-remote                  | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | enter             |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | DIALOG                      | KEYS              |
+      | welcome                     | enter             |
+      | aliases                     | enter             |
+      | main branch                 | enter             |
+      | perennial branches          | enter             |
+      | perennial regex             | enter             |
+      | feature regex               | enter             |
+      | contribution regex          | enter             |
+      | observed regex              | enter             |
+      | unknown branch type         | enter             |
+      | dev-remote                  | enter             |
+      | origin hostname             | enter             |
+      | forge type: auto-detect     | enter             |
+      | codeberg token              | 1 2 3 4 5 6 enter |
+      | token scope                 | enter             |
+      | sync-feature-strategy       | enter             |
+      | sync-perennial-strategy     | enter             |
+      | sync-prototype-strategy     | enter             |
+      | sync-upstream               | enter             |
+      | sync-tags                   | enter             |
+      | share-new-branches          | enter             |
+      | push-hook                   | enter             |
+      | new-branch-type             | enter             |
+      | ship-strategy               | enter             |
+      | ship-delete-tracking-branch | enter             |
+      | save config to Git metadata | down enter        |
     Then Git Town runs the commands
       | COMMAND                                     |
       | git config git-town.codeberg-token 123456   |
@@ -42,32 +42,32 @@ Feature: enter the Codeberg API token
 
   Scenario: select Codeberg manually
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS                 | DESCRIPTION                                 |
-      | welcome                     | enter                |                                             |
-      | aliases                     | enter                |                                             |
-      | main branch                 | enter                |                                             |
-      | perennial branches          |                      | no input here since the dialog doesn't show |
-      | perennial regex             | enter                |                                             |
-      | feature regex               | enter                |                                             |
-      | contribution regex          | enter                |                                             |
-      | observed regex              | enter                |                                             |
-      | unknown branch type         | enter                |                                             |
-      | dev-remote                  | enter                |                                             |
-      | origin hostname             | enter                |                                             |
-      | forge type                  | down down down enter |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
-      | token scope                 | enter                |                                             |
-      | sync-feature-strategy       | enter                |                                             |
-      | sync-perennial-strategy     | enter                |                                             |
-      | sync-prototype-strategy     | enter                |                                             |
-      | sync-upstream               | enter                |                                             |
-      | sync-tags                   | enter                |                                             |
-      | share-new-branches          | enter                |                                             |
-      | push-hook                   | enter                |                                             |
-      | new-branch-type             | enter                |                                             |
-      | ship-strategy               | enter                |                                             |
-      | ship-delete-tracking-branch | enter                |                                             |
-      | save config to Git metadata | down enter           |                                             |
+      | DIALOG                      | KEYS                 |
+      | welcome                     | enter                |
+      | aliases                     | enter                |
+      | main branch                 | enter                |
+      | perennial branches          | enter                |
+      | perennial regex             | enter                |
+      | feature regex               | enter                |
+      | contribution regex          | enter                |
+      | observed regex              | enter                |
+      | unknown branch type         | enter                |
+      | dev-remote                  | enter                |
+      | origin hostname             | enter                |
+      | forge type                  | down down down enter |
+      | codeberg token              |    1 2 3 4 5 6 enter |
+      | token scope                 | enter                |
+      | sync-feature-strategy       | enter                |
+      | sync-perennial-strategy     | enter                |
+      | sync-prototype-strategy     | enter                |
+      | sync-upstream               | enter                |
+      | sync-tags                   | enter                |
+      | share-new-branches          | enter                |
+      | push-hook                   | enter                |
+      | new-branch-type             | enter                |
+      | ship-strategy               | enter                |
+      | ship-delete-tracking-branch | enter                |
+      | save config to Git metadata | down enter           |
     Then Git Town runs the commands
       | COMMAND                                     |
       | git config git-town.codeberg-token 123456   |
@@ -79,32 +79,32 @@ Feature: enter the Codeberg API token
   Scenario: store Codeberge API token globally
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | dev-remote                  | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | down enter        |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | DIALOG                      | KEYS              |
+      | welcome                     | enter             |
+      | aliases                     | enter             |
+      | main branch                 | enter             |
+      | perennial branches          | enter             |
+      | perennial regex             | enter             |
+      | feature regex               | enter             |
+      | contribution regex          | enter             |
+      | observed regex              | enter             |
+      | unknown branch type         | enter             |
+      | dev-remote                  | enter             |
+      | origin hostname             | enter             |
+      | forge type: auto-detect     | enter             |
+      | codeberg token              | 1 2 3 4 5 6 enter |
+      | token scope                 | down enter        |
+      | sync-feature-strategy       | enter             |
+      | sync-perennial-strategy     | enter             |
+      | sync-prototype-strategy     | enter             |
+      | sync-upstream               | enter             |
+      | sync-tags                   | enter             |
+      | share-new-branches          | enter             |
+      | push-hook                   | enter             |
+      | new-branch-type             | enter             |
+      | ship-strategy               | enter             |
+      | ship-delete-tracking-branch | enter             |
+      | save config to Git metadata | down enter        |
     Then Git Town runs the commands
       | COMMAND                                            |
       | git config --global git-town.codeberg-token 123456 |
@@ -115,32 +115,32 @@ Feature: enter the Codeberg API token
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
     Given global Git setting "git-town.codeberg-token" is "123"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS                                      | DESCRIPTION                                 |
-      | welcome                     | enter                                     |                                             |
-      | aliases                     | enter                                     |                                             |
-      | main branch                 | enter                                     |                                             |
-      | perennial branches          |                                           | no input here since the dialog doesn't show |
-      | perennial regex             | enter                                     |                                             |
-      | feature regex               | enter                                     |                                             |
-      | contribution regex          | enter                                     |                                             |
-      | observed regex              | enter                                     |                                             |
-      | unknown branch type         | enter                                     |                                             |
-      | dev-remote                  | enter                                     |                                             |
-      | origin hostname             | enter                                     |                                             |
-      | forge type: auto-detect     | enter                                     |                                             |
-      | github token                | backspace backspace backspace 4 5 6 enter |                                             |
-      | token scope                 | enter                                     |                                             |
-      | sync-feature-strategy       | enter                                     |                                             |
-      | sync-perennial-strategy     | enter                                     |                                             |
-      | sync-prototype-strategy     | enter                                     |                                             |
-      | sync-upstream               | enter                                     |                                             |
-      | sync-tags                   | enter                                     |                                             |
-      | share-new-branches          | enter                                     |                                             |
-      | push-hook                   | enter                                     |                                             |
-      | new-branch-type             | enter                                     |                                             |
-      | ship-strategy               | enter                                     |                                             |
-      | ship-delete-tracking-branch | enter                                     |                                             |
-      | save config to Git metadata | down enter                                |                                             |
+      | DIALOG                      | KEYS                                      |
+      | welcome                     | enter                                     |
+      | aliases                     | enter                                     |
+      | main branch                 | enter                                     |
+      | perennial branches          | enter                                     |
+      | perennial regex             | enter                                     |
+      | feature regex               | enter                                     |
+      | contribution regex          | enter                                     |
+      | observed regex              | enter                                     |
+      | unknown branch type         | enter                                     |
+      | dev-remote                  | enter                                     |
+      | origin hostname             | enter                                     |
+      | forge type: auto-detect     | enter                                     |
+      | github token                | backspace backspace backspace 4 5 6 enter |
+      | token scope                 | enter                                     |
+      | sync-feature-strategy       | enter                                     |
+      | sync-perennial-strategy     | enter                                     |
+      | sync-prototype-strategy     | enter                                     |
+      | sync-upstream               | enter                                     |
+      | sync-tags                   | enter                                     |
+      | share-new-branches          | enter                                     |
+      | push-hook                   | enter                                     |
+      | new-branch-type             | enter                                     |
+      | ship-strategy               | enter                                     |
+      | ship-delete-tracking-branch | enter                                     |
+      | save config to Git metadata | down enter                                |
     Then Git Town runs the commands
       | COMMAND                                         |
       | git config --global git-town.codeberg-token 456 |

--- a/internal/cli/dialog/dialogcomponents/checklist.go
+++ b/internal/cli/dialog/dialogcomponents/checklist.go
@@ -12,8 +12,9 @@ import (
 
 // lets the user select zero, one, or many of the given entries
 func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInput) (selected []S, exit dialogdomain.Exit, err error) {
+	cursor := entries.FirstEnabled()
 	program := tea.NewProgram(CheckListModel[S]{
-		List:       list.NewList(entries, 0),
+		List:       list.NewList(entries, cursor),
 		Selections: selections,
 		help:       help,
 		title:      title,

--- a/internal/cli/dialog/dialogcomponents/list/entries.go
+++ b/internal/cli/dialog/dialogcomponents/list/entries.go
@@ -30,6 +30,16 @@ func (self Entries[S]) AllDisabled() bool {
 	return true
 }
 
+// provides the index of the first entry that is not disabled
+func (self Entries[S]) FirstEnabled() int {
+	for e, entry := range self {
+		if !entry.Disabled {
+			return e
+		}
+	}
+	return 0
+}
+
 // provides the position of the given needle in this list
 func (self Entries[S]) IndexOf(needle S) int {
 	for e, entry := range self {

--- a/internal/cli/dialog/dialogcomponents/list/entries_test.go
+++ b/internal/cli/dialog/dialogcomponents/list/entries_test.go
@@ -34,6 +34,43 @@ func TestEntries(t *testing.T) {
 		})
 	})
 
+	t.Run("FirstEnabled", func(t *testing.T) {
+		t.Parallel()
+		t.Run("first entry is disabled", func(t *testing.T) {
+			t.Parallel()
+			entries := list.Entries[configdomain.HostingOriginHostname]{
+				{Disabled: true},
+				{Disabled: false},
+			}
+			have := entries.FirstEnabled()
+			must.EqOp(t, 1, have)
+		})
+		t.Run("second entry is disabled", func(t *testing.T) {
+			t.Parallel()
+			entries := list.Entries[configdomain.HostingOriginHostname]{
+				{Disabled: false},
+				{Disabled: true},
+			}
+			have := entries.FirstEnabled()
+			must.EqOp(t, 0, have)
+		})
+		t.Run("all entries are disabled", func(t *testing.T) {
+			t.Parallel()
+			entries := list.Entries[configdomain.HostingOriginHostname]{
+				{Disabled: true},
+				{Disabled: true},
+			}
+			have := entries.FirstEnabled()
+			must.EqOp(t, 0, have)
+		})
+		t.Run("no entries", func(t *testing.T) {
+			t.Parallel()
+			entries := list.Entries[configdomain.HostingOriginHostname]{}
+			have := entries.FirstEnabled()
+			must.EqOp(t, 0, have)
+		})
+	})
+
 	t.Run("IndexOf", func(t *testing.T) {
 		t.Parallel()
 		t.Run("works with correctly comparable types", func(t *testing.T) {

--- a/internal/cli/dialog/perennial_branches.go
+++ b/internal/cli/dialog/perennial_branches.go
@@ -48,6 +48,7 @@ func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBra
 	selections = append(selections, slices.Index(perennialCandidates, mainBranch))
 	selectedBranchesList, exit, err := dialogcomponents.CheckList(entries, selections, perennialBranchesTitle, PerennialBranchesHelp, inputs)
 	selectedBranches := gitdomain.LocalBranchNames(selectedBranchesList)
+	selectedBranches = selectedBranches.Remove(mainBranch)
 	selectionText := selectedBranches.Join(", ")
 	if selectionText == "" {
 		selectionText = "(none)"

--- a/internal/cli/dialog/perennial_branches.go
+++ b/internal/cli/dialog/perennial_branches.go
@@ -32,7 +32,7 @@ The main branch is automatically perennial.
 // This includes asking the user and updating the respective settings based on the user selection.
 func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBranches gitdomain.LocalBranchNames, mainBranch gitdomain.LocalBranchName, inputs dialogcomponents.TestInput) (gitdomain.LocalBranchNames, dialogdomain.Exit, error) {
 	perennialCandidates := localBranches.AppendAllMissing(oldPerennialBranches...)
-	if len(perennialCandidates) == 0 {
+	if len(perennialCandidates) < 2 {
 		return gitdomain.LocalBranchNames{}, false, nil
 	}
 	entries := make(list.Entries[gitdomain.LocalBranchName], len(perennialCandidates))

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -139,11 +139,9 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		}
 	}
 	perennialBranches := repo.UnvalidatedConfig.NormalConfig.PerennialBranches
-	if len(configFile.PerennialBranches) == 0 {
-		perennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), perennialBranches, mainBranch, data.dialogInputs.Next())
-		if err != nil || exit {
-			return emptyResult, exit, err
-		}
+	perennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), perennialBranches, mainBranch, data.dialogInputs.Next())
+	if err != nil || exit {
+		return emptyResult, exit, err
 	}
 	perennialRegex := repo.UnvalidatedConfig.NormalConfig.PerennialRegex
 	if configFile.PerennialRegex.IsNone() {

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -139,9 +139,11 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		}
 	}
 	perennialBranches := repo.UnvalidatedConfig.NormalConfig.PerennialBranches
-	perennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), perennialBranches, mainBranch, data.dialogInputs.Next())
-	if err != nil || exit {
-		return emptyResult, exit, err
+	if len(configFile.PerennialBranches) == 0 {
+		perennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), perennialBranches, mainBranch, data.dialogInputs.Next())
+		if err != nil || exit {
+			return emptyResult, exit, err
+		}
 	}
 	perennialRegex := repo.UnvalidatedConfig.NormalConfig.PerennialRegex
 	if configFile.PerennialRegex.IsNone() {


### PR DESCRIPTION
When asking for perennial branches, the setup assistant:

- displays the main branch selected and disabled because it is perennial
- preselects the perennial branches configured by Git metadata

