### PR TITLE
Skip empty answers in E2E tests

### DIFF
--- a/features/config/setup/abort.feature
+++ b/features/config/setup/abort.feature
@@ -13,6 +13,7 @@ Feature: aborting the setup assistant
       | perennial branches | enter |
       | perennial regex    | esc   |
 
+  @debug @this
   Scenario: result
     Then Git Town runs no commands
     And the main branch is still not set

--- a/features/config/setup/abort.feature
+++ b/features/config/setup/abort.feature
@@ -13,7 +13,6 @@ Feature: aborting the setup assistant
       | perennial branches | enter |
       | perennial regex    | esc   |
 
-  @debug @this
   Scenario: result
     Then Git Town runs no commands
     And the main branch is still not set

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -4,17 +4,19 @@ Feature: enter the Codeberg API token
   Background:
     Given a Git repo with origin
 
+  @debug @this
   Scenario: auto-detected Codeberg platform
     Given my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
+    # And inspect the repo
     When I run "git-town config setup" and enter into the dialog:
       | DIALOG                      | KEYS              | DESCRIPTION                                 |
       | welcome                     | enter             |                                             |
       | aliases                     | enter             |                                             |
       | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
+      | perennial branches          | enter             | no input here since the dialog doesn't show |
+      | perennial regex             |           1 enter |                                             |
+      | feature regex               |           2 enter |                                             |
+      | contribution regex          |           3 enter |                                             |
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
@@ -63,7 +65,7 @@ Feature: enter the Codeberg API token
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
+      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                |                                             |
       | sync-feature-strategy       | enter                |                                             |
       | sync-perennial-strategy     | enter                |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -13,10 +13,10 @@ Feature: enter the Codeberg API token
       | welcome                     | enter             |                                             |
       | aliases                     | enter             |                                             |
       | main branch                 | enter             |                                             |
-      | perennial branches          | enter             | no input here since the dialog doesn't show |
+      | perennial branches          |                   | no input here since the dialog doesn't show |
       | perennial regex             |           1 enter |                                             |
       | feature regex               |           2 enter |                                             |
-      | contribution regex          |           3 enter |                                             |
+      | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -63,7 +63,7 @@ Feature: enter the Codeberg API token
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
+      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
       | token scope                 | enter                |                                             |
       | sync-feature-strategy       | enter                |                                             |
       | sync-perennial-strategy     | enter                |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -6,7 +6,6 @@ Feature: enter the Codeberg API token
 
   Scenario: auto-detected Codeberg platform
     Given my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
-    # And inspect the repo
     When I run "git-town config setup" and enter into the dialog:
       | DIALOG                      | KEYS              | DESCRIPTION                                 |
       | welcome                     | enter             |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -4,7 +4,6 @@ Feature: enter the Codeberg API token
   Background:
     Given a Git repo with origin
 
-  @debug @this
   Scenario: auto-detected Codeberg platform
     Given my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
     # And inspect the repo
@@ -14,8 +13,8 @@ Feature: enter the Codeberg API token
       | aliases                     | enter             |                                             |
       | main branch                 | enter             |                                             |
       | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             |           1 enter |                                             |
-      | feature regex               |           2 enter |                                             |
+      | perennial regex             | enter             |                                             |
+      | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -9,7 +9,7 @@ Feature: Configure a different development remote
       | welcome                     | enter    |
       | aliases                     | enter    |
       | main branch                 | enter    |
-      | perennial branches          | enter    |
+      | perennial branches          |          |
       | perennial regex             | enter    |
       | feature regex               | enter    |
       | contribution regex          | enter    |
@@ -38,23 +38,23 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
       perennials = []
       perennial-regex = ""
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -38,23 +38,23 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
       perennials = []
       perennial-regex = ""
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "fork"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/internal/cli/dialog/aliases.go
+++ b/internal/cli/dialog/aliases.go
@@ -31,7 +31,7 @@ You can always adjust later.
 
 // Aliases lets the user select which Git Town commands should have shorter aliases.
 // This includes asking the user and updating the respective settings based on the user selection.
-func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliases configdomain.Aliases, inputs dialogcomponents.TestInput) (configdomain.Aliases, dialogdomain.Exit, error) {
+func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliases configdomain.Aliases, inputs dialogcomponents.TestInputs) (configdomain.Aliases, dialogdomain.Exit, error) {
 	program := tea.NewProgram(AliasesModel{
 		AllAliasableCommands: allAliasableCommands,
 		CurrentSelections:    NewAliasSelections(allAliasableCommands, existingAliases),
@@ -39,7 +39,7 @@ func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliase
 		OriginalAliases:      existingAliases,
 		selectedColor:        colors.Green(),
 	})
-	dialogcomponents.SendInputs(inputs, program)
+	dialogcomponents.SendInputs(inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(AliasesModel)
 	if err != nil || result.Aborted() {

--- a/internal/cli/dialog/bitbucket_app_password.go
+++ b/internal/cli/dialog/bitbucket_app_password.go
@@ -28,12 +28,12 @@ Git Town will not use the Bitbucket API.
 )
 
 // BitbucketAppPassword lets the user enter the Bitbucket API token.
-func BitbucketAppPassword(oldValue Option[forgedomain.BitbucketAppPassword], inputs dialogcomponents.TestInput) (Option[forgedomain.BitbucketAppPassword], dialogdomain.Exit, error) {
+func BitbucketAppPassword(oldValue Option[forgedomain.BitbucketAppPassword], inputs dialogcomponents.TestInputs) (Option[forgedomain.BitbucketAppPassword], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          bitbucketAppPasswordHelp,
 		Prompt:        "Bitbucket App Password/Token: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         bitbucketAppPasswordTitle,
 	})
 	fmt.Printf(messages.BitbucketAppPassword, dialogcomponents.FormattedSecret(text, exit))

--- a/internal/cli/dialog/bitbucket_username.go
+++ b/internal/cli/dialog/bitbucket_username.go
@@ -24,12 +24,12 @@ Git Town will not use the Bitbucket API.
 `
 )
 
-func BitbucketUsername(oldValue Option[forgedomain.BitbucketUsername], inputs dialogcomponents.TestInput) (Option[forgedomain.BitbucketUsername], dialogdomain.Exit, error) {
+func BitbucketUsername(oldValue Option[forgedomain.BitbucketUsername], inputs dialogcomponents.TestInputs) (Option[forgedomain.BitbucketUsername], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          bitbucketUsernameHelp,
 		Prompt:        "Your Bitbucket username: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         bitbucketUsernameTitle,
 	})
 	fmt.Printf(messages.BitbucketUsername, dialogcomponents.FormattedSecret(text, exit))

--- a/internal/cli/dialog/codeberg_token.go
+++ b/internal/cli/dialog/codeberg_token.go
@@ -26,12 +26,12 @@ Git Town will not use the codeberg API.
 )
 
 // CodebergToken lets the user enter the Gitea API token.
-func CodebergToken(oldValue Option[forgedomain.CodebergToken], inputs dialogcomponents.TestInput) (Option[forgedomain.CodebergToken], dialogdomain.Exit, error) {
+func CodebergToken(oldValue Option[forgedomain.CodebergToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.CodebergToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          codebergTokenHelp,
 		Prompt:        "Your Codeberg API token: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         codebergTokenTitle,
 	})
 	fmt.Printf(messages.CodebergToken, dialogcomponents.FormattedSecret(text, exit))

--- a/internal/cli/dialog/commits_to_beam.go
+++ b/internal/cli/dialog/commits_to_beam.go
@@ -15,7 +15,7 @@ import (
 const commitsToBeamTitle = `Select the commits to beam into branch %q`
 
 // lets the user select commits to beam to the target branch
-func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranchName, git git.Commands, querier subshelldomain.Querier, inputs dialogcomponents.TestInput) (gitdomain.Commits, dialogdomain.Exit, error) {
+func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranchName, git git.Commands, querier subshelldomain.Querier, inputs dialogcomponents.TestInputs) (gitdomain.Commits, dialogdomain.Exit, error) {
 	if len(commits) == 0 {
 		return gitdomain.Commits{}, false, nil
 	}

--- a/internal/cli/dialog/config_storage.go
+++ b/internal/cli/dialog/config_storage.go
@@ -32,7 +32,7 @@ const (
 	ConfigStorageOptionGit  ConfigStorageOption = `Git metadata`
 )
 
-func ConfigStorage(inputs dialogcomponents.TestInput) (ConfigStorageOption, dialogdomain.Exit, error) {
+func ConfigStorage(inputs dialogcomponents.TestInputs) (ConfigStorageOption, dialogdomain.Exit, error) {
 	entries := list.NewEntries(
 		ConfigStorageOptionFile,
 		ConfigStorageOptionGit,

--- a/internal/cli/dialog/contribution_regex.go
+++ b/internal/cli/dialog/contribution_regex.go
@@ -22,12 +22,12 @@ is set to something other than "contribution".
 `
 )
 
-func ContributionRegex(existingValue Option[configdomain.ContributionRegex], inputs dialogcomponents.TestInput) (Option[configdomain.ContributionRegex], dialogdomain.Exit, error) {
+func ContributionRegex(existingValue Option[configdomain.ContributionRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.ContributionRegex], dialogdomain.Exit, error) {
 	value, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: existingValue.String(),
 		Help:          contributionRegexHelp,
 		Prompt:        "Contribution regex: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         contributionRegexTitle,
 	})
 	fmt.Printf(messages.ContributionRegex, dialogcomponents.FormattedSelection(value, exit))

--- a/internal/cli/dialog/credentials_no_access.go
+++ b/internal/cli/dialog/credentials_no_access.go
@@ -20,7 +20,7 @@ API error message: %v
 `
 )
 
-func CredentialsNoAccess(connectorError error, inputs dialogcomponents.TestInput) (repeat bool, exit dialogdomain.Exit, err error) {
+func CredentialsNoAccess(connectorError error, inputs dialogcomponents.TestInputs) (repeat bool, exit dialogdomain.Exit, err error) {
 	entries := list.NewEntries(
 		CredentialsNoAccessChoiceRetry,
 		CredentialsNoAccessChoiceIgnore,

--- a/internal/cli/dialog/credentials_no_proposal_access.go
+++ b/internal/cli/dialog/credentials_no_proposal_access.go
@@ -20,7 +20,7 @@ Received error: %v
 `
 )
 
