### PR TITLE
Verify correct E2E steps

### DIFF
--- a/features/append/beam/propose_from_local_branch.feature
+++ b/features/append/beam/propose_from_local_branch.feature
@@ -20,8 +20,8 @@ Feature: beam commits and uncommitted changes from a local branch onto a new chi
     And an uncommitted file
     And I ran "git add ."
     When I run "git-town append new --beam --commit --message uncommitted --propose" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/append/beam/propose_with_uncommitted_changes.feature
+++ b/features/append/beam/propose_with_uncommitted_changes.feature
@@ -20,8 +20,8 @@ Feature: beam a commit and uncommitted changes onto a new child branch and propo
     And an uncommitted file
     And I ran "git add ."
     When I run "git-town append new --beam --commit --message uncommitted --propose" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/append/beam/select_commits.feature
+++ b/features/append/beam/select_commits.feature
@@ -16,8 +16,8 @@ Feature: beam multiple commits onto a new child branch
     And the current branch is "existing"
     And Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town append new --beam" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/append/beam/with_uncommitted_changes.feature
+++ b/features/append/beam/with_uncommitted_changes.feature
@@ -18,8 +18,8 @@ Feature: beam a commit and uncommitted changes onto a new child branch
     And an uncommitted file
     And I ran "git add ."
     When I run "git-town append new --beam --commit --message uncommitted" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/append/on_feature_branch/missing_lineage/unknown_parent.feature
+++ b/features/append/on_feature_branch/missing_lineage/unknown_parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent branch information
       | feature | feature | main   | local, origin |
     And the current branch is "feature"
     When I run "git-town append new" and enter into the dialog:
-      | DIALOG                    | KEYS  |
-      | parent branch for feature | enter |
+      | DIALOG                      | KEYS  |
+      | parent branch for "feature" | enter |
     Then this lineage exists now
       | BRANCH  | PARENT  |
       | feature | main    |

--- a/features/append/on_feature_branch/missing_lineage/unknown_parent.feature
+++ b/features/append/on_feature_branch/missing_lineage/unknown_parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent branch information
       | feature | feature | main   | local, origin |
     And the current branch is "feature"
     When I run "git-town append new" and enter into the dialog:
-      | DIALOG                             | KEYS  |
-      | select parent branch for "feature" | enter |
+      | DIALOG                    | KEYS  |
+      | parent branch for feature | enter |
     Then this lineage exists now
       | BRANCH  | PARENT  |
       | feature | main    |

--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -21,7 +21,7 @@ Feature: override an existing Git alias
       | sync feature strategy       | enter   |
       | sync perennial strategy     | enter   |
       | sync prototype strategy     | enter   |
-      | sync-upstream               | enter   |
+      | sync upstream               | enter   |
       | sync tags                   | enter   |
       | share new branches          | enter   |
       | push hook                   | enter   |

--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -22,12 +22,12 @@ Feature: override an existing Git alias
       | sync perennial strategy     | enter   |
       | sync prototype strategy     | enter   |
       | sync-upstream               | enter   |
-      | sync-tags                   | enter   |
-      | share-new-branches          | enter   |
-      | push-hook                   | enter   |
-      | new-branch-type             | enter   |
-      | ship-strategy               | enter   |
-      | ship-delete-tracking-branch | enter   |
+      | sync tags                   | enter   |
+      | share new branches          | enter   |
+      | push hook                   | enter   |
+      | new branch type             | enter   |
+      | ship strategy               | enter   |
+      | ship delete tracking branch | enter   |
       | save config to config file  | enter   |
 
   Scenario: result

--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -28,7 +28,7 @@ Feature: override an existing Git alias
       | new branch type             | enter   |
       | ship strategy               | enter   |
       | ship delete tracking branch | enter   |
-      | save config to config file  | enter   |
+      | config storage              | enter   |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -18,9 +18,9 @@ Feature: override an existing Git alias
       | unknown branch type         | enter   |
       | origin hostname             | enter   |
       | forge type                  | enter   |
-      | sync-feature-strategy       | enter   |
-      | sync-perennial-strategy     | enter   |
-      | sync-prototype-strategy     | enter   |
+      | sync feature strategy       | enter   |
+      | sync perennial strategy     | enter   |
+      | sync prototype strategy     | enter   |
       | sync-upstream               | enter   |
       | sync-tags                   | enter   |
       | share-new-branches          | enter   |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -33,10 +33,10 @@ Feature: change existing information in Git metadata
       | sync perennial strategy             | down enter             |
       | sync prototype strategy             | down enter             |
       | sync-upstream                       | down enter             |
-      | sync-tags                           | down enter             |
+      | sync tags                           | down enter             |
       | enable share-new-branches           | down enter             |
       | enable the push hook                | down enter             |
-      | new-branch-type                     | down enter             |
+      | new branch type                     | down enter             |
       | set ship-strategy to "fast-forward" | down down enter        |
       | disable ship-delete-tracking-branch | down enter             |
       | save config to Git metadata         | down enter             |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -32,7 +32,7 @@ Feature: change existing information in Git metadata
       | sync feature strategy               | down enter             |
       | sync perennial strategy             | down enter             |
       | sync prototype strategy             | down enter             |
-      | sync-upstream                       | down enter             |
+      | sync upstream                       | down enter             |
       | sync tags                           | down enter             |
       | enable share-new-branches           | down enter             |
       | enable the push hook                | down enter             |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -39,7 +39,7 @@ Feature: change existing information in Git metadata
       | new branch type                     | down enter             |
       | set ship-strategy to "fast-forward" | down down enter        |
       | disable ship-delete-tracking-branch | down enter             |
-      | save config to Git metadata         | down enter             |
+      | config storage                      | down enter             |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -14,32 +14,32 @@ Feature: change existing information in Git metadata
     And local Git setting "git-town.sync-tags" is "false"
     And local Git setting "git-town.ship-delete-tracking-branch" is "false"
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG                              | KEYS                   |
-      | welcome                             | enter                  |
-      | add all aliases                     | a enter                |
-      | main branch                         | enter                  |
-      | change the perennial branches       | space down space enter |
-      | enter a perennial regex             |          3 3 6 6 enter |
-      | feature regex                       | u s e r enter          |
-      | contribution regex                  |          1 1 1 1 enter |
-      | observed regex                      |          2 2 2 2 enter |
-      | unknown branch type                 | down enter             |
-      | origin hostname                     | c o d e enter          |
-      | set forge type to "github"          | up up enter            |
-      | set github forge type to "API"      | enter                  |
-      | github token                        |      1 2 3 4 5 6 enter |
-      | token scope                         | enter                  |
-      | sync feature strategy               | down enter             |
-      | sync perennial strategy             | down enter             |
-      | sync prototype strategy             | down enter             |
-      | sync upstream                       | down enter             |
-      | sync tags                           | down enter             |
-      | enable share-new-branches           | down enter             |
-      | enable the push hook                | down enter             |
-      | new branch type                     | down enter             |
-      | set ship-strategy to "fast-forward" | down down enter        |
-      | disable ship-delete-tracking-branch | down enter             |
-      | config storage                      | down enter             |
+      | DIALOG                      | KEYS                   |
+      | welcome                     | enter                  |
+      | aliases                     | a enter                |
+      | main branch                 | enter                  |
+      | perennial branches          | space down space enter |
+      | perennial regex             |          3 3 6 6 enter |
+      | feature regex               | u s e r enter          |
+      | contribution regex          |          1 1 1 1 enter |
+      | observed regex              |          2 2 2 2 enter |
+      | unknown branch type         | down enter             |
+      | origin hostname             | c o d e enter          |
+      | forge type                  | up up enter            |
+      | github connector type       | enter                  |
+      | github token                |      1 2 3 4 5 6 enter |
+      | token scope                 | enter                  |
+      | sync feature strategy       | down enter             |
+      | sync perennial strategy     | down enter             |
+      | sync prototype strategy     | down enter             |
+      | sync upstream               | down enter             |
+      | sync tags                   | down enter             |
+      | share-new-branches          | down enter             |
+      | push hook                   | down enter             |
+      | new branch type             | down enter             |
+      | ship strategy               | down down enter        |
+      | ship delete tracking branch | down enter             |
+      | config storage              | down enter             |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -19,19 +19,19 @@ Feature: change existing information in Git metadata
       | add all aliases                     | a enter                |
       | main branch                         | enter                  |
       | change the perennial branches       | space down space enter |
-      | enter a perennial regex             | 3 3 6 6 enter          |
+      | enter a perennial regex             |          3 3 6 6 enter |
       | feature regex                       | u s e r enter          |
-      | contribution regex                  | 1 1 1 1 enter          |
-      | observed regex                      | 2 2 2 2 enter          |
+      | contribution regex                  |          1 1 1 1 enter |
+      | observed regex                      |          2 2 2 2 enter |
       | unknown branch type                 | down enter             |
       | origin hostname                     | c o d e enter          |
       | set forge type to "github"          | up up enter            |
       | set github forge type to "API"      | enter                  |
-      | github token                        | 1 2 3 4 5 6 enter      |
+      | github token                        |      1 2 3 4 5 6 enter |
       | token scope                         | enter                  |
-      | sync-feature-strategy               | down enter             |
-      | sync-perennial-strategy             | down enter             |
-      | sync-prototype-strategy             | down enter             |
+      | sync feature strategy               | down enter             |
+      | sync perennial strategy             | down enter             |
+      | sync prototype strategy             | down enter             |
       | sync-upstream                       | down enter             |
       | sync-tags                           | down enter             |
       | enable share-new-branches           | down enter             |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -19,15 +19,15 @@ Feature: change existing information in Git metadata
       | aliases                     | a enter                |
       | main branch                 | enter                  |
       | perennial branches          | space down space enter |
-      | perennial regex             |          3 3 6 6 enter |
+      | perennial regex             | 3 3 6 6 enter          |
       | feature regex               | u s e r enter          |
-      | contribution regex          |          1 1 1 1 enter |
-      | observed regex              |          2 2 2 2 enter |
+      | contribution regex          | 1 1 1 1 enter          |
+      | observed regex              | 2 2 2 2 enter          |
       | unknown branch type         | down enter             |
       | origin hostname             | c o d e enter          |
       | forge type                  | up up enter            |
       | github connector type       | enter                  |
-      | github token                |      1 2 3 4 5 6 enter |
+      | github token                | 1 2 3 4 5 6 enter      |
       | token scope                 | enter                  |
       | sync feature strategy       | down enter             |
       | sync perennial strategy     | down enter             |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -19,15 +19,15 @@ Feature: change existing information in Git metadata
       | add all aliases                     | a enter                |
       | main branch                         | enter                  |
       | change the perennial branches       | space down space enter |
-      | enter a perennial regex             |          3 3 6 6 enter |
+      | enter a perennial regex             | 3 3 6 6 enter          |
       | feature regex                       | u s e r enter          |
-      | contribution regex                  |          1 1 1 1 enter |
-      | observed regex                      |          2 2 2 2 enter |
+      | contribution regex                  | 1 1 1 1 enter          |
+      | observed regex                      | 2 2 2 2 enter          |
       | unknown branch type                 | down enter             |
       | origin hostname                     | c o d e enter          |
       | set forge type to "github"          | up up enter            |
       | set github forge type to "API"      | enter                  |
-      | github token                        |      1 2 3 4 5 6 enter |
+      | github token                        | 1 2 3 4 5 6 enter      |
       | token scope                         | enter                  |
       | sync-feature-strategy               | down enter             |
       | sync-perennial-strategy             | down enter             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -18,7 +18,7 @@ Feature: enter the Codeberg API token
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
+      | forge type                  | enter             |                                             |
       | codeberg token              | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
       | sync feature strategy       | enter             |                                             |
@@ -31,7 +31,7 @@ Feature: enter the Codeberg API token
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.codeberg-token 123456            |
@@ -75,7 +75,7 @@ Feature: enter the Codeberg API token
       | new branch type             | enter                |                                             |
       | ship strategy               | enter                |                                             |
       | ship delete tracking branch | enter                |                                             |
-      | save config to Git metadata | down enter           |                                             |
+      | config storage              | down enter           |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.codeberg-token 123456            |
@@ -108,7 +108,7 @@ Feature: enter the Codeberg API token
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
+      | forge type                  | enter             |                                             |
       | codeberg token              | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | down enter        |                                             |
       | sync feature strategy       | enter             |                                             |
@@ -121,7 +121,7 @@ Feature: enter the Codeberg API token
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.codeberg-token 123456   |
@@ -153,7 +153,7 @@ Feature: enter the Codeberg API token
       | observed regex              | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
-      | forge type: auto-detect     | enter                                     |                                             |
+      | forge type                  | enter                                     |                                             |
       | github token                | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
       | sync feature strategy       | enter                                     |                                             |
@@ -166,7 +166,7 @@ Feature: enter the Codeberg API token
       | new branch type             | enter                                     |                                             |
       | ship strategy               | enter                                     |                                             |
       | ship delete tracking branch | enter                                     |                                             |
-      | save config to Git metadata | down enter                                |                                             |
+      | config storage              | down enter                                |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.codeberg-token 456      |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -63,7 +63,7 @@ Feature: enter the Codeberg API token
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
+      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
       | token scope                 | enter                |                                             |
       | sync-feature-strategy       | enter                |                                             |
       | sync-perennial-strategy     | enter                |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -63,7 +63,7 @@ Feature: enter the Codeberg API token
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
+      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
       | token scope                 | enter                |                                             |
       | sync feature strategy       | enter                |                                             |
       | sync perennial strategy     | enter                |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -25,12 +25,12 @@ Feature: enter the Codeberg API token
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -69,12 +69,12 @@ Feature: enter the Codeberg API token
       | sync perennial strategy     | enter                |                                             |
       | sync prototype strategy     | enter                |                                             |
       | sync-upstream               | enter                |                                             |
-      | sync-tags                   | enter                |                                             |
-      | share-new-branches          | enter                |                                             |
-      | push-hook                   | enter                |                                             |
-      | new-branch-type             | enter                |                                             |
-      | ship-strategy               | enter                |                                             |
-      | ship-delete-tracking-branch | enter                |                                             |
+      | sync tags                   | enter                |                                             |
+      | share new branches          | enter                |                                             |
+      | push hook                   | enter                |                                             |
+      | new branch type             | enter                |                                             |
+      | ship strategy               | enter                |                                             |
+      | ship delete tracking branch | enter                |                                             |
       | save config to Git metadata | down enter           |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -115,12 +115,12 @@ Feature: enter the Codeberg API token
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -160,12 +160,12 @@ Feature: enter the Codeberg API token
       | sync perennial strategy     | enter                                     |                                             |
       | sync prototype strategy     | enter                                     |                                             |
       | sync-upstream               | enter                                     |                                             |
-      | sync-tags                   | enter                                     |                                             |
-      | share-new-branches          | enter                                     |                                             |
-      | push-hook                   | enter                                     |                                             |
-      | new-branch-type             | enter                                     |                                             |
-      | ship-strategy               | enter                                     |                                             |
-      | ship-delete-tracking-branch | enter                                     |                                             |
+      | sync tags                   | enter                                     |                                             |
+      | share new branches          | enter                                     |                                             |
+      | push hook                   | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
+      | ship strategy               | enter                                     |                                             |
+      | ship delete tracking branch | enter                                     |                                             |
       | save config to Git metadata | down enter                                |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -154,7 +154,7 @@ Feature: enter the Codeberg API token
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
-      | github token                | backspace backspace backspace 4 5 6 enter |                                             |
+      | codeberg token              | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
       | sync feature strategy       | enter                                     |                                             |
       | sync perennial strategy     | enter                                     |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -63,7 +63,7 @@ Feature: enter the Codeberg API token
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
+      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                |                                             |
       | sync-feature-strategy       | enter                |                                             |
       | sync-perennial-strategy     | enter                |                                             |
@@ -100,7 +100,7 @@ Feature: enter the Codeberg API token
       | DIALOG                      | KEYS              | DESCRIPTION                                 |
       | welcome                     | enter             |                                             |
       | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
+      | main-branch                 | enter             |                                             |
       | perennial branches          |                   | no input here since the dialog doesn't show |
       | perennial regex             | enter             |                                             |
       | feature regex               | enter             |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -24,7 +24,7 @@ Feature: enter the Codeberg API token
       | sync feature strategy       | enter             |                                             |
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
+      | sync upstream               | enter             |                                             |
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
@@ -68,7 +68,7 @@ Feature: enter the Codeberg API token
       | sync feature strategy       | enter                |                                             |
       | sync perennial strategy     | enter                |                                             |
       | sync prototype strategy     | enter                |                                             |
-      | sync-upstream               | enter                |                                             |
+      | sync upstream               | enter                |                                             |
       | sync tags                   | enter                |                                             |
       | share new branches          | enter                |                                             |
       | push hook                   | enter                |                                             |
@@ -114,7 +114,7 @@ Feature: enter the Codeberg API token
       | sync feature strategy       | enter             |                                             |
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
+      | sync upstream               | enter             |                                             |
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
@@ -159,7 +159,7 @@ Feature: enter the Codeberg API token
       | sync feature strategy       | enter                                     |                                             |
       | sync perennial strategy     | enter                                     |                                             |
       | sync prototype strategy     | enter                                     |                                             |
-      | sync-upstream               | enter                                     |                                             |
+      | sync upstream               | enter                                     |                                             |
       | sync tags                   | enter                                     |                                             |
       | share new branches          | enter                                     |                                             |
       | push hook                   | enter                                     |                                             |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -21,9 +21,9 @@ Feature: enter the Codeberg API token
       | forge type: auto-detect     | enter             |                                             |
       | codeberg token              | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
       | sync-tags                   | enter             |                                             |
       | share-new-branches          | enter             |                                             |
@@ -63,11 +63,11 @@ Feature: enter the Codeberg API token
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
+      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                |                                             |
-      | sync-feature-strategy       | enter                |                                             |
-      | sync-perennial-strategy     | enter                |                                             |
-      | sync-prototype-strategy     | enter                |                                             |
+      | sync feature strategy       | enter                |                                             |
+      | sync perennial strategy     | enter                |                                             |
+      | sync prototype strategy     | enter                |                                             |
       | sync-upstream               | enter                |                                             |
       | sync-tags                   | enter                |                                             |
       | share-new-branches          | enter                |                                             |
@@ -111,9 +111,9 @@ Feature: enter the Codeberg API token
       | forge type: auto-detect     | enter             |                                             |
       | codeberg token              | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | down enter        |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
       | sync-tags                   | enter             |                                             |
       | share-new-branches          | enter             |                                             |
@@ -156,9 +156,9 @@ Feature: enter the Codeberg API token
       | forge type: auto-detect     | enter                                     |                                             |
       | github token                | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
-      | sync-feature-strategy       | enter                                     |                                             |
-      | sync-perennial-strategy     | enter                                     |                                             |
-      | sync-prototype-strategy     | enter                                     |                                             |
+      | sync feature strategy       | enter                                     |                                             |
+      | sync perennial strategy     | enter                                     |                                             |
+      | sync prototype strategy     | enter                                     |                                             |
       | sync-upstream               | enter                                     |                                             |
       | sync-tags                   | enter                                     |                                             |
       | share-new-branches          | enter                                     |                                             |

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -60,21 +60,21 @@ Feature: Accepting all default values leads to a working setup
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "origin"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -32,7 +32,7 @@ Feature: Accepting all default values leads to a working setup
       | new branch type             | enter |
       | ship strategy               | enter |
       | ship delete tracking branch | enter |
-      | save config to config file  | enter |
+      | config storage              | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -25,7 +25,7 @@ Feature: Accepting all default values leads to a working setup
       | sync feature strategy       | enter |
       | sync perennial strategy     | enter |
       | sync prototype strategy     | enter |
