### PR TITLE
E2E test for new user in repo with config file

### DIFF
--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -14,27 +14,27 @@ Feature: don't ask for information already provided by the config file
       perennial-regex = "release-"
       perennials = ["staging"]
       unknown-type = "observed"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "propose"
-
+      
       [hosting]
       dev-remote = "something"
       origin-hostname = "github.com"
       forge-type = "github"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
       push-hook = true
       tags = true
       upstream = true
-
+      
       [sync-strategy]
       feature-branches = "rebase"
       prototype-branches = "merge"

--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -47,25 +47,8 @@ Feature: don't ask for information already provided by the config file
       | github connector type: API | enter             |
       | GitHub token               | 1 2 3 4 5 6 enter |
       | token scope: local         | enter             |
-      | save config to config file | down enter        |
+      | save config to Git         | down enter        |
     Then Git Town runs the commands
       | COMMAND                                  |
       | git config git-town.github-token 123456  |
       | git config git-town.github-connector api |
-    And there are still no perennial branches
-    And local Git setting "git-town.dev-remote" still doesn't exist
-    And local Git setting "git-town.new-branch-type" still doesn't exist
-    And local Git setting "git-town.main-branch" still doesn't exist
-    And local Git setting "git-town.perennial-branches" still doesn't exist
-    And local Git setting "git-town.feature-regex" still doesn't exist
-    And local Git setting "git-town.forge-type" still doesn't exist
-    And local Git setting "git-town.github-token" is now "123456"
-    And local Git setting "git-town.share-new-branches" still doesn't exist
-    And local Git setting "git-town.push-hook" still doesn't exist
-    And local Git setting "git-town.sync-feature-strategy" still doesn't exist
-    And local Git setting "git-town.sync-perennial-strategy" still doesn't exist
-    And local Git setting "git-town.sync-upstream" still doesn't exist
-    And local Git setting "git-town.sync-tags" still doesn't exist
-    And local Git setting "git-town.ship-strategy" still doesn't exist
-    And local Git setting "git-town.ship-delete-tracking-branch" still doesn't exist
-    And local Git setting "git-town.unknown-branch-type" still doesn't exist

--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -14,27 +14,27 @@ Feature: don't ask for information already provided by the config file
       perennial-regex = "release-"
       perennials = ["staging"]
       unknown-type = "observed"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "propose"
-      
+
       [hosting]
       dev-remote = "something"
       origin-hostname = "github.com"
       forge-type = "github"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
       push-hook = true
       tags = true
       upstream = true
-      
+
       [sync-strategy]
       feature-branches = "rebase"
       prototype-branches = "merge"

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -8,15 +8,15 @@ Feature: ask for information not provided by the config file
       """
       [branches]
       main = "main"
-      
+
       [hosting]
       dev-remote = "something"
       forge-type = "github"
       origin-hostname = "github.com"
-      
+
       [ship]
       delete-tracking-branch = false
-      
+
       [sync]
       tags = false
       upstream = false

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -1,0 +1,59 @@
+@messyoutput
+Feature: ask for information not provided by the config file
+
+  Scenario:
+    Given a Git repo with origin
+    And Git Town is not configured
+    And the committed configuration file:
+      """
+      [branches]
+      main = "main"
+      
+      [hosting]
+      dev-remote = "something"
+      forge-type = "github"
+      origin-hostname = "github.com"
+      
+      [ship]
+      delete-tracking-branch = false
+      
+      [sync]
+      tags = false
+      upstream = false
+      """
+    When I run "git-town config setup" and enter into the dialogs:
+      | DIALOG                     | KEYS        |
+      | welcome                    | enter       |
+      | aliases                    | enter       |
+      | perennial regex            | 1 1 1 enter |
+      | feature regex              | 2 2 2 enter |
+      | contribution regex         | 3 3 3 enter |
+      | observed regex             | 4 4 4 enter |
+      | unknown branch type        | enter       |
+      | github connector type: API | enter       |
+      | GitHub token               | 9 9 9 enter |
+      | token scope: local         | enter       |
+      | sync-feature-branches      | enter       |
+      | sync-perennial-branches    | enter       |
+      | sync-prototype-branches    | enter       |
+      | share-new-branches         | enter       |
+      | push-hook                  | enter       |
+      | new-branch-type            | enter       |
+      | ship-strategy              | enter       |
+      | save config to Git         | down enter  |
+    Then Git Town runs the commands
+      | COMMAND                                            |
+      | git config git-town.github-token 999               |
+      | git config git-town.new-branch-type feature        |
+      | git config git-town.github-connector api           |
+      | git config git-town.perennial-regex 111            |
+      | git config git-town.unknown-branch-type feature    |
+      | git config git-town.feature-regex 222              |
+      | git config git-town.contribution-regex 333         |
+      | git config git-town.observed-regex 444             |
+      | git config git-town.push-hook true                 |
+      | git config git-town.share-new-branches no          |
+      | git config git-town.ship-strategy api              |
+      | git config git-town.sync-feature-strategy merge    |
+      | git config git-town.sync-perennial-strategy rebase |
+      | git config git-town.sync-prototype-strategy merge  |


### PR DESCRIPTION
This PR adds an E2E test for a typical use case: somebody starts working on a repo that contains a Git Town config file that defines only some Git Town settings and leaves others open to each developer.