### PR TITLE
Fix bug when updating base branch using `gh`

### DIFF
--- a/internal/forge/gh/connector.go
+++ b/internal/forge/gh/connector.go
@@ -98,7 +98,7 @@ func (self Connector) squashMergeProposal(number int, message gitdomain.CommitMe
 }
 
 func (self Connector) updateProposalTarget(proposalData forgedomain.ProposalInterface, target gitdomain.LocalBranchName) error {
-	return self.Frontend.Run("gh", "edit", strconv.Itoa(proposalData.Data().Number), "--base="+target.String())
+	return self.Frontend.Run("gh", "pr", "edit", strconv.Itoa(proposalData.Data().Number), "--base="+target.String())
 }
 
 func ParsePermissionsOutput(output string) forgedomain.VerifyConnectionResult {


### PR DESCRIPTION
Running `git town delete` in a non-leaf branch of a stack causes the following error when configured with `git config --global git-town.github-connector gh`

```
$ git town switch my/base-branch
$ git town delete      

[my/branch] git fetch --prune --tags

[my/branch] gh edit 123 --base=my/base-branch
unknown command "edit" for "gh"

Usage:  gh <command> <subcommand> [flags]

Available commands:
  alias
  api
  attestation
  auth
  browse
  cache
  co
  codespace
  completion
  config
  extension
  gist
  gpg-key
  issue
  label
  org
  pr
  preview
  project
  release
  repo
  ruleset
  run
  search
  secret
  ssh-key
  status
  variable
  workflow


Error: exit status 1
Auto-undo... 


Error: cannot update the target branch of proposal 123 on your forge
```

Changing the command from `gh edit` to `gh pr edit` fixes the bug.