### PR TITLE
setup assistant: make config value infrastructure optional

### DIFF
--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -60,21 +60,21 @@ Feature: Accepting all default values leads to a working setup
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "origin"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -60,23 +60,21 @@ Feature: Accepting all default values leads to a working setup
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
-      perennials = []
-      perennial-regex = ""
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -54,23 +54,21 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "initial"
-      perennials = []
-      perennial-regex = ""
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -54,21 +54,21 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "initial"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "origin"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -38,21 +38,21 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "fork"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -38,23 +38,21 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
-      perennials = []
-      perennial-regex = ""
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -380,9 +380,12 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		GitHubToken:              githubToken,
 		GitLabConnectorType:      gitlabConnectorTypeOpt,
 		GitLabToken:              gitlabToken,
+		GitUserEmail:             None[gitdomain.GitUserEmail](),
+		GitUserName:              None[gitdomain.GitUserName](),
 		GiteaToken:               giteaToken,
 		HostingOriginHostname:    hostingOriginHostName,
 		Lineage:                  configdomain.Lineage{}, // the setup assistant doesn't ask for this
+		MainBranch:               Some(mainBranch),
 		NewBranchType:            newBranchType,
 		ObservedRegex:            observedRegex,
 		Offline:                  None[configdomain.Offline](), // the setup assistant doesn't ask for this
@@ -408,13 +411,13 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 	if !data.dialogInputs.IsEmpty() {
 		panic("unused dialog inputs")
 	}