-func CredentialsNoProposalAccess(connectorError error, inputs dialogcomponents.TestInput) (repeat bool, exit dialogdomain.Exit, err error) {
+func CredentialsNoProposalAccess(connectorError error, inputs dialogcomponents.TestInputs) (repeat bool, exit dialogdomain.Exit, err error) {
 	entries := list.NewEntries(
 		CredentialsNoAccessChoiceRetry,
 		CredentialsNoAccessChoiceIgnore,

--- a/internal/cli/dialog/dev_remote.go
+++ b/internal/cli/dialog/dev_remote.go
@@ -22,7 +22,7 @@ Typically that's the "origin" remote.
 `
 )
 
-func DevRemote(existingValue gitdomain.Remote, options gitdomain.Remotes, inputs dialogcomponents.TestInput) (gitdomain.Remote, dialogdomain.Exit, error) {
+func DevRemote(existingValue gitdomain.Remote, options gitdomain.Remotes, inputs dialogcomponents.TestInputs) (gitdomain.Remote, dialogdomain.Exit, error) {
 	cursor := slice.Index(options, existingValue).GetOrElse(0)
 	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, DevRemoteTypeTitle, DevRemoteHelp, inputs)
 	fmt.Printf(messages.DevRemote, dialogcomponents.FormattedSelection(selection.String(), exit))

--- a/internal/cli/dialog/dialogcomponents/checklist.go
+++ b/internal/cli/dialog/dialogcomponents/checklist.go
@@ -11,7 +11,7 @@ import (
 )
 
 // lets the user select zero, one, or many of the given entries
-func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInput) (selected []S, exit dialogdomain.Exit, err error) {
+func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInputs) (selected []S, exit dialogdomain.Exit, err error) {
 	cursor := entries.FirstEnabled()
 	program := tea.NewProgram(CheckListModel[S]{
 		List:       list.NewList(entries, cursor),
@@ -19,7 +19,7 @@ func CheckList[S comparable](entries list.Entries[S], selections []int, title, h
 		help:       help,
 		title:      title,
 	})
-	SendInputs(inputs, program)
+	SendInputs(inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(CheckListModel[S])
 	return result.CheckedEntries(), result.Aborted(), err

--- a/internal/cli/dialog/dialogcomponents/radiolist.go
+++ b/internal/cli/dialog/dialogcomponents/radiolist.go
@@ -13,13 +13,13 @@ import (
 const WindowSize = 9
 
 // RadioList lets the user select one of the given entries.
-func RadioList[S comparable](entries list.Entries[S], cursor int, title, help string, inputs TestInput) (selected S, exit dialogdomain.Exit, err error) { //nolint:ireturn
+func RadioList[S comparable](entries list.Entries[S], cursor int, title, help string, inputs TestInputs) (selected S, exit dialogdomain.Exit, err error) { //nolint:ireturn
 	program := tea.NewProgram(radioListModel[S]{
 		List:  list.NewList(entries, cursor),
 		help:  help,
 		title: title,
 	})
-	SendInputs(inputs, program)
+	SendInputs(inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(radioListModel[S])
 	return result.SelectedData(), result.Aborted(), err

--- a/internal/cli/dialog/dialogcomponents/text_display.go
+++ b/internal/cli/dialog/dialogcomponents/text_display.go
@@ -9,7 +9,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
 )
 
-func TextDisplay(title, text string, inputs TestInput) (dialogdomain.Exit, error) {
+func TextDisplay(title, text string, inputs TestInputs) (dialogdomain.Exit, error) {
 	model := textDisplayModel{
 		colors: colors.NewDialogColors(),
 		status: list.StatusActive,
@@ -17,7 +17,7 @@ func TextDisplay(title, text string, inputs TestInput) (dialogdomain.Exit, error
 		title:  title,
 	}
 	program := tea.NewProgram(model)
-	SendInputs(inputs, program)
+	SendInputs(inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(textDisplayModel)
 	return result.status == list.StatusExit, err

--- a/internal/cli/dialog/dialogcomponents/text_field.go
+++ b/internal/cli/dialog/dialogcomponents/text_field.go
@@ -23,7 +23,7 @@ func TextField(args TextFieldArgs) (string, dialogdomain.Exit, error) {
 		title:     args.Title,
 	}
 	program := tea.NewProgram(model)
-	SendInputs(args.TestInput, program)
+	SendInputs(args.TestInputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(textFieldModel)
 	return result.textInput.Value(), result.status == list.StatusExit, err
@@ -33,7 +33,7 @@ type TextFieldArgs struct {
 	ExistingValue string
 	Help          string
 	Prompt        string
-	TestInput     TestInput
+	TestInputs    TestInputs
 	Title         string
 }
 

--- a/internal/cli/dialog/dialogcomponents/text_field.go
+++ b/internal/cli/dialog/dialogcomponents/text_field.go
@@ -23,8 +23,7 @@ func TextField(args TextFieldArgs) (string, dialogdomain.Exit, error) {
 		title:     args.Title,
 	}
 	program := tea.NewProgram(model)
-	nextInput := args.TestInputs.Next()
-	SendInputs(nextInput, program)
+	SendInputs(args.TestInputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(textFieldModel)
 	return result.textInput.Value(), result.status == list.StatusExit, err

--- a/internal/cli/dialog/dialogcomponents/text_field.go
+++ b/internal/cli/dialog/dialogcomponents/text_field.go
@@ -23,7 +23,8 @@ func TextField(args TextFieldArgs) (string, dialogdomain.Exit, error) {
 		title:     args.Title,
 	}
 	program := tea.NewProgram(model)
-	SendInputs(args.TestInputs.Next(), program)
+	nextInput := args.TestInputs.Next()
+	SendInputs(nextInput, program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(textFieldModel)
 	return result.textInput.Value(), result.status == list.StatusExit, err

--- a/internal/cli/dialog/feature_regex.go
+++ b/internal/cli/dialog/feature_regex.go
@@ -22,12 +22,12 @@ is set to something other than "feature".
 `
 )
 
-func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs dialogcomponents.TestInput) (Option[configdomain.FeatureRegex], dialogdomain.Exit, error) {
+func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.FeatureRegex], dialogdomain.Exit, error) {
 	value, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: existingValue.String(),
 		Help:          FeatureRegexHelp,
 		Prompt:        "Feature regex: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         featureRegexTitle,
 	})
 	fmt.Printf(messages.FeatureRegex, dialogcomponents.FormattedSelection(value, exit))

--- a/internal/cli/dialog/feature_regex.go
+++ b/internal/cli/dialog/feature_regex.go
@@ -35,5 +35,5 @@ func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs dialog
 		return None[configdomain.FeatureRegex](), exit, err
 	}
 	featureRegex, err := configdomain.ParseFeatureRegex(value)
-	return featureRegex, false, err
+	return featureRegex, exit, err
 }

--- a/internal/cli/dialog/feature_regex.go
+++ b/internal/cli/dialog/feature_regex.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"cmp"
 	"fmt"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
@@ -23,7 +24,7 @@ is set to something other than "feature".
 )
 
 func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.FeatureRegex], dialogdomain.Exit, error) {
-	value, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+	value, exit, err1 := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: existingValue.String(),
 		Help:          FeatureRegexHelp,
 		Prompt:        "Feature regex: ",
@@ -31,9 +32,6 @@ func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs dialog
 		Title:         featureRegexTitle,
 	})
 	fmt.Printf(messages.FeatureRegex, dialogcomponents.FormattedSelection(value, exit))
-	if err != nil {
-		return None[configdomain.FeatureRegex](), exit, err
-	}
-	featureRegex, err := configdomain.ParseFeatureRegex(value)
-	return featureRegex, exit, err
+	featureRegex, err2 := configdomain.ParseFeatureRegex(value)
+	return featureRegex, exit, cmp.Or(err1, err2)
 }

--- a/internal/cli/dialog/forge_type.go
+++ b/internal/cli/dialog/forge_type.go
@@ -24,7 +24,7 @@ is hosted at a custom URL.
 `
 )
 
-func ForgeType(existingValue Option[forgedomain.ForgeType], inputs dialogcomponents.TestInput) (Option[forgedomain.ForgeType], dialogdomain.Exit, error) {
+func ForgeType(existingValue Option[forgedomain.ForgeType], inputs dialogcomponents.TestInputs) (Option[forgedomain.ForgeType], dialogdomain.Exit, error) {
 	entries := list.Entries[Option[forgedomain.ForgeType]]{
 		{
 			Data: None[forgedomain.ForgeType](),

--- a/internal/cli/dialog/gitea_token.go
+++ b/internal/cli/dialog/gitea_token.go
@@ -26,12 +26,12 @@ Git Town will not use the gitea API.
 )
 
 // GiteaToken lets the user enter the Gitea API token.
-func GiteaToken(oldValue Option[forgedomain.GiteaToken], inputs dialogcomponents.TestInput) (Option[forgedomain.GiteaToken], dialogdomain.Exit, error) {
+func GiteaToken(oldValue Option[forgedomain.GiteaToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.GiteaToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          giteaTokenHelp,
 		Prompt:        "Your Gitea API token: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         giteaTokenTitle,
 	})
 	fmt.Printf(messages.GiteaToken, dialogcomponents.FormattedSecret(text, exit))

--- a/internal/cli/dialog/github_connector_type.go
+++ b/internal/cli/dialog/github_connector_type.go
@@ -28,7 +28,7 @@ Git Town supports two ways to connect to GitHub:
 `
 )
 