-      | sync-upstream               | enter |
+      | sync upstream               | enter |
       | sync tags                   | enter |
       | share new branches          | enter |
       | push hook                   | enter |

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -22,9 +22,9 @@ Feature: Accepting all default values leads to a working setup
       | unknown branch type         | enter |
       | origin hostname             | enter |
       | forge type                  | enter |
-      | sync-feature-strategy       | enter |
-      | sync-perennial-strategy     | enter |
-      | sync-prototype-strategy     | enter |
+      | sync feature strategy       | enter |
+      | sync perennial strategy     | enter |
+      | sync prototype strategy     | enter |
       | sync-upstream               | enter |
       | sync-tags                   | enter |
       | share-new-branches          | enter |
@@ -60,21 +60,21 @@ Feature: Accepting all default values leads to a working setup
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -26,12 +26,12 @@ Feature: Accepting all default values leads to a working setup
       | sync perennial strategy     | enter |
       | sync prototype strategy     | enter |
       | sync-upstream               | enter |
-      | sync-tags                   | enter |
-      | share-new-branches          | enter |
-      | push-hook                   | enter |
-      | new-branch-type             | enter |
-      | ship-strategy               | enter |
-      | ship-delete-tracking-branch | enter |
+      | sync tags                   | enter |
+      | share new branches          | enter |
+      | push hook                   | enter |
+      | new branch type             | enter |
+      | ship strategy               | enter |
+      | ship delete tracking branch | enter |
       | save config to config file  | enter |
 
   Scenario: result

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -54,21 +54,21 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "initial"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "origin"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -19,7 +19,7 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       | sync feature strategy       | enter |
       | sync perennial strategy     | enter |
       | sync prototype strategy     | enter |
-      | sync-upstream               | enter |
+      | sync upstream               | enter |
       | sync tags                   | enter |
       | share new branches          | enter |
       | push hook                   | enter |

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -16,9 +16,9 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       | unknown branch type         | enter |
       | origin hostname             | enter |
       | forge type                  | enter |
-      | sync-feature-strategy       | enter |
-      | sync-perennial-strategy     | enter |
-      | sync-prototype-strategy     | enter |
+      | sync feature strategy       | enter |
+      | sync perennial strategy     | enter |
+      | sync prototype strategy     | enter |
       | sync-upstream               | enter |
       | sync-tags                   | enter |
       | share-new-branches          | enter |
@@ -54,21 +54,21 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "initial"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -26,7 +26,7 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       | new branch type             | enter |
       | ship strategy               | enter |
       | ship delete tracking branch | enter |
-      | save config to config file  | enter |
+      | config storage              | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -20,12 +20,12 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       | sync perennial strategy     | enter |
       | sync prototype strategy     | enter |
       | sync-upstream               | enter |
-      | sync-tags                   | enter |
-      | share-new-branches          | enter |
-      | push-hook                   | enter |
-      | new-branch-type             | enter |
-      | ship-strategy               | enter |
-      | ship-delete-tracking-branch | enter |
+      | sync tags                   | enter |
+      | share new branches          | enter |
+      | push hook                   | enter |
+      | new branch type             | enter |
+      | ship strategy               | enter |
+      | ship delete tracking branch | enter |
       | save config to config file  | enter |
 
   Scenario: result

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -63,7 +63,7 @@ Feature: enter the Gitea API token
       | unknown branch type         | enter                     |                                             |
       | origin hostname             | enter                     |                                             |
       | forge type                  | down down down down enter |                                             |
-      | gitea token                 |         1 2 3 4 5 6 enter |                                             |
+      | gitea token                 | 1 2 3 4 5 6 enter         |                                             |
       | token scope                 | enter                     |                                             |
       | sync feature strategy       | enter                     |                                             |
       | sync perennial strategy     | enter                     |                                             |

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -4,6 +4,7 @@ Feature: enter the Gitea API token
   Background:
     Given a Git repo with origin
 
+  @debug @this
   Scenario: auto-detected Gitea platform
     And my repo's "origin" remote is "git@gitea.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:
@@ -63,7 +64,7 @@ Feature: enter the Gitea API token
       | unknown branch type         | enter                     |                                             |
       | origin hostname             | enter                     |                                             |
       | forge type                  | down down down down enter |                                             |
-      | gitea token                 | 1 2 3 4 5 6 enter         |                                             |
+      | gitea token                 |         1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                     |                                             |
       | sync-feature-strategy       | enter                     |                                             |
       | sync-perennial-strategy     | enter                     |                                             |

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -19,7 +19,7 @@ Feature: enter the Gitea API token
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
+      | forge type                  | enter             | auto-detect                                 |
       | gitea token                 | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
       | sync-feature-strategy       | enter             |                                             |

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -138,7 +138,6 @@ Feature: enter the Gitea API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.gitea-token" is now "123456"
 
-  @debug @this
   Scenario: edit global Gitea token
     Given my repo's "origin" remote is "git@gitea.com:git-town/git-town.git"
     And global Git setting "git-town.gitea-token" is "123"

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -4,7 +4,6 @@ Feature: enter the Gitea API token
   Background:
     Given a Git repo with origin
 
-  @this
   Scenario: auto-detected Gitea platform
     And my repo's "origin" remote is "git@gitea.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:
@@ -66,17 +65,17 @@ Feature: enter the Gitea API token
       | forge type                  | down down down down enter |                                             |
       | gitea token                 |         1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                     |                                             |
-      | sync-feature-strategy       | enter                     |                                             |
-      | sync-perennial-strategy     | enter                     |                                             |
-      | sync-prototype-strategy     | enter                     |                                             |
-      | sync-upstream               | enter                     |                                             |
-      | sync-tags                   | enter                     |                                             |
-      | share-new-branches          | enter                     |                                             |
-      | push-hook                   | enter                     |                                             |
-      | new-branch-type             | enter                     |                                             |
-      | ship-strategy               | enter                     |                                             |
-      | ship-delete-tracking-branch | enter                     |                                             |
-      | save config to Git metadata | down enter                |                                             |
+      | sync feature strategy       | enter                     |                                             |
+      | sync perennial strategy     | enter                     |                                             |
+      | sync prototype strategy     | enter                     |                                             |
+      | sync upstream               | enter                     |                                             |
+      | sync tags                   | enter                     |                                             |
+      | share new branches          | enter                     |                                             |
+      | push hook                   | enter                     |                                             |
+      | new branch type             | enter                     |                                             |
+      | ship strategy               | enter                     |                                             |
+      | ship delete tracking branch | enter                     |                                             |
+      | config storage              | down enter                | git metadata                                |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.gitea-token 123456               |
@@ -112,17 +111,17 @@ Feature: enter the Gitea API token
       | forge type                  | enter             |                                             |
       | gitea token                 | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | down enter        |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
+      | sync upstream               | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
+      | config storage              | down enter        | git metadata                                |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.gitea-token 123456      |
@@ -139,6 +138,7 @@ Feature: enter the Gitea API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.gitea-token" is now "123456"
 
+  @debug @this
   Scenario: edit global Gitea token
     Given my repo's "origin" remote is "git@gitea.com:git-town/git-town.git"
     And global Git setting "git-town.gitea-token" is "123"
@@ -155,19 +155,19 @@ Feature: enter the Gitea API token
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
-      | github token                | backspace backspace backspace 4 5 6 enter |                                             |
+      | gitea token                 | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
-      | sync-feature-strategy       | enter                                     |                                             |
-      | sync-perennial-strategy     | enter                                     |                                             |
-      | sync-prototype-strategy     | enter                                     |                                             |
-      | sync-upstream               | enter                                     |                                             |
-      | sync-tags                   | enter                                     |                                             |
-      | share-new-branches          | enter                                     |                                             |
-      | push-hook                   | enter                                     |                                             |
-      | new-branch-type             | enter                                     |                                             |
-      | ship-strategy               | enter                                     |                                             |
-      | ship-delete-tracking-branch | enter                                     |                                             |
-      | save config to Git metadata | down enter                                |                                             |
+      | sync feature strategy       | enter                                     |                                             |
+      | sync perennial strategy     | enter                                     |                                             |
+      | sync prototype strategy     | enter                                     |                                             |
+      | sync upstream               | enter                                     |                                             |
+      | sync tags                   | enter                                     |                                             |
+      | share new branches          | enter                                     |                                             |
+      | push hook                   | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
+      | ship strategy               | enter                                     |                                             |
+      | ship delete tracking branch | enter                                     |                                             |
+      | config storage              | down enter                                | git metadata                                |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.gitea-token 456         |

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -4,7 +4,7 @@ Feature: enter the Gitea API token
   Background:
     Given a Git repo with origin
 
-  @debug @this
+  @this
   Scenario: auto-detected Gitea platform
     And my repo's "origin" remote is "git@gitea.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:
@@ -22,17 +22,17 @@ Feature: enter the Gitea API token
       | forge type                  | enter             | auto-detect                                 |
       | gitea token                 | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
+      | sync upstream               | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
+      | config storage              | down enter        | git metadata                                |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.gitea-token 123456               |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -18,7 +18,7 @@ Feature: enter the GitHub API token
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
+      | forge type                  | enter             |                                             |
       | github connector type: API  | enter             |                                             |
       | github token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
@@ -32,7 +32,7 @@ Feature: enter the GitHub API token
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.github-token 123456              |
@@ -78,7 +78,7 @@ Feature: enter the GitHub API token
       | new branch type             | enter                          |                                             |
       | ship strategy               | enter                          |                                             |
       | ship delete tracking branch | enter                          |                                             |
-      | save config to Git metadata | down enter                     |                                             |
+      | config storage              | down enter                     |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.github-token 123456              |
@@ -113,7 +113,7 @@ Feature: enter the GitHub API token
       | observed regex              | enter                               |                                             |
       | unknown branch type         | enter                               |                                             |
       | origin hostname             | enter                               |                                             |
-      | forge type: auto-detect     | enter                               |                                             |
+      | forge type                  | enter                               |                                             |
       | github connector type: API  | enter                               |                                             |
       | github token                | backspace backspace backspace enter |                                             |
       | sync feature strategy       | enter                               |                                             |
@@ -126,7 +126,7 @@ Feature: enter the GitHub API token
       | new branch type             | enter                               |                                             |
       | ship strategy               | enter                               |                                             |
       | ship delete tracking branch | enter                               |                                             |
-      | save config to Git metadata | down enter                          |                                             |
+      | config storage              | down enter                          |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --unset git-town.github-token             |
@@ -173,7 +173,7 @@ Feature: enter the GitHub API token
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.github-token 123456     |
@@ -220,7 +220,7 @@ Feature: enter the GitHub API token
       | new branch type             | enter                                     |                                             |
       | ship strategy               | enter                                     |                                             |
       | ship delete tracking branch | enter                                     |                                             |
-      | save config to Git metadata | down enter                                |                                             |
+      | config storage              | down enter                                |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.github-token 456        |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -19,7 +19,7 @@ Feature: enter the GitHub API token
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
-      | github connector type: API  | enter             |                                             |
+      | github connector type       | enter             |                                             |
       | github token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
       | sync feature strategy       | enter             |                                             |
@@ -65,7 +65,7 @@ Feature: enter the GitHub API token
       | unknown branch type         | enter                          |                                             |
       | origin hostname             | enter                          |                                             |
       | forge type                  | down down down down down enter |                                             |
-      | github connector type: API  | enter                          |                                             |
+      | github connector type       | enter                          |                                             |
       | github token                |              1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                          |                                             |
       | sync feature strategy       | enter                          |                                             |
@@ -114,7 +114,7 @@ Feature: enter the GitHub API token
       | unknown branch type         | enter                               |                                             |
       | origin hostname             | enter                               |                                             |
       | forge type                  | enter                               |                                             |
-      | github connector type: API  | enter                               |                                             |
+      | github connector type       | enter                               |                                             |
       | github token                | backspace backspace backspace enter |                                             |
       | sync feature strategy       | enter                               |                                             |
       | sync perennial strategy     | enter                               |                                             |
@@ -160,7 +160,7 @@ Feature: enter the GitHub API token
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
-      | github connector type: API  | enter             |                                             |
+      | github connector type       | enter             |                                             |
       | github token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | down enter        |                                             |
       | sync feature strategy       | enter             |                                             |
@@ -191,6 +191,7 @@ Feature: enter the GitHub API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.github-token" is now "123456"
 
+  @debug @this
   Scenario: edit global GitHub token
     Given my repo's "origin" remote is "git@github.com:git-town/git-town.git"
     And global Git setting "git-town.github-token" is "123"
@@ -207,7 +208,7 @@ Feature: enter the GitHub API token
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
-      | github connector type: API  | enter                                     |                                             |
+      | github connector type       | enter                                     |                                             |
       | github token                | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
       | sync feature strategy       | enter                                     |                                             |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -66,7 +66,7 @@ Feature: enter the GitHub API token
       | origin hostname             | enter                          |                                             |
       | forge type                  | down down down down down enter |                                             |
       | github connector type       | enter                          |                                             |
-      | github token                |              1 2 3 4 5 6 enter |                                             |
+      | github token                | 1 2 3 4 5 6 enter              |                                             |
       | token scope                 | enter                          |                                             |
       | sync feature strategy       | enter                          |                                             |
       | sync perennial strategy     | enter                          |                                             |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -25,7 +25,7 @@ Feature: enter the GitHub API token
       | sync feature strategy       | enter             |                                             |
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
+      | sync upstream               | enter             |                                             |
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
@@ -71,7 +71,7 @@ Feature: enter the GitHub API token
       | sync feature strategy       | enter                          |                                             |
       | sync perennial strategy     | enter                          |                                             |
       | sync prototype strategy     | enter                          |                                             |
-      | sync-upstream               | enter                          |                                             |
+      | sync upstream               | enter                          |                                             |
       | sync tags                   | enter                          |                                             |
       | share new branches          | enter                          |                                             |
       | push hook                   | enter                          |                                             |
@@ -119,7 +119,7 @@ Feature: enter the GitHub API token
       | sync feature strategy       | enter                               |                                             |
       | sync perennial strategy     | enter                               |                                             |
       | sync prototype strategy     | enter                               |                                             |
-      | sync-upstream               | enter                               |                                             |
+      | sync upstream               | enter                               |                                             |
       | sync tags                   | enter                               |                                             |
       | share new branches          | enter                               |                                             |
       | push hook                   | enter                               |                                             |
@@ -166,7 +166,7 @@ Feature: enter the GitHub API token
       | sync feature strategy       | enter             |                                             |
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
+      | sync upstream               | enter             |                                             |
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
@@ -213,7 +213,7 @@ Feature: enter the GitHub API token
       | sync feature strategy       | enter                                     |                                             |
       | sync perennial strategy     | enter                                     |                                             |
       | sync prototype strategy     | enter                                     |                                             |
-      | sync-upstream               | enter                                     |                                             |
+      | sync upstream               | enter                                     |                                             |
       | sync tags                   | enter                                     |                                             |
       | share new branches          | enter                                     |                                             |
       | push hook                   | enter                                     |                                             |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -191,7 +191,6 @@ Feature: enter the GitHub API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.github-token" is now "123456"
 
-  @debug @this
   Scenario: edit global GitHub token
     Given my repo's "origin" remote is "git@github.com:git-town/git-town.git"
     And global Git setting "git-town.github-token" is "123"

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -26,12 +26,12 @@ Feature: enter the GitHub API token
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -72,12 +72,12 @@ Feature: enter the GitHub API token
       | sync perennial strategy     | enter                          |                                             |
       | sync prototype strategy     | enter                          |                                             |
       | sync-upstream               | enter                          |                                             |
-      | sync-tags                   | enter                          |                                             |
-      | share-new-branches          | enter                          |                                             |
-      | push-hook                   | enter                          |                                             |
-      | new-branch-type             | enter                          |                                             |
-      | ship-strategy               | enter                          |                                             |
-      | ship-delete-tracking-branch | enter                          |                                             |
+      | sync tags                   | enter                          |                                             |
+      | share new branches          | enter                          |                                             |
+      | push hook                   | enter                          |                                             |
+      | new branch type             | enter                          |                                             |
+      | ship strategy               | enter                          |                                             |
+      | ship delete tracking branch | enter                          |                                             |
       | save config to Git metadata | down enter                     |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -120,12 +120,12 @@ Feature: enter the GitHub API token
       | sync perennial strategy     | enter                               |                                             |
       | sync prototype strategy     | enter                               |                                             |
       | sync-upstream               | enter                               |                                             |
-      | sync-tags                   | enter                               |                                             |
-      | share-new-branches          | enter                               |                                             |
-      | push-hook                   | enter                               |                                             |
-      | new-branch-type             | enter                               |                                             |
-      | ship-strategy               | enter                               |                                             |
-      | ship-delete-tracking-branch | enter                               |                                             |
+      | sync tags                   | enter                               |                                             |
+      | share new branches          | enter                               |                                             |
+      | push hook                   | enter                               |                                             |
+      | new branch type             | enter                               |                                             |
+      | ship strategy               | enter                               |                                             |
+      | ship delete tracking branch | enter                               |                                             |
       | save config to Git metadata | down enter                          |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -167,12 +167,12 @@ Feature: enter the GitHub API token
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -214,12 +214,12 @@ Feature: enter the GitHub API token
       | sync perennial strategy     | enter                                     |                                             |
       | sync prototype strategy     | enter                                     |                                             |
       | sync-upstream               | enter                                     |                                             |
-      | sync-tags                   | enter                                     |                                             |
-      | share-new-branches          | enter                                     |                                             |
-      | push-hook                   | enter                                     |                                             |
-      | new-branch-type             | enter                                     |                                             |
-      | ship-strategy               | enter                                     |                                             |
-      | ship-delete-tracking-branch | enter                                     |                                             |
+      | sync tags                   | enter                                     |                                             |
+      | share new branches          | enter                                     |                                             |
+      | push hook                   | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
+      | ship strategy               | enter                                     |                                             |
+      | ship delete tracking branch | enter                                     |                                             |
       | save config to Git metadata | down enter                                |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -22,9 +22,9 @@ Feature: enter the GitHub API token
       | github connector type: API  | enter             |                                             |
       | github token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
       | sync-tags                   | enter             |                                             |
       | share-new-branches          | enter             |                                             |
@@ -66,11 +66,11 @@ Feature: enter the GitHub API token
       | origin hostname             | enter                          |                                             |
       | forge type                  | down down down down down enter |                                             |
       | github connector type: API  | enter                          |                                             |
-      | github token                | 1 2 3 4 5 6 enter              |                                             |
+      | github token                |              1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                          |                                             |
-      | sync-feature-strategy       | enter                          |                                             |
-      | sync-perennial-strategy     | enter                          |                                             |
-      | sync-prototype-strategy     | enter                          |                                             |
+      | sync feature strategy       | enter                          |                                             |
+      | sync perennial strategy     | enter                          |                                             |
+      | sync prototype strategy     | enter                          |                                             |
       | sync-upstream               | enter                          |                                             |
       | sync-tags                   | enter                          |                                             |
       | share-new-branches          | enter                          |                                             |
@@ -116,9 +116,9 @@ Feature: enter the GitHub API token
       | forge type: auto-detect     | enter                               |                                             |
       | github connector type: API  | enter                               |                                             |
       | github token                | backspace backspace backspace enter |                                             |
-      | sync-feature-strategy       | enter                               |                                             |
-      | sync-perennial-strategy     | enter                               |                                             |
-      | sync-prototype-strategy     | enter                               |                                             |
+      | sync feature strategy       | enter                               |                                             |
+      | sync perennial strategy     | enter                               |                                             |
+      | sync prototype strategy     | enter                               |                                             |
       | sync-upstream               | enter                               |                                             |
       | sync-tags                   | enter                               |                                             |
       | share-new-branches          | enter                               |                                             |
@@ -163,9 +163,9 @@ Feature: enter the GitHub API token
       | github connector type: API  | enter             |                                             |
       | github token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | down enter        |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
       | sync-tags                   | enter             |                                             |
       | share-new-branches          | enter             |                                             |
@@ -210,9 +210,9 @@ Feature: enter the GitHub API token
       | github connector type: API  | enter                                     |                                             |
       | github token                | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
-      | sync-feature-strategy       | enter                                     |                                             |
-      | sync-perennial-strategy     | enter                                     |                                             |
-      | sync-prototype-strategy     | enter                                     |                                             |
+      | sync feature strategy       | enter                                     |                                             |
+      | sync perennial strategy     | enter                                     |                                             |
+      | sync prototype strategy     | enter                                     |                                             |
       | sync-upstream               | enter                                     |                                             |
       | sync-tags                   | enter                                     |                                             |
       | share-new-branches          | enter                                     |                                             |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -26,12 +26,12 @@ Feature: enter the GitLab API token
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -71,12 +71,12 @@ Feature: enter the GitLab API token
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -119,12 +119,12 @@ Feature: enter the GitLab API token
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
@@ -166,12 +166,12 @@ Feature: enter the GitLab API token
       | sync perennial strategy     | enter                                     |                                             |
       | sync prototype strategy     | enter                                     |                                             |
       | sync-upstream               | enter                                     |                                             |
-      | sync-tags                   | enter                                     |                                             |
-      | share-new-branches          | enter                                     |                                             |
-      | push-hook                   | enter                                     |                                             |
-      | new-branch-type             | enter                                     |                                             |
-      | ship-strategy               | enter                                     |                                             |
-      | ship-delete-tracking-branch | enter                                     |                                             |
+      | sync tags                   | enter                                     |                                             |
+      | share new branches          | enter                                     |                                             |
+      | push hook                   | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
+      | ship strategy               | enter                                     |                                             |
+      | ship delete tracking branch | enter                                     |                                             |
       | save config to Git metadata | down enter                                |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -4,7 +4,6 @@ Feature: enter the GitLab API token
   Background:
     Given a Git repo with origin
 
-  @debug @this
   Scenario: auto-detected GitLab platform
     Given my repo's "origin" remote is "git@gitlab.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -143,7 +143,6 @@ Feature: enter the GitLab API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.gitlab-token" is now "123456"
 
-  @debug @this
   Scenario: edit global GitLab token
     Given my repo's "origin" remote is "git@gitlab.com:git-town/git-town.git"
     And global Git setting "git-town.gitlab-token" is "123"
@@ -173,7 +172,7 @@ Feature: enter the GitLab API token
       | new branch type             | enter                                     |                                             |
       | ship strategy               | enter                                     |                                             |
       | ship delete tracking branch | enter                                     |                                             |
-      | save config to Git metadata | down enter                                |                                             |
+      | config storage              | down enter                                |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.gitlab-token 456        |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -50,7 +50,6 @@ Feature: enter the GitLab API token
       | git config git-town.sync-tags true                   |
     And local Git setting "git-town.forge-type" still doesn't exist
 
-  @debug @this
   Scenario: select GitLab manually
     When I run "git-town config setup" and enter into the dialog:
       | DIALOG                      | KEYS              | DESCRIPTION                                 |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -25,7 +25,7 @@ Feature: enter the GitLab API token
       | sync feature strategy       | enter             |                                             |
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
+      | sync upstream               | enter             |                                             |
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
@@ -70,7 +70,7 @@ Feature: enter the GitLab API token
       | sync feature strategy       | enter             |                                             |
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
+      | sync upstream               | enter             |                                             |
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
@@ -118,7 +118,7 @@ Feature: enter the GitLab API token
       | sync feature strategy       | enter             |                                             |
       | sync perennial strategy     | enter             |                                             |
       | sync prototype strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
+      | sync upstream               | enter             |                                             |
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
@@ -143,6 +143,7 @@ Feature: enter the GitLab API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.gitlab-token" is now "123456"
 
+  @debug @this
   Scenario: edit global GitLab token
     Given my repo's "origin" remote is "git@gitlab.com:git-town/git-town.git"
     And global Git setting "git-town.gitlab-token" is "123"
@@ -159,13 +160,13 @@ Feature: enter the GitLab API token
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
-      | gitlab connector type: api  | enter                                     |                                             |
+      | gitlab connector type       | enter                                     |                                             |
       | gitlab token                | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
       | sync feature strategy       | enter                                     |                                             |
       | sync perennial strategy     | enter                                     |                                             |
       | sync prototype strategy     | enter                                     |                                             |
-      | sync-upstream               | enter                                     |                                             |
+      | sync upstream               | enter                                     |                                             |
       | sync tags                   | enter                                     |                                             |
       | share new branches          | enter                                     |                                             |
       | push hook                   | enter                                     |                                             |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -112,7 +112,7 @@ Feature: enter the GitLab API token
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
-      | gitlab connector type: api  | enter             |                                             |
+      | gitlab connector type       | enter             | api                                         |
       | gitlab token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | down enter        |                                             |
       | sync feature strategy       | enter             |                                             |
@@ -125,7 +125,7 @@ Feature: enter the GitLab API token
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        | git metadata                                |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config --global git-town.gitlab-token 123456     |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -4,6 +4,7 @@ Feature: enter the GitLab API token
   Background:
     Given a Git repo with origin
 
+  @debug @this
   Scenario: auto-detected GitLab platform
     Given my repo's "origin" remote is "git@gitlab.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:
@@ -18,8 +19,8 @@ Feature: enter the GitLab API token
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
-      | gitlab connector type: api  | enter             |                                             |
+      | forge type                  | enter             |                                             |
+      | gitlab connector type       | enter             |                                             |
       | gitlab token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
       | sync feature strategy       | enter             |                                             |
@@ -32,7 +33,7 @@ Feature: enter the GitLab API token
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.gitlab-token 123456              |
@@ -50,6 +51,7 @@ Feature: enter the GitLab API token
       | git config git-town.sync-tags true                   |
     And local Git setting "git-town.forge-type" still doesn't exist
 
+  @debug @this
   Scenario: select GitLab manually
     When I run "git-town config setup" and enter into the dialog:
       | DIALOG                      | KEYS              | DESCRIPTION                                 |
@@ -64,7 +66,7 @@ Feature: enter the GitLab API token
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | up enter          |                                             |
-      | gitlab connector type: api  | enter             |                                             |
+      | gitlab connector type       | enter             |                                             |
       | gitlab token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
       | sync feature strategy       | enter             |                                             |
@@ -77,7 +79,7 @@ Feature: enter the GitLab API token
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.gitlab-token 123456              |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -22,9 +22,9 @@ Feature: enter the GitLab API token
       | gitlab connector type: api  | enter             |                                             |
       | gitlab token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
       | sync-tags                   | enter             |                                             |
       | share-new-branches          | enter             |                                             |
@@ -67,9 +67,9 @@ Feature: enter the GitLab API token
       | gitlab connector type: api  | enter             |                                             |
       | gitlab token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
       | sync-tags                   | enter             |                                             |
       | share-new-branches          | enter             |                                             |
@@ -115,9 +115,9 @@ Feature: enter the GitLab API token
       | gitlab connector type: api  | enter             |                                             |
       | gitlab token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | down enter        |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
       | sync-upstream               | enter             |                                             |
       | sync-tags                   | enter             |                                             |
       | share-new-branches          | enter             |                                             |
@@ -162,9 +162,9 @@ Feature: enter the GitLab API token
       | gitlab connector type: api  | enter                                     |                                             |
       | gitlab token                | backspace backspace backspace 4 5 6 enter |                                             |
       | token scope                 | enter                                     |                                             |
-      | sync-feature-strategy       | enter                                     |                                             |
-      | sync-perennial-strategy     | enter                                     |                                             |
-      | sync-prototype-strategy     | enter                                     |                                             |
+      | sync feature strategy       | enter                                     |                                             |
+      | sync perennial strategy     | enter                                     |                                             |
+      | sync prototype strategy     | enter                                     |                                             |
       | sync-upstream               | enter                                     |                                             |
       | sync-tags                   | enter                                     |                                             |
       | share-new-branches          | enter                                     |                                             |

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -1,6 +1,7 @@
 @messyoutput
 Feature: a global API token of another forge exists
 
+  @debug @this
   Scenario: on GitHub, with global GitLab token
     Given a Git repo with origin
     And my repo's "origin" remote is "git@github.com:git-town/git-town.git"
@@ -17,20 +18,20 @@ Feature: a global API token of another forge exists
       | observed regex              | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
-      | forge type: auto-detect     | enter             |                                             |
-      | github connector type: API  | enter             |                                             |
+      | forge type                  | enter             |                                             |
+      | github connector type       | enter             |                                             |
       | github token                | 1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter             |                                             |
-      | sync-feature-strategy       | enter             |                                             |
-      | sync-perennial-strategy     | enter             |                                             |
-      | sync-prototype-strategy     | enter             |                                             |
-      | sync-upstream               | enter             |                                             |
-      | sync-tags                   | enter             |                                             |
-      | share-new-branches          | enter             |                                             |
-      | push-hook                   | enter             |                                             |
-      | new-branch-type             | enter             |                                             |
-      | ship-strategy               | enter             |                                             |
-      | ship-delete-tracking-branch | enter             |                                             |
+      | sync feature strategy       | enter             |                                             |
+      | sync perennial strategy     | enter             |                                             |
+      | sync prototype strategy     | enter             |                                             |
+      | sync upstream               | enter             |                                             |
+      | sync tags                   | enter             |                                             |
+      | share new branches          | enter             |                                             |
+      | push hook                   | enter             |                                             |
+      | new branch type             | enter             |                                             |
+      | ship strategy               | enter             |                                             |
+      | ship delete tracking branch | enter             |                                             |
       | save config to Git metadata | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: a global API token of another forge exists
 
-  @debug @this
   Scenario: on GitHub, with global GitLab token
     Given a Git repo with origin
     And my repo's "origin" remote is "git@github.com:git-town/git-town.git"
@@ -32,7 +31,7 @@ Feature: a global API token of another forge exists
       | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
-      | save config to Git metadata | down enter        |                                             |
+      | config storage              | down enter        |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
       | git config git-town.github-token 123456              |

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -23,28 +23,28 @@ Feature: migrate existing configuration in Git metadata to a config file
     When I run "git-town config setup" and enter into the dialogs:
       | DIALOG                      | KEYS  |
       | welcome                     | enter |
-      | add all aliases             | enter |
+      | aliases                     | enter |
       | main branch                 | enter |
-      | perennial branches          |       |
+      | perennial branches          | enter |
       | perennial regex             | enter |
       | feature regex               | enter |
       | contribution regex          | enter |
       | observed regex              | enter |
       | unknown branch type         | enter |
-      | dev-remote                  | enter |
+      | dev-remote                  |       |
       | origin hostname             | enter |
       | forge type                  | enter |
-      | sync-feature-strategy       | enter |
-      | sync-perennial-strategy     | enter |
-      | sync-prototype-strategy     | enter |
-      | sync-upstream               | enter |
-      | sync-tags                   | enter |
-      | share-new-branches          | enter |
-      | disable the push hook       | enter |
-      | new-branch-type             | enter |
-      | ship-strategy               | enter |
-      | ship-delete-tracking-branch | enter |
-      | save config to config file  | enter |
+      | sync feature strategy       | enter |
+      | sync perennial strategy     | enter |
+      | sync prototype strategy     | enter |
+      | sync upstream               | enter |
+      | sync tags                   | enter |
+      | share new branches          | enter |
+      | push hook                   | enter |
+      | new branch type             | enter |
+      | ship strategy               | enter |
+      | ship delete tracking branch | enter |
+      | config storage              | enter |
 
   Scenario: result
     Then Git Town runs the commands
@@ -83,23 +83,23 @@ Feature: migrate existing configuration in Git metadata to a config file
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
       perennials = ["qa"]
       perennial-regex = "release-.*"
-
+      
       [create]
       new-branch-type = "prototype"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = false
       strategy = "squash-merge"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -83,23 +83,23 @@ Feature: migrate existing configuration in Git metadata to a config file
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
       perennials = ["qa"]
       perennial-regex = "release-.*"
-      
+
       [create]
       new-branch-type = "prototype"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "fork"
-      
+
       [ship]
       delete-tracking-branch = false
       strategy = "squash-merge"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -21,7 +21,7 @@ Feature: Configure a different development remote
       | sync feature strategy       | enter    |
       | sync perennial strategy     | enter    |
       | sync prototype strategy     | enter    |
-      | sync-upstream               | enter    |
+      | sync upstream               | enter    |
       | sync tags                   | enter    |
       | share new branches          | enter    |
       | push hook                   | enter    |

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -22,12 +22,12 @@ Feature: Configure a different development remote
       | sync perennial strategy     | enter    |
       | sync prototype strategy     | enter    |
       | sync-upstream               | enter    |
-      | sync-tags                   | enter    |
-      | share-new-branches          | enter    |
-      | push-hook                   | enter    |
-      | new-branch-type             | enter    |
-      | ship-strategy               | enter    |
-      | ship-delete-tracking-branch | enter    |
+      | sync tags                   | enter    |
+      | share new branches          | enter    |
+      | push hook                   | enter    |
+      | new branch type             | enter    |
+      | ship strategy               | enter    |
+      | ship delete tracking branch | enter    |
       | config storage              | enter    |
 
   Scenario: result

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -38,21 +38,21 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-      
+
       [branches]
       main = "main"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-      
+
       [hosting]
       dev-remote = "fork"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -18,9 +18,9 @@ Feature: Configure a different development remote
       | dev-remote                  | up enter |
       | origin hostname             | enter    |
       | forge type                  | enter    |
-      | sync-feature-strategy       | enter    |
-      | sync-perennial-strategy     | enter    |
-      | sync-prototype-strategy     | enter    |
+      | sync feature strategy       | enter    |
+      | sync perennial strategy     | enter    |
+      | sync prototype strategy     | enter    |
       | sync-upstream               | enter    |
       | sync-tags                   | enter    |
       | share-new-branches          | enter    |

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -28,7 +28,7 @@ Feature: Configure a different development remote
       | new-branch-type             | enter    |
       | ship-strategy               | enter    |
       | ship-delete-tracking-branch | enter    |
-      | save config to config file  | enter    |
+      | config storage              | enter    |
 
   Scenario: result
     Then Git Town runs the commands
@@ -38,21 +38,21 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -60,7 +60,7 @@ Feature: remove existing configuration in Git metadata
       | sync feature strategy       | up enter                                                                    |                     |
       | sync perennial strategy     | down enter                                                                  |                     |
       | sync prototype strategy     | up enter                                                                    |                     |
-      | sync-upstream               | down enter                                                                  |                     |
+      | sync upstream               | down enter                                                                  |                     |
       | sync tags                   | down enter                                                                  |                     |
       | share new branches          | up enter                                                                    | enable              |
       | push hook                   | down enter                                                                  | enable              |

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -61,12 +61,12 @@ Feature: remove existing configuration in Git metadata
       | sync perennial strategy     | down enter                                                                  |                     |
       | sync prototype strategy     | up enter                                                                    |                     |
       | sync-upstream               | down enter                                                                  |                     |
-      | sync-tags                   | down enter                                                                  |                     |
-      | share-new-branches          | up enter                                                                    | enable              |
+      | sync tags                   | down enter                                                                  |                     |
+      | share new branches          | up enter                                                                    | enable              |
       | push hook                   | down enter                                                                  | enable              |
-      | new-branch-type             | up enter                                                                    |                     |
-      | ship-strategy               | down enter                                                                  |                     |
-      | ship-delete-tracking-branch | down enter                                                                  | disable             |
+      | new branch type             | up enter                                                                    |                     |
+      | ship strategy               | down enter                                                                  |                     |
+      | ship delete tracking branch | down enter                                                                  | disable             |
       | config storage              | down enter                                                                  | git metadata        |
 
   Scenario: result

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -57,9 +57,9 @@ Feature: remove existing configuration in Git metadata
       | unknown branch type         | up enter                                                                    |                     |
       | origin hostname             | backspace backspace backspace backspace enter                               | remove the override |
       | forge type                  | up up up up up enter                                                        | remove the override |
-      | sync-feature-strategy       | up enter                                                                    |                     |
-      | sync-perennial-strategy     | down enter                                                                  |                     |
-      | sync-prototype-strategy     | up enter                                                                    |                     |
+      | sync feature strategy       | up enter                                                                    |                     |
+      | sync perennial strategy     | down enter                                                                  |                     |
+      | sync prototype strategy     | up enter                                                                    |                     |
       | sync-upstream               | down enter                                                                  |                     |
       | sync-tags                   | down enter                                                                  |                     |
       | share-new-branches          | up enter                                                                    | enable              |

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -45,29 +45,29 @@ Feature: remove existing configuration in Git metadata
     And local Git setting "git-town.ship-strategy" is "squash-merge"
     And local Git setting "git-town.ship-delete-tracking-branch" is "false"
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG                                  | KEYS                                                                        |
-      | welcome                                 | enter                                                                       |
-      | remove all aliases                      | n enter                                                                     |
-      | keep the already configured main branch | enter                                                                       |
-      | remove the perennial branches           | down space enter                                                            |
-      | remove the perennial regex              | backspace backspace backspace backspace enter                               |
-      | feature regex                           | backspace backspace backspace backspace backspace backspace enter           |
-      | contribution regex                      | backspace backspace backspace backspace backspace backspace backspace enter |
-      | observed regex                          | backspace backspace backspace backspace backspace enter                     |
-      | unknown branch type                     | up enter                                                                    |
-      | remove origin hostname                  | backspace backspace backspace backspace enter                               |
-      | remove forge type override              | up up up up up enter                                                        |
-      | sync-feature-strategy                   | up enter                                                                    |
-      | sync-perennial-strategy                 | down enter                                                                  |
-      | sync-prototype-strategy                 | up enter                                                                    |
-      | sync-upstream                           | down enter                                                                  |
-      | sync-tags                               | down enter                                                                  |
-      | enable share-new-branches               | up enter                                                                    |
-      | enable the push hook                    | down enter                                                                  |
-      | new-branch-type                         | up enter                                                                    |
-      | change ship-strategy                    | down enter                                                                  |
-      | disable ship-delete-tracking-branch     | down enter                                                                  |
-      | save config to Git metadata             | down enter                                                                  |
+      | DIALOG                      | KEYS                                                                        | DESCRIPTION         |
+      | welcome                     | enter                                                                       |                     |
+      | aliases                     | n enter                                                                     | remove all aliases  |
+      | main branch                 | enter                                                                       |                     |
+      | perennial branches          | down space enter                                                            |                     |
+      | perennial regex             | backspace backspace backspace backspace enter                               |                     |
+      | feature regex               | backspace backspace backspace backspace backspace backspace enter           |                     |
+      | contribution regex          | backspace backspace backspace backspace backspace backspace backspace enter |                     |
+      | observed regex              | backspace backspace backspace backspace backspace enter                     |                     |
+      | unknown branch type         | up enter                                                                    |                     |
+      | origin hostname             | backspace backspace backspace backspace enter                               | remove the override |
+      | forge type                  | up up up up up enter                                                        | remove the override |
+      | sync-feature-strategy       | up enter                                                                    |                     |
+      | sync-perennial-strategy     | down enter                                                                  |                     |
+      | sync-prototype-strategy     | up enter                                                                    |                     |
+      | sync-upstream               | down enter                                                                  |                     |
+      | sync-tags                   | down enter                                                                  |                     |
+      | share-new-branches          | up enter                                                                    | enable              |
+      | push hook                   | down enter                                                                  | enable              |
+      | new-branch-type             | up enter                                                                    |                     |
+      | ship-strategy               | down enter                                                                  |                     |
+      | ship-delete-tracking-branch | down enter                                                                  | disable             |
+      | config storage              | down enter                                                                  | git metadata        |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -17,9 +17,9 @@ Feature: remove an existing forge type override
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | up up up up up enter |                                             |
-      | sync-feature-strategy       | enter                |                                             |
-      | sync-perennial-strategy     | enter                |                                             |
-      | sync-prototype-strategy     | enter                |                                             |
+      | sync feature strategy       | enter                |                                             |
+      | sync perennial strategy     | enter                |                                             |
+      | sync prototype strategy     | enter                |                                             |
       | sync-upstream               | enter                |                                             |
       | sync-tags                   | enter                |                                             |
       | share-new-branches          | enter                |                                             |

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -20,7 +20,7 @@ Feature: remove an existing forge type override
       | sync feature strategy       | enter                |                                             |
       | sync perennial strategy     | enter                |                                             |
       | sync prototype strategy     | enter                |                                             |