-	return userInput{actualForgeType, normalData, tokenScope, configStorage, validatedData}, false, nil
+	return userInput{normalData, actualForgeType, tokenScope, configStorage, validatedData}, false, nil
 }
 
 // data entered by the user in the setup assistant
 type userInput struct {
-	determinedForgeType Option[forgedomain.ForgeType] // the forge type that was determined by the setup assistant - not necessarily what the user entered (could also be "auto detect")
 	data                configdomain.PartialConfig
+	determinedForgeType Option[forgedomain.ForgeType] // the forge type that was determined by the setup assistant - not necessarily what the user entered (could also be "auto detect")
 	scope               configdomain.ConfigScope
 	storageLocation     dialog.ConfigStorageOption
 	validatedConfig     configdomain.ValidatedConfigData

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -1074,7 +1074,8 @@ func saveSyncTags(valueToWriteToGit Option[configdomain.SyncTags], valueAlreadyI
 }
 
 func saveToFile(userInput userInput, gitConfig configdomain.PartialConfig, runner subshelldomain.Runner) error {
-	if err := configfile.Save(userInput.data, userInput.validatedConfig.MainBranch); err != nil {
+	userInput.data.MainBranch = Some(userInput.validatedConfig.MainBranch)
+	if err := configfile.Save(userInput.data); err != nil {
 		return err
 	}
 	if gitConfig.DevRemote.IsSome() {

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -1043,25 +1043,34 @@ func saveSyncPerennialStrategy(valueToWriteToGit Option[configdomain.SyncPerenni
 	return gitconfig.RemoveSyncPerennialStrategy(runner)
 }
 
-func saveSyncPrototypeStrategy(valueToWriteToGit configdomain.SyncPrototypeStrategy, valueAlreadyInGit Option[configdomain.SyncPrototypeStrategy], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveSyncPrototypeStrategy(valueToWriteToGit Option[configdomain.SyncPrototypeStrategy], valueAlreadyInGit Option[configdomain.SyncPrototypeStrategy], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetSyncPrototypeStrategy(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetSyncPrototypeStrategy(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveSyncPrototypeStrategy(runner)
 }
 
-func saveSyncUpstream(valueToWriteToGit configdomain.SyncUpstream, valueAlreadyInGit Option[configdomain.SyncUpstream], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveSyncUpstream(valueToWriteToGit Option[configdomain.SyncUpstream], valueAlreadyInGit Option[configdomain.SyncUpstream], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetSyncUpstream(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetSyncUpstream(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveSyncUpstream(runner)
 }
 
-func saveSyncTags(valueToWriteToGit configdomain.SyncTags, valueAlreadyInGit Option[configdomain.SyncTags], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveSyncTags(valueToWriteToGit Option[configdomain.SyncTags], valueAlreadyInGit Option[configdomain.SyncTags], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetSyncTags(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetSyncTags(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveSyncTags(runner)
 }
 
 func saveToFile(userInput userInput, gitConfig configdomain.PartialConfig, runner subshelldomain.Runner) error {

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -993,39 +993,54 @@ func savePushHook(valueToWriteToGit Option[configdomain.PushHook], valueAlreadyI
 	return gitconfig.RemovePushHook(runner)
 }
 
-func saveShareNewBranches(valueToWriteToGit configdomain.ShareNewBranches, valueAlreadyInGit Option[configdomain.ShareNewBranches], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveShareNewBranches(valueToWriteToGit Option[configdomain.ShareNewBranches], valueAlreadyInGit Option[configdomain.ShareNewBranches], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetShareNewBranches(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetShareNewBranches(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveShareNewBranches(runner)
 }
 
-func saveShipDeleteTrackingBranch(valueToWriteToGit configdomain.ShipDeleteTrackingBranch, valueAlreadyInGit Option[configdomain.ShipDeleteTrackingBranch], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveShipDeleteTrackingBranch(valueToWriteToGit Option[configdomain.ShipDeleteTrackingBranch], valueAlreadyInGit Option[configdomain.ShipDeleteTrackingBranch], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetShipDeleteTrackingBranch(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetShipDeleteTrackingBranch(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveShipDeleteTrackingBranch(runner)
 }
 
-func saveShipStrategy(valueToWriteToGit configdomain.ShipStrategy, valueAlreadyInGit Option[configdomain.ShipStrategy], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveShipStrategy(valueToWriteToGit Option[configdomain.ShipStrategy], valueAlreadyInGit Option[configdomain.ShipStrategy], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetShipStrategy(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetShipStrategy(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveShipStrategy(runner)
 }
 
-func saveSyncFeatureStrategy(valueToWriteToGit configdomain.SyncFeatureStrategy, valueAlreadyInGit Option[configdomain.SyncFeatureStrategy], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveSyncFeatureStrategy(valueToWriteToGit Option[configdomain.SyncFeatureStrategy], valueAlreadyInGit Option[configdomain.SyncFeatureStrategy], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetSyncFeatureStrategy(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetSyncFeatureStrategy(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveSyncFeatureStrategy(runner)
 }
 
-func saveSyncPerennialStrategy(valueToWriteToGit configdomain.SyncPerennialStrategy, valueAlreadyInGit Option[configdomain.SyncPerennialStrategy], runner subshelldomain.Runner) error {
-	if valueAlreadyInGit.EqualSome(valueToWriteToGit) {
+func saveSyncPerennialStrategy(valueToWriteToGit Option[configdomain.SyncPerennialStrategy], valueAlreadyInGit Option[configdomain.SyncPerennialStrategy], runner subshelldomain.Runner) error {
+	if valueAlreadyInGit.Equal(valueToWriteToGit) {
 		return nil
 	}
-	return gitconfig.SetSyncPerennialStrategy(runner, valueToWriteToGit, configdomain.ConfigScopeLocal)
+	if value, has := valueToWriteToGit.Get(); has {
+		return gitconfig.SetSyncPerennialStrategy(runner, value, configdomain.ConfigScopeLocal)
+	}
+	return gitconfig.RemoveSyncPerennialStrategy(runner)
 }
 
 func saveSyncPrototypeStrategy(valueToWriteToGit configdomain.SyncPrototypeStrategy, valueAlreadyInGit Option[configdomain.SyncPrototypeStrategy], runner subshelldomain.Runner) error {

--- a/internal/config/configfile/save.go
+++ b/internal/config/configfile/save.go
@@ -16,28 +16,28 @@ func RenderPerennialBranches(perennials gitdomain.LocalBranchNames) string {
 	return fmt.Sprintf(`["%s"]`, perennials.Join(`", "`))
 }
 
-func RenderTOML(config configdomain.PartialConfig) string {
+func RenderTOML(data configdomain.PartialConfig) string {
 	result := strings.Builder{}
 	result.WriteString("# More info around this file at https://www.git-town.com/configuration-file\n")
 
-	main, hasMain := config.MainBranch.Get()
-	hasPerennialBranches := len(config.PerennialBranches) > 0
-	perennialRegex, hasPerennialRegex := config.PerennialRegex.Get()
+	main, hasMain := data.MainBranch.Get()
+	hasPerennialBranches := len(data.PerennialBranches) > 0
+	perennialRegex, hasPerennialRegex := data.PerennialRegex.Get()
 	if hasMain || hasPerennialBranches || hasPerennialRegex {
 		result.WriteString("\n[branches]\n")
 		if hasMain {
 			result.WriteString(fmt.Sprintf("main = %q\n", main))
 		}
 		if hasPerennialBranches {
-			result.WriteString(fmt.Sprintf("perennials = %s\n", RenderPerennialBranches(config.PerennialBranches)))
+			result.WriteString(fmt.Sprintf("perennials = %s\n", RenderPerennialBranches(data.PerennialBranches)))
 		}
 		if hasPerennialRegex {
 			result.WriteString(fmt.Sprintf("perennial-regex = %q\n", perennialRegex))
 		}
 	}
 
-	newBranchType, hasNewBranchType := config.NewBranchType.Get()
-	shareNewBranches, hasShareNewBranches := config.ShareNewBranches.Get()
+	newBranchType, hasNewBranchType := data.NewBranchType.Get()
+	shareNewBranches, hasShareNewBranches := data.ShareNewBranches.Get()
 	if hasNewBranchType || hasShareNewBranches {
 		result.WriteString("\n[create]\n")
 		if hasNewBranchType {
@@ -48,9 +48,9 @@ func RenderTOML(config configdomain.PartialConfig) string {
 		}
 	}
 
-	devRemote, hasDevRemote := config.DevRemote.Get()
-	forgeType, hasForgeType := config.ForgeType.Get()
-	originHostName, hasOriginHostName := config.HostingOriginHostname.Get()
+	devRemote, hasDevRemote := data.DevRemote.Get()
+	forgeType, hasForgeType := data.ForgeType.Get()
+	originHostName, hasOriginHostName := data.HostingOriginHostname.Get()
 	if hasDevRemote || hasForgeType || hasOriginHostName {
 		result.WriteString("\n[hosting]\n")
 		if hasDevRemote {
@@ -64,8 +64,8 @@ func RenderTOML(config configdomain.PartialConfig) string {
 		}
 	}
 
-	deleteTrackingBranch, hasDeleteTrackingBranch := config.ShipDeleteTrackingBranch.Get()
-	shipStrategy, hasShipStrategy := config.ShipStrategy.Get()
+	deleteTrackingBranch, hasDeleteTrackingBranch := data.ShipDeleteTrackingBranch.Get()
+	shipStrategy, hasShipStrategy := data.ShipStrategy.Get()
 	if hasDeleteTrackingBranch || hasShipStrategy {
 		result.WriteString("\n[ship]\n")
 		if hasDeleteTrackingBranch {
@@ -76,12 +76,12 @@ func RenderTOML(config configdomain.PartialConfig) string {
 		}
 	}
 
-	syncFeatureStrategy, hasSyncFeatureStrategy := config.SyncFeatureStrategy.Get()
-	syncPerennialStrategy, hasSyncPerennialStrategy := config.SyncPerennialStrategy.Get()
-	syncPrototypeStrategy, hasSyncPrototypeStrategy := config.SyncPrototypeStrategy.Get()
-	pushHook, hasPushHook := config.PushHook.Get()
-	syncTags, hasSyncTags := config.SyncTags.Get()
-	syncUpstream, hasSyncUpstream := config.SyncUpstream.Get()
+	syncFeatureStrategy, hasSyncFeatureStrategy := data.SyncFeatureStrategy.Get()
+	syncPerennialStrategy, hasSyncPerennialStrategy := data.SyncPerennialStrategy.Get()
+	syncPrototypeStrategy, hasSyncPrototypeStrategy := data.SyncPrototypeStrategy.Get()
+	pushHook, hasPushHook := data.PushHook.Get()
+	syncTags, hasSyncTags := data.SyncTags.Get()
+	syncUpstream, hasSyncUpstream := data.SyncUpstream.Get()
 	if hasSyncFeatureStrategy || hasSyncPerennialStrategy || hasSyncPrototypeStrategy || hasPushHook || hasSyncTags || hasSyncUpstream {
 		result.WriteString("\n[sync]\n")
 		if hasSyncFeatureStrategy {
@@ -106,6 +106,6 @@ func RenderTOML(config configdomain.PartialConfig) string {
 	return result.String()
 }
 
-func Save(config configdomain.PartialConfig) error {
-	return os.WriteFile(FileName, []byte(RenderTOML(config)), 0o600)
+func Save(data configdomain.PartialConfig) error {
+	return os.WriteFile(FileName, []byte(RenderTOML(data)), 0o600)
 }

--- a/internal/config/configfile/save.go
+++ b/internal/config/configfile/save.go
@@ -16,37 +16,41 @@ func RenderPerennialBranches(perennials gitdomain.LocalBranchNames) string {
 	return fmt.Sprintf(`["%s"]`, perennials.Join(`", "`))
 }
 
-func RenderTOML(normalConfig configdomain.NormalConfigData, mainBranch gitdomain.LocalBranchName) string {
+func RenderTOML(data configdomain.PartialConfig, mainBranch gitdomain.LocalBranchName) string {
 	result := strings.Builder{}
 	result.WriteString("# More info around this file at https://www.git-town.com/configuration-file\n")
 	result.WriteString("\n[branches]\n")
 	result.WriteString(fmt.Sprintf("main = %q\n", mainBranch))
-	result.WriteString(fmt.Sprintf("perennials = %s\n", RenderPerennialBranches(normalConfig.PerennialBranches)))
-	result.WriteString(fmt.Sprintf("perennial-regex = %q\n", normalConfig.PerennialRegex))
+	if len(data.PerennialBranches) > 0 {
+		result.WriteString(fmt.Sprintf("perennials = %s\n", RenderPerennialBranches(data.PerennialBranches)))
+	}
+	if value, has := data.PerennialRegex.Get(); has {
+		result.WriteString(fmt.Sprintf("perennial-regex = %q\n", value))
+	}
 	result.WriteString("\n[create]\n")
-	result.WriteString(fmt.Sprintf("new-branch-type = %q\n", normalConfig.NewBranchType))
-	result.WriteString(fmt.Sprintf("share-new-branches = %q\n", normalConfig.ShareNewBranches))
+	result.WriteString(fmt.Sprintf("new-branch-type = %q\n", data.NewBranchType))
+	result.WriteString(fmt.Sprintf("share-new-branches = %q\n", data.ShareNewBranches))
 	result.WriteString("\n[hosting]\n")
-	result.WriteString(fmt.Sprintf("dev-remote = %q\n", normalConfig.DevRemote.String()))
-	if forgeType, has := normalConfig.ForgeType.Get(); has {
+	result.WriteString(fmt.Sprintf("dev-remote = %q\n", data.DevRemote.String()))
+	if forgeType, has := data.ForgeType.Get(); has {
 		result.WriteString(fmt.Sprintf("forge-type = %q\n", forgeType))
 	}
-	if hostName, has := normalConfig.HostingOriginHostname.Get(); has {
+	if hostName, has := data.HostingOriginHostname.Get(); has {
 		result.WriteString(fmt.Sprintf("origin-hostname = %q\n", hostName))
 	}
 	result.WriteString("\n[ship]\n")
-	result.WriteString(fmt.Sprintf("delete-tracking-branch = %t\n", normalConfig.ShipDeleteTrackingBranch))
-	result.WriteString(fmt.Sprintf("strategy = %q\n", normalConfig.ShipStrategy))
+	result.WriteString(fmt.Sprintf("delete-tracking-branch = %t\n", data.ShipDeleteTrackingBranch))
+	result.WriteString(fmt.Sprintf("strategy = %q\n", data.ShipStrategy))
 	result.WriteString("\n[sync]\n")
-	result.WriteString(fmt.Sprintf("feature-strategy = %q\n", normalConfig.SyncFeatureStrategy))
-	result.WriteString(fmt.Sprintf("perennial-strategy = %q\n", normalConfig.SyncPerennialStrategy))
-	result.WriteString(fmt.Sprintf("prototype-strategy = %q\n", normalConfig.SyncPrototypeStrategy))
-	result.WriteString(fmt.Sprintf("push-hook = %t\n", normalConfig.PushHook))
-	result.WriteString(fmt.Sprintf("tags = %t\n", normalConfig.SyncTags))
-	result.WriteString(fmt.Sprintf("upstream = %t\n", normalConfig.SyncUpstream))
+	result.WriteString(fmt.Sprintf("feature-strategy = %q\n", data.SyncFeatureStrategy))
+	result.WriteString(fmt.Sprintf("perennial-strategy = %q\n", data.SyncPerennialStrategy))
+	result.WriteString(fmt.Sprintf("prototype-strategy = %q\n", data.SyncPrototypeStrategy))
+	result.WriteString(fmt.Sprintf("push-hook = %t\n", data.PushHook))
+	result.WriteString(fmt.Sprintf("tags = %t\n", data.SyncTags))
+	result.WriteString(fmt.Sprintf("upstream = %t\n", data.SyncUpstream))
 	return result.String()
 }
 
-func Save(normalConfig configdomain.NormalConfigData, mainBranch gitdomain.LocalBranchName) error {
+func Save(normalConfig configdomain.PartialConfig, mainBranch gitdomain.LocalBranchName) error {
 	return os.WriteFile(FileName, []byte(RenderTOML(normalConfig, mainBranch)), 0o600)
 }

--- a/internal/config/configfile/save.go
+++ b/internal/config/configfile/save.go
@@ -16,41 +16,96 @@ func RenderPerennialBranches(perennials gitdomain.LocalBranchNames) string {
 	return fmt.Sprintf(`["%s"]`, perennials.Join(`", "`))
 }
 
-func RenderTOML(data configdomain.PartialConfig, mainBranch gitdomain.LocalBranchName) string {
+func RenderTOML(config configdomain.PartialConfig) string {
 	result := strings.Builder{}
 	result.WriteString("# More info around this file at https://www.git-town.com/configuration-file\n")
-	result.WriteString("\n[branches]\n")
-	result.WriteString(fmt.Sprintf("main = %q\n", mainBranch))
-	if len(data.PerennialBranches) > 0 {
-		result.WriteString(fmt.Sprintf("perennials = %s\n", RenderPerennialBranches(data.PerennialBranches)))
+
+	main, hasMain := config.MainBranch.Get()
+	hasPerennialBranches := len(config.PerennialBranches) > 0
+	perennialRegex, hasPerennialRegex := config.PerennialRegex.Get()
+	if hasMain || hasPerennialBranches || hasPerennialRegex {
+		result.WriteString("\n[branches]\n")
+		if hasMain {
+			result.WriteString(fmt.Sprintf("main = %q\n", main))
+		}
+		if hasPerennialBranches {
+			result.WriteString(fmt.Sprintf("perennials = %s\n", RenderPerennialBranches(config.PerennialBranches)))
+		}
+		if hasPerennialRegex {
+			result.WriteString(fmt.Sprintf("perennial-regex = %q\n", perennialRegex))
+		}
 	}
-	if value, has := data.PerennialRegex.Get(); has {
-		result.WriteString(fmt.Sprintf("perennial-regex = %q\n", value))
+
+	newBranchType, hasNewBranchType := config.NewBranchType.Get()
+	shareNewBranches, hasShareNewBranches := config.ShareNewBranches.Get()
+	if hasNewBranchType || hasShareNewBranches {
+		result.WriteString("\n[create]\n")
+		if hasNewBranchType {
+			result.WriteString(fmt.Sprintf("new-branch-type = %q\n", newBranchType))
+		}
+		if hasShareNewBranches {
+			result.WriteString(fmt.Sprintf("share-new-branches = %q\n", shareNewBranches))
+		}
 	}
-	result.WriteString("\n[create]\n")
-	result.WriteString(fmt.Sprintf("new-branch-type = %q\n", data.NewBranchType))
-	result.WriteString(fmt.Sprintf("share-new-branches = %q\n", data.ShareNewBranches))
-	result.WriteString("\n[hosting]\n")
-	result.WriteString(fmt.Sprintf("dev-remote = %q\n", data.DevRemote.String()))
-	if forgeType, has := data.ForgeType.Get(); has {
-		result.WriteString(fmt.Sprintf("forge-type = %q\n", forgeType))
+
+	devRemote, hasDevRemote := config.DevRemote.Get()
+	forgeType, hasForgeType := config.ForgeType.Get()
+	originHostName, hasOriginHostName := config.HostingOriginHostname.Get()
+	if hasDevRemote || hasForgeType || hasOriginHostName {
+		result.WriteString("\n[hosting]\n")
+		if hasDevRemote {
+			result.WriteString(fmt.Sprintf("dev-remote = %q\n", devRemote))
+		}
+		if hasForgeType {
+			result.WriteString(fmt.Sprintf("forge-type = %q\n", forgeType))
+		}
+		if hasOriginHostName {
+			result.WriteString(fmt.Sprintf("origin-hostname = %q\n", originHostName))
+		}
 	}
-	if hostName, has := data.HostingOriginHostname.Get(); has {
-		result.WriteString(fmt.Sprintf("origin-hostname = %q\n", hostName))
+
+	deleteTrackingBranch, hasDeleteTrackingBranch := config.ShipDeleteTrackingBranch.Get()
+	shipStrategy, hasShipStrategy := config.ShipStrategy.Get()
+	if hasDeleteTrackingBranch || hasShipStrategy {
+		result.WriteString("\n[ship]\n")
+		if hasDeleteTrackingBranch {
+			result.WriteString(fmt.Sprintf("delete-tracking-branch = %t\n", deleteTrackingBranch))
+		}
+		if hasShipStrategy {
+			result.WriteString(fmt.Sprintf("strategy = %q\n", shipStrategy))
+		}
 	}
-	result.WriteString("\n[ship]\n")
-	result.WriteString(fmt.Sprintf("delete-tracking-branch = %t\n", data.ShipDeleteTrackingBranch))
-	result.WriteString(fmt.Sprintf("strategy = %q\n", data.ShipStrategy))
-	result.WriteString("\n[sync]\n")
-	result.WriteString(fmt.Sprintf("feature-strategy = %q\n", data.SyncFeatureStrategy))
-	result.WriteString(fmt.Sprintf("perennial-strategy = %q\n", data.SyncPerennialStrategy))
-	result.WriteString(fmt.Sprintf("prototype-strategy = %q\n", data.SyncPrototypeStrategy))
-	result.WriteString(fmt.Sprintf("push-hook = %t\n", data.PushHook))
-	result.WriteString(fmt.Sprintf("tags = %t\n", data.SyncTags))
-	result.WriteString(fmt.Sprintf("upstream = %t\n", data.SyncUpstream))
+
+	syncFeatureStrategy, hasSyncFeatureStrategy := config.SyncFeatureStrategy.Get()
+	syncPerennialStrategy, hasSyncPerennialStrategy := config.SyncPerennialStrategy.Get()
+	syncPrototypeStrategy, hasSyncPrototypeStrategy := config.SyncPrototypeStrategy.Get()
+	pushHook, hasPushHook := config.PushHook.Get()
+	syncTags, hasSyncTags := config.SyncTags.Get()
+	syncUpstream, hasSyncUpstream := config.SyncUpstream.Get()
+	if hasSyncFeatureStrategy || hasSyncPerennialStrategy || hasSyncPrototypeStrategy || hasPushHook || hasSyncTags || hasSyncUpstream {
+		result.WriteString("\n[sync]\n")
+		if hasSyncFeatureStrategy {
+			result.WriteString(fmt.Sprintf("feature-strategy = %q\n", syncFeatureStrategy))
+		}
+		if hasSyncPerennialStrategy {
+			result.WriteString(fmt.Sprintf("perennial-strategy = %q\n", syncPerennialStrategy))
+		}
+		if hasSyncPrototypeStrategy {
+			result.WriteString(fmt.Sprintf("prototype-strategy = %q\n", syncPrototypeStrategy))
+		}
+		if hasPushHook {
+			result.WriteString(fmt.Sprintf("push-hook = %t\n", pushHook))
+		}
+		if hasSyncTags {
+			result.WriteString(fmt.Sprintf("tags = %t\n", syncTags))
+		}
+		if hasSyncUpstream {
+			result.WriteString(fmt.Sprintf("upstream = %t\n", syncUpstream))
+		}
+	}
 	return result.String()
 }
 
-func Save(normalConfig configdomain.PartialConfig, mainBranch gitdomain.LocalBranchName) error {
-	return os.WriteFile(FileName, []byte(RenderTOML(normalConfig, mainBranch)), 0o600)
+func Save(config configdomain.PartialConfig) error {
+	return os.WriteFile(FileName, []byte(RenderTOML(config)), 0o600)
 }

--- a/internal/config/gitconfig/high_level.go
+++ b/internal/config/gitconfig/high_level.go
@@ -156,6 +156,10 @@ func RemoveSyncUpstream(runner subshelldomain.Runner) error {
 	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeySyncUpstream)
 }
 
+func RemoveUnknownBranchType(runner subshelldomain.Runner) error {
+	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyUnknownBranchType)
+}
+
 func SetAlias(runner subshelldomain.Runner, aliasableCommand configdomain.AliasableCommand) error {
 	return SetConfigValue(runner, configdomain.ConfigScopeGlobal, aliasableCommand.Key().Key(), "town "+aliasableCommand.String())
 }


### PR DESCRIPTION
Upcoming changes will skip individual screens of the setup assistent if the
information to be entered there can be derived.

For example, if there is only one Git remote, it makes no sense to ask the user
what the dev remote is, or whether to sync with upstream.

This PR lays the foundation for these changes by making all values that the user
can enter optional. No changes to the actual input yet.