-func GitHubConnectorType(existing Option[forgedomain.GitHubConnectorType], inputs dialogcomponents.TestInput) (Option[forgedomain.GitHubConnectorType], dialogdomain.Exit, error) {
+func GitHubConnectorType(existing Option[forgedomain.GitHubConnectorType], inputs dialogcomponents.TestInputs) (Option[forgedomain.GitHubConnectorType], dialogdomain.Exit, error) {
 	entries := list.Entries[forgedomain.GitHubConnectorType]{
 		{
 			Data: forgedomain.GitHubConnectorTypeAPI,

--- a/internal/cli/dialog/github_token.go
+++ b/internal/cli/dialog/github_token.go
@@ -30,12 +30,12 @@ with the GitHub API.
 )
 
 // GitHubToken lets the user enter the GitHub API token.
-func GitHubToken(oldValue Option[forgedomain.GitHubToken], inputs dialogcomponents.TestInput) (Option[forgedomain.GitHubToken], dialogdomain.Exit, error) {
+func GitHubToken(oldValue Option[forgedomain.GitHubToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.GitHubToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          gitHubTokenHelp,
 		Prompt:        "Your GitHub API token: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         githubTokenTitle,
 	})
 	fmt.Printf(messages.GitHubToken, dialogcomponents.FormattedSecret(text, exit))

--- a/internal/cli/dialog/gitlab_connector_type.go
+++ b/internal/cli/dialog/gitlab_connector_type.go
@@ -28,7 +28,7 @@ Git Town supports two ways to connect to GitLab:
 `
 )
 
-func GitLabConnectorType(existing Option[forgedomain.GitLabConnectorType], inputs dialogcomponents.TestInput) (Option[forgedomain.GitLabConnectorType], dialogdomain.Exit, error) {
+func GitLabConnectorType(existing Option[forgedomain.GitLabConnectorType], inputs dialogcomponents.TestInputs) (Option[forgedomain.GitLabConnectorType], dialogdomain.Exit, error) {
 	entries := list.Entries[forgedomain.GitLabConnectorType]{
 		{
 			Data: forgedomain.GitLabConnectorTypeAPI,

--- a/internal/cli/dialog/gitlab_token.go
+++ b/internal/cli/dialog/gitlab_token.go
@@ -27,12 +27,12 @@ Git Town will not use the GitLab API.
 )
 
 // GitLabToken lets the user enter the GitHub API token.
-func GitLabToken(oldValue Option[forgedomain.GitLabToken], inputs dialogcomponents.TestInput) (Option[forgedomain.GitLabToken], dialogdomain.Exit, error) {
+func GitLabToken(oldValue Option[forgedomain.GitLabToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.GitLabToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          gitLabTokenHelp,
 		Prompt:        "Your GitLab API token: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         gitLabTokenTitle,
 	})
 	fmt.Printf(messages.GitLabToken, dialogcomponents.FormattedSecret(text, exit))

--- a/internal/cli/dialog/lineage.go
+++ b/internal/cli/dialog/lineage.go
@@ -51,12 +51,12 @@ func Lineage(args LineageArgs) (additionalLineage configdomain.Lineage, addition
 		}
 		// ask for parent
 		outcome, selectedBranch, err := Parent(ParentArgs{
-			Branch:          branchToVerify,
-			DefaultChoice:   args.DefaultChoice,
-			DialogTestInput: args.DialogTestInputs.Next(),
-			Lineage:         args.Lineage,
-			LocalBranches:   args.LocalBranches,
-			MainBranch:      args.MainBranch,
+			Branch:        branchToVerify,
+			DefaultChoice: args.DefaultChoice,
+			Inputs:        args.DialogTestInputs,
+			Lineage:       args.Lineage,
+			LocalBranches: args.LocalBranches,
+			MainBranch:    args.MainBranch,
 		})
 		if err != nil {
 			return additionalLineage, additionalPerennials, false, err

--- a/internal/cli/dialog/main_and_perennial.go
+++ b/internal/cli/dialog/main_and_perennial.go
@@ -21,11 +21,11 @@ func MainAndPerennials(args MainAndPerennialsArgs) (mainBranch gitdomain.LocalBr
 		return unvalidatedMain, args.UnvalidatedPerennials, false, errors.New(messages.ConfigMainbranchInConfigFile)
 	}
 	fmt.Print(messages.ConfigNeeded)
-	mainBranch, exit, err = MainBranch(args.LocalBranches, args.GetDefaultBranch(args.Backend), args.DialogInputs.Next())
+	mainBranch, exit, err = MainBranch(args.LocalBranches, args.GetDefaultBranch(args.Backend), args.DialogInputs)
 	if err != nil || exit {
 		return mainBranch, args.UnvalidatedPerennials, exit, err
 	}
-	perennials, exit, err = PerennialBranches(args.LocalBranches, args.UnvalidatedPerennials, mainBranch, args.DialogInputs.Next())
+	perennials, exit, err = PerennialBranches(args.LocalBranches, args.UnvalidatedPerennials, mainBranch, args.DialogInputs)
 	return mainBranch, perennials, exit, err
 }
 

--- a/internal/cli/dialog/main_branch.go
+++ b/internal/cli/dialog/main_branch.go
@@ -26,7 +26,7 @@ This is typically the branch called
 )
 
 // MainBranch lets the user select a new main branch for this repo.
-func MainBranch(localBranches gitdomain.LocalBranchNames, defaultEntryOpt Option[gitdomain.LocalBranchName], inputs dialogcomponents.TestInput) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
+func MainBranch(localBranches gitdomain.LocalBranchNames, defaultEntryOpt Option[gitdomain.LocalBranchName], inputs dialogcomponents.TestInputs) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
 	cursor := 0
 	if defaultEntry, hasDefaultEntry := defaultEntryOpt.Get(); hasDefaultEntry {
 		cursor = slice.Index(localBranches, defaultEntry).GetOrElse(0)

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -23,7 +23,7 @@ More details: https://www.git-town.com/preferences/new-branch-type.
 `
 )
 
-func NewBranchType(existingOpt Option[configdomain.BranchType], inputs dialogcomponents.TestInput) (Option[configdomain.BranchType], dialogdomain.Exit, error) {
+func NewBranchType(existingOpt Option[configdomain.BranchType], inputs dialogcomponents.TestInputs) (Option[configdomain.BranchType], dialogdomain.Exit, error) {
 	entries := list.Entries[Option[configdomain.BranchType]]{
 		{
 			Data: Some(configdomain.BranchTypeFeatureBranch),

--- a/internal/cli/dialog/observed_regex.go
+++ b/internal/cli/dialog/observed_regex.go
@@ -22,12 +22,12 @@ is set to something other than "observed".
 `
 )
 
-func ObservedRegex(existingValue Option[configdomain.ObservedRegex], inputs dialogcomponents.TestInput) (Option[configdomain.ObservedRegex], dialogdomain.Exit, error) {
+func ObservedRegex(existingValue Option[configdomain.ObservedRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.ObservedRegex], dialogdomain.Exit, error) {
 	value, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: existingValue.String(),
 		Help:          observedRegexHelp,
 		Prompt:        "Observed regex: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         observedRegexTitle,
 	})
 	fmt.Printf(messages.ObservedRegex, dialogcomponents.FormattedSelection(value, exit))

--- a/internal/cli/dialog/origin_hostname.go
+++ b/internal/cli/dialog/origin_hostname.go
@@ -23,12 +23,12 @@ if Git Town's auto-detection doesn't work.
 `
 )
 
-func OriginHostname(oldValue Option[configdomain.HostingOriginHostname], inputs dialogcomponents.TestInput) (Option[configdomain.HostingOriginHostname], dialogdomain.Exit, error) {
+func OriginHostname(oldValue Option[configdomain.HostingOriginHostname], inputs dialogcomponents.TestInputs) (Option[configdomain.HostingOriginHostname], dialogdomain.Exit, error) {
 	token, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          OriginHostnameHelp,
 		Prompt:        "Origin hostname override: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         originHostnameTitle,
 	})
 	fmt.Printf(messages.OriginHostname, dialogcomponents.FormattedSelection(token, exit))

--- a/internal/cli/dialog/parent.go
+++ b/internal/cli/dialog/parent.go
@@ -29,7 +29,7 @@ func Parent(args ParentArgs) (ParentOutcome, gitdomain.LocalBranchName, error) {
 	cursor := slice.Index(parentCandidates, args.DefaultChoice).GetOrElse(0)
 	title := fmt.Sprintf(parentBranchTitleTemplate, args.Branch)
 	help := fmt.Sprintf(parentBranchHelpTemplate, args.Branch)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.DialogTestInput)
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.Inputs)
 	fmt.Printf(messages.ParentDialogSelected, args.Branch, dialogcomponents.FormattedSelection(selection.String(), exit))
 	if exit {
 		return ParentOutcomeExit, selection, err
@@ -41,12 +41,12 @@ func Parent(args ParentArgs) (ParentOutcome, gitdomain.LocalBranchName, error) {
 }
 
 type ParentArgs struct {
-	Branch          gitdomain.LocalBranchName
-	DefaultChoice   gitdomain.LocalBranchName
-	DialogTestInput dialogcomponents.TestInput
-	Lineage         configdomain.Lineage
-	LocalBranches   gitdomain.LocalBranchNames
-	MainBranch      gitdomain.LocalBranchName
+	Branch        gitdomain.LocalBranchName
+	DefaultChoice gitdomain.LocalBranchName
+	Inputs        dialogcomponents.TestInputs
+	Lineage       configdomain.Lineage
+	LocalBranches gitdomain.LocalBranchNames
+	MainBranch    gitdomain.LocalBranchName
 }
 
 func ParentCandidateNames(args ParentArgs) gitdomain.LocalBranchNames {

--- a/internal/cli/dialog/parent_test.go
+++ b/internal/cli/dialog/parent_test.go
@@ -28,12 +28,12 @@ func TestParent(t *testing.T) {
 				branch3: main,
 			})
 			have := dialog.ParentCandidateNames(dialog.ParentArgs{
-				Branch:          branch2,
-				DefaultChoice:   main,
-				DialogTestInput: dialogcomponents.TestInput{},
-				Lineage:         lineage,
-				LocalBranches:   localBranches,
-				MainBranch:      main,
+				Branch:        branch2,
+				DefaultChoice: main,
+				Inputs:        dialogcomponents.TestInputs{},
+				Lineage:       lineage,
+				LocalBranches: localBranches,
+				MainBranch:    main,
 			})
 			want := gitdomain.LocalBranchNames{dialog.PerennialBranchOption, main, branch1, branch3}
 			must.Eq(t, want, have)
@@ -55,12 +55,12 @@ func TestParent(t *testing.T) {
 				branch3:  main,
 			})
 			have := dialog.ParentCandidateNames(dialog.ParentArgs{
-				Branch:          branch2,
-				DefaultChoice:   main,
-				DialogTestInput: dialogcomponents.TestInput{},
-				Lineage:         lineage,
-				LocalBranches:   localBranches,
-				MainBranch:      main,
+				Branch:        branch2,
+				DefaultChoice: main,
+				Inputs:        dialogcomponents.TestInputs{},
+				Lineage:       lineage,
+				LocalBranches: localBranches,
+				MainBranch:    main,
 			})
 			want := gitdomain.LocalBranchNames{dialog.PerennialBranchOption, main, branch1, branch1a, branch3}
 			must.Eq(t, want, have)

--- a/internal/cli/dialog/perennial_branches.go
+++ b/internal/cli/dialog/perennial_branches.go
@@ -31,7 +31,7 @@ and therefore always selected in this list.
 
 // PerennialBranches lets the user update the perennial branches.
 // This includes asking the user and updating the respective settings based on the user selection.
-func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBranches gitdomain.LocalBranchNames, mainBranch gitdomain.LocalBranchName, inputs dialogcomponents.TestInput) (gitdomain.LocalBranchNames, dialogdomain.Exit, error) {
+func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBranches gitdomain.LocalBranchNames, mainBranch gitdomain.LocalBranchName, inputs dialogcomponents.TestInputs) (gitdomain.LocalBranchNames, dialogdomain.Exit, error) {
 	perennialCandidates := localBranches.AppendAllMissing(oldPerennialBranches...)
 	if len(perennialCandidates) < 2 {
 		return gitdomain.LocalBranchNames{}, false, nil

--- a/internal/cli/dialog/perennial_regex.go
+++ b/internal/cli/dialog/perennial_regex.go
@@ -25,12 +25,12 @@ it's safe to leave it blank.
 `
 )
 
-func PerennialRegex(oldValue Option[configdomain.PerennialRegex], inputs dialogcomponents.TestInput) (Option[configdomain.PerennialRegex], dialogdomain.Exit, error) {
+func PerennialRegex(oldValue Option[configdomain.PerennialRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.PerennialRegex], dialogdomain.Exit, error) {
 	value, exit, err1 := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
 		ExistingValue: oldValue.String(),
 		Help:          PerennialRegexHelp,
 		Prompt:        "Perennial regex: ",
-		TestInput:     inputs,
+		TestInputs:    inputs,
 		Title:         perennialRegexTitle,
 	})
 	fmt.Printf(messages.PerennialRegex, dialogcomponents.FormattedSelection(value, exit))

--- a/internal/cli/dialog/push_hook.go
+++ b/internal/cli/dialog/push_hook.go
@@ -27,7 +27,7 @@ More details: https://www.git-town.com/preferences/push-hook.
 `
 )
 
-func PushHook(existing configdomain.PushHook, inputs dialogcomponents.TestInput) (configdomain.PushHook, dialogdomain.Exit, error) {
+func PushHook(existing configdomain.PushHook, inputs dialogcomponents.TestInputs) (configdomain.PushHook, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.PushHook]{
 		{
 			Data: true,

--- a/internal/cli/dialog/select_squash_commit_author.go
+++ b/internal/cli/dialog/select_squash_commit_author.go
@@ -13,7 +13,7 @@ import (
 const squashCommitAuthorTitle = `Squash commit author`
 
 // SelectSquashCommitAuthor allows the user to select an author amongst a given list of authors.
-func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []gitdomain.Author, dialogTestInputs dialogcomponents.TestInput) (gitdomain.Author, dialogdomain.Exit, error) {
+func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []gitdomain.Author, dialogTestInputs dialogcomponents.TestInputs) (gitdomain.Author, dialogdomain.Exit, error) {
 	if len(authors) == 1 {
 		return authors[0], false, nil
 	}

--- a/internal/cli/dialog/share_new_branches.go
+++ b/internal/cli/dialog/share_new_branches.go
@@ -24,7 +24,7 @@ Possible options:
 `
 )
 
-func ShareNewBranches(existing configdomain.ShareNewBranches, inputs dialogcomponents.TestInput) (configdomain.ShareNewBranches, dialogdomain.Exit, error) {
+func ShareNewBranches(existing configdomain.ShareNewBranches, inputs dialogcomponents.TestInputs) (configdomain.ShareNewBranches, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.ShareNewBranches]{
 		{
 			Data: configdomain.ShareNewBranchesNone,

--- a/internal/cli/dialog/ship_delete_tracking_branch.go
+++ b/internal/cli/dialog/ship_delete_tracking_branch.go
@@ -24,7 +24,7 @@ branches when pull requests are merged through its UI.
 `
 )
 
-func ShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, inputs dialogcomponents.TestInput) (configdomain.ShipDeleteTrackingBranch, dialogdomain.Exit, error) {
+func ShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, inputs dialogcomponents.TestInputs) (configdomain.ShipDeleteTrackingBranch, dialogdomain.Exit, error) {
 	entries := list.Entries[bool]{
 		{
 			Data: true,

--- a/internal/cli/dialog/ship_strategy.go
+++ b/internal/cli/dialog/ship_strategy.go
@@ -33,7 +33,7 @@ Options:
 `
 )
 
-func ShipStrategy(existing configdomain.ShipStrategy, inputs dialogcomponents.TestInput) (configdomain.ShipStrategy, dialogdomain.Exit, error) {
+func ShipStrategy(existing configdomain.ShipStrategy, inputs dialogcomponents.TestInputs) (configdomain.ShipStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.ShipStrategy]{
 		{
 			Data: configdomain.ShipStrategyAPI,

--- a/internal/cli/dialog/switch_branch.go
+++ b/internal/cli/dialog/switch_branch.go
@@ -167,14 +167,14 @@ func ShouldDisplayBranchType(branchType configdomain.BranchType) bool {
 	panic("unhandled branch type:" + branchType.String())
 }
 
-func SwitchBranch(entries []SwitchBranchEntry, cursor int, uncommittedChanges bool, displayTypes configdomain.DisplayTypes, inputs dialogcomponents.TestInput) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
+func SwitchBranch(entries []SwitchBranchEntry, cursor int, uncommittedChanges bool, displayTypes configdomain.DisplayTypes, inputs dialogcomponents.TestInputs) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
 	dialogProgram := tea.NewProgram(SwitchModel{
 		DisplayBranchTypes: displayTypes,
 		InitialBranchPos:   cursor,
 		List:               list.NewList(newSwitchBranchListEntries(entries), cursor),
 		UncommittedChanges: uncommittedChanges,
 	})
-	dialogcomponents.SendInputs(inputs, dialogProgram)
+	dialogcomponents.SendInputs(inputs.Next(), dialogProgram)
 	dialogResult, err := dialogProgram.Run()
 	result := dialogResult.(SwitchModel)
 	selectedData := result.List.SelectedData()

--- a/internal/cli/dialog/sync_feature_strategy.go
+++ b/internal/cli/dialog/sync_feature_strategy.go
@@ -25,7 +25,7 @@ new features and bug fixes.
 `
 )
 
-func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs dialogcomponents.TestInput) (configdomain.SyncFeatureStrategy, dialogdomain.Exit, error) {
+func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs dialogcomponents.TestInputs) (configdomain.SyncFeatureStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncFeatureStrategy]{
 		{
 			Data: configdomain.SyncFeatureStrategyMerge,

--- a/internal/cli/dialog/sync_perennial_strategy.go
+++ b/internal/cli/dialog/sync_perennial_strategy.go
@@ -23,7 +23,7 @@ by shipping feature branches.
 `
 )
 
-func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs dialogcomponents.TestInput) (configdomain.SyncPerennialStrategy, dialogdomain.Exit, error) {
+func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs dialogcomponents.TestInputs) (configdomain.SyncPerennialStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncPerennialStrategy]{
 		{
 			Data: configdomain.SyncPerennialStrategyFFOnly,

--- a/internal/cli/dialog/sync_prototype_strategy.go
+++ b/internal/cli/dialog/sync_prototype_strategy.go
@@ -23,7 +23,7 @@ and limiting the sharing of confidential changes.
 `
 )
 
-func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs dialogcomponents.TestInput) (configdomain.SyncPrototypeStrategy, dialogdomain.Exit, error) {
+func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs dialogcomponents.TestInputs) (configdomain.SyncPrototypeStrategy, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncPrototypeStrategy]{
 		{
 			Data: configdomain.SyncPrototypeStrategyMerge,

--- a/internal/cli/dialog/sync_tags.go
+++ b/internal/cli/dialog/sync_tags.go
@@ -19,7 +19,7 @@ Should "git town sync" sync Git tags with origin?
 `
 )
 
-func SyncTags(existing configdomain.SyncTags, inputs dialogcomponents.TestInput) (configdomain.SyncTags, dialogdomain.Exit, error) {
+func SyncTags(existing configdomain.SyncTags, inputs dialogcomponents.TestInputs) (configdomain.SyncTags, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncTags]{
 		{
 			Data: true,

--- a/internal/cli/dialog/sync_upstream.go
+++ b/internal/cli/dialog/sync_upstream.go
@@ -31,7 +31,7 @@ made to the original project.
 `
 )
 
-func SyncUpstream(existing configdomain.SyncUpstream, inputs dialogcomponents.TestInput) (configdomain.SyncUpstream, dialogdomain.Exit, error) {
+func SyncUpstream(existing configdomain.SyncUpstream, inputs dialogcomponents.TestInputs) (configdomain.SyncUpstream, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.SyncUpstream]{
 		{
 			Data: true,

--- a/internal/cli/dialog/token_scope.go
+++ b/internal/cli/dialog/token_scope.go
@@ -21,7 +21,7 @@ or for all Git repos on this machine?
 )
 
 // GitHubToken lets the user enter the GitHub API token.
-func TokenScope(oldValue configdomain.ConfigScope, inputs dialogcomponents.TestInput) (configdomain.ConfigScope, dialogdomain.Exit, error) {
+func TokenScope(oldValue configdomain.ConfigScope, inputs dialogcomponents.TestInputs) (configdomain.ConfigScope, dialogdomain.Exit, error) {
 	entries := list.Entries[configdomain.ConfigScope]{
 		{
 			Data: configdomain.ConfigScopeGlobal,

--- a/internal/cli/dialog/unfinished_run_state.go
+++ b/internal/cli/dialog/unfinished_run_state.go
@@ -36,7 +36,7 @@ const (
 )
 
 // AskHowToHandleUnfinishedRunState prompts the user for how to handle the unfinished run state.
-func AskHowToHandleUnfinishedRunState(command string, endBranch gitdomain.LocalBranchName, endTime time.Time, canSkip bool, dialogTestInput dialogcomponents.TestInput) (Response, dialogdomain.Exit, error) {
+func AskHowToHandleUnfinishedRunState(command string, endBranch gitdomain.LocalBranchName, endTime time.Time, canSkip bool, dialogTestInput dialogcomponents.TestInputs) (Response, dialogdomain.Exit, error) {
 	entries := list.Entries[Response]{
 		{
 			Data: ResponseQuit,

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -24,7 +24,7 @@ on the next screen.
 `
 )
 
-func UnknownBranchType(existingValue configdomain.BranchType, inputs dialogcomponents.TestInput) (configdomain.BranchType, dialogdomain.Exit, error) {
+func UnknownBranchType(existingValue configdomain.BranchType, inputs dialogcomponents.TestInputs) (configdomain.BranchType, dialogdomain.Exit, error) {
 	options := []configdomain.BranchType{
 		configdomain.BranchTypeContributionBranch,
 		configdomain.BranchTypeFeatureBranch,

--- a/internal/cli/dialog/welcome.go
+++ b/internal/cli/dialog/welcome.go
@@ -30,6 +30,6 @@ When you're ready, press ENTER or O to continue.
 )
 
 // MainBranch lets the user select a new main branch for this repo.
-func Welcome(inputs dialogcomponents.TestInput) (dialogdomain.Exit, error) {
+func Welcome(inputs dialogcomponents.TestInputs) (dialogdomain.Exit, error) {
 	return dialogcomponents.TextDisplay(welcomeTitle, welcomeText, inputs)
 }

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -298,7 +298,7 @@ func determineAppendData(cliConfig cliconfig.CliConfig, targetBranch gitdomain.L
 		if err != nil {
 			return data, false, err
 		}
-		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs.Next())
+		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs)
 		if err != nil || exit {
 			return data, exit, err
 		}

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -118,7 +118,7 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 	if err != nil || exit {
 		return emptyResult, exit, err
 	}
-	aliases, exit, err := dialog.Aliases(configdomain.AllAliasableCommands(), repo.UnvalidatedConfig.NormalConfig.Aliases, data.dialogInputs.Next())
+	aliases, exit, err := dialog.Aliases(configdomain.AllAliasableCommands(), repo.UnvalidatedConfig.NormalConfig.Aliases, data.dialogInputs)
 	if err != nil || exit {
 		return emptyResult, exit, err
 	}
@@ -133,56 +133,56 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		if existingMainBranch.IsNone() {
 			existingMainBranch = repo.Git.OriginHead(repo.Backend)
 		}
-		mainBranch, exit, err = dialog.MainBranch(data.localBranches.Names(), existingMainBranch, data.dialogInputs.Next())
+		mainBranch, exit, err = dialog.MainBranch(data.localBranches.Names(), existingMainBranch, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	perennialBranches := repo.UnvalidatedConfig.NormalConfig.PerennialBranches
 	if len(configFile.PerennialBranches) == 0 {
-		perennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), perennialBranches, mainBranch, data.dialogInputs.Next())
+		perennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), perennialBranches, mainBranch, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	perennialRegex := repo.UnvalidatedConfig.NormalConfig.PerennialRegex
 	if configFile.PerennialRegex.IsNone() {
-		perennialRegex, exit, err = dialog.PerennialRegex(perennialRegex, data.dialogInputs.Next())
+		perennialRegex, exit, err = dialog.PerennialRegex(perennialRegex, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	featureRegex := repo.UnvalidatedConfig.NormalConfig.FeatureRegex
 	if configFile.FeatureRegex.IsNone() {
-		featureRegex, exit, err = dialog.FeatureRegex(featureRegex, data.dialogInputs.Next())
+		featureRegex, exit, err = dialog.FeatureRegex(featureRegex, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	contributionRegex := repo.UnvalidatedConfig.NormalConfig.ContributionRegex
 	if configFile.ContributionRegex.IsNone() {
-		contributionRegex, exit, err = dialog.ContributionRegex(contributionRegex, data.dialogInputs.Next())
+		contributionRegex, exit, err = dialog.ContributionRegex(contributionRegex, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	observedRegex := repo.UnvalidatedConfig.NormalConfig.ObservedRegex
 	if configFile.ObservedRegex.IsNone() {
-		observedRegex, exit, err = dialog.ObservedRegex(observedRegex, data.dialogInputs.Next())
+		observedRegex, exit, err = dialog.ObservedRegex(observedRegex, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	unknownBranchType := repo.UnvalidatedConfig.NormalConfig.UnknownBranchType
 	if configFile.UnknownBranchType.IsNone() {
-		unknownBranchType, exit, err = dialog.UnknownBranchType(unknownBranchType, data.dialogInputs.Next())
+		unknownBranchType, exit, err = dialog.UnknownBranchType(unknownBranchType, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	devRemote := repo.UnvalidatedConfig.NormalConfig.DevRemote
 	if len(data.remotes) > 1 && configFile.DevRemote.IsNone() {
-		devRemote, exit, err = dialog.DevRemote(devRemote, data.remotes, data.dialogInputs.Next())
+		devRemote, exit, err = dialog.DevRemote(devRemote, data.remotes, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
@@ -201,13 +201,13 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 	gitlabToken := repo.UnvalidatedConfig.NormalConfig.GitLabToken
 	for {
 		if configFile.HostingOriginHostname.IsNone() {
-			hostingOriginHostName, exit, err = dialog.OriginHostname(hostingOriginHostName, data.dialogInputs.Next())
+			hostingOriginHostName, exit, err = dialog.OriginHostname(hostingOriginHostName, data.dialogInputs)
 			if err != nil || exit {
 				return emptyResult, exit, err
 			}
 		}
 		if configFile.ForgeType.IsNone() {
-			enteredForgeType, exit, err = dialog.ForgeType(enteredForgeType, data.dialogInputs.Next())
+			enteredForgeType, exit, err = dialog.ForgeType(enteredForgeType, data.dialogInputs)
 			if err != nil || exit {
 				return emptyResult, exit, err
 			}
@@ -216,36 +216,36 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		if forgeType, hasForgeType := actualForgeType.Get(); hasForgeType {
 			switch forgeType {
 			case forgedomain.ForgeTypeBitbucket, forgedomain.ForgeTypeBitbucketDatacenter:
-				bitbucketUsername, exit, err = dialog.BitbucketUsername(bitbucketUsername, data.dialogInputs.Next())
+				bitbucketUsername, exit, err = dialog.BitbucketUsername(bitbucketUsername, data.dialogInputs)
 				if err != nil || exit {
 					return emptyResult, exit, err
 				}
-				bitbucketAppPassword, exit, err = dialog.BitbucketAppPassword(bitbucketAppPassword, data.dialogInputs.Next())
+				bitbucketAppPassword, exit, err = dialog.BitbucketAppPassword(bitbucketAppPassword, data.dialogInputs)
 			case forgedomain.ForgeTypeCodeberg:
-				codebergToken, exit, err = dialog.CodebergToken(codebergToken, data.dialogInputs.Next())
+				codebergToken, exit, err = dialog.CodebergToken(codebergToken, data.dialogInputs)
 			case forgedomain.ForgeTypeGitea:
-				giteaToken, exit, err = dialog.GiteaToken(giteaToken, data.dialogInputs.Next())
+				giteaToken, exit, err = dialog.GiteaToken(giteaToken, data.dialogInputs)
 			case forgedomain.ForgeTypeGitHub:
-				githubConnectorTypeOpt, exit, err = dialog.GitHubConnectorType(githubConnectorTypeOpt, data.dialogInputs.Next())
+				githubConnectorTypeOpt, exit, err = dialog.GitHubConnectorType(githubConnectorTypeOpt, data.dialogInputs)
 				if err != nil || exit {
 					return emptyResult, exit, err
 				}
 				if githubConnectorType, has := githubConnectorTypeOpt.Get(); has {
 					switch githubConnectorType {
 					case forgedomain.GitHubConnectorTypeAPI:
-						githubToken, exit, err = dialog.GitHubToken(githubToken, data.dialogInputs.Next())
+						githubToken, exit, err = dialog.GitHubToken(githubToken, data.dialogInputs)
 					case forgedomain.GitHubConnectorTypeGh:
 					}
 				}
 			case forgedomain.ForgeTypeGitLab:
-				gitlabConnectorTypeOpt, exit, err = dialog.GitLabConnectorType(gitlabConnectorTypeOpt, data.dialogInputs.Next())
+				gitlabConnectorTypeOpt, exit, err = dialog.GitLabConnectorType(gitlabConnectorTypeOpt, data.dialogInputs)
 				if err != nil || exit {
 					return emptyResult, exit, err
 				}
 				if gitlabConnectorType, has := gitlabConnectorTypeOpt.Get(); has {
 					switch gitlabConnectorType {
 					case forgedomain.GitLabConnectorTypeAPI:
-						gitlabToken, exit, err = dialog.GitLabToken(gitlabToken, data.dialogInputs.Next())
+						gitlabToken, exit, err = dialog.GitLabToken(gitlabToken, data.dialogInputs)
 					case forgedomain.GitLabConnectorTypeGlab:
 					}
 				}
@@ -293,75 +293,75 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 	}
 	syncFeatureStrategy := repo.UnvalidatedConfig.NormalConfig.SyncFeatureStrategy
 	if configFile.SyncFeatureStrategy.IsNone() {
-		syncFeatureStrategy, exit, err = dialog.SyncFeatureStrategy(syncFeatureStrategy, data.dialogInputs.Next())
+		syncFeatureStrategy, exit, err = dialog.SyncFeatureStrategy(syncFeatureStrategy, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	syncPerennialStrategy := repo.UnvalidatedConfig.NormalConfig.SyncPerennialStrategy
 	if configFile.SyncPerennialStrategy.IsNone() {
-		syncPerennialStrategy, exit, err = dialog.SyncPerennialStrategy(syncPerennialStrategy, data.dialogInputs.Next())
+		syncPerennialStrategy, exit, err = dialog.SyncPerennialStrategy(syncPerennialStrategy, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	syncPrototypeStrategy := repo.UnvalidatedConfig.NormalConfig.SyncPrototypeStrategy
 	if configFile.SyncPrototypeStrategy.IsNone() {
-		syncPrototypeStrategy, exit, err = dialog.SyncPrototypeStrategy(syncPrototypeStrategy, data.dialogInputs.Next())
+		syncPrototypeStrategy, exit, err = dialog.SyncPrototypeStrategy(syncPrototypeStrategy, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	syncUpstream := repo.UnvalidatedConfig.NormalConfig.SyncUpstream
 	if configFile.SyncUpstream.IsNone() {
-		syncUpstream, exit, err = dialog.SyncUpstream(syncUpstream, data.dialogInputs.Next())
+		syncUpstream, exit, err = dialog.SyncUpstream(syncUpstream, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	syncTags := repo.UnvalidatedConfig.NormalConfig.SyncTags
 	if configFile.SyncTags.IsNone() {
-		syncTags, exit, err = dialog.SyncTags(syncTags, data.dialogInputs.Next())
+		syncTags, exit, err = dialog.SyncTags(syncTags, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	shareNewBranches := repo.UnvalidatedConfig.NormalConfig.ShareNewBranches
 	if configFile.ShareNewBranches.IsNone() {
-		shareNewBranches, exit, err = dialog.ShareNewBranches(shareNewBranches, data.dialogInputs.Next())
+		shareNewBranches, exit, err = dialog.ShareNewBranches(shareNewBranches, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	pushHook := repo.UnvalidatedConfig.NormalConfig.PushHook
 	if configFile.PushHook.IsNone() {
-		pushHook, exit, err = dialog.PushHook(pushHook, data.dialogInputs.Next())
+		pushHook, exit, err = dialog.PushHook(pushHook, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	newBranchType := repo.UnvalidatedConfig.NormalConfig.NewBranchType
 	if configFile.NewBranchType.IsNone() {
-		newBranchType, exit, err = dialog.NewBranchType(newBranchType, data.dialogInputs.Next())
+		newBranchType, exit, err = dialog.NewBranchType(newBranchType, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	shipStrategy := repo.UnvalidatedConfig.NormalConfig.ShipStrategy
 	if configFile.ShipStrategy.IsNone() {
-		shipStrategy, exit, err = dialog.ShipStrategy(shipStrategy, data.dialogInputs.Next())
+		shipStrategy, exit, err = dialog.ShipStrategy(shipStrategy, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
 	shipDeleteTrackingBranch := repo.UnvalidatedConfig.NormalConfig.ShipDeleteTrackingBranch
 	if configFile.ShipDeleteTrackingBranch.IsNone() {
-		shipDeleteTrackingBranch, exit, err = dialog.ShipDeleteTrackingBranch(shipDeleteTrackingBranch, data.dialogInputs.Next())
+		shipDeleteTrackingBranch, exit, err = dialog.ShipDeleteTrackingBranch(shipDeleteTrackingBranch, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}
 	}
-	configStorage, exit, err := dialog.ConfigStorage(data.dialogInputs.Next())
+	configStorage, exit, err := dialog.ConfigStorage(data.dialogInputs)
 	if err != nil || exit {
 		return emptyResult, exit, err
 	}
@@ -445,13 +445,13 @@ func testForgeAuth(args testForgeAuthArgs) (repeat bool, exit dialogdomain.Exit,
 	}
 	verifyResult := connector.VerifyConnection()
 	if verifyResult.AuthenticationError != nil {
-		return dialog.CredentialsNoAccess(verifyResult.AuthenticationError, args.inputs.Next())
+		return dialog.CredentialsNoAccess(verifyResult.AuthenticationError, args.inputs)
 	}
 	if user, hasUser := verifyResult.AuthenticatedUser.Get(); hasUser {
 		fmt.Printf(messages.CredentialsForgeUserName, dialogcomponents.FormattedSelection(user, exit))
 	}
 	if verifyResult.AuthorizationError != nil {
-		return dialog.CredentialsNoProposalAccess(verifyResult.AuthorizationError, args.inputs.Next())
+		return dialog.CredentialsNoProposalAccess(verifyResult.AuthorizationError, args.inputs)
 	}
 	fmt.Println(messages.CredentialsAccess)
 	return false, false, nil
@@ -517,19 +517,19 @@ func tokenScopeDialog(args enterTokenScopeArgs) (configdomain.ConfigScope, dialo
 		switch forgeType {
 		case forgedomain.ForgeTypeBitbucket, forgedomain.ForgeTypeBitbucketDatacenter:
 			existingScope := determineExistingScope(args.repo.ConfigSnapshot, configdomain.KeyBitbucketUsername, args.repo.UnvalidatedConfig.NormalConfig.BitbucketUsername)
-			return dialog.TokenScope(existingScope, args.inputs.Next())
+			return dialog.TokenScope(existingScope, args.inputs)
 		case forgedomain.ForgeTypeCodeberg:
 			existingScope := determineExistingScope(args.repo.ConfigSnapshot, configdomain.KeyCodebergToken, args.repo.UnvalidatedConfig.NormalConfig.CodebergToken)
-			return dialog.TokenScope(existingScope, args.inputs.Next())
+			return dialog.TokenScope(existingScope, args.inputs)
 		case forgedomain.ForgeTypeGitea:
 			existingScope := determineExistingScope(args.repo.ConfigSnapshot, configdomain.KeyGiteaToken, args.repo.UnvalidatedConfig.NormalConfig.GiteaToken)
-			return dialog.TokenScope(existingScope, args.inputs.Next())
+			return dialog.TokenScope(existingScope, args.inputs)
 		case forgedomain.ForgeTypeGitHub:
 			existingScope := determineExistingScope(args.repo.ConfigSnapshot, configdomain.KeyGitHubToken, args.repo.UnvalidatedConfig.NormalConfig.GitHubToken)
-			return dialog.TokenScope(existingScope, args.inputs.Next())
+			return dialog.TokenScope(existingScope, args.inputs)
 		case forgedomain.ForgeTypeGitLab:
 			existingScope := determineExistingScope(args.repo.ConfigSnapshot, configdomain.KeyGitLabToken, args.repo.UnvalidatedConfig.NormalConfig.GitLabToken)
-			return dialog.TokenScope(existingScope, args.inputs.Next())
+			return dialog.TokenScope(existingScope, args.inputs)
 		}
 	}
 	return configdomain.ConfigScopeLocal, false, nil

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -114,7 +114,7 @@ func determineForgeType(userChoice Option[forgedomain.ForgeType], devURL Option[
 func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdomain.Exit, error) {
 	var emptyResult userInput
 	configFile := data.configFile.GetOrDefault()
-	exit, err := dialog.Welcome(data.dialogInputs.Next())
+	exit, err := dialog.Welcome(data.dialogInputs)
 	if err != nil || exit {
 		return emptyResult, exit, err
 	}

--- a/internal/cmd/debug/enter_aliases.go
+++ b/internal/cmd/debug/enter_aliases.go
@@ -20,7 +20,7 @@ func enterAliases() *cobra.Command {
 				configdomain.AliasableCommandRepo:   "other command",
 			}
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.Aliases(all, existing, dialogTestInputs.Next())
+			_, _, err := dialog.Aliases(all, existing, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_bitbucket_app_password.go
+++ b/internal/cmd/debug/enter_bitbucket_app_password.go
@@ -15,7 +15,7 @@ func enterBitbucketAppPassword() *cobra.Command {
 		Use: "bitbucket-app-password",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.BitbucketAppPassword(None[forgedomain.BitbucketAppPassword](), dialogInputs.Next())
+			_, _, err := dialog.BitbucketAppPassword(None[forgedomain.BitbucketAppPassword](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_bitbucket_username.go
+++ b/internal/cmd/debug/enter_bitbucket_username.go
@@ -15,7 +15,7 @@ func enterBitbucketUsername() *cobra.Command {
 		Use: "bitbucket-username",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.BitbucketUsername(None[forgedomain.BitbucketUsername](), dialogInputs.Next())
+			_, _, err := dialog.BitbucketUsername(None[forgedomain.BitbucketUsername](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_commits_to_beam.go
+++ b/internal/cmd/debug/enter_commits_to_beam.go
@@ -36,7 +36,7 @@ func enterCommitsToBeam() *cobra.Command {
 				commits[i] = allCommits[i]
 			}
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.CommitsToBeam(commits, "target-branch", repo.Git, repo.Backend, dialogTestInputs.Next())
+			_, _, err := dialog.CommitsToBeam(commits, "target-branch", repo.Git, repo.Backend, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_dev_remote.go
+++ b/internal/cmd/debug/enter_dev_remote.go
@@ -14,7 +14,7 @@ func enterDevRemote() *cobra.Command {
 		Use: "dev-remote",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.DevRemote(gitdomain.RemoteOrigin, gitdomain.Remotes{gitdomain.RemoteOrigin, "fork"}, dialogInputs.Next())
+			_, _, err := dialog.DevRemote(gitdomain.RemoteOrigin, gitdomain.Remotes{gitdomain.RemoteOrigin, "fork"}, dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_feature_regex.go
+++ b/internal/cmd/debug/enter_feature_regex.go
@@ -15,7 +15,7 @@ func enterFeatureRegex() *cobra.Command {
 		Use: "feature-regex",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.FeatureRegex(None[configdomain.FeatureRegex](), dialogInputs.Next())
+			_, _, err := dialog.FeatureRegex(None[configdomain.FeatureRegex](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_forge_type.go
+++ b/internal/cmd/debug/enter_forge_type.go
@@ -15,7 +15,7 @@ func enterForgeType() *cobra.Command {
 		Use: "forge-type",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.ForgeType(None[forgedomain.ForgeType](), dialogInputs.Next())
+			_, _, err := dialog.ForgeType(None[forgedomain.ForgeType](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_gitea_token.go
+++ b/internal/cmd/debug/enter_gitea_token.go
@@ -15,7 +15,7 @@ func enterGiteaToken() *cobra.Command {
 		Use: "gitea-token",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.GiteaToken(None[forgedomain.GiteaToken](), dialogInputs.Next())
+			_, _, err := dialog.GiteaToken(None[forgedomain.GiteaToken](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_github_token.go
+++ b/internal/cmd/debug/enter_github_token.go
@@ -15,7 +15,7 @@ func enterGitHubToken() *cobra.Command {
 		Use: "github-token",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.GitHubToken(None[forgedomain.GitHubToken](), dialogInputs.Next())
+			_, _, err := dialog.GitHubToken(None[forgedomain.GitHubToken](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_gitlab_token.go
+++ b/internal/cmd/debug/enter_gitlab_token.go
@@ -15,7 +15,7 @@ func enterGitLabToken() *cobra.Command {
 		Use: "gitlab-token",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.GitLabToken(None[forgedomain.GitLabToken](), dialogInputs.Next())
+			_, _, err := dialog.GitLabToken(None[forgedomain.GitLabToken](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_main_branch.go
+++ b/internal/cmd/debug/enter_main_branch.go
@@ -17,7 +17,7 @@ func enterMainBranchCmd() *cobra.Command {
 			localBranches := gitdomain.NewLocalBranchNames("main", "branch-1", "branch-2", "branch-3", "branch-4", "branch-5", "branch-6", "branch-7", "branch-8", "branch-9", "branch-A", "branch-B")
 			main := gitdomain.NewLocalBranchName("main")
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.MainBranch(localBranches, Some(main), dialogInputs.Next())
+			_, _, err := dialog.MainBranch(localBranches, Some(main), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_new_branch_type.go
+++ b/internal/cmd/debug/enter_new_branch_type.go
@@ -15,7 +15,7 @@ func enterNewBranchType() *cobra.Command {
 		Use: "new-branch-type",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.NewBranchType(Some(configdomain.BranchTypePrototypeBranch), dialogTestInputs.Next())
+			_, _, err := dialog.NewBranchType(Some(configdomain.BranchTypePrototypeBranch), dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_origin_hostname.go
+++ b/internal/cmd/debug/enter_origin_hostname.go
@@ -14,7 +14,7 @@ func enterOriginHostname() *cobra.Command {
 		Use: "origin-hostname",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.OriginHostname(configdomain.ParseHostingOriginHostname(""), dialogInputs.Next())
+			_, _, err := dialog.OriginHostname(configdomain.ParseHostingOriginHostname(""), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_parent.go
+++ b/internal/cmd/debug/enter_parent.go
@@ -28,12 +28,12 @@ func enterParentCmd() *cobra.Command {
 			lineage := configdomain.Lineage{}
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
 			_, _, err = dialog.Parent(dialog.ParentArgs{
-				Branch:          "branch-2",
-				DefaultChoice:   "main",
-				DialogTestInput: dialogTestInputs.Next(),
-				Lineage:         lineage,
-				LocalBranches:   localBranches,
-				MainBranch:      "main",
+				Branch:        "branch-2",
+				DefaultChoice: "main",
+				Inputs:        dialogTestInputs,
+				Lineage:       lineage,
+				LocalBranches: localBranches,
+				MainBranch:    "main",
 			})
 			return err
 		},

--- a/internal/cmd/debug/enter_perennial_branches.go
+++ b/internal/cmd/debug/enter_perennial_branches.go
@@ -26,7 +26,7 @@ func enterPerennialBranches() *cobra.Command {
 			}
 			existingPerennialBranches := gitdomain.NewLocalBranchNames("branch-2", "branch-4")
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err = dialog.PerennialBranches(localBranches, existingPerennialBranches, "main", dialogTestInputs.Next())
+			_, _, err = dialog.PerennialBranches(localBranches, existingPerennialBranches, "main", dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_perennial_regex.go
+++ b/internal/cmd/debug/enter_perennial_regex.go
@@ -15,7 +15,7 @@ func enterPerennialRegex() *cobra.Command {
 		Use: "perennial-regex",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.PerennialRegex(None[configdomain.PerennialRegex](), dialogInputs.Next())
+			_, _, err := dialog.PerennialRegex(None[configdomain.PerennialRegex](), dialogInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_push_hook.go
+++ b/internal/cmd/debug/enter_push_hook.go
@@ -13,7 +13,7 @@ func enterPushHookCmd() *cobra.Command {
 		Use: "push-hook",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.PushHook(true, dialogTestInputs.Next())
+			_, _, err := dialog.PushHook(true, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_share_new_branches.go
+++ b/internal/cmd/debug/enter_share_new_branches.go
@@ -14,7 +14,7 @@ func enterShareNewBranches() *cobra.Command {
 		Use: "share-new-branches",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.ShareNewBranches(configdomain.ShareNewBranchesNone, dialogTestInputs.Next())
+			_, _, err := dialog.ShareNewBranches(configdomain.ShareNewBranchesNone, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_ship_delete_tracking_branch.go
+++ b/internal/cmd/debug/enter_ship_delete_tracking_branch.go
@@ -13,7 +13,7 @@ func enterShipDeleteTrackingBranch() *cobra.Command {
 		Use: "ship-delete-tracking-branch",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.ShipDeleteTrackingBranch(true, dialogTestInputs.Next())
+			_, _, err := dialog.ShipDeleteTrackingBranch(true, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_ship_strategy.go
+++ b/internal/cmd/debug/enter_ship_strategy.go
@@ -14,7 +14,7 @@ func enterShipStrategy() *cobra.Command {
 		Use: "ship-strategy",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.ShipStrategy(configdomain.ShipStrategyAPI, dialogTestInputs.Next())
+			_, _, err := dialog.ShipStrategy(configdomain.ShipStrategyAPI, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_sync_feature_strategy.go
+++ b/internal/cmd/debug/enter_sync_feature_strategy.go
@@ -14,7 +14,7 @@ func enterSyncFeatureStrategy() *cobra.Command {
 		Use: "sync-feature-strategy",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.SyncFeatureStrategy(configdomain.SyncFeatureStrategyMerge, dialogTestInputs.Next())
+			_, _, err := dialog.SyncFeatureStrategy(configdomain.SyncFeatureStrategyMerge, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_sync_perennial_strategy.go
+++ b/internal/cmd/debug/enter_sync_perennial_strategy.go
@@ -14,7 +14,7 @@ func enterSyncPerennialStrategy() *cobra.Command {
 		Use: "sync-perennial-strategy",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.SyncPerennialStrategy(configdomain.SyncPerennialStrategyRebase, dialogTestInputs.Next())
+			_, _, err := dialog.SyncPerennialStrategy(configdomain.SyncPerennialStrategyRebase, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_sync_prototype_strategy.go
+++ b/internal/cmd/debug/enter_sync_prototype_strategy.go
@@ -14,7 +14,7 @@ func enterSyncPrototypeStrategy() *cobra.Command {
 		Use: "sync-prototype-strategy",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.SyncPrototypeStrategy(configdomain.SyncPrototypeStrategyMerge, dialogTestInputs.Next())
+			_, _, err := dialog.SyncPrototypeStrategy(configdomain.SyncPrototypeStrategyMerge, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_sync_tags.go
+++ b/internal/cmd/debug/enter_sync_tags.go
@@ -13,7 +13,7 @@ func enterSyncTags() *cobra.Command {
 		Use: "sync-tags",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.SyncTags(true, dialogTestInputs.Next())
+			_, _, err := dialog.SyncTags(true, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_sync_upstream.go
+++ b/internal/cmd/debug/enter_sync_upstream.go
@@ -13,7 +13,7 @@ func enterSyncUpstream() *cobra.Command {
 		Use: "sync-upstream",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.SyncUpstream(true, dialogTestInputs.Next())
+			_, _, err := dialog.SyncUpstream(true, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_token_scope.go
+++ b/internal/cmd/debug/enter_token_scope.go
@@ -14,7 +14,7 @@ func enterTokenScope() *cobra.Command {
 		Use: "token-scope",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.TokenScope(configdomain.ConfigScopeGlobal, dialogTestInputs.Next())
+			_, _, err := dialog.TokenScope(configdomain.ConfigScopeGlobal, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/enter_unknown_branch.go
+++ b/internal/cmd/debug/enter_unknown_branch.go
@@ -14,7 +14,7 @@ func enterUnknownBranch() *cobra.Command {
 		Use: "unknown-branch-type",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.UnknownBranchType(configdomain.BranchTypeFeatureBranch, dialogTestInputs.Next())
+			_, _, err := dialog.UnknownBranchType(configdomain.BranchTypeFeatureBranch, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/select_commit_author.go
+++ b/internal/cmd/debug/select_commit_author.go
@@ -15,7 +15,7 @@ func selectCommitAuthorCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			authors := []gitdomain.Author{"Jean-Luc Picard <captain@enterprise.com>", "William Riker <numberone@enterprise.com>"}
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.SelectSquashCommitAuthor("feature-branch", authors, dialogTestInputs.Next())
+			_, _, err := dialog.SelectSquashCommitAuthor("feature-branch", authors, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/switch.go
+++ b/internal/cmd/debug/switch.go
@@ -31,7 +31,7 @@ func switchBranch() *cobra.Command {
 				}
 			}
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err = dialog.SwitchBranch(entries, 0, false, false, dialogTestInputs.Next())
+			_, _, err = dialog.SwitchBranch(entries, 0, false, false, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/unfinished_state.go
+++ b/internal/cmd/debug/unfinished_state.go
@@ -14,7 +14,7 @@ func unfinishedStateCommitAuthorCmd() *cobra.Command {
 		Use: "unfinished-state",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.AskHowToHandleUnfinishedRunState("sync", "feature-branch", time.Now().Add(time.Second*-1), true, dialogTestInputs.Next())
+			_, _, err := dialog.AskHowToHandleUnfinishedRunState("sync", "feature-branch", time.Now().Add(time.Second*-1), true, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/debug/welcome.go
+++ b/internal/cmd/debug/welcome.go
@@ -13,7 +13,7 @@ func welcome() *cobra.Command {
 		Use: "welcome",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, err := dialog.Welcome(dialogTestInputs.Next())
+			_, err := dialog.Welcome(dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -354,7 +354,7 @@ func determineHackData(args []string, repo execute.OpenRepoResult, cliConfig cli
 		if err != nil {
 			return data, false, err
 		}
-		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs.Next())
+		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs)
 		if err != nil || exit {
 			return data, exit, err
 		}

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -307,7 +307,7 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, cliConfig 
 		if err != nil {
 			return data, false, err
 		}
-		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs.Next())
+		commitsToBeam, exit, err = dialog.CommitsToBeam(commitsInBranch, targetBranch, repo.Git, repo.Backend, dialogTestInputs)
 		if err != nil || exit {
 			return data, exit, err
 		}

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -111,12 +111,12 @@ func executeSetParent(args []string, cliConfig cliconfig.CliConfig) error {
 		}
 	} else {
 		outcome, selectedBranch, err = dialog.Parent(dialog.ParentArgs{
-			Branch:          data.initialBranch,
-			DefaultChoice:   data.defaultChoice,
-			DialogTestInput: data.dialogTestInputs.Next(),
-			Lineage:         data.config.NormalConfig.Lineage,
-			LocalBranches:   data.branchesSnapshot.Branches.LocalBranches().Names(),
-			MainBranch:      data.mainBranch,
+			Branch:        data.initialBranch,
+			DefaultChoice: data.defaultChoice,
+			Inputs:        data.dialogTestInputs,
+			Lineage:       data.config.NormalConfig.Lineage,
+			LocalBranches: data.branchesSnapshot.Branches.LocalBranches().Names(),
+			MainBranch:    data.mainBranch,
 		})
 		if err != nil {
 			return err

--- a/internal/cmd/switch.go
+++ b/internal/cmd/switch.go
@@ -85,7 +85,7 @@ func executeSwitch(args []string, cliConfig cliconfig.CliConfig, allBranches con
 		return errors.New(messages.SwitchNoBranches)
 	}
 	cursor := SwitchBranchCursorPos(entries, data.initialBranch)
-	branchToCheckout, exit, err := dialog.SwitchBranch(entries, cursor, data.uncommittedChanges, displayTypes, data.dialogInputs.Next())
+	branchToCheckout, exit, err := dialog.SwitchBranch(entries, cursor, data.uncommittedChanges, displayTypes, data.dialogInputs)
 	if err != nil || exit {
 		return err
 	}

--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -887,8 +887,8 @@ func defineSteps(sc *godog.ScenarioContext) {
 			env = envvars.Replace(env, browser.EnvVarName, browserPath)
 		}
 		answers := asserts.NoError1(helpers.TableToInputEnv(input))
-		for dialogNumber, answer := range answers {
-			env = append(env, fmt.Sprintf("%s_%02d=%s", dialogcomponents.TestInputKey, dialogNumber, answer))
+		for a, answer := range answers {
+			env = append(env, fmt.Sprintf("%s_%02d=%s", dialogcomponents.TestInputKey, a, answer))
 		}
 		output, exitCode := devRepo.MustQueryStringCodeWith(cmd, &subshell.Options{Env: env})
 		state.runOutput = Some(output)

--- a/internal/test/helpers/table_to_input.go
+++ b/internal/test/helpers/table_to_input.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/cucumber/godog"
@@ -18,7 +17,6 @@ func TableToInputEnv(table *godog.Table) ([]string, error) {
 	for i := 1; i < len(table.Rows); i++ {
 		row := table.Rows[i]
 		answersEnvStyle := strings.ReplaceAll(row.Cells[keyColumn].Value, " ", "|")
-		fmt.Println("111111111111111111111111111111111", answersEnvStyle)
 		if len(answersEnvStyle) > 0 {
 			result = append(result, answersEnvStyle)
 		}

--- a/internal/test/helpers/table_to_input.go
+++ b/internal/test/helpers/table_to_input.go
@@ -16,9 +16,10 @@ func TableToInputEnv(table *godog.Table) ([]string, error) {
 	}
 	for i := 1; i < len(table.Rows); i++ {
 		row := table.Rows[i]
-		answersCucumberStyle := row.Cells[keyColumn].Value
-		answersEnvStyle := strings.ReplaceAll(answersCucumberStyle, " ", "|")
-		result = append(result, answersEnvStyle)
+		answersEnvStyle := strings.ReplaceAll(row.Cells[keyColumn].Value, " ", "|")
+		if len(answersEnvStyle) > 0 {
+			result = append(result, answersEnvStyle)
+		}
 	}
 	return result, nil
 }

--- a/internal/test/helpers/table_to_input.go
+++ b/internal/test/helpers/table_to_input.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/cucumber/godog"
@@ -17,6 +18,7 @@ func TableToInputEnv(table *godog.Table) ([]string, error) {
 	for i := 1; i < len(table.Rows); i++ {
 		row := table.Rows[i]
 		answersEnvStyle := strings.ReplaceAll(row.Cells[keyColumn].Value, " ", "|")
+		fmt.Println("111111111111111111111111111111111", answersEnvStyle)
 		if len(answersEnvStyle) > 0 {
 			result = append(result, answersEnvStyle)
 		}

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -42,7 +42,7 @@ func HandleUnfinishedState(args UnfinishedStateArgs) (dialogdomain.Exit, error) 
 		unfinishedDetails.EndBranch,
 		unfinishedDetails.EndTime,
 		unfinishedDetails.CanSkip,
-		args.DialogTestInputs.Next(),
+		args.DialogTestInputs,
 	)
 	if err != nil {
 		return false, err
@@ -156,7 +156,7 @@ func quickValidateConfig(args quickValidateConfigArgs) (config.ValidatedConfig, 
 			return config.EmptyValidatedConfig(), false, err
 		}
 		localBranches := branchesSnapshot.Branches.LocalBranches().Names()
-		validatedMain, exit, err := dialog.MainBranch(localBranches, gitconfig.DefaultBranch(args.backend), args.dialogInputs.Next())
+		validatedMain, exit, err := dialog.MainBranch(localBranches, gitconfig.DefaultBranch(args.backend), args.dialogInputs)
 		if err != nil || exit {
 			return config.EmptyValidatedConfig(), exit, err
 		}

--- a/internal/vm/opcodes/merge_squash_program.go
+++ b/internal/vm/opcodes/merge_squash_program.go
@@ -21,7 +21,7 @@ type MergeSquashProgram struct {
 }
 
 func (self *MergeSquashProgram) Run(args shared.RunArgs) error {
-	author, exit, err := dialog.SelectSquashCommitAuthor(self.Branch, self.Authors, args.DialogTestInputs.Next())
+	author, exit, err := dialog.SelectSquashCommitAuthor(self.Branch, self.Authors, args.DialogTestInputs)
 	if err != nil {
 		return fmt.Errorf(messages.SquashCommitAuthorProblem, err)
 	}


### PR DESCRIPTION
This PR makes two changes that need to ship together.

Change 1: To make the test code for dialogs more robust, dialogs now always receive a `dialogcomponents.TestInputs` value rather than a `dialogcomponents.TestInput`. This allows them to use zero, one, or multiple test inputs as needed. This helps with upcoming changes that skip unnecessary dialog fields.

Change 2: It no longer created empty test input data dialogs that are skipped in an E2E test.