### PR TITLE
setup assistant: create modern config filename

### DIFF
--- a/features/config/view/invalid_config_file.feature
+++ b/features/config/view/invalid_config_file.feature
@@ -9,5 +9,5 @@ Feature: print nice error message for invalid config file
     When I run "git-town config"
     Then Git Town prints the error:
       """
-      the configuration file ".git-branches.toml" does not contain TOML-formatted content
+      the configuration file ".git-town.toml" does not contain TOML-formatted content
       """

--- a/internal/cli/dialog/config_storage.go
+++ b/internal/cli/dialog/config_storage.go
@@ -15,7 +15,7 @@ const (
 How do you want to store the configuration data?
 
 You can store it as a configuration file
-(.git-branches.toml), which you commit
+(.git-town.toml), which you commit
 to the repository. This sets up Git Town
 for all people working on this codebase.
 Personal data like your API tokens

--- a/internal/config/configfile/filename.go
+++ b/internal/config/configfile/filename.go
@@ -1,6 +1,6 @@
 package configfile
 
 const (
-	FileName            = ".git-branches.toml"
-	AlternativeFileName = ".git-town.toml"
+	FileName            = ".git-town.toml"
+	AlternativeFileName = ".git-branches.toml"
 )


### PR DESCRIPTION
The setup assistant was still creating .git-branches.toml files. This PR changes it to create git-town.toml files.