-      | sync-upstream               | enter                |                                             |
+      | sync upstream               | enter                |                                             |
       | sync tags                   | enter                |                                             |
       | share new branches          | enter                |                                             |
       | push hook                   | enter                |                                             |

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -27,7 +27,7 @@ Feature: remove an existing forge type override
       | new branch type             | enter                |                                             |
       | ship strategy               | enter                |                                             |
       | ship delete tracking branch | enter                |                                             |
-      | save config to Git metadata | down enter           |                                             |
+      | config storage              | down enter           |                                             |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -21,12 +21,12 @@ Feature: remove an existing forge type override
       | sync perennial strategy     | enter                |                                             |
       | sync prototype strategy     | enter                |                                             |
       | sync-upstream               | enter                |                                             |
-      | sync-tags                   | enter                |                                             |
-      | share-new-branches          | enter                |                                             |
-      | push-hook                   | enter                |                                             |
-      | new-branch-type             | enter                |                                             |
-      | ship-strategy               | enter                |                                             |
-      | ship-delete-tracking-branch | enter                |                                             |
+      | sync tags                   | enter                |                                             |
+      | share new branches          | enter                |                                             |
+      | push hook                   | enter                |                                             |
+      | new branch type             | enter                |                                             |
+      | ship strategy               | enter                |                                             |
+      | ship delete tracking branch | enter                |                                             |
       | save config to Git metadata | down enter           |                                             |
 
   Scenario: result

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -17,9 +17,9 @@ Feature: don't ask for perennial branches if no branches that could be perennial
       | unknown branch type         | enter      |                                             |
       | origin hostname             | enter      |                                             |
       | forge type                  | enter      |                                             |
-      | sync-feature-strategy       | enter      |                                             |
-      | sync-perennial-strategy     | enter      |                                             |
-      | sync-prototype-strategy     | enter      |                                             |
+      | sync feature strategy       | enter      |                                             |
+      | sync perennial strategy     | enter      |                                             |
+      | sync prototype strategy     | enter      |                                             |
       | sync-upstream               | enter      |                                             |
       | sync-tags                   | enter      |                                             |
       | share-new-branches          | enter      |                                             |

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -21,12 +21,12 @@ Feature: don't ask for perennial branches if no branches that could be perennial
       | sync perennial strategy     | enter      |                                             |
       | sync prototype strategy     | enter      |                                             |
       | sync-upstream               | enter      |                                             |
-      | sync-tags                   | enter      |                                             |
-      | share-new-branches          | enter      |                                             |
-      | push-hook                   | enter      |                                             |
-      | new-branch-type             | enter      |                                             |
-      | ship-strategy               | enter      |                                             |
-      | ship-delete-tracking-branch | enter      |                                             |
+      | sync tags                   | enter      |                                             |
+      | share new branches          | enter      |                                             |
+      | push hook                   | enter      |                                             |
+      | new branch type             | enter      |                                             |
+      | ship strategy               | enter      |                                             |
+      | ship delete tracking branch | enter      |                                             |
       | save config to Git metadata | down enter |                                             |
 
   Scenario: result

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -27,7 +27,7 @@ Feature: don't ask for perennial branches if no branches that could be perennial
       | new branch type             | enter      |                                             |
       | ship strategy               | enter      |                                             |
       | ship delete tracking branch | enter      |                                             |
-      | save config to Git metadata | down enter |                                             |
+      | config storage              | down enter |                                             |
 
   Scenario: result
     Then the main branch is now "main"

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -20,7 +20,7 @@ Feature: don't ask for perennial branches if no branches that could be perennial
       | sync feature strategy       | enter      |                                             |
       | sync perennial strategy     | enter      |                                             |
       | sync prototype strategy     | enter      |                                             |
-      | sync-upstream               | enter      |                                             |
+      | sync upstream               | enter      |                                             |
       | sync tags                   | enter      |                                             |
       | share new branches          | enter      |                                             |
       | push hook                   | enter      |                                             |

--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: don't ask for information already provided by the config file
 
-  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -48,7 +47,7 @@ Feature: don't ask for information already provided by the config file
       | github connector type | enter             |
       | github token          | 1 2 3 4 5 6 enter |
       | token scope           | enter             |
-      | save config to Git    | down enter        |
+      | config storage        | down enter        |
     Then Git Town runs the commands
       | COMMAND                                  |
       | git config git-town.github-token 123456  |

--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -1,6 +1,7 @@
 @messyoutput
 Feature: don't ask for information already provided by the config file
 
+  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -45,8 +46,8 @@ Feature: don't ask for information already provided by the config file
       | welcome               | enter             |
       | aliases               | enter             |
       | github connector type | enter             |
-      | GitHub token          | 1 2 3 4 5 6 enter |
-      | token scope: local    | enter             |
+      | github token          | 1 2 3 4 5 6 enter |
+      | token scope           | enter             |
       | save config to Git    | down enter        |
     Then Git Town runs the commands
       | COMMAND                                  |

--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -14,40 +14,40 @@ Feature: don't ask for information already provided by the config file
       perennial-regex = "release-"
       perennials = ["staging"]
       unknown-type = "observed"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "propose"
-
+      
       [hosting]
       dev-remote = "something"
       origin-hostname = "github.com"
       forge-type = "github"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
       push-hook = true
       tags = true
       upstream = true
-
+      
       [sync-strategy]
       feature-branches = "rebase"
       prototype-branches = "merge"
       perennial-branches = "ff-only"
       """
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG                     | KEYS              |
-      | welcome                    | enter             |
-      | aliases                    | enter             |
-      | github connector type: API | enter             |
-      | GitHub token               | 1 2 3 4 5 6 enter |
-      | token scope: local         | enter             |
-      | save config to Git         | down enter        |
+      | DIALOG                | KEYS              |
+      | welcome               | enter             |
+      | aliases               | enter             |
+      | github connector type | enter             |
+      | GitHub token          | 1 2 3 4 5 6 enter |
+      | token scope: local    | enter             |
+      | save config to Git    | down enter        |
     Then Git Town runs the commands
       | COMMAND                                  |
       | git config git-town.github-token 123456  |

--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -14,27 +14,27 @@ Feature: don't ask for information already provided by the config file
       perennial-regex = "release-"
       perennials = ["staging"]
       unknown-type = "observed"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "propose"
-      
+
       [hosting]
       dev-remote = "something"
       origin-hostname = "github.com"
       forge-type = "github"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
       push-hook = true
       tags = true
       upstream = true
-      
+
       [sync-strategy]
       feature-branches = "rebase"
       prototype-branches = "merge"

--- a/features/config/setup/unconfigured_with_config_file_and_global_api_token.feature
+++ b/features/config/setup/unconfigured_with_config_file_and_global_api_token.feature
@@ -43,11 +43,11 @@ Feature: don't ask for information already provided by the config file
       perennial-branches = "ff-only"
       """
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG         | KEYS       |
-      | welcome        | enter      |
-      | aliases        | enter      |
-      | GitHub token   | enter      |
-      | config storage | down enter |
+      | DIALOG                | KEYS       |
+      | welcome               | enter      |
+      | aliases               | enter      |
+      | github connector type | enter      |
+      | config storage        | down enter |
     Then Git Town runs no commands
     And there are still no perennial branches
     And local Git setting "git-town.dev-remote" still doesn't exist

--- a/features/config/setup/unconfigured_with_config_file_and_global_api_token.feature
+++ b/features/config/setup/unconfigured_with_config_file_and_global_api_token.feature
@@ -15,39 +15,39 @@ Feature: don't ask for information already provided by the config file
       perennial-regex = "release-"
       perennials = ["staging"]
       unknown-type = "observed"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "propose"
-
+      
       [hosting]
       dev-remote = "something"
       origin-hostname = "github.com"
       forge-type = "github"
       github-connector = "gh"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
       push-hook = true
       tags = true
       upstream = true
-
+      
       [sync-strategy]
       feature-branches = "rebase"
       prototype-branches = "merge"
       perennial-branches = "ff-only"
       """
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG                     | KEYS       |
-      | welcome                    | enter      |
-      | aliases                    | enter      |
-      | GitHub token               | enter      |
-      | save config to config file | down enter |
+      | DIALOG         | KEYS       |
+      | welcome        | enter      |
+      | aliases        | enter      |
+      | GitHub token   | enter      |
+      | config storage | down enter |
     Then Git Town runs no commands
     And there are still no perennial branches
     And local Git setting "git-town.dev-remote" still doesn't exist

--- a/features/config/setup/unconfigured_with_config_file_and_global_api_token.feature
+++ b/features/config/setup/unconfigured_with_config_file_and_global_api_token.feature
@@ -15,28 +15,28 @@ Feature: don't ask for information already provided by the config file
       perennial-regex = "release-"
       perennials = ["staging"]
       unknown-type = "observed"
-      
+
       [create]
       new-branch-type = "feature"
       share-new-branches = "propose"
-      
+
       [hosting]
       dev-remote = "something"
       origin-hostname = "github.com"
       forge-type = "github"
       github-connector = "gh"
-      
+
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-      
+
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
       push-hook = true
       tags = true
       upstream = true
-      
+
       [sync-strategy]
       feature-branches = "rebase"
       prototype-branches = "merge"

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -31,11 +31,11 @@ Feature: ask for information not provided by the config file
       | observed regex          | 4 4 4 enter |
       | unknown branch type     | enter       |
       | github connector type   | enter       |
-      | GitHub token            | 9 9 9 enter |
+      | github token            | 9 9 9 enter |
       | token scope             | enter       |
-      | sync feature branches   | enter       |
-      | sync perennial branches | enter       |
-      | sync prototype branches | enter       |
+      | sync feature strategy   | enter       |
+      | sync perennial strategy | enter       |
+      | sync prototype strategy | enter       |
       | share new branches      | enter       |
       | push hook               | enter       |
       | new branch type         | enter       |

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -32,10 +32,10 @@ Feature: ask for information not provided by the config file
       | unknown branch type     | enter       |
       | github connector type   | enter       |
       | GitHub token            | 9 9 9 enter |
-      | token scope: local      | enter       |
-      | sync-feature-branches   | enter       |
-      | sync-perennial-branches | enter       |
-      | sync-prototype-branches | enter       |
+      | token scope             | enter       |
+      | sync feature branches   | enter       |
+      | sync perennial branches | enter       |
+      | sync prototype branches | enter       |
       | share new branches      | enter       |
       | push hook               | enter       |
       | new branch type         | enter       |

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -8,15 +8,15 @@ Feature: ask for information not provided by the config file
       """
       [branches]
       main = "main"
-      
+
       [hosting]
       dev-remote = "something"
       forge-type = "github"
       origin-hostname = "github.com"
-      
+
       [ship]
       delete-tracking-branch = false
-      
+
       [sync]
       tags = false
       upstream = false

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -8,15 +8,15 @@ Feature: ask for information not provided by the config file
       """
       [branches]
       main = "main"
-
+      
       [hosting]
       dev-remote = "something"
       forge-type = "github"
       origin-hostname = "github.com"
-
+      
       [ship]
       delete-tracking-branch = false
-
+      
       [sync]
       tags = false
       upstream = false
@@ -36,10 +36,10 @@ Feature: ask for information not provided by the config file
       | sync-feature-branches      | enter       |
       | sync-perennial-branches    | enter       |
       | sync-prototype-branches    | enter       |
-      | share-new-branches         | enter       |
-      | push-hook                  | enter       |
-      | new-branch-type            | enter       |
-      | ship-strategy              | enter       |
+      | share new branches         | enter       |
+      | push hook                  | enter       |
+      | new branch type            | enter       |
+      | ship strategy              | enter       |
       | save config to Git         | down enter  |
     Then Git Town runs the commands
       | COMMAND                                            |

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -22,25 +22,25 @@ Feature: ask for information not provided by the config file
       upstream = false
       """
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG                     | KEYS        |
-      | welcome                    | enter       |
-      | aliases                    | enter       |
-      | perennial regex            | 1 1 1 enter |
-      | feature regex              | 2 2 2 enter |
-      | contribution regex         | 3 3 3 enter |
-      | observed regex             | 4 4 4 enter |
-      | unknown branch type        | enter       |
-      | github connector type: API | enter       |
-      | GitHub token               | 9 9 9 enter |
-      | token scope: local         | enter       |
-      | sync-feature-branches      | enter       |
-      | sync-perennial-branches    | enter       |
-      | sync-prototype-branches    | enter       |
-      | share new branches         | enter       |
-      | push hook                  | enter       |
-      | new branch type            | enter       |
-      | ship strategy              | enter       |
-      | save config to Git         | down enter  |
+      | DIALOG                  | KEYS        |
+      | welcome                 | enter       |
+      | aliases                 | enter       |
+      | perennial regex         | 1 1 1 enter |
+      | feature regex           | 2 2 2 enter |
+      | contribution regex      | 3 3 3 enter |
+      | observed regex          | 4 4 4 enter |
+      | unknown branch type     | enter       |
+      | github connector type   | enter       |
+      | GitHub token            | 9 9 9 enter |
+      | token scope: local      | enter       |
+      | sync-feature-branches   | enter       |
+      | sync-perennial-branches | enter       |
+      | sync-prototype-branches | enter       |
+      | share new branches      | enter       |
+      | push hook               | enter       |
+      | new branch type         | enter       |
+      | ship strategy           | enter       |
+      | save config to Git      | down enter  |
     Then Git Town runs the commands
       | COMMAND                                            |
       | git config git-town.github-token 999               |

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -40,7 +40,7 @@ Feature: ask for information not provided by the config file
       | push hook               | enter       |
       | new branch type         | enter       |
       | ship strategy           | enter       |
-      | save config to Git      | down enter  |
+      | config storage          | down enter  |
     Then Git Town runs the commands
       | COMMAND                                            |
       | git config git-town.github-token 999               |

--- a/features/diff_parent/stack/unknown_parent.feature
+++ b/features/diff_parent/stack/unknown_parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent
       | feature | feature | main   | local     |
     And the current branch is "feature"
     When I run "git-town diff-parent" and enter into the dialog:
-      | DIALOG                   | KEYS  |
-      | parent branch of feature | enter |
+      | DIALOG                    | KEYS  |
+      | parent branch for feature | enter |
     Then Git Town runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git diff --merge-base main feature |

--- a/features/diff_parent/stack/unknown_parent.feature
+++ b/features/diff_parent/stack/unknown_parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent
       | feature | feature | main   | local     |
     And the current branch is "feature"
     When I run "git-town diff-parent" and enter into the dialog:
-      | DIALOG                    | KEYS  |
-      | parent branch for feature | enter |
+      | DIALOG                      | KEYS  |
+      | parent branch for "feature" | enter |
     Then Git Town runs the commands
       | BRANCH  | COMMAND                            |
       | feature | git diff --merge-base main feature |

--- a/features/diff_parent/supplied_branch/unknown_parent.feature
+++ b/features/diff_parent/supplied_branch/unknown_parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent
       | feature | feature | main   | local     |
     And the current branch is "main"
     When I run "git-town diff-parent feature" and enter into the dialog:
-      | DIALOG                    | KEYS  |
-      | parent branch for feature | enter |
+      | DIALOG                      | KEYS  |
+      | parent branch for "feature" | enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND                            |
       | main   | git diff --merge-base main feature |

--- a/features/diff_parent/supplied_branch/unknown_parent.feature
+++ b/features/diff_parent/supplied_branch/unknown_parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent
       | feature | feature | main   | local     |
     And the current branch is "main"
     When I run "git-town diff-parent feature" and enter into the dialog:
-      | DIALOG                   | KEYS  |
-      | parent branch of feature | enter |
+      | DIALOG                    | KEYS  |
+      | parent branch for feature | enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND                            |
       | main   | git diff --merge-base main feature |

--- a/features/hack/give_non_existing_branch/beam/beam_and_propose_from_local_branch.feature
+++ b/features/hack/give_non_existing_branch/beam/beam_and_propose_from_local_branch.feature
@@ -19,8 +19,8 @@ Feature: beam commits and uncommitted changes from a local branch onto a new fea
     And an uncommitted file
     And I ran "git add ."
     When I run "git-town hack new --beam --commit --message uncommitted --propose" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/hack/give_non_existing_branch/beam/propose_with_uncommitted_changes.feature
+++ b/features/hack/give_non_existing_branch/beam/propose_with_uncommitted_changes.feature
@@ -19,8 +19,8 @@ Feature: beam a commit and uncommitted changes onto a new feature branch and pro
     And an uncommitted file
     And I ran "git add ."
     When I run "git-town hack new --beam --commit --message uncommitted --propose" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/hack/give_non_existing_branch/beam/select_commits.feature
+++ b/features/hack/give_non_existing_branch/beam/select_commits.feature
@@ -15,8 +15,8 @@ Feature: beam multiple commits onto a new feature branch
       | existing | local    | commit 4    |
     And the current branch is "existing"
     When I run "git-town hack new --beam" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/hack/give_non_existing_branch/beam/with_uncommitted_changes.feature
+++ b/features/hack/give_non_existing_branch/beam/with_uncommitted_changes.feature
@@ -17,7 +17,7 @@ Feature: beam a commit and uncommitted changes onto a new feature branch
     And I ran "git add ."
     When I run "git-town hack new --beam --commit --message uncommitted" and enter into the dialog:
       | DIALOG          | KEYS             |
-      | select commit 2 | down space enter |
+      | commits to beam | down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/merge/lineage/unknown_parent.feature
+++ b/features/merge/lineage/unknown_parent.feature
@@ -6,9 +6,9 @@ Feature: merging with missing lineage
     And I ran "git checkout -b alpha"
     And I ran "git checkout -b beta"
     When I run "git-town merge" and enter into the dialog:
-      | DIALOG                          | KEYS       |
-      | select parent branch for "beta" | down enter |
-      | select parent branch for "beta" | enter      |
+      | DIALOG                  | KEYS       |
+      | parent branch for beta  | down enter |
+      | parent branch for alpha | enter      |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/merge/lineage/unknown_parent.feature
+++ b/features/merge/lineage/unknown_parent.feature
@@ -6,9 +6,9 @@ Feature: merging with missing lineage
     And I ran "git checkout -b alpha"
     And I ran "git checkout -b beta"
     When I run "git-town merge" and enter into the dialog:
-      | DIALOG                  | KEYS       |
-      | parent branch for beta  | down enter |
-      | parent branch for alpha | enter      |
+      | DIALOG                    | KEYS       |
+      | parent branch for "beta"  | down enter |
+      | parent branch for "alpha" | enter      |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/prepend/beam/compress.feature
+++ b/features/prepend/beam/compress.feature
@@ -16,8 +16,8 @@ Feature: prepend a branch to a feature branch using the "compress" sync strategy
     And Git setting "git-town.sync-feature-strategy" is "compress"
     And wait 1 second to ensure new Git timestamps
     When I run "git-town prepend parent --beam" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/prepend/beam/merge.feature
+++ b/features/prepend/beam/merge.feature
@@ -15,8 +15,8 @@ Feature: prepend a branch to a feature branch using the "merge" sync strategy
     And the current branch is "old"
     And Git setting "git-town.sync-feature-strategy" is "merge"
     When I run "git-town prepend parent --beam" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 2 and 4 | down space down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | down space down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/prepend/beam/propose.feature
+++ b/features/prepend/beam/propose.feature
@@ -17,8 +17,8 @@ Feature: propose a newly prepended branch
     And tool "open" is installed
     And a proposal for this branch does not exist
     When I run "git-town prepend new --beam --propose" and enter into the dialog:
-      | DIALOG                    | KEYS             |
-      | select "unrelated commit" | down space enter |
+      | DIALOG          | KEYS             |
+      | commits to beam | down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/prepend/beam/propose_with_title_and_body.feature
+++ b/features/prepend/beam/propose_with_title_and_body.feature
@@ -16,8 +16,8 @@ Feature: propose a newly prepended branch
     And tool "open" is installed
     And a proposal for this branch does not exist
     When I run "git-town prepend new --beam --propose --title='proposal title' --body='proposal body'" and enter into the dialog:
-      | DIALOG                    | KEYS             |
-      | select "unrelated commit" | down space enter |
+      | DIALOG          | KEYS             |
+      | commits to beam | down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/prepend/beam/rebase_different_files.feature
+++ b/features/prepend/beam/rebase_different_files.feature
@@ -15,8 +15,8 @@ Feature: prepend a branch to a feature branch using the "rebase" sync strategy
     And the current branch is "old"
     And Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town prepend parent --beam" and enter into the dialog:
-      | DIALOG                 | KEYS                             |
-      | select commits 1 and 4 | space down down down space enter |
+      | DIALOG          | KEYS                             |
+      | commits to beam | space down down down space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/prepend/beam/rebase_local_branch.feature
+++ b/features/prepend/beam/rebase_local_branch.feature
@@ -15,7 +15,7 @@ Feature: prepend a branch to a local feature branch using the "rebase" sync stra
     And wait 1 second to ensure new Git timestamps
     When I run "git-town prepend parent --beam" and enter into the dialog:
       | DIALOG          | KEYS        |
-      | select commit 1 | space enter |
+      | commits to beam | space enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/prepend/beam/rebase_same_file.feature
+++ b/features/prepend/beam/rebase_same_file.feature
@@ -15,7 +15,7 @@ Feature: prepend a branch to a feature branch using the "rebase" sync strategy
     And Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town prepend parent --beam" and enter into the dialog:
       | DIALOG          | KEYS             |
-      | select commit 2 | down space enter |
+      | commits to beam | down space enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND                                      |
       | old    | git checkout -b parent main                  |

--- a/features/prepend/unknown_lineage/parent.feature
+++ b/features/prepend/unknown_lineage/parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent information
       | old  | (none) | local     |
     And the current branch is "old"
     When I run "git-town prepend new" and enter into the dialog:
-      | DIALOG                | KEYS  |
-      | parent branch for old | enter |
+      | DIALOG                  | KEYS  |
+      | parent branch for "old" | enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND                  |
       | old    | git fetch --prune --tags |

--- a/features/prepend/unknown_lineage/parent.feature
+++ b/features/prepend/unknown_lineage/parent.feature
@@ -8,8 +8,8 @@ Feature: ask for missing parent information
       | old  | (none) | local     |
     And the current branch is "old"
     When I run "git-town prepend new" and enter into the dialog:
-      | DIALOG               | KEYS  |
-      | parent branch of old | enter |
+      | DIALOG                | KEYS  |
+      | parent branch for old | enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND                  |
       | old    | git fetch --prune --tags |

--- a/features/rename/branch_type/overridden_branch_type.feature
+++ b/features/rename/branch_type/overridden_branch_type.feature
@@ -13,8 +13,8 @@ Feature: rename a branch that has an overridden branch type
     And the current branch is "old"
     And Git setting "git-town-branch.old.branchtype" is "feature"
     When I run "git-town rename new" and enter into the dialog:
-      | DIALOG                 | KEYS  |
-      | parent branch of "old" | enter |
+      | DIALOG                  | KEYS  |
+      | parent branch for "old" | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/rename/branch_type/overridden_branch_type.feature
+++ b/features/rename/branch_type/overridden_branch_type.feature
@@ -13,8 +13,8 @@ Feature: rename a branch that has an overridden branch type
     And the current branch is "old"
     And Git setting "git-town-branch.old.branchtype" is "feature"
     When I run "git-town rename new" and enter into the dialog:
-      | DIALOG                | KEYS  |
-      | parent branch for old | enter |
+      | DIALOG                  | KEYS  |
+      | parent branch for "old" | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/rename/branch_type/overridden_branch_type.feature
+++ b/features/rename/branch_type/overridden_branch_type.feature
@@ -13,8 +13,8 @@ Feature: rename a branch that has an overridden branch type
     And the current branch is "old"
     And Git setting "git-town-branch.old.branchtype" is "feature"
     When I run "git-town rename new" and enter into the dialog:
-      | DIALOG                  | KEYS  |
-      | parent branch for "old" | enter |
+      | DIALOG                | KEYS  |
+      | parent branch for old | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/set_parent/branch_type/make_perennial.feature
+++ b/features/set_parent/branch_type/make_perennial.feature
@@ -9,8 +9,8 @@ Feature: make a feature branch perennial
       | child  | feature | parent | local, origin |
     And the current branch is "child"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS       |
-      | parent branch of child | down enter |
+      | DIALOG                  | KEYS       |
+      | parent branch for child | down enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/branch_type/make_perennial.feature
+++ b/features/set_parent/branch_type/make_perennial.feature
@@ -9,8 +9,8 @@ Feature: make a feature branch perennial
       | child  | feature | parent | local, origin |
     And the current branch is "child"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                  | KEYS       |
-      | parent branch for child | down enter |
+      | DIALOG                    | KEYS       |
+      | parent branch for "child" | down enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/dialog/abort.feature
+++ b/features/set_parent/dialog/abort.feature
@@ -9,8 +9,8 @@ Feature: abort the dialog
       | child  | feature | parent | local, origin |
     And the current branch is "child"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                  | KEYS |
-      | parent branch for child | esc  |
+      | DIALOG                    | KEYS |
+      | parent branch for "child" | esc  |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/dialog/abort.feature
+++ b/features/set_parent/dialog/abort.feature
@@ -9,8 +9,8 @@ Feature: abort the dialog
       | child  | feature | parent | local, origin |
     And the current branch is "child"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS |
-      | parent branch of child | esc  |
+      | DIALOG                  | KEYS |
+      | parent branch for child | esc  |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/dialog/enter_parent.feature
+++ b/features/set_parent/dialog/enter_parent.feature
@@ -9,10 +9,9 @@ Feature: select the new parent via a visual dialog
       | branch-2 | feature | main   | local, origin |
     And the current branch is "branch-2"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                  | KEYS       |
-      | parent branch for child | down enter |
+      | DIALOG                     | KEYS       |
+      | parent branch for branch-2 | down enter |
 
-  @debug @this
   Scenario: result
     Then Git Town prints:
       """

--- a/features/set_parent/dialog/enter_parent.feature
+++ b/features/set_parent/dialog/enter_parent.feature
@@ -9,9 +9,10 @@ Feature: select the new parent via a visual dialog
       | branch-2 | feature | main   | local, origin |
     And the current branch is "branch-2"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS       |
-      | parent branch of child | down enter |
+      | DIALOG                  | KEYS       |
+      | parent branch for child | down enter |
 
+  @debug @this
   Scenario: result
     Then Git Town prints:
       """

--- a/features/set_parent/dialog/enter_parent.feature
+++ b/features/set_parent/dialog/enter_parent.feature
@@ -9,8 +9,8 @@ Feature: select the new parent via a visual dialog
       | branch-2 | feature | main   | local, origin |
     And the current branch is "branch-2"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                     | KEYS       |
-      | parent branch for branch-2 | down enter |
+      | DIALOG                       | KEYS       |
+      | parent branch for "branch-2" | down enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/dialog/no_change.feature
+++ b/features/set_parent/dialog/no_change.feature
@@ -9,8 +9,8 @@ Feature: update the parent of a feature branch
       | child  | feature | parent | local, origin |
     And the current branch is "child"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS  |
-      | parent branch of child | enter |
+      | DIALOG                  | KEYS  |
+      | parent branch for child | enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/dialog/no_change.feature
+++ b/features/set_parent/dialog/no_change.feature
@@ -9,8 +9,8 @@ Feature: update the parent of a feature branch
       | child  | feature | parent | local, origin |
     And the current branch is "child"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                  | KEYS  |
-      | parent branch for child | enter |
+      | DIALOG                    | KEYS  |
+      | parent branch for "child" | enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/compress/make_perennial.feature
+++ b/features/set_parent/sync_strategy/compress/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "compress"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                     | KEYS        |
-      | parent branch for branch-2 | up up enter |
+      | DIALOG                       | KEYS        |
+      | parent branch for "branch-2" | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/compress/make_perennial.feature
+++ b/features/set_parent/sync_strategy/compress/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "compress"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                  | KEYS        |
-      | parent branch for child | up up enter |
+      | DIALOG                     | KEYS        |
+      | parent branch for branch-2 | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/compress/make_perennial.feature
+++ b/features/set_parent/sync_strategy/compress/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "compress"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS        |
-      | parent branch of child | up up enter |
+      | DIALOG                  | KEYS        |
+      | parent branch for child | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/merge/make_perennial.feature
+++ b/features/set_parent/sync_strategy/merge/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "merge"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS        |
-      | parent branch of child | up up enter |
+      | DIALOG                  | KEYS        |
+      | parent branch for child | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/merge/make_perennial.feature
+++ b/features/set_parent/sync_strategy/merge/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "merge"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                     | KEYS        |
-      | parent branch for branch-2 | up up enter |
+      | DIALOG                       | KEYS        |
+      | parent branch for "branch-2" | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/merge/make_perennial.feature
+++ b/features/set_parent/sync_strategy/merge/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "merge"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                  | KEYS        |
-      | parent branch for child | up up enter |
+      | DIALOG                     | KEYS        |
+      | parent branch for branch-2 | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/rebase/make_perennial.feature
+++ b/features/set_parent/sync_strategy/rebase/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                 | KEYS        |
-      | parent branch of child | up up enter |
+      | DIALOG                  | KEYS        |
+      | parent branch for child | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/rebase/make_perennial.feature
+++ b/features/set_parent/sync_strategy/rebase/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                     | KEYS        |
-      | parent branch for branch-2 | up up enter |
+      | DIALOG                       | KEYS        |
+      | parent branch for "branch-2" | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/set_parent/sync_strategy/rebase/make_perennial.feature
+++ b/features/set_parent/sync_strategy/rebase/make_perennial.feature
@@ -24,8 +24,8 @@ Feature: remove a branch from a stack
     And the current branch is "branch-2"
     And local Git setting "git-town.sync-feature-strategy" is "rebase"
     When I run "git-town set-parent" and enter into the dialog:
-      | DIALOG                  | KEYS        |
-      | parent branch for child | up up enter |
+      | DIALOG                     | KEYS        |
+      | parent branch for branch-2 | up up enter |
 
   Scenario: result
     Then Git Town prints:

--- a/features/ship/squash_merge/current_branch/other_authors/multiple_authors.feature
+++ b/features/ship/squash_merge/current_branch/other_authors/multiple_authors.feature
@@ -1,5 +1,4 @@
-@messyoutput
-@skipWindows
+@messyoutput @skipWindows
 Feature: ship a coworker's feature branch
 
   Background:
@@ -17,8 +16,8 @@ Feature: ship a coworker's feature branch
 
   Scenario: choose myself as the author
     When I run "git-town ship -m 'feature done'" and enter into the dialog:
-      | DIALOG                              | KEYS  |
-      | choose author for the squash commit | enter |
+      | DIALOG               | KEYS  |
+      | squash commit author | enter |
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE      | AUTHOR                            |
       | main   | local, origin | feature done | developer <developer@example.com> |
@@ -26,8 +25,8 @@ Feature: ship a coworker's feature branch
 
   Scenario: choose a coworker as the author
     When I run "git-town ship -m 'feature done'" and enter into the dialog:
-      | DIALOG                              | KEYS       |
-      | choose author for the squash commit | down enter |
+      | DIALOG               | KEYS       |
+      | squash commit author | down enter |
     And these commits exist now
       | BRANCH | LOCATION      | MESSAGE      | AUTHOR                          |
       | main   | local, origin | feature done | coworker <coworker@example.com> |
@@ -35,8 +34,8 @@ Feature: ship a coworker's feature branch
 
   Scenario: undo
     Given I ran "git-town ship -m 'feature done'" and enter into the dialog:
-      | DIALOG                              | KEYS  |
-      | choose author for the squash commit | enter |
+      | DIALOG               | KEYS  |
+      | squash commit author | enter |
     When I run "git-town undo"
     Then Git Town runs the commands
       | BRANCH | COMMAND                                        |

--- a/features/switch/abort/abort.feature
+++ b/features/switch/abort/abort.feature
@@ -9,6 +9,6 @@ Feature: switch branches
       | beta  | feature | main   | local, origin |
     And the current branch is "alpha"
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS     |
-      | down esc |
+      | DIALOG      | KEYS     |
+      | branch-tree | down esc |
     Then Git Town runs no commands

--- a/features/switch/all_flag/all_flag.feature
+++ b/features/switch/all_flag/all_flag.feature
@@ -11,8 +11,8 @@ Feature: switch to a new remote branch
     And the current branch is "local-2"
     And I ran "git fetch"
     When I run "git-town switch <FLAG>" and enter into the dialogs:
-      | KEYS            |
-      | down down enter |
+      | DIALOG      | KEYS            |
+      | branch-tree | down down enter |
     Then Git Town runs the commands
       | BRANCH  | COMMAND               |
       | local-2 | git checkout remote-1 |

--- a/features/switch/color.ui/always.feature
+++ b/features/switch/color.ui/always.feature
@@ -10,8 +10,8 @@ Feature: switch branches
     And the current branch is "alpha"
     And local Git setting "color.ui" is "always"
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND           |
       | alpha  | git checkout beta |

--- a/features/switch/happy_path.feature
+++ b/features/switch/happy_path.feature
@@ -9,8 +9,8 @@ Feature: switch branches
       | beta  | feature | main   | local, origin |
     And the current branch is "alpha"
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND           |
       | alpha  | git checkout beta |

--- a/features/switch/headless.feature
+++ b/features/switch/headless.feature
@@ -13,8 +13,8 @@ Feature: switch branches from detached head
     And the current branch is "alpha"
     And I ran "git checkout HEAD^"
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS     |
-      | up enter |
+      | DIALOG      | KEYS     |
+      | branch-tree | up enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/switch/merge_flag/merge_flag.feature
+++ b/features/switch/merge_flag/merge_flag.feature
@@ -12,8 +12,8 @@ Feature: switch branches using the "merge" flag
       | other  | local    | other commit |
     And the current branch is "current"
     When I run "git-town switch <FLAG>" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH  | COMMAND               |
       | current | git checkout other -m |

--- a/features/switch/missing_branches/manually_deleted_branch.feature
+++ b/features/switch/missing_branches/manually_deleted_branch.feature
@@ -11,8 +11,8 @@ Feature: switch branches while a manually deleted branch is still listed in the 
     And the current branch is "alpha"
     And I run "git branch -D beta"
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND            |
       | alpha  | git checkout gamma |

--- a/features/switch/missing_metadata/lineage.feature
+++ b/features/switch/missing_metadata/lineage.feature
@@ -9,8 +9,8 @@ Feature: switch branches that have no lineage information
       | beta  | (none) | local     |
     And the current branch is "alpha"
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND           |
       | alpha  | git checkout beta |

--- a/features/switch/regex_args/multiple_regex.feature
+++ b/features/switch/regex_args/multiple_regex.feature
@@ -11,8 +11,8 @@ Feature: switch to branches described by several regexes
       | beta    | feature | main   | local     |
     And the current branch is "alpha"
     When I run "git-town switch ^al main" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND           |
       | alpha  | git checkout main |

--- a/features/switch/regex_args/single_regex.feature
+++ b/features/switch/regex_args/single_regex.feature
@@ -11,8 +11,8 @@ Feature: switch to branches described by a regex
       | beta    | feature | main   | local     |
     And the current branch is "alpha"
     When I run "git-town switch ^al" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND            |
       | alpha  | git checkout aloha |

--- a/features/switch/stay_on_branch/stay_on_branch.feature
+++ b/features/switch/stay_on_branch/stay_on_branch.feature
@@ -9,6 +9,6 @@ Feature: stay on the same branch
       | beta  | feature | main   | local, origin |
     And the current branch is "alpha"
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS  |
-      | enter |
+      | DIALOG      | KEYS  |
+      | branch-tree | enter |
     Then Git Town runs no commands

--- a/features/switch/type_flag/multiple_types.feature
+++ b/features/switch/type_flag/multiple_types.feature
@@ -16,24 +16,24 @@ Feature: switch branches using multiple types
 
   Scenario: long form
     When I run "git-town switch --type=observed+prototype" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH     | COMMAND                |
       | observed-2 | git checkout prototype |
 
   Scenario: short form
     When I run "git-town switch -to+pr" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH     | COMMAND                |
       | observed-2 | git checkout prototype |
 
   Scenario: undo
     Given I ran "git-town switch -to+pr" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     When I run "git-town undo"
     Then Git Town runs no commands
     And the initial branches and lineage exist now

--- a/features/switch/type_flag/single_type.feature
+++ b/features/switch/type_flag/single_type.feature
@@ -16,24 +16,24 @@ Feature: switch branches of a single type
 
   Scenario: long form
     When I run "git-town switch --type=observed" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH     | COMMAND                 |
       | observed-2 | git checkout observed-1 |
 
   Scenario: short form
     When I run "git-town switch -to" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH     | COMMAND                 |
       | observed-2 | git checkout observed-1 |
 
   Scenario: undo
     Given I ran "git-town switch -to" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     When I run "git-town undo"
     Then Git Town runs no commands
     And the initial branches and lineage exist now

--- a/features/switch/uncommitted_changes/uncommitted_changes.feature
+++ b/features/switch/uncommitted_changes/uncommitted_changes.feature
@@ -13,8 +13,8 @@ Feature: switch to another branch with uncommitted changes
     And the current branch is "alpha"
     And an uncommitted file
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/switch/worktree/branches_in_other_worktree.feature
+++ b/features/switch/worktree/branches_in_other_worktree.feature
@@ -11,8 +11,8 @@ Feature: switch branches
     And the current branch is "alpha"
     And branch "beta" is active in another worktree
     When I run "git-town switch" and enter into the dialogs:
-      | KEYS       |
-      | down enter |
+      | DIALOG      | KEYS       |
+      | branch-tree | down enter |
     Then Git Town runs the commands
       | BRANCH | COMMAND            |
       | alpha  | git checkout gamma |

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
@@ -13,8 +13,8 @@ Feature: sync the current branch which has a branch-type override
     And the current branch is "contribution"
     And I ran "git-town hack"
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                           | KEYS  |
-      | parent branch for "contribution" | enter |
+      | DIALOG                         | KEYS  |
+      | parent branch for contribution | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
@@ -13,8 +13,8 @@ Feature: sync the current branch which has a branch-type override
     And the current branch is "contribution"
     And I ran "git-town hack"
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                         | KEYS  |
-      | parent branch for contribution | enter |
+      | DIALOG                           | KEYS  |
+      | parent branch for "contribution" | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/overridden_branch_type/overridden_branch_type.feature
@@ -13,8 +13,8 @@ Feature: sync the current branch which has a branch-type override
     And the current branch is "contribution"
     And I ran "git-town hack"
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                          | KEYS  |
-      | parent branch of "contribution" | enter |
+      | DIALOG                           | KEYS  |
+      | parent branch for "contribution" | enter |
 
   Scenario: result
     Then Git Town runs the commands

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_vs_tracking_branch.feature
@@ -35,8 +35,8 @@ Feature: handle conflicts between the current feature branch and its tracking br
   @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG            | KEYS    |
-      | choose what to do | 3 enter |
+      | DIALOG              | KEYS    |
+      | unfinished runstate | 3 enter |
     Then Git Town prints:
       """
       Handle unfinished command: undo

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/with/conflict_feature_branch_with_update_vs_main_branch.feature
@@ -44,8 +44,8 @@ Feature: handle conflicts between the current feature branch and the main branch
   @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG            | KEYS    |
-      | choose what to do | 3 enter |
+      | DIALOG              | KEYS    |
+      | unfinished runstate | 3 enter |
     Then Git Town prints:
       """
       Handle unfinished command: undo

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_feature_vs_main.feature
@@ -41,8 +41,8 @@ Feature: handle conflicts between the current feature branch and the main branch
   @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG            | KEYS    |
-      | choose what to do | 3 enter |
+      | DIALOG              | KEYS    |
+      | unfinished runstate | 3 enter |
     Then Git Town prints:
       """
       Handle unfinished command: undo

--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -36,8 +36,8 @@ Feature: handle conflicts between the main branch and its tracking branch
   @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG            | KEYS    |
-      | choose what to do | 2 enter |
+      | DIALOG              | KEYS    |
+      | unfinished runstate | 2 enter |
     Then Git Town prints:
       """
       Handle unfinished command: undo

--- a/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
+++ b/features/sync/current_branch/feature_branch/rebase_sync_strategy/tracking_branch/without/conflict_main_local_vs_main_tracking.feature
@@ -37,8 +37,8 @@ Feature: handle conflicts between the main branch and its tracking branch
   @messyoutput
   Scenario: undo through another sync invocation
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG            | KEYS    |
-      | choose what to do | 2 enter |
+      | DIALOG              | KEYS    |
+      | unfinished runstate | 2 enter |
     Then Git Town prints:
       """
       Handle unfinished command: undo

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -11,17 +11,17 @@ Feature: enter a parent branch name when prompted
 
   Scenario: choose the default branch name
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                 | KEYS  |
-      | parent branch for beta | enter |
+      | DIALOG                   | KEYS  |
+      | parent branch for "beta" | enter |
     Then this lineage exists now
       | BRANCH | PARENT |
       | beta   | main   |
 
   Scenario: choose other branches
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                  | KEYS       |
-      | parent branch for beta  | down enter |
-      | parent branch for alpha | enter      |
+      | DIALOG                    | KEYS       |
+      | parent branch for "beta"  | down enter |
+      | parent branch for "alpha" | enter      |
     And this lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |
@@ -29,15 +29,15 @@ Feature: enter a parent branch name when prompted
 
   Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                 | KEYS     |
-      | parent branch for beta | up enter |
+      | DIALOG                   | KEYS     |
+      | parent branch for "beta" | up enter |
     Then the perennial branches are now "beta"
 
   Scenario: enter the parent for several branches
     When I run "git-town sync --all" and enter into the dialog:
-      | DIALOG                  | KEYS  |
-      | parent branch for beta  | enter |
-      | parent branch for alpha | enter |
+      | DIALOG                    | KEYS  |
+      | parent branch for "beta"  | enter |
+      | parent branch for "alpha" | enter |
     Then this lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -36,8 +36,8 @@ Feature: enter a parent branch name when prompted
   Scenario: enter the parent for several branches
     When I run "git-town sync --all" and enter into the dialog:
       | DIALOG                  | KEYS  |
-      | parent branch for alpha | enter |
       | parent branch for beta  | enter |
+      | parent branch for alpha | enter |
     Then this lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |

--- a/features/sync/features/unknown_parent_branch.feature
+++ b/features/sync/features/unknown_parent_branch.feature
@@ -11,17 +11,17 @@ Feature: enter a parent branch name when prompted
 
   Scenario: choose the default branch name
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                | KEYS  |
-      | parent branch of beta | enter |
+      | DIALOG                 | KEYS  |
+      | parent branch for beta | enter |
     Then this lineage exists now
       | BRANCH | PARENT |
       | beta   | main   |
 
   Scenario: choose other branches
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                 | KEYS       |
-      | parent branch of beta  | down enter |
-      | parent branch of alpha | enter      |
+      | DIALOG                  | KEYS       |
+      | parent branch for beta  | down enter |
+      | parent branch for alpha | enter      |
     And this lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |
@@ -29,15 +29,15 @@ Feature: enter a parent branch name when prompted
 
   Scenario: choose "<none> (make a perennial branch)"
     When I run "git-town sync" and enter into the dialog:
-      | DIALOG                | KEYS     |
-      | parent branch of beta | up enter |
+      | DIALOG                 | KEYS     |
+      | parent branch for beta | up enter |
     Then the perennial branches are now "beta"
 
   Scenario: enter the parent for several branches
     When I run "git-town sync --all" and enter into the dialog:
-      | DIALOG                 | KEYS  |
-      | parent branch of alpha | enter |
-      | parent branch of beta  | enter |
+      | DIALOG                  | KEYS  |
+      | parent branch for alpha | enter |
+      | parent branch for beta  | enter |
     Then this lineage exists now
       | BRANCH | PARENT |
       | alpha  | main   |

--- a/internal/cli/dialog/aliases.go
+++ b/internal/cli/dialog/aliases.go
@@ -39,7 +39,7 @@ func Aliases(allAliasableCommands configdomain.AliasableCommands, existingAliase
 		OriginalAliases:      existingAliases,
 		selectedColor:        colors.Green(),
 	})
-	dialogcomponents.SendInputs(inputs.Next(), program)
+	dialogcomponents.SendInputs("aliases", inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(AliasesModel)
 	if err != nil || result.Aborted() {

--- a/internal/cli/dialog/bitbucket_app_password.go
+++ b/internal/cli/dialog/bitbucket_app_password.go
@@ -30,6 +30,7 @@ Git Town will not use the Bitbucket API.
 // BitbucketAppPassword lets the user enter the Bitbucket API token.
 func BitbucketAppPassword(oldValue Option[forgedomain.BitbucketAppPassword], inputs dialogcomponents.TestInputs) (Option[forgedomain.BitbucketAppPassword], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "bitbucket-app-password",
 		ExistingValue: oldValue.String(),
 		Help:          bitbucketAppPasswordHelp,
 		Prompt:        "Bitbucket App Password/Token: ",

--- a/internal/cli/dialog/bitbucket_username.go
+++ b/internal/cli/dialog/bitbucket_username.go
@@ -26,6 +26,7 @@ Git Town will not use the Bitbucket API.
 
 func BitbucketUsername(oldValue Option[forgedomain.BitbucketUsername], inputs dialogcomponents.TestInputs) (Option[forgedomain.BitbucketUsername], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "bitbucket-username",
 		ExistingValue: oldValue.String(),
 		Help:          bitbucketUsernameHelp,
 		Prompt:        "Your Bitbucket username: ",

--- a/internal/cli/dialog/codeberg_token.go
+++ b/internal/cli/dialog/codeberg_token.go
@@ -28,6 +28,7 @@ Git Town will not use the codeberg API.
 // CodebergToken lets the user enter the Gitea API token.
 func CodebergToken(oldValue Option[forgedomain.CodebergToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.CodebergToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "codeberg-token",
 		ExistingValue: oldValue.String(),
 		Help:          codebergTokenHelp,
 		Prompt:        "Your Codeberg API token: ",

--- a/internal/cli/dialog/commits_to_beam.go
+++ b/internal/cli/dialog/commits_to_beam.go
@@ -30,7 +30,7 @@ func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranc
 			Text: fmt.Sprintf("%s %s", shortSHA, commit.Message.String()),
 		}
 	}
-	selection, exit, err := dialogcomponents.CheckList(entries, []int{}, fmt.Sprintf(commitsToBeamTitle, targetBranch), "", inputs)
+	selection, exit, err := dialogcomponents.CheckList(entries, []int{}, fmt.Sprintf(commitsToBeamTitle, targetBranch), "", inputs, "commits to beam")
 	fmt.Printf(messages.CommitsSelected, len(selection))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/commits_to_beam.go
+++ b/internal/cli/dialog/commits_to_beam.go
@@ -30,7 +30,7 @@ func CommitsToBeam(commits []gitdomain.Commit, targetBranch gitdomain.LocalBranc
 			Text: fmt.Sprintf("%s %s", shortSHA, commit.Message.String()),
 		}
 	}
-	selection, exit, err := dialogcomponents.CheckList(entries, []int{}, fmt.Sprintf(commitsToBeamTitle, targetBranch), "", inputs, "commits to beam")
+	selection, exit, err := dialogcomponents.CheckList(entries, []int{}, fmt.Sprintf(commitsToBeamTitle, targetBranch), "", inputs, "commits-to-beam")
 	fmt.Printf(messages.CommitsSelected, len(selection))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/config_storage.go
+++ b/internal/cli/dialog/config_storage.go
@@ -37,7 +37,7 @@ func ConfigStorage(inputs dialogcomponents.TestInputs) (ConfigStorageOption, dia
 		ConfigStorageOptionFile,
 		ConfigStorageOptionGit,
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, configStorageTitle, configStorageHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, configStorageTitle, configStorageHelp, inputs, "config storage")
 	fmt.Printf(messages.ConfigStorage, dialogcomponents.FormattedSelection(selection.Short(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/config_storage.go
+++ b/internal/cli/dialog/config_storage.go
@@ -37,7 +37,7 @@ func ConfigStorage(inputs dialogcomponents.TestInputs) (ConfigStorageOption, dia
 		ConfigStorageOptionFile,
 		ConfigStorageOptionGit,
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, configStorageTitle, configStorageHelp, inputs, "config storage")
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, configStorageTitle, configStorageHelp, inputs, "config-storage")
 	fmt.Printf(messages.ConfigStorage, dialogcomponents.FormattedSelection(selection.Short(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/contribution_regex.go
+++ b/internal/cli/dialog/contribution_regex.go
@@ -24,6 +24,7 @@ is set to something other than "contribution".
 
 func ContributionRegex(existingValue Option[configdomain.ContributionRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.ContributionRegex], dialogdomain.Exit, error) {
 	value, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "contribution-regex",
 		ExistingValue: existingValue.String(),
 		Help:          contributionRegexHelp,
 		Prompt:        "Contribution regex: ",

--- a/internal/cli/dialog/credentials_no_access.go
+++ b/internal/cli/dialog/credentials_no_access.go
@@ -25,7 +25,7 @@ func CredentialsNoAccess(connectorError error, inputs dialogcomponents.TestInput
 		CredentialsNoAccessChoiceRetry,
 		CredentialsNoAccessChoiceIgnore,
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoAccessTitle, fmt.Sprintf(credentialsNoAccessHelp, connectorError), inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoAccessTitle, fmt.Sprintf(credentialsNoAccessHelp, connectorError), inputs, "credentials no API access")
 	fmt.Printf(messages.CredentialsNoAccess, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection.Repeat(), exit, err
 }

--- a/internal/cli/dialog/credentials_no_access.go
+++ b/internal/cli/dialog/credentials_no_access.go
@@ -25,7 +25,7 @@ func CredentialsNoAccess(connectorError error, inputs dialogcomponents.TestInput
 		CredentialsNoAccessChoiceRetry,
 		CredentialsNoAccessChoiceIgnore,
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoAccessTitle, fmt.Sprintf(credentialsNoAccessHelp, connectorError), inputs, "credentials no API access")
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoAccessTitle, fmt.Sprintf(credentialsNoAccessHelp, connectorError), inputs, "credentials-no-access-to-api")
 	fmt.Printf(messages.CredentialsNoAccess, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection.Repeat(), exit, err
 }

--- a/internal/cli/dialog/credentials_no_proposal_access.go
+++ b/internal/cli/dialog/credentials_no_proposal_access.go
@@ -25,7 +25,7 @@ func CredentialsNoProposalAccess(connectorError error, inputs dialogcomponents.T
 		CredentialsNoAccessChoiceRetry,
 		CredentialsNoAccessChoiceIgnore,
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoProposalAccessTitle, fmt.Sprintf(credentialsNoProposalAccessHelp, connectorError), inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoProposalAccessTitle, fmt.Sprintf(credentialsNoProposalAccessHelp, connectorError), inputs, "credentials no access to proposals")
 	fmt.Printf(messages.CredentialsNoAccess, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection.Repeat(), exit, err
 }

--- a/internal/cli/dialog/credentials_no_proposal_access.go
+++ b/internal/cli/dialog/credentials_no_proposal_access.go
@@ -25,7 +25,7 @@ func CredentialsNoProposalAccess(connectorError error, inputs dialogcomponents.T
 		CredentialsNoAccessChoiceRetry,
 		CredentialsNoAccessChoiceIgnore,
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoProposalAccessTitle, fmt.Sprintf(credentialsNoProposalAccessHelp, connectorError), inputs, "credentials no access to proposals")
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, credentialsNoProposalAccessTitle, fmt.Sprintf(credentialsNoProposalAccessHelp, connectorError), inputs, "credentials-no-access-to-proposal")
 	fmt.Printf(messages.CredentialsNoAccess, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection.Repeat(), exit, err
 }

--- a/internal/cli/dialog/dev_remote.go
+++ b/internal/cli/dialog/dev_remote.go
@@ -24,7 +24,7 @@ Typically that's the "origin" remote.
 
 func DevRemote(existingValue gitdomain.Remote, options gitdomain.Remotes, inputs dialogcomponents.TestInputs) (gitdomain.Remote, dialogdomain.Exit, error) {
 	cursor := slice.Index(options, existingValue).GetOrElse(0)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, DevRemoteTypeTitle, DevRemoteHelp, inputs, "dev remote")
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, DevRemoteTypeTitle, DevRemoteHelp, inputs, "dev-remote")
 	fmt.Printf(messages.DevRemote, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/dev_remote.go
+++ b/internal/cli/dialog/dev_remote.go
@@ -24,7 +24,7 @@ Typically that's the "origin" remote.
 
 func DevRemote(existingValue gitdomain.Remote, options gitdomain.Remotes, inputs dialogcomponents.TestInputs) (gitdomain.Remote, dialogdomain.Exit, error) {
 	cursor := slice.Index(options, existingValue).GetOrElse(0)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, DevRemoteTypeTitle, DevRemoteHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, DevRemoteTypeTitle, DevRemoteHelp, inputs, "dev remote")
 	fmt.Printf(messages.DevRemote, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/dialogcomponents/checklist.go
+++ b/internal/cli/dialog/dialogcomponents/checklist.go
@@ -11,7 +11,7 @@ import (
 )
 
 // lets the user select zero, one, or many of the given entries
-func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInputs) (selected []S, exit dialogdomain.Exit, err error) {
+func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInputs, dialogName string) (selected []S, exit dialogdomain.Exit, err error) {
 	cursor := entries.FirstEnabled()
 	program := tea.NewProgram(CheckListModel[S]{
 		List:       list.NewList(entries, cursor),
@@ -19,7 +19,7 @@ func CheckList[S comparable](entries list.Entries[S], selections []int, title, h
 		help:       help,
 		title:      title,
 	})
-	SendInputs(inputs.Next(), program)
+	SendInputs(dialogName, inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(CheckListModel[S])
 	return result.CheckedEntries(), result.Aborted(), err

--- a/internal/cli/dialog/dialogcomponents/radiolist.go
+++ b/internal/cli/dialog/dialogcomponents/radiolist.go
@@ -13,13 +13,13 @@ import (
 const WindowSize = 9
 
 // RadioList lets the user select one of the given entries.
-func RadioList[S comparable](entries list.Entries[S], cursor int, title, help string, inputs TestInputs) (selected S, exit dialogdomain.Exit, err error) { //nolint:ireturn
+func RadioList[S comparable](entries list.Entries[S], cursor int, title, help string, inputs TestInputs, dialogName string) (selected S, exit dialogdomain.Exit, err error) { //nolint:ireturn
 	program := tea.NewProgram(radioListModel[S]{
 		List:  list.NewList(entries, cursor),
 		help:  help,
 		title: title,
 	})
-	SendInputs(inputs.Next(), program)
+	SendInputs(dialogName, inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(radioListModel[S])
 	return result.SelectedData(), result.Aborted(), err

--- a/internal/cli/dialog/dialogcomponents/send_inputs.go
+++ b/internal/cli/dialog/dialogcomponents/send_inputs.go
@@ -6,7 +6,7 @@ import (
 )
 
 // SendInputs sends the given keystrokes to the given bubbletea program.
-func SendInputs(input Option[TestInput], program *tea.Program) {
+func SendInputs(stepName string, input Option[TestInput], program *tea.Program) {
 	if input, has := input.Get(); has {
 		go func() {
 			for _, msg := range input.Messages {

--- a/internal/cli/dialog/dialogcomponents/send_inputs.go
+++ b/internal/cli/dialog/dialogcomponents/send_inputs.go
@@ -11,7 +11,7 @@ import (
 func SendInputs(stepName string, input Option[TestInput], program *tea.Program) {
 	if input, has := input.Get(); has {
 		if stepName != input.StepName {
-			panic(fmt.Sprintf("mismatching dialog names: want %q but have %q", input.StepName, stepName))
+			panic(fmt.Sprintf("mismatching dialog names: want %q but have %q", stepName, input.StepName))
 		}
 		go func() {
 			for _, msg := range input.Messages {

--- a/internal/cli/dialog/dialogcomponents/send_inputs.go
+++ b/internal/cli/dialog/dialogcomponents/send_inputs.go
@@ -1,6 +1,8 @@
 package dialogcomponents
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
@@ -8,6 +10,9 @@ import (
 // SendInputs sends the given keystrokes to the given bubbletea program.
 func SendInputs(stepName string, input Option[TestInput], program *tea.Program) {
 	if input, has := input.Get(); has {
+		if stepName != input.StepName {
+			panic(fmt.Sprintf("mismatching dialog names: want %q but have %q", input.StepName, stepName))
+		}
 		go func() {
 			for _, msg := range input.Messages {
 				program.Send(msg)

--- a/internal/cli/dialog/dialogcomponents/test_input.go
+++ b/internal/cli/dialog/dialogcomponents/test_input.go
@@ -20,8 +20,8 @@ type TestInput struct {
 // into the format understood by Git Town's dialogs.
 func ParseTestInput(envData string) TestInput {
 	messages := []tea.Msg{}
-	stepName, keys, ok := strings.Cut(envData, "@")
-	if !ok {
+	stepName, keys, has := strings.Cut(envData, "@")
+	if !has {
 		panic(fmt.Sprintf("found test input without step name: %q", envData))
 	}
 	for _, input := range strings.Split(keys, "|") {

--- a/internal/cli/dialog/dialogcomponents/test_input.go
+++ b/internal/cli/dialog/dialogcomponents/test_input.go
@@ -20,7 +20,7 @@ type TestInput struct {
 // into the format understood by Git Town's dialogs.
 func ParseTestInput(envData string) TestInput {
 	messages := []tea.Msg{}
-	stepName, keys, ok := strings.Cut(envData, "|")
+	stepName, keys, ok := strings.Cut(envData, "@")
 	if !ok {
 		panic(fmt.Sprintf("found test input without step name: %q", envData))
 	}

--- a/internal/cli/dialog/dialogcomponents/test_input.go
+++ b/internal/cli/dialog/dialogcomponents/test_input.go
@@ -29,10 +29,7 @@ func ParseTestInput(envData string) TestInput {
 			messages = append(messages, recognizeTestInput(input))
 		}
 	}
-	return TestInput{
-		Messages: messages,
-		StepName: stepName,
-	}
+	return TestInput{messages, stepName}
 }
 
 // recognizeTestInput provides the matching BubbleTea message for the given string.

--- a/internal/cli/dialog/dialogcomponents/test_input.go
+++ b/internal/cli/dialog/dialogcomponents/test_input.go
@@ -29,7 +29,10 @@ func ParseTestInput(envData string) TestInput {
 			messages = append(messages, recognizeTestInput(input))
 		}
 	}
-	return TestInput{messages, stepName}
+	return TestInput{
+		Messages: messages,
+		StepName: stepName,
+	}
 }
 
 // recognizeTestInput provides the matching BubbleTea message for the given string.

--- a/internal/cli/dialog/dialogcomponents/test_input_test.go
+++ b/internal/cli/dialog/dialogcomponents/test_input_test.go
@@ -15,7 +15,7 @@ func TestTestInput(t *testing.T) {
 		t.Parallel()
 		t.Run("multiple values", func(t *testing.T) {
 			t.Parallel()
-			have := dialogcomponents.ParseTestInput("enter|space|ctrl+c")
+			have := dialogcomponents.ParseTestInput("step@enter|space|ctrl+c")
 			want := dialogcomponents.TestInput{
 				Messages: []tea.Msg{
 					tea.KeyMsg{
@@ -28,26 +28,29 @@ func TestTestInput(t *testing.T) {
 						Type: tea.KeyCtrlC,
 					},
 				},
+				StepName: "step",
 			}
 			must.Eq(t, want, have)
 		})
 		t.Run("single value", func(t *testing.T) {
 			t.Parallel()
-			have := dialogcomponents.ParseTestInput("enter")
+			have := dialogcomponents.ParseTestInput("step@enter")
 			want := dialogcomponents.TestInput{
 				Messages: []tea.Msg{
 					tea.KeyMsg{
 						Type: tea.KeyEnter,
 					},
 				},
+				StepName: "step",
 			}
 			must.Eq(t, want, have)
 		})
 		t.Run("empty", func(t *testing.T) {
 			t.Parallel()
-			have := dialogcomponents.ParseTestInput("")
+			have := dialogcomponents.ParseTestInput("step@")
 			want := dialogcomponents.TestInput{
 				Messages: []tea.Msg{},
+				StepName: "step",
 			}
 			must.Eq(t, want, have)
 		})

--- a/internal/cli/dialog/dialogcomponents/test_inputs_test.go
+++ b/internal/cli/dialog/dialogcomponents/test_inputs_test.go
@@ -16,9 +16,9 @@ func TestTestInputs(t *testing.T) {
 		t.Parallel()
 		env := []string{
 			"foo=bar",
-			"GITTOWN_DIALOG_INPUT_1=enter",
-			"GITTOWN_DIALOG_INPUT_2=space|down|space|5|enter",
-			"GITTOWN_DIALOG_INPUT_3=ctrl+c",
+			"GITTOWN_DIALOG_INPUT_1=welcome@enter",
+			"GITTOWN_DIALOG_INPUT_2=perennial-branches@space|down|space|5|enter",
+			"GITTOWN_DIALOG_INPUT_3=perennial-regex@ctrl+c",
 		}
 		have := dialogcomponents.LoadTestInputs(env)
 		want := dialogcomponents.NewTestInputs(
@@ -26,6 +26,7 @@ func TestTestInputs(t *testing.T) {
 				Messages: []tea.Msg{
 					tea.KeyMsg{Type: tea.KeyEnter},
 				},
+				StepName: "welcome",
 			},
 			dialogcomponents.TestInput{
 				Messages: []tea.Msg{
@@ -35,11 +36,13 @@ func TestTestInputs(t *testing.T) {
 					tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}},
 					tea.KeyMsg{Type: tea.KeyEnter},
 				},
+				StepName: "perennial-branches",
 			},
 			dialogcomponents.TestInput{
 				Messages: []tea.Msg{
 					tea.KeyMsg{Type: tea.KeyCtrlC},
 				},
+				StepName: "perennial-regex",
 			},
 		)
 		must.Eq(t, want, have)

--- a/internal/cli/dialog/dialogcomponents/text_display.go
+++ b/internal/cli/dialog/dialogcomponents/text_display.go
@@ -9,7 +9,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
 )
 
-func TextDisplay(title, text string, inputs TestInputs) (dialogdomain.Exit, error) {
+func TextDisplay(title, text string, inputs TestInputs, dialogName string) (dialogdomain.Exit, error) {
 	model := textDisplayModel{
 		colors: colors.NewDialogColors(),
 		status: list.StatusActive,
@@ -17,7 +17,7 @@ func TextDisplay(title, text string, inputs TestInputs) (dialogdomain.Exit, erro
 		title:  title,
 	}
 	program := tea.NewProgram(model)
-	SendInputs(inputs.Next(), program)
+	SendInputs(dialogName, inputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(textDisplayModel)
 	return result.status == list.StatusExit, err

--- a/internal/cli/dialog/dialogcomponents/text_field.go
+++ b/internal/cli/dialog/dialogcomponents/text_field.go
@@ -23,13 +23,14 @@ func TextField(args TextFieldArgs) (string, dialogdomain.Exit, error) {
 		title:     args.Title,
 	}
 	program := tea.NewProgram(model)
-	SendInputs(args.TestInputs.Next(), program)
+	SendInputs(args.DialogName, args.TestInputs.Next(), program)
 	dialogResult, err := program.Run()
 	result := dialogResult.(textFieldModel)
 	return result.textInput.Value(), result.status == list.StatusExit, err
 }
 
 type TextFieldArgs struct {
+	DialogName    string
 	ExistingValue string
 	Help          string
 	Prompt        string

--- a/internal/cli/dialog/feature_regex.go
+++ b/internal/cli/dialog/feature_regex.go
@@ -25,6 +25,7 @@ is set to something other than "feature".
 
 func FeatureRegex(existingValue Option[configdomain.FeatureRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.FeatureRegex], dialogdomain.Exit, error) {
 	value, exit, err1 := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "feature-regex",
 		ExistingValue: existingValue.String(),
 		Help:          FeatureRegexHelp,
 		Prompt:        "Feature regex: ",

--- a/internal/cli/dialog/forge_type.go
+++ b/internal/cli/dialog/forge_type.go
@@ -58,7 +58,7 @@ func ForgeType(existingValue Option[forgedomain.ForgeType], inputs dialogcompone
 	cursor := entries.IndexOfFunc(existingValue, func(optA, optB Option[forgedomain.ForgeType]) bool {
 		return optA.Equal(optB)
 	})
-	newValue, exit, err := dialogcomponents.RadioList(entries, cursor, forgeTypeTitle, forgeTypeHelp, inputs)
+	newValue, exit, err := dialogcomponents.RadioList(entries, cursor, forgeTypeTitle, forgeTypeHelp, inputs, "forge type")
 	fmt.Printf(messages.Forge, dialogcomponents.FormattedSelection(newValue.GetOrElse(messages.AutoDetect).String(), exit))
 	return newValue, exit, err
 }

--- a/internal/cli/dialog/forge_type.go
+++ b/internal/cli/dialog/forge_type.go
@@ -58,7 +58,7 @@ func ForgeType(existingValue Option[forgedomain.ForgeType], inputs dialogcompone
 	cursor := entries.IndexOfFunc(existingValue, func(optA, optB Option[forgedomain.ForgeType]) bool {
 		return optA.Equal(optB)
 	})
-	newValue, exit, err := dialogcomponents.RadioList(entries, cursor, forgeTypeTitle, forgeTypeHelp, inputs, "forge type")
+	newValue, exit, err := dialogcomponents.RadioList(entries, cursor, forgeTypeTitle, forgeTypeHelp, inputs, "forge-type")
 	fmt.Printf(messages.Forge, dialogcomponents.FormattedSelection(newValue.GetOrElse(messages.AutoDetect).String(), exit))
 	return newValue, exit, err
 }

--- a/internal/cli/dialog/gitea_token.go
+++ b/internal/cli/dialog/gitea_token.go
@@ -28,6 +28,7 @@ Git Town will not use the gitea API.
 // GiteaToken lets the user enter the Gitea API token.
 func GiteaToken(oldValue Option[forgedomain.GiteaToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.GiteaToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "gitea-token",
 		ExistingValue: oldValue.String(),
 		Help:          giteaTokenHelp,
 		Prompt:        "Your Gitea API token: ",

--- a/internal/cli/dialog/github_connector_type.go
+++ b/internal/cli/dialog/github_connector_type.go
@@ -43,7 +43,7 @@ func GitHubConnectorType(existing Option[forgedomain.GitHubConnectorType], input
 	if existingValue, hasExisting := existing.Get(); hasExisting {
 		defaultPos = entries.IndexOf(existingValue)
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitHubConnectorTypeTitle, gitHubConnectorTypeHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitHubConnectorTypeTitle, gitHubConnectorTypeHelp, inputs, "GitHub connector type")
 	fmt.Printf(messages.GitHubConnectorType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return NewOption(selection), exit, err
 }

--- a/internal/cli/dialog/github_connector_type.go
+++ b/internal/cli/dialog/github_connector_type.go
@@ -43,7 +43,7 @@ func GitHubConnectorType(existing Option[forgedomain.GitHubConnectorType], input
 	if existingValue, hasExisting := existing.Get(); hasExisting {
 		defaultPos = entries.IndexOf(existingValue)
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitHubConnectorTypeTitle, gitHubConnectorTypeHelp, inputs, "GitHub connector type")
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitHubConnectorTypeTitle, gitHubConnectorTypeHelp, inputs, "github-connector-type")
 	fmt.Printf(messages.GitHubConnectorType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return NewOption(selection), exit, err
 }

--- a/internal/cli/dialog/github_token.go
+++ b/internal/cli/dialog/github_token.go
@@ -32,6 +32,7 @@ with the GitHub API.
 // GitHubToken lets the user enter the GitHub API token.
 func GitHubToken(oldValue Option[forgedomain.GitHubToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.GitHubToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "github-token",
 		ExistingValue: oldValue.String(),
 		Help:          gitHubTokenHelp,
 		Prompt:        "Your GitHub API token: ",

--- a/internal/cli/dialog/gitlab_connector_type.go
+++ b/internal/cli/dialog/gitlab_connector_type.go
@@ -43,7 +43,7 @@ func GitLabConnectorType(existing Option[forgedomain.GitLabConnectorType], input
 	if existingValue, hasExisting := existing.Get(); hasExisting {
 		defaultPos = entries.IndexOf(existingValue)
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitLabConnectorTypeTitle, gitLabConnectorTypeHelp, inputs, "GitLab connector type")
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitLabConnectorTypeTitle, gitLabConnectorTypeHelp, inputs, "gitlab-connector-type")
 	fmt.Printf(messages.GitLabConnectorType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return NewOption(selection), exit, err
 }

--- a/internal/cli/dialog/gitlab_connector_type.go
+++ b/internal/cli/dialog/gitlab_connector_type.go
@@ -43,7 +43,7 @@ func GitLabConnectorType(existing Option[forgedomain.GitLabConnectorType], input
 	if existingValue, hasExisting := existing.Get(); hasExisting {
 		defaultPos = entries.IndexOf(existingValue)
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitLabConnectorTypeTitle, gitLabConnectorTypeHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, gitLabConnectorTypeTitle, gitLabConnectorTypeHelp, inputs, "GitLab connector type")
 	fmt.Printf(messages.GitLabConnectorType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return NewOption(selection), exit, err
 }

--- a/internal/cli/dialog/gitlab_token.go
+++ b/internal/cli/dialog/gitlab_token.go
@@ -29,6 +29,7 @@ Git Town will not use the GitLab API.
 // GitLabToken lets the user enter the GitHub API token.
 func GitLabToken(oldValue Option[forgedomain.GitLabToken], inputs dialogcomponents.TestInputs) (Option[forgedomain.GitLabToken], dialogdomain.Exit, error) {
 	text, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "gitlab-token",
 		ExistingValue: oldValue.String(),
 		Help:          gitLabTokenHelp,
 		Prompt:        "Your GitLab API token: ",

--- a/internal/cli/dialog/main_branch.go
+++ b/internal/cli/dialog/main_branch.go
@@ -31,7 +31,7 @@ func MainBranch(localBranches gitdomain.LocalBranchNames, defaultEntryOpt Option
 	if defaultEntry, hasDefaultEntry := defaultEntryOpt.Get(); hasDefaultEntry {
 		cursor = slice.Index(localBranches, defaultEntry).GetOrElse(0)
 	}
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(localBranches...), cursor, mainBranchTitle, MainBranchHelp, inputs, "main branch")
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(localBranches...), cursor, mainBranchTitle, MainBranchHelp, inputs, "main-branch")
 	fmt.Printf(messages.MainBranch, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/main_branch.go
+++ b/internal/cli/dialog/main_branch.go
@@ -31,7 +31,7 @@ func MainBranch(localBranches gitdomain.LocalBranchNames, defaultEntryOpt Option
 	if defaultEntry, hasDefaultEntry := defaultEntryOpt.Get(); hasDefaultEntry {
 		cursor = slice.Index(localBranches, defaultEntry).GetOrElse(0)
 	}
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(localBranches...), cursor, mainBranchTitle, MainBranchHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(localBranches...), cursor, mainBranchTitle, MainBranchHelp, inputs, "main branch")
 	fmt.Printf(messages.MainBranch, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -48,7 +48,7 @@ func NewBranchType(existingOpt Option[configdomain.BranchType], inputs dialogcom
 			defaultPos = e
 		}
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs, "new branch type")
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs, "new-branch-type")
 	fmt.Println(messages.NewBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/new_branch_type.go
+++ b/internal/cli/dialog/new_branch_type.go
@@ -48,7 +48,7 @@ func NewBranchType(existingOpt Option[configdomain.BranchType], inputs dialogcom
 			defaultPos = e
 		}
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, newBranchTypeTitle, NewBranchTypeHelp, inputs, "new branch type")
 	fmt.Println(messages.NewBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/observed_regex.go
+++ b/internal/cli/dialog/observed_regex.go
@@ -24,6 +24,7 @@ is set to something other than "observed".
 
 func ObservedRegex(existingValue Option[configdomain.ObservedRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.ObservedRegex], dialogdomain.Exit, error) {
 	value, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "observed-regex",
 		ExistingValue: existingValue.String(),
 		Help:          observedRegexHelp,
 		Prompt:        "Observed regex: ",

--- a/internal/cli/dialog/origin_hostname.go
+++ b/internal/cli/dialog/origin_hostname.go
@@ -25,6 +25,7 @@ if Git Town's auto-detection doesn't work.
 
 func OriginHostname(oldValue Option[configdomain.HostingOriginHostname], inputs dialogcomponents.TestInputs) (Option[configdomain.HostingOriginHostname], dialogdomain.Exit, error) {
 	token, exit, err := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "origin-hostname",
 		ExistingValue: oldValue.String(),
 		Help:          OriginHostnameHelp,
 		Prompt:        "Origin hostname override: ",

--- a/internal/cli/dialog/parent.go
+++ b/internal/cli/dialog/parent.go
@@ -29,7 +29,7 @@ func Parent(args ParentArgs) (ParentOutcome, gitdomain.LocalBranchName, error) {
 	cursor := slice.Index(parentCandidates, args.DefaultChoice).GetOrElse(0)
 	title := fmt.Sprintf(parentBranchTitleTemplate, args.Branch)
 	help := fmt.Sprintf(parentBranchHelpTemplate, args.Branch)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.Inputs, "parent-branch-for-"+args.Branch.String())
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.Inputs, fmt.Sprintf("parent-branch-for-%q", args.Branch))
 	fmt.Printf(messages.ParentDialogSelected, args.Branch, dialogcomponents.FormattedSelection(selection.String(), exit))
 	if exit {
 		return ParentOutcomeExit, selection, err

--- a/internal/cli/dialog/parent.go
+++ b/internal/cli/dialog/parent.go
@@ -29,7 +29,7 @@ func Parent(args ParentArgs) (ParentOutcome, gitdomain.LocalBranchName, error) {
 	cursor := slice.Index(parentCandidates, args.DefaultChoice).GetOrElse(0)
 	title := fmt.Sprintf(parentBranchTitleTemplate, args.Branch)
 	help := fmt.Sprintf(parentBranchHelpTemplate, args.Branch)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.Inputs)
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.Inputs, title)
 	fmt.Printf(messages.ParentDialogSelected, args.Branch, dialogcomponents.FormattedSelection(selection.String(), exit))
 	if exit {
 		return ParentOutcomeExit, selection, err

--- a/internal/cli/dialog/parent.go
+++ b/internal/cli/dialog/parent.go
@@ -29,7 +29,7 @@ func Parent(args ParentArgs) (ParentOutcome, gitdomain.LocalBranchName, error) {
 	cursor := slice.Index(parentCandidates, args.DefaultChoice).GetOrElse(0)
 	title := fmt.Sprintf(parentBranchTitleTemplate, args.Branch)
 	help := fmt.Sprintf(parentBranchHelpTemplate, args.Branch)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.Inputs, title)
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(parentCandidates...), cursor, title, help, args.Inputs, "parent-branch-for-"+args.Branch.String())
 	fmt.Printf(messages.ParentDialogSelected, args.Branch, dialogcomponents.FormattedSelection(selection.String(), exit))
 	if exit {
 		return ParentOutcomeExit, selection, err

--- a/internal/cli/dialog/perennial_branches.go
+++ b/internal/cli/dialog/perennial_branches.go
@@ -3,7 +3,6 @@ package dialog
 import (
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -48,7 +47,7 @@ func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBra
 	}
 	selections := slice.FindMany(perennialCandidates, oldPerennialBranches)
 	selections = append(selections, slices.Index(perennialCandidates, mainBranch))
-	selectedBranchesList, exit, err := dialogcomponents.CheckList(entries, selections, perennialBranchesTitle, PerennialBranchesHelp, inputs, strings.ToLower(perennialBranchesTitle))
+	selectedBranchesList, exit, err := dialogcomponents.CheckList(entries, selections, perennialBranchesTitle, PerennialBranchesHelp, inputs, "perennial-branches")
 	selectedBranches := gitdomain.LocalBranchNames(selectedBranchesList)
 	selectedBranches = selectedBranches.Remove(mainBranch)
 	selectionText := selectedBranches.Join(", ")

--- a/internal/cli/dialog/perennial_branches.go
+++ b/internal/cli/dialog/perennial_branches.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -47,7 +48,7 @@ func PerennialBranches(localBranches gitdomain.LocalBranchNames, oldPerennialBra
 	}
 	selections := slice.FindMany(perennialCandidates, oldPerennialBranches)
 	selections = append(selections, slices.Index(perennialCandidates, mainBranch))
-	selectedBranchesList, exit, err := dialogcomponents.CheckList(entries, selections, perennialBranchesTitle, PerennialBranchesHelp, inputs)
+	selectedBranchesList, exit, err := dialogcomponents.CheckList(entries, selections, perennialBranchesTitle, PerennialBranchesHelp, inputs, strings.ToLower(perennialBranchesTitle))
 	selectedBranches := gitdomain.LocalBranchNames(selectedBranchesList)
 	selectedBranches = selectedBranches.Remove(mainBranch)
 	selectionText := selectedBranches.Join(", ")

--- a/internal/cli/dialog/perennial_regex.go
+++ b/internal/cli/dialog/perennial_regex.go
@@ -27,6 +27,7 @@ it's safe to leave it blank.
 
 func PerennialRegex(oldValue Option[configdomain.PerennialRegex], inputs dialogcomponents.TestInputs) (Option[configdomain.PerennialRegex], dialogdomain.Exit, error) {
 	value, exit, err1 := dialogcomponents.TextField(dialogcomponents.TextFieldArgs{
+		DialogName:    "perennial-regex",
 		ExistingValue: oldValue.String(),
 		Help:          PerennialRegexHelp,
 		Prompt:        "Perennial regex: ",

--- a/internal/cli/dialog/push_hook.go
+++ b/internal/cli/dialog/push_hook.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -39,7 +40,7 @@ func PushHook(existing configdomain.PushHook, inputs dialogcomponents.TestInputs
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, pushHookTitle, PushHookHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, pushHookTitle, PushHookHelp, inputs, strings.ToLower(pushHookTitle))
 	fmt.Printf(messages.PushHook, dialogcomponents.FormattedSelection(format.Bool(selection.IsTrue()), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/push_hook.go
+++ b/internal/cli/dialog/push_hook.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -40,7 +39,7 @@ func PushHook(existing configdomain.PushHook, inputs dialogcomponents.TestInputs
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, pushHookTitle, PushHookHelp, inputs, strings.ToLower(pushHookTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, pushHookTitle, PushHookHelp, inputs, "push-hook")
 	fmt.Printf(messages.PushHook, dialogcomponents.FormattedSelection(format.Bool(selection.IsTrue()), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/select_squash_commit_author.go
+++ b/internal/cli/dialog/select_squash_commit_author.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -18,7 +17,7 @@ func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []gitdom
 	if len(authors) == 1 {
 		return authors[0], false, nil
 	}
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(authors...), 0, squashCommitAuthorTitle, fmt.Sprintf(messages.BranchAuthorMultiple, branch), dialogTestInputs, strings.ToLower(squashCommitAuthorTitle))
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(authors...), 0, squashCommitAuthorTitle, fmt.Sprintf(messages.BranchAuthorMultiple, branch), dialogTestInputs, "squash-commit-author")
 	fmt.Printf(messages.SquashCommitAuthorSelection, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/select_squash_commit_author.go
+++ b/internal/cli/dialog/select_squash_commit_author.go
@@ -10,6 +10,8 @@ import (
 	"github.com/git-town/git-town/v21/internal/messages"
 )
 
+// TODO: rename this file to squash_commit_author.go
+
 const squashCommitAuthorTitle = `Squash commit author`
 
 // SelectSquashCommitAuthor allows the user to select an author amongst a given list of authors.

--- a/internal/cli/dialog/select_squash_commit_author.go
+++ b/internal/cli/dialog/select_squash_commit_author.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -17,7 +18,7 @@ func SelectSquashCommitAuthor(branch gitdomain.LocalBranchName, authors []gitdom
 	if len(authors) == 1 {
 		return authors[0], false, nil
 	}
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(authors...), 0, squashCommitAuthorTitle, fmt.Sprintf(messages.BranchAuthorMultiple, branch), dialogTestInputs)
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(authors...), 0, squashCommitAuthorTitle, fmt.Sprintf(messages.BranchAuthorMultiple, branch), dialogTestInputs, strings.ToLower(squashCommitAuthorTitle))
 	fmt.Printf(messages.SquashCommitAuthorSelection, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/share_new_branches.go
+++ b/internal/cli/dialog/share_new_branches.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -40,7 +41,7 @@ func ShareNewBranches(existing configdomain.ShareNewBranches, inputs dialogcompo
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shareNewBranchesTitle, ShareNewBranchesHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shareNewBranchesTitle, ShareNewBranchesHelp, inputs, strings.ToLower(shareNewBranchesTitle))
 	fmt.Printf(messages.ShareNewBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/share_new_branches.go
+++ b/internal/cli/dialog/share_new_branches.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -41,7 +40,7 @@ func ShareNewBranches(existing configdomain.ShareNewBranches, inputs dialogcompo
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shareNewBranchesTitle, ShareNewBranchesHelp, inputs, strings.ToLower(shareNewBranchesTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shareNewBranchesTitle, ShareNewBranchesHelp, inputs, "share-new-branches")
 	fmt.Printf(messages.ShareNewBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/ship_delete_tracking_branch.go
+++ b/internal/cli/dialog/ship_delete_tracking_branch.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -41,7 +42,7 @@ func ShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, in
 	} else {
 		defaultPos = 1
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipDeleteTrackingBranchTitle, ShipDeleteTrackingBranchHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipDeleteTrackingBranchTitle, ShipDeleteTrackingBranchHelp, inputs, strings.ToLower(shipDeleteTrackingBranchTitle))
 	fmt.Printf(messages.ShipDeletesTrackingBranches, dialogcomponents.FormattedSelection(format.Bool(selection), exit))
 	return configdomain.ShipDeleteTrackingBranch(selection), exit, err
 }

--- a/internal/cli/dialog/ship_delete_tracking_branch.go
+++ b/internal/cli/dialog/ship_delete_tracking_branch.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -42,7 +41,7 @@ func ShipDeleteTrackingBranch(existing configdomain.ShipDeleteTrackingBranch, in
 	} else {
 		defaultPos = 1
 	}
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipDeleteTrackingBranchTitle, ShipDeleteTrackingBranchHelp, inputs, strings.ToLower(shipDeleteTrackingBranchTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipDeleteTrackingBranchTitle, ShipDeleteTrackingBranchHelp, inputs, "ship-delete-tracking-branch")
 	fmt.Printf(messages.ShipDeletesTrackingBranches, dialogcomponents.FormattedSelection(format.Bool(selection), exit))
 	return configdomain.ShipDeleteTrackingBranch(selection), exit, err
 }

--- a/internal/cli/dialog/ship_strategy.go
+++ b/internal/cli/dialog/ship_strategy.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -53,7 +54,7 @@ func ShipStrategy(existing configdomain.ShipStrategy, inputs dialogcomponents.Te
 		},
 	}
 	defaultPos := shipStrategyEntryIndex(entries, existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipStrategyTitle, ShipStrategyHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipStrategyTitle, ShipStrategyHelp, inputs, strings.ToLower("shipStrategyTitle"))
 	fmt.Printf(messages.ShipStrategy, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/ship_strategy.go
+++ b/internal/cli/dialog/ship_strategy.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -54,7 +53,7 @@ func ShipStrategy(existing configdomain.ShipStrategy, inputs dialogcomponents.Te
 		},
 	}
 	defaultPos := shipStrategyEntryIndex(entries, existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipStrategyTitle, ShipStrategyHelp, inputs, strings.ToLower("shipStrategyTitle"))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shipStrategyTitle, ShipStrategyHelp, inputs, "ship-strategy")
 	fmt.Printf(messages.ShipStrategy, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/switch_branch.go
+++ b/internal/cli/dialog/switch_branch.go
@@ -174,7 +174,7 @@ func SwitchBranch(entries []SwitchBranchEntry, cursor int, uncommittedChanges bo
 		List:               list.NewList(newSwitchBranchListEntries(entries), cursor),
 		UncommittedChanges: uncommittedChanges,
 	})
-	dialogcomponents.SendInputs("branch tree", inputs.Next(), dialogProgram)
+	dialogcomponents.SendInputs("branch-tree", inputs.Next(), dialogProgram)
 	dialogResult, err := dialogProgram.Run()
 	result := dialogResult.(SwitchModel)
 	selectedData := result.List.SelectedData()

--- a/internal/cli/dialog/switch_branch.go
+++ b/internal/cli/dialog/switch_branch.go
@@ -174,7 +174,7 @@ func SwitchBranch(entries []SwitchBranchEntry, cursor int, uncommittedChanges bo
 		List:               list.NewList(newSwitchBranchListEntries(entries), cursor),
 		UncommittedChanges: uncommittedChanges,
 	})
-	dialogcomponents.SendInputs(inputs.Next(), dialogProgram)
+	dialogcomponents.SendInputs("branch tree", inputs.Next(), dialogProgram)
 	dialogResult, err := dialogProgram.Run()
 	result := dialogResult.(SwitchModel)
 	selectedData := result.List.SelectedData()

--- a/internal/cli/dialog/sync_feature_strategy.go
+++ b/internal/cli/dialog/sync_feature_strategy.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -41,7 +42,7 @@ func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs dialo
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs, strings.ToLower(syncFeatureStrategyTitle))
 	fmt.Printf(messages.SyncFeatureBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_feature_strategy.go
+++ b/internal/cli/dialog/sync_feature_strategy.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -42,7 +41,7 @@ func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs dialo
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs, strings.ToLower(syncFeatureStrategyTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs, "feature-sync-strategy")
 	fmt.Printf(messages.SyncFeatureBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_feature_strategy.go
+++ b/internal/cli/dialog/sync_feature_strategy.go
@@ -41,7 +41,7 @@ func SyncFeatureStrategy(existing configdomain.SyncFeatureStrategy, inputs dialo
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs, "feature-sync-strategy")
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncFeatureStrategyTitle, SyncFeatureStrategyHelp, inputs, "sync-feature-strategy")
 	fmt.Printf(messages.SyncFeatureBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_perennial_strategy.go
+++ b/internal/cli/dialog/sync_perennial_strategy.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -35,7 +36,7 @@ func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs d
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs, strings.ToLower(syncPerennialStrategyTitle))
 	fmt.Printf(messages.SyncPerennialBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_perennial_strategy.go
+++ b/internal/cli/dialog/sync_perennial_strategy.go
@@ -35,7 +35,7 @@ func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs d
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs, "perennial-sync-strategy")
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs, "sync-perennial-strategy")
 	fmt.Printf(messages.SyncPerennialBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_perennial_strategy.go
+++ b/internal/cli/dialog/sync_perennial_strategy.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -36,7 +35,7 @@ func SyncPerennialStrategy(existing configdomain.SyncPerennialStrategy, inputs d
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs, strings.ToLower(syncPerennialStrategyTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPerennialStrategyTitle, SyncPerennialStrategyHelp, inputs, "perennial-sync-strategy")
 	fmt.Printf(messages.SyncPerennialBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_prototype_strategy.go
+++ b/internal/cli/dialog/sync_prototype_strategy.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -39,7 +40,7 @@ func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs d
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs, strings.ToLower(syncPrototypeStrategyTitle))
 	fmt.Printf(messages.SyncPrototypeBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_prototype_strategy.go
+++ b/internal/cli/dialog/sync_prototype_strategy.go
@@ -39,7 +39,7 @@ func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs d
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs, "prototype-sync-strategy")
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs, "sync-prototype-strategy")
 	fmt.Printf(messages.SyncPrototypeBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_prototype_strategy.go
+++ b/internal/cli/dialog/sync_prototype_strategy.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -40,7 +39,7 @@ func SyncPrototypeStrategy(existing configdomain.SyncPrototypeStrategy, inputs d
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs, strings.ToLower(syncPrototypeStrategyTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncPrototypeStrategyTitle, SyncPrototypeStrategyHelp, inputs, "prototype-sync-strategy")
 	fmt.Printf(messages.SyncPrototypeBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_tags.go
+++ b/internal/cli/dialog/sync_tags.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -32,7 +31,7 @@ func SyncTags(existing configdomain.SyncTags, inputs dialogcomponents.TestInputs
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncTagsTitle, SyncTagsHelp, inputs, strings.ToLower(syncTagsTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncTagsTitle, SyncTagsHelp, inputs, "sync-tags")
 	fmt.Printf(messages.SyncTags, dialogcomponents.FormattedSelection(format.Bool(selection.IsTrue()), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_tags.go
+++ b/internal/cli/dialog/sync_tags.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -31,7 +32,7 @@ func SyncTags(existing configdomain.SyncTags, inputs dialogcomponents.TestInputs
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncTagsTitle, SyncTagsHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncTagsTitle, SyncTagsHelp, inputs, strings.ToLower(syncTagsTitle))
 	fmt.Printf(messages.SyncTags, dialogcomponents.FormattedSelection(format.Bool(selection.IsTrue()), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_upstream.go
+++ b/internal/cli/dialog/sync_upstream.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -44,7 +43,7 @@ func SyncUpstream(existing configdomain.SyncUpstream, inputs dialogcomponents.Te
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncUpstreamTitle, SyncUpstreamHelp, inputs, strings.ToLower(syncUpstreamTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncUpstreamTitle, SyncUpstreamHelp, inputs, "sync-upstream")
 	fmt.Printf(messages.SyncWithUpstream, dialogcomponents.FormattedSelection(format.Bool(selection.IsTrue()), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/sync_upstream.go
+++ b/internal/cli/dialog/sync_upstream.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -43,7 +44,7 @@ func SyncUpstream(existing configdomain.SyncUpstream, inputs dialogcomponents.Te
 		},
 	}
 	defaultPos := entries.IndexOf(existing)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncUpstreamTitle, SyncUpstreamHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, syncUpstreamTitle, SyncUpstreamHelp, inputs, strings.ToLower(syncUpstreamTitle))
 	fmt.Printf(messages.SyncWithUpstream, dialogcomponents.FormattedSelection(format.Bool(selection.IsTrue()), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/token_scope.go
+++ b/internal/cli/dialog/token_scope.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -34,7 +33,7 @@ func TokenScope(oldValue configdomain.ConfigScope, inputs dialogcomponents.TestI
 		},
 	}
 	defaultPos := entries.IndexOf(oldValue)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, tokenScopeTitle, tokenScopeHelp, inputs, strings.ToLower(tokenScopeTitle))
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, tokenScopeTitle, tokenScopeHelp, inputs, "token-scope")
 	fmt.Printf(messages.ForgeAPITokenLocation, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/token_scope.go
+++ b/internal/cli/dialog/token_scope.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -33,7 +34,7 @@ func TokenScope(oldValue configdomain.ConfigScope, inputs dialogcomponents.TestI
 		},
 	}
 	defaultPos := entries.IndexOf(oldValue)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, tokenScopeTitle, tokenScopeHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, tokenScopeTitle, tokenScopeHelp, inputs, strings.ToLower(tokenScopeTitle))
 	fmt.Printf(messages.ForgeAPITokenLocation, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/unfinished_run_state.go
+++ b/internal/cli/dialog/unfinished_run_state.go
@@ -63,7 +63,7 @@ func AskHowToHandleUnfinishedRunState(command string, endBranch gitdomain.LocalB
 			Text: messages.UnfinishedRunStateDiscard,
 		},
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, unfinishedRunstateTitle, fmt.Sprintf(unfinishedRunstateHelp, command, endBranch, humanize.Time(endTime)), dialogTestInput, "unfinished runstate")
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, unfinishedRunstateTitle, fmt.Sprintf(unfinishedRunstateHelp, command, endBranch, humanize.Time(endTime)), dialogTestInput, "unfinished-runstate")
 	fmt.Printf(messages.UnfinishedCommandHandle, dialogcomponents.FormattedSelection(string(selection), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/unfinished_run_state.go
+++ b/internal/cli/dialog/unfinished_run_state.go
@@ -63,7 +63,7 @@ func AskHowToHandleUnfinishedRunState(command string, endBranch gitdomain.LocalB
 			Text: messages.UnfinishedRunStateDiscard,
 		},
 	)
-	selection, exit, err := dialogcomponents.RadioList(entries, 0, unfinishedRunstateTitle, fmt.Sprintf(unfinishedRunstateHelp, command, endBranch, humanize.Time(endTime)), dialogTestInput)
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, unfinishedRunstateTitle, fmt.Sprintf(unfinishedRunstateHelp, command, endBranch, humanize.Time(endTime)), dialogTestInput, "unfinished runstate")
 	fmt.Printf(messages.UnfinishedCommandHandle, dialogcomponents.FormattedSelection(string(selection), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -34,7 +33,7 @@ func UnknownBranchType(existingValue configdomain.BranchType, inputs dialogcompo
 		configdomain.BranchTypePrototypeBranch,
 	}
 	cursor := slice.Index(options, existingValue).GetOrElse(0)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs, strings.ToLower(unknownBranchTypeTitle))
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs, "unknown-branch-type")
 	fmt.Printf(messages.UnknownBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents/list"
@@ -33,7 +34,7 @@ func UnknownBranchType(existingValue configdomain.BranchType, inputs dialogcompo
 		configdomain.BranchTypePrototypeBranch,
 	}
 	cursor := slice.Index(options, existingValue).GetOrElse(0)
-	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs)
+	selection, exit, err := dialogcomponents.RadioList(list.NewEntries(options...), cursor, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs, strings.ToLower(unknownBranchTypeTitle))
 	fmt.Printf(messages.UnknownBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }

--- a/internal/cli/dialog/welcome.go
+++ b/internal/cli/dialog/welcome.go
@@ -31,5 +31,5 @@ When you're ready, press ENTER or O to continue.
 
 // MainBranch lets the user select a new main branch for this repo.
 func Welcome(inputs dialogcomponents.TestInputs) (dialogdomain.Exit, error) {
-	return dialogcomponents.TextDisplay(welcomeTitle, welcomeText, inputs)
+	return dialogcomponents.TextDisplay(welcomeTitle, welcomeText, inputs, "welcome")
 }

--- a/internal/test/helpers/table_to_input.go
+++ b/internal/test/helpers/table_to_input.go
@@ -18,7 +18,7 @@ func TableToInputEnv(table *godog.Table) []string {
 		input := row.Cells[inputColumn].Value
 		inputEnvStyle := strings.ReplaceAll(input, " ", "|")
 		if len(inputEnvStyle) > 0 {
-			result = append(result, dialogName+"|"+inputEnvStyle)
+			result = append(result, dialogName+"@"+inputEnvStyle)
 		}
 	}
 	return result

--- a/internal/test/helpers/table_to_input.go
+++ b/internal/test/helpers/table_to_input.go
@@ -14,7 +14,8 @@ func TableToInputEnv(table *godog.Table) []string {
 	inputColumn := detectColumn("KEYS", table.Rows[0])
 	for i := 1; i < len(table.Rows); i++ {
 		row := table.Rows[i]
-		dialogName := row.Cells[dialogColumn].Value
+		dialogName := strings.ReplaceAll(row.Cells[dialogColumn].Value, " ", "-")
+		fmt.Println("1111111111111111111111", dialogName)
 		input := row.Cells[inputColumn].Value
 		inputEnvStyle := strings.ReplaceAll(input, " ", "|")
 		if len(inputEnvStyle) > 0 {

--- a/internal/test/helpers/table_to_input.go
+++ b/internal/test/helpers/table_to_input.go
@@ -15,10 +15,9 @@ func TableToInputEnv(table *godog.Table) []string {
 	for i := 1; i < len(table.Rows); i++ {
 		row := table.Rows[i]
 		dialogName := strings.ReplaceAll(row.Cells[dialogColumn].Value, " ", "-")
-		input := row.Cells[inputColumn].Value
-		inputEnvStyle := strings.ReplaceAll(input, " ", "|")
-		if len(inputEnvStyle) > 0 {
-			result = append(result, dialogName+"@"+inputEnvStyle)
+		input := strings.ReplaceAll(row.Cells[inputColumn].Value, " ", "|")
+		if len(input) > 0 {
+			result = append(result, dialogName+"@"+input)
 		}
 	}
 	return result

--- a/internal/test/helpers/table_to_input.go
+++ b/internal/test/helpers/table_to_input.go
@@ -15,7 +15,6 @@ func TableToInputEnv(table *godog.Table) []string {
 	for i := 1; i < len(table.Rows); i++ {
 		row := table.Rows[i]
 		dialogName := strings.ReplaceAll(row.Cells[dialogColumn].Value, " ", "-")
-		fmt.Println("1111111111111111111111", dialogName)
 		input := row.Cells[inputColumn].Value
 		inputEnvStyle := strings.ReplaceAll(input, " ", "|")
 		if len(inputEnvStyle) > 0 {


### PR DESCRIPTION
An ongoing pain point when maintaining E2E tests is verifying that the steps the test defines match the steps that actually run. Currently that needs to happen manually by visually verifying the debug output of E2E tests.

This PR introduces an automation for this problem. Steps defined by the E2E test get tagged what step they are for, and the Git Town executable verifies that dialog inputs it uses are indeed for the correct step.

This has surfaced a large number of wrong tests, which this PR also fixes.