### PR TITLE
Move Git values out of ValidatedConfig

### DIFF
--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -280,7 +280,7 @@ func determineAppendData(cliConfig cliconfig.CliConfig, targetBranch gitdomain.L
 	if err != nil || exit {
 		return data, exit, err
 	}
-	branchNamesToSync := validatedConfig.NormalConfig.Git.Lineage.BranchAndAncestors(initialBranch)
+	branchNamesToSync := validatedConfig.NormalConfig.Lineage.BranchAndAncestors(initialBranch)
 	if detached {
 		branchNamesToSync = validatedConfig.RemovePerennials(branchNamesToSync)
 	}
@@ -289,10 +289,10 @@ func determineAppendData(cliConfig cliconfig.CliConfig, targetBranch gitdomain.L
 	if err != nil {
 		return data, false, err
 	}
-	initialAndAncestors := validatedConfig.NormalConfig.Git.Lineage.BranchAndAncestors(initialBranch)
+	initialAndAncestors := validatedConfig.NormalConfig.Lineage.BranchAndAncestors(initialBranch)
 	slices.Reverse(initialAndAncestors)
 	commitsToBeam := []gitdomain.Commit{}
-	ancestor, hasAncestor := latestExistingAncestor(initialBranch, branchesSnapshot.Branches, validatedConfig.NormalConfig.Git.Lineage).Get()
+	ancestor, hasAncestor := latestExistingAncestor(initialBranch, branchesSnapshot.Branches, validatedConfig.NormalConfig.Lineage).Get()
 	if beam.IsTrue() && hasAncestor {
 		commitsInBranch, err := repo.Git.CommitsInFeatureBranch(repo.Backend, initialBranch, ancestor.BranchName())
 		if err != nil {

--- a/internal/cmd/branch.go
+++ b/internal/cmd/branch.go
@@ -113,7 +113,7 @@ func determineBranchData(repo execute.OpenRepoResult, cliConfig cliconfig.CliCon
 		branchesAndTypes:  branchesAndTypes,
 		colors:            colors,
 		initialBranchOpt:  initialBranchOpt,
-		lineage:           repo.UnvalidatedConfig.NormalConfig.Git.Lineage,
+		lineage:           repo.UnvalidatedConfig.NormalConfig.Lineage,
 		unknownBranchType: unknownBranchType,
 	}, false, err
 }

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -249,7 +249,7 @@ func determineCompressBranchesData(repo execute.OpenRepoResult, cliConfig clicon
 	perennialBranches := branchesAndTypes.BranchesOfTypes(configdomain.BranchTypePerennialBranch, configdomain.BranchTypeMainBranch)
 	var branchNamesToCompress gitdomain.LocalBranchNames
 	if compressEntireStack {
-		branchNamesToCompress = validatedConfig.NormalConfig.Git.Lineage.BranchLineageWithoutRoot(initialBranch, perennialBranches)
+		branchNamesToCompress = validatedConfig.NormalConfig.Lineage.BranchLineageWithoutRoot(initialBranch, perennialBranches)
 	} else {
 		branchNamesToCompress = gitdomain.LocalBranchNames{initialBranch}
 	}
@@ -269,7 +269,7 @@ func determineCompressBranchesData(repo execute.OpenRepoResult, cliConfig clicon
 		if err := validateBranchIsSynced(branchNameToCompress, branchInfo.SyncStatus); err != nil {
 			return data, exit, err
 		}
-		parent := validatedConfig.NormalConfig.Git.Lineage.Parent(branchNameToCompress)
+		parent := validatedConfig.NormalConfig.Lineage.Parent(branchNameToCompress)
 		commits, err := repo.Git.CommitsInBranch(repo.Backend, branchNameToCompress, parent)
 		if err != nil {
 			return data, exit, err
@@ -397,7 +397,7 @@ func validateBranchIsSynced(branchName gitdomain.LocalBranchName, syncStatus git
 
 func validateCompressBranchesData(data compressBranchesData, repo execute.OpenRepoResult) error {
 	for _, branch := range data.branchesToCompress {
-		if parent, hasParent := data.config.NormalConfig.Git.Lineage.Parent(branch.name).Get(); hasParent {
+		if parent, hasParent := data.config.NormalConfig.Lineage.Parent(branch.name).Get(); hasParent {
 			isInSyncWithParent, err := repo.Git.BranchInSyncWithParent(repo.Backend, branch.name, parent.BranchName())
 			if err != nil {
 				return err

--- a/internal/cmd/config/get_parent.go
+++ b/internal/cmd/config/get_parent.go
@@ -57,7 +57,7 @@ func executeGetParent(args []string, cliConfig cliconfig.CliConfig) error {
 	} else {
 		childBranch = gitdomain.NewLocalBranchName(args[0])
 	}
-	parentOpt := repo.UnvalidatedConfig.NormalConfig.Git.Lineage.Parent(childBranch)
+	parentOpt := repo.UnvalidatedConfig.NormalConfig.Lineage.Parent(childBranch)
 	if parent, hasParent := parentOpt.Get(); hasParent {
 		fmt.Print(parent)
 	}

--- a/internal/cmd/config/root.go
+++ b/internal/cmd/config/root.go
@@ -106,7 +106,7 @@ func printConfig(config config.UnvalidatedConfig) {
 	print.Entry("sync tags", format.Bool(config.NormalConfig.SyncTags.IsTrue()))
 	print.Entry("sync with upstream", format.Bool(config.NormalConfig.SyncUpstream.IsTrue()))
 	fmt.Println()
-	if config.NormalConfig.Git.Lineage.Len() > 0 {
-		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Git.Lineage))
+	if config.NormalConfig.Lineage.Len() > 0 {
+		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
 	}
 }

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -75,7 +75,7 @@ func executeConfigSetup(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	if err = saveAll(enterDataResult, repo.UnvalidatedConfig.NormalConfig.Git, data.configFile, data, repo.Frontend); err != nil {
+	if err = saveAll(enterDataResult, repo.UnvalidatedConfig.Git, data.configFile, data, repo.Frontend); err != nil {
 		return err
 	}
 	return configinterpreter.Finished(configinterpreter.FinishedArgs{

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -256,12 +256,12 @@ func determineDeleteData(args []string, repo execute.OpenRepoResult, cliConfig c
 	})
 	proposalsOfChildBranches := ship.LoadProposalsOfChildBranches(ship.LoadProposalsOfChildBranchesArgs{
 		ConnectorOpt:               connector,
-		Lineage:                    validatedConfig.NormalConfig.Git.Lineage,
+		Lineage:                    validatedConfig.NormalConfig.Lineage,
 		Offline:                    repo.IsOffline,
 		OldBranch:                  branchNameToDelete,
 		OldBranchHasTrackingBranch: branchToDelete.HasTrackingBranch(),
 	})
-	lineageBranches := validatedConfig.NormalConfig.Git.Lineage.BranchNames()
+	lineageBranches := validatedConfig.NormalConfig.Lineage.BranchNames()
 	_, nonExistingBranches := branchesSnapshot.Branches.Select(repo.UnvalidatedConfig.NormalConfig.DevRemote, lineageBranches...)
 	return deleteData{
 		branchInfosLastRun:       branchInfosLastRun,
@@ -347,7 +347,7 @@ func deleteLocalBranch(prog, finalUndoProgram Mutable[program.Program], data del
 		}
 		// delete the commits of this branch from all descendents
 		if data.config.NormalConfig.SyncFeatureStrategy == configdomain.SyncFeatureStrategyRebase {
-			descendents := data.config.NormalConfig.Git.Lineage.Descendants(localBranchToDelete)
+			descendents := data.config.NormalConfig.Lineage.Descendants(localBranchToDelete)
 			for _, descendent := range descendents {
 				if branchInfo, hasBranchInfo := data.branchesSnapshot.Branches.FindByLocalName(descendent).Get(); hasBranchInfo {
 					sync.RemoveAncestorCommits(sync.RemoveAncestorCommitsArgs{
@@ -367,7 +367,7 @@ func deleteLocalBranch(prog, finalUndoProgram Mutable[program.Program], data del
 		if !data.dryRun {
 			sync.RemoveBranchConfiguration(sync.RemoveBranchConfigurationArgs{
 				Branch:  localBranchToDelete,
-				Lineage: data.config.NormalConfig.Git.Lineage,
+				Lineage: data.config.NormalConfig.Lineage,
 				Program: prog,
 			})
 		}

--- a/internal/cmd/detach.go
+++ b/internal/cmd/detach.go
@@ -258,7 +258,7 @@ func determineDetachData(args []string, repo execute.OpenRepoResult, cliConfig c
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)
 	}
 	previousBranchOpt := repo.Git.PreviouslyCheckedOutBranch(repo.Backend)
-	parentBranch, hasParentBranch := validatedConfig.NormalConfig.Git.Lineage.Parent(branchNameToDetach).Get()
+	parentBranch, hasParentBranch := validatedConfig.NormalConfig.Lineage.Parent(branchNameToDetach).Get()
 	if !hasParentBranch {
 		return data, false, errors.New(messages.DetachNoParent)
 	}
@@ -269,7 +269,7 @@ func determineDetachData(args []string, repo execute.OpenRepoResult, cliConfig c
 	if branchHasMergeCommits {
 		return data, false, fmt.Errorf(messages.BranchContainsMergeCommits, branchNameToDetach)
 	}
-	childBranches := validatedConfig.NormalConfig.Git.Lineage.Children(branchNameToDetach)
+	childBranches := validatedConfig.NormalConfig.Lineage.Children(branchNameToDetach)
 	children := make([]detachChildBranch, len(childBranches))
 	for c, childBranch := range childBranches {
 		proposal := None[forgedomain.Proposal]()
@@ -291,7 +291,7 @@ func determineDetachData(args []string, repo execute.OpenRepoResult, cliConfig c
 			proposal: proposal,
 		}
 	}
-	descendentNames := validatedConfig.NormalConfig.Git.Lineage.Descendants(branchNameToDetach)
+	descendentNames := validatedConfig.NormalConfig.Lineage.Descendants(branchNameToDetach)
 	descendents := make([]detachChildBranch, len(descendentNames))
 	for d, descendentName := range descendentNames {
 		info, has := branchesSnapshot.Branches.FindByLocalName(descendentName).Get()
@@ -304,7 +304,7 @@ func determineDetachData(args []string, repo execute.OpenRepoResult, cliConfig c
 			proposal: None[forgedomain.Proposal](),
 		}
 	}
-	lineageBranches := validatedConfig.NormalConfig.Git.Lineage.BranchNames()
+	lineageBranches := validatedConfig.NormalConfig.Lineage.BranchNames()
 	_, nonExistingBranches := branchesSnapshot.Branches.Select(repo.UnvalidatedConfig.NormalConfig.DevRemote, lineageBranches...)
 	return detachData{
 		branchInfosLastRun:  branchInfosLastRun,
@@ -366,7 +366,7 @@ func detachProgram(repo execute.OpenRepoResult, data detachData, finalMessages s
 				Parent: data.config.ValidatedConfigData.MainBranch,
 			},
 		)
-		for _, child := range data.config.NormalConfig.Git.Lineage.Children(data.branchToDetachName) {
+		for _, child := range data.config.NormalConfig.Lineage.Children(data.branchToDetachName) {
 			prog.Value.Add(
 				&opcodes.LineageParentSet{
 					Branch: child,

--- a/internal/cmd/diff_parent.go
+++ b/internal/cmd/diff_parent.go
@@ -158,7 +158,7 @@ func determineDiffParentData(args []string, repo execute.OpenRepoResult, cliConf
 	if err != nil || exit {
 		return data, exit, err
 	}
-	parentBranch, hasParent := validatedConfig.NormalConfig.Git.Lineage.Parent(branch).Get()
+	parentBranch, hasParent := validatedConfig.NormalConfig.Lineage.Parent(branch).Get()
 	if !hasParent {
 		return data, false, errors.New(messages.DiffParentNoFeatureBranch)
 	}

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -348,7 +348,7 @@ func determineHackData(args []string, repo execute.OpenRepoResult, cliConfig cli
 		return data, false, err
 	}
 	commitsToBeam := []gitdomain.Commit{}
-	ancestor, hasAncestor := latestExistingAncestor(initialBranch, branchesSnapshot.Branches, validatedConfig.NormalConfig.Git.Lineage).Get()
+	ancestor, hasAncestor := latestExistingAncestor(initialBranch, branchesSnapshot.Branches, validatedConfig.NormalConfig.Lineage).Get()
 	if beam.IsTrue() && hasAncestor {
 		commitsInBranch, err := repo.Git.CommitsInFeatureBranch(repo.Backend, initialBranch, ancestor.BranchName())
 		if err != nil {

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -235,11 +235,11 @@ func determineMergeData(repo execute.OpenRepoResult, cliConfig cliconfig.CliConf
 	if err != nil || exit {
 		return mergeData{}, exit, err
 	}
-	parentBranch, hasParentBranch := validatedConfig.NormalConfig.Git.Lineage.Parent(initialBranch).Get()
+	parentBranch, hasParentBranch := validatedConfig.NormalConfig.Lineage.Parent(initialBranch).Get()
 	if !hasParentBranch {
 		return mergeData{}, false, fmt.Errorf(messages.MergeNoParent, initialBranch)
 	}
-	grandParentBranch := validatedConfig.NormalConfig.Git.Lineage.Parent(parentBranch)
+	grandParentBranch := validatedConfig.NormalConfig.Lineage.Parent(parentBranch)
 	if grandParentBranch.IsNone() {
 		return mergeData{}, false, fmt.Errorf(messages.MergeNoGrandParent, initialBranch, parentBranch)
 	}
@@ -353,7 +353,7 @@ func validateMergeData(repo execute.OpenRepoResult, data mergeData) error {
 	case gitdomain.SyncStatusOtherWorktree:
 		return fmt.Errorf(messages.BranchOtherWorktree, data.parentBranch)
 	}
-	children := data.config.NormalConfig.Git.Lineage.Children(data.parentBranch)
+	children := data.config.NormalConfig.Lineage.Children(data.parentBranch)
 	if len(children) > 1 {
 		return fmt.Errorf("branch %q has more than one child", data.parentBranch)
 	}

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -296,7 +296,7 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, cliConfig 
 	if err != nil || exit {
 		return data, exit, err
 	}
-	ancestorOpt := latestExistingAncestor(initialBranch, branchesSnapshot.Branches, validatedConfig.NormalConfig.Git.Lineage)
+	ancestorOpt := latestExistingAncestor(initialBranch, branchesSnapshot.Branches, validatedConfig.NormalConfig.Lineage)
 	ancestor, hasAncestor := ancestorOpt.Get()
 	if !hasAncestor {
 		return data, false, fmt.Errorf(messages.SetParentNoFeatureBranch, branchesSnapshot.Active)
@@ -312,7 +312,7 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, cliConfig 
 			return data, exit, err
 		}
 	}
-	branchNamesToSync := validatedConfig.NormalConfig.Git.Lineage.BranchAndAncestors(initialBranch)
+	branchNamesToSync := validatedConfig.NormalConfig.Lineage.BranchAndAncestors(initialBranch)
 	if detached {
 		branchNamesToSync = validatedConfig.RemovePerennials(branchNamesToSync)
 	}
@@ -321,7 +321,7 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, cliConfig 
 	if err != nil {
 		return data, false, err
 	}
-	parentAndAncestors := validatedConfig.NormalConfig.Git.Lineage.BranchAndAncestors(ancestor)
+	parentAndAncestors := validatedConfig.NormalConfig.Lineage.BranchAndAncestors(ancestor)
 	slices.Reverse(parentAndAncestors)
 	proposalOpt := None[forgedomain.Proposal]()
 	if !repo.IsOffline {

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -257,16 +257,16 @@ func determineProposeData(repo execute.OpenRepoResult, cliConfig cliconfig.CliCo
 	var branchNamesToPropose gitdomain.LocalBranchNames
 	var branchNamesToSync gitdomain.LocalBranchNames
 	if fullStack {
-		branchNamesToSync = validatedConfig.NormalConfig.Git.Lineage.BranchLineageWithoutRoot(initialBranch, perennialAndMain)
+		branchNamesToSync = validatedConfig.NormalConfig.Lineage.BranchLineageWithoutRoot(initialBranch, perennialAndMain)
 		branchNamesToPropose = make(gitdomain.LocalBranchNames, len(branchNamesToSync))
 		copy(branchNamesToPropose, branchNamesToSync)
 	} else {
-		branchNamesToSync = validatedConfig.NormalConfig.Git.Lineage.BranchAndAncestorsWithoutRoot(initialBranch)
+		branchNamesToSync = validatedConfig.NormalConfig.Lineage.BranchAndAncestorsWithoutRoot(initialBranch)
 		branchNamesToPropose = gitdomain.LocalBranchNames{initialBranch}
 		if err = validateBranchTypeToPropose(branchesAndTypes[initialBranch]); err != nil {
 			return data, false, err
 		}
-		if validatedConfig.NormalConfig.Git.Lineage.Parent(initialBranch).IsNone() {
+		if validatedConfig.NormalConfig.Lineage.Parent(initialBranch).IsNone() {
 			return data, false, fmt.Errorf(messages.ProposalNoParent, initialBranch)
 		}
 	}
@@ -283,7 +283,7 @@ func determineProposeData(repo execute.OpenRepoResult, cliConfig cliconfig.CliCo
 		}
 		existingProposalURL := None[string]()
 		if canFindProposals {
-			if parent, hasParent := validatedConfig.NormalConfig.Git.Lineage.Parent(branchNameToPropose).Get(); hasParent {
+			if parent, hasParent := validatedConfig.NormalConfig.Lineage.Parent(branchNameToPropose).Get(); hasParent {
 				existingProposalOpt, err := findProposal(branchNameToPropose, parent)
 				if err != nil {
 					print.Error(err)

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -244,8 +244,8 @@ func determineRenameData(args []string, cliConfig cliconfig.CliConfig, force con
 	if branchesSnapshot.Branches.HasMatchingTrackingBranchFor(newBranchName, repo.UnvalidatedConfig.NormalConfig.DevRemote) {
 		return data, false, fmt.Errorf(messages.BranchAlreadyExistsRemotely, newBranchName)
 	}
-	parentOpt := validatedConfig.NormalConfig.Git.Lineage.Parent(initialBranch)
-	lineageBranches := validatedConfig.NormalConfig.Git.Lineage.BranchNames()
+	parentOpt := validatedConfig.NormalConfig.Lineage.Parent(initialBranch)
+	lineageBranches := validatedConfig.NormalConfig.Lineage.BranchNames()
 	_, nonExistingBranches := branchesSnapshot.Branches.Select(repo.UnvalidatedConfig.NormalConfig.DevRemote, lineageBranches...)
 	proposalOpt := None[forgedomain.Proposal]()
 	if !repo.IsOffline {
@@ -253,7 +253,7 @@ func determineRenameData(args []string, cliConfig cliconfig.CliConfig, force con
 	}
 	proposalsOfChildBranches := ship.LoadProposalsOfChildBranches(ship.LoadProposalsOfChildBranchesArgs{
 		ConnectorOpt:               connector,
-		Lineage:                    validatedConfig.NormalConfig.Git.Lineage,
+		Lineage:                    validatedConfig.NormalConfig.Lineage,
 		Offline:                    false,
 		OldBranch:                  oldBranchName,
 		OldBranchHasTrackingBranch: oldBranch.HasTrackingBranch(),
@@ -302,12 +302,12 @@ func renameProgram(repo execute.OpenRepoResult, data renameData, finalMessages s
 				},
 			)
 		}
-		if parentBranch, hasParent := data.config.NormalConfig.Git.Lineage.Parent(oldLocalBranch).Get(); hasParent {
+		if parentBranch, hasParent := data.config.NormalConfig.Lineage.Parent(oldLocalBranch).Get(); hasParent {
 			prog.Value.Add(&opcodes.LineageParentSet{Branch: data.newBranch, Parent: parentBranch})
 		}
 		prog.Value.Add(&opcodes.LineageParentRemove{Branch: oldLocalBranch})
 	}
-	for _, child := range data.config.NormalConfig.Git.Lineage.Children(oldLocalBranch) {
+	for _, child := range data.config.NormalConfig.Lineage.Children(oldLocalBranch) {
 		prog.Value.Add(&opcodes.LineageParentSet{Branch: child, Parent: data.newBranch})
 	}
 	if oldTrackingBranch, hasOldTrackingBranch := data.oldBranch.RemoteName.Get(); hasOldTrackingBranch {

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -114,7 +114,7 @@ func executeSetParent(args []string, cliConfig cliconfig.CliConfig) error {
 			Branch:        data.initialBranch,
 			DefaultChoice: data.defaultChoice,
 			Inputs:        data.dialogTestInputs,
-			Lineage:       data.config.NormalConfig.Git.Lineage,
+			Lineage:       data.config.NormalConfig.Lineage,
 			LocalBranches: data.branchesSnapshot.Branches.LocalBranches().Names(),
 			MainBranch:    data.mainBranch,
 		})
@@ -247,7 +247,7 @@ func determineSetParentData(repo execute.OpenRepoResult, cliConfig cliconfig.Cli
 	if !hasInitialBranch {
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)
 	}
-	parentOpt := validatedConfig.NormalConfig.Git.Lineage.Parent(initialBranch)
+	parentOpt := validatedConfig.NormalConfig.Lineage.Parent(initialBranch)
 	existingParent, hasParent := parentOpt.Get()
 	var defaultChoice gitdomain.LocalBranchName
 	if hasParent {
@@ -312,7 +312,7 @@ func setParentProgram(dialogOutcome dialog.ParentOutcome, selectedBranch gitdoma
 					&opcodes.PullCurrentBranch{},
 				)
 			}
-			parentOpt := data.config.NormalConfig.Git.Lineage.Parent(data.initialBranch)
+			parentOpt := data.config.NormalConfig.Lineage.Parent(data.initialBranch)
 			if parent, hasParent := parentOpt.Get(); hasParent {
 				prog.Add(
 					&opcodes.RebaseOntoKeepDeleted{
@@ -334,7 +334,7 @@ func setParentProgram(dialogOutcome dialog.ParentOutcome, selectedBranch gitdoma
 				)
 			}
 			// remove commits from descendents
-			descendents := data.config.NormalConfig.Git.Lineage.Descendants(data.initialBranch)
+			descendents := data.config.NormalConfig.Lineage.Descendants(data.initialBranch)
 			for _, descendent := range descendents {
 				prog.Add(
 					&opcodes.CheckoutIfNeeded{

--- a/internal/cmd/ship/cmd.go
+++ b/internal/cmd/ship/cmd.go
@@ -182,7 +182,7 @@ func validateSharedData(data sharedShipData, toParent configdomain.ShipIntoNonpe
 		branch := data.branchToShip.LocalName.GetOrPanic()
 		parentBranch := data.targetBranch.LocalName.GetOrPanic()
 		if !data.config.IsMainOrPerennialBranch(parentBranch) {
-			ancestors := data.config.NormalConfig.Git.Lineage.Ancestors(branch)
+			ancestors := data.config.NormalConfig.Lineage.Ancestors(branch)
 			ancestorsWithoutMainOrPerennial := ancestors[1:]
 			oldestAncestor := ancestorsWithoutMainOrPerennial[0]
 			return fmt.Errorf(messages.ShipChildBranch, stringslice.Connect(ancestorsWithoutMainOrPerennial.Strings()), oldestAncestor)

--- a/internal/cmd/ship/shared.go
+++ b/internal/cmd/ship/shared.go
@@ -139,7 +139,7 @@ func determineSharedShipData(args []string, repo execute.OpenRepoResult, cliConf
 		configdomain.BranchTypeParkedBranch,
 		configdomain.BranchTypePrototypeBranch:
 	}
-	targetBranchName, hasTargetBranch := validatedConfig.NormalConfig.Git.Lineage.Parent(branchNameToShip).Get()
+	targetBranchName, hasTargetBranch := validatedConfig.NormalConfig.Lineage.Parent(branchNameToShip).Get()
 	if !hasTargetBranch {
 		return data, false, fmt.Errorf(messages.ShipBranchHasNoParent, branchNameToShip)
 	}
@@ -147,10 +147,10 @@ func determineSharedShipData(args []string, repo execute.OpenRepoResult, cliConf
 	if !hasTargetBranch {
 		return data, false, fmt.Errorf(messages.BranchDoesntExist, targetBranchName)
 	}
-	childBranches := validatedConfig.NormalConfig.Git.Lineage.Children(branchNameToShip)
+	childBranches := validatedConfig.NormalConfig.Lineage.Children(branchNameToShip)
 	proposalsOfChildBranches := LoadProposalsOfChildBranches(LoadProposalsOfChildBranchesArgs{
 		ConnectorOpt:               connector,
-		Lineage:                    validatedConfig.NormalConfig.Git.Lineage,
+		Lineage:                    validatedConfig.NormalConfig.Lineage,
 		Offline:                    repo.IsOffline,
 		OldBranch:                  branchNameToShip,
 		OldBranchHasTrackingBranch: branchToShip.HasTrackingBranch(),

--- a/internal/cmd/swap.go
+++ b/internal/cmd/swap.go
@@ -255,7 +255,7 @@ func determineSwapData(args []string, repo execute.OpenRepoResult, cliConfig cli
 		return data, exit, errors.New(messages.CurrentBranchCannotDetermine)
 	}
 	previousBranchOpt := repo.Git.PreviouslyCheckedOutBranch(repo.Backend)
-	parentBranch, hasParentBranch := validatedConfig.NormalConfig.Git.Lineage.Parent(branchNameToSwap).Get()
+	parentBranch, hasParentBranch := validatedConfig.NormalConfig.Lineage.Parent(branchNameToSwap).Get()
 	if !hasParentBranch {
 		return data, false, errors.New(messages.SwapNoParent)
 	}
@@ -264,11 +264,11 @@ func determineSwapData(args []string, repo execute.OpenRepoResult, cliConfig cli
 		return data, false, fmt.Errorf(messages.SwapParentNotLocal, parentBranch)
 	}
 	parentBranchType := validatedConfig.BranchType(parentBranch)
-	grandParentBranch, hasGrandParentBranch := validatedConfig.NormalConfig.Git.Lineage.Parent(parentBranch).Get()
+	grandParentBranch, hasGrandParentBranch := validatedConfig.NormalConfig.Lineage.Parent(parentBranch).Get()
 	if !hasGrandParentBranch {
 		return data, false, errors.New(messages.SwapNoGrandParent)
 	}
-	childBranches := validatedConfig.NormalConfig.Git.Lineage.Children(branchNameToSwap)
+	childBranches := validatedConfig.NormalConfig.Lineage.Children(branchNameToSwap)
 	children := make([]swapChildBranch, len(childBranches))
 	for c, childBranch := range childBranches {
 		proposal := None[forgedomain.Proposal]()
@@ -304,7 +304,7 @@ func determineSwapData(args []string, repo execute.OpenRepoResult, cliConfig cli
 	if parentContainsMerges {
 		return data, false, fmt.Errorf(messages.SwapNeedsCompress, parentBranch)
 	}
-	lineageBranches := validatedConfig.NormalConfig.Git.Lineage.BranchNames()
+	lineageBranches := validatedConfig.NormalConfig.Lineage.BranchNames()
 	_, nonExistingBranches := branchesSnapshot.Branches.Select(repo.UnvalidatedConfig.NormalConfig.DevRemote, lineageBranches...)
 	return swapData{
 		branchInfosLastRun:  branchInfosLastRun,

--- a/internal/cmd/switch.go
+++ b/internal/cmd/switch.go
@@ -80,7 +80,7 @@ func executeSwitch(args []string, cliConfig cliconfig.CliConfig, allBranches con
 	}
 	branchesAndTypes := repo.UnvalidatedConfig.UnvalidatedBranchesAndTypes(data.branchNames)
 	unknownBranchType := repo.UnvalidatedConfig.NormalConfig.UnknownBranchType
-	entries := SwitchBranchEntries(data.branchesSnapshot.Branches, branchTypes, branchesAndTypes, data.config.NormalConfig.Git.Lineage, unknownBranchType, allBranches, data.regexes)
+	entries := SwitchBranchEntries(data.branchesSnapshot.Branches, branchTypes, branchesAndTypes, data.config.NormalConfig.Lineage, unknownBranchType, allBranches, data.regexes)
 	if len(entries) == 0 {
 		return errors.New(messages.SwitchNoBranches)
 	}
@@ -157,7 +157,7 @@ func determineSwitchData(args []string, repo execute.OpenRepoResult, cliConfig c
 		config:             repo.UnvalidatedConfig,
 		dialogInputs:       dialogTestInputs,
 		initialBranch:      initialBranch,
-		lineage:            repo.UnvalidatedConfig.NormalConfig.Git.Lineage,
+		lineage:            repo.UnvalidatedConfig.NormalConfig.Lineage,
 		regexes:            regexes,
 		uncommittedChanges: repoStatus.OpenChanges,
 	}, false, err

--- a/internal/cmd/sync/cmd.go
+++ b/internal/cmd/sync/cmd.go
@@ -308,7 +308,7 @@ func determineSyncData(cliConfig cliconfig.CliConfig, syncAllBranches configdoma
 	case syncAllBranches.Enabled():
 		branchNamesToSync = localBranches
 	case syncStack.Enabled():
-		branchNamesToSync = validatedConfig.NormalConfig.Git.Lineage.BranchLineageWithoutRoot(initialBranch, perennialAndMain)
+		branchNamesToSync = validatedConfig.NormalConfig.Lineage.BranchLineageWithoutRoot(initialBranch, perennialAndMain)
 	default:
 		branchNamesToSync = gitdomain.LocalBranchNames{initialBranch}
 	}
@@ -339,7 +339,7 @@ func determineSyncData(cliConfig cliconfig.CliConfig, syncAllBranches configdoma
 	default:
 		shouldPushTags = validatedConfig.IsMainOrPerennialBranch(initialBranch)
 	}
-	allBranchNamesToSync := validatedConfig.NormalConfig.Git.Lineage.BranchesAndAncestors(branchNamesToSync)
+	allBranchNamesToSync := validatedConfig.NormalConfig.Lineage.BranchesAndAncestors(branchNamesToSync)
 	if detached {
 		allBranchNamesToSync = allBranchNamesToSync.Remove(perennialAndMain...)
 	}
@@ -378,7 +378,7 @@ func BranchesToSync(branchInfosToSync gitdomain.BranchInfos, allBranchInfos gitd
 			}
 			continue
 		}
-		parentLocalName, hasParentName := repo.UnvalidatedConfig.NormalConfig.Git.Lineage.Parent(branchNameToSync.LocalName()).Get()
+		parentLocalName, hasParentName := repo.UnvalidatedConfig.NormalConfig.Lineage.Parent(branchNameToSync.LocalName()).Get()
 		if !hasParentName {
 			parentLocalName = mainBranch
 		}

--- a/internal/cmd/sync/sync_branch.go
+++ b/internal/cmd/sync/sync_branch.go
@@ -12,7 +12,7 @@ import (
 
 // BranchProgram syncs the given branch.
 func BranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomain.BranchInfo, firstCommitMessage Option[gitdomain.CommitMessage], args BranchProgramArgs) {
-	initialParentName := args.Config.NormalConfig.Git.Lineage.Parent(localName)
+	initialParentName := args.Config.NormalConfig.Lineage.Parent(localName)
 	initialParentSHA := None[gitdomain.SHA]()
 	parentName, hasParentName := initialParentName.Get()
 	if hasParentName {
@@ -22,8 +22,8 @@ func BranchProgram(localName gitdomain.LocalBranchName, branchInfo gitdomain.Bra
 	}
 	trackingBranchGone := branchInfo.SyncStatus == gitdomain.SyncStatusDeletedAtRemote
 	rebaseSyncStrategy := args.Config.NormalConfig.SyncFeatureStrategy == configdomain.SyncFeatureStrategyRebase
-	hasDescendents := args.Config.NormalConfig.Git.Lineage.HasDescendents(localName)
-	parentToRemove, hasParentToRemove := args.Config.NormalConfig.Git.Lineage.LatestAncestor(localName, args.BranchesToDelete.Value.Values()).Get()
+	hasDescendents := args.Config.NormalConfig.Lineage.HasDescendents(localName)
+	parentToRemove, hasParentToRemove := args.Config.NormalConfig.Lineage.LatestAncestor(localName, args.BranchesToDelete.Value.Values()).Get()
 	if hasParentToRemove && rebaseSyncStrategy {
 		RemoveAncestorCommits(RemoveAncestorCommitsArgs{
 			Ancestor:          parentToRemove.BranchName(),

--- a/internal/cmd/sync/sync_deleted_branch.go
+++ b/internal/cmd/sync/sync_deleted_branch.go
@@ -75,7 +75,7 @@ func syncDeleteLocalBranchProgram(prog Mutable[program.Program], branch gitdomai
 	)
 	RemoveBranchConfiguration(RemoveBranchConfigurationArgs{
 		Branch:  branch,
-		Lineage: args.Config.NormalConfig.Git.Lineage,
+		Lineage: args.Config.NormalConfig.Lineage,
 		Program: prog,
 	})
 }

--- a/internal/cmd/walk.go
+++ b/internal/cmd/walk.go
@@ -251,7 +251,7 @@ func determineWalkData(cliConfig cliconfig.CliConfig, all configdomain.AllBranch
 	case all.Enabled():
 		branchesToWalk = localBranches.Remove(perennialBranchNames...)
 	case stack.Enabled():
-		branchesToWalk = validatedConfig.NormalConfig.Git.Lineage.BranchLineageWithoutRoot(initialBranch, perennialBranchNames)
+		branchesToWalk = validatedConfig.NormalConfig.Lineage.BranchLineageWithoutRoot(initialBranch, perennialBranchNames)
 	}
 	return walkData{
 		branchInfosLastRun: branchInfosLastRun,

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -27,6 +27,7 @@ type NormalConfigData struct {
 	GitLabToken              Option[forgedomain.GitLabToken]
 	GiteaToken               Option[forgedomain.GiteaToken]
 	HostingOriginHostname    Option[HostingOriginHostname]
+	Lineage                  Lineage
 	NewBranchType            Option[BranchType]
 	ObservedRegex            Option[ObservedRegex]
 	Offline                  Offline

--- a/internal/config/configdomain/normal_config_data.go
+++ b/internal/config/configdomain/normal_config_data.go
@@ -115,6 +115,7 @@ func DefaultNormalConfig() NormalConfigData {
 		GitLabToken:              None[forgedomain.GitLabToken](),
 		GiteaToken:               None[forgedomain.GiteaToken](),
 		HostingOriginHostname:    None[HostingOriginHostname](),
+		Lineage:                  NewLineage(),
 		NewBranchType:            None[BranchType](),
 		ObservedRegex:            None[ObservedRegex](),
 		Offline:                  false,

--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -115,6 +115,7 @@ func (self PartialConfig) ToNormalConfig(defaults NormalConfigData) NormalConfig
 		GitLabToken:              self.GitLabToken,
 		GiteaToken:               self.GiteaToken,
 		HostingOriginHostname:    self.HostingOriginHostname,
+		Lineage:                  self.Lineage,
 		NewBranchType:            self.NewBranchType.Or(defaults.NewBranchType),
 		ObservedRegex:            self.ObservedRegex,
 		Offline:                  self.Offline.GetOrElse(defaults.Offline),

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -18,8 +18,7 @@ import (
 
 type NormalConfig struct {
 	configdomain.NormalConfigData
-	Git        configdomain.PartialConfig // configuration data taken from Git metadata, in particular the unscoped Git metadata
-	GitVersion git.Version                // version of the installed Git executable
+	GitVersion git.Version // version of the installed Git executable
 }
 
 // removes the given branch from the lineage, and updates its children

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -74,11 +74,12 @@ func (self *NormalConfig) SetParent(runner subshelldomain.Runner, branch, parent
 
 // SetPerennialBranches marks the given branches as perennial branches.
 func (self *NormalConfig) SetPerennialBranches(runner subshelldomain.Runner, branches gitdomain.LocalBranchNames) error {
-	self.PerennialBranches = branches
+	var err error
 	if slices.Compare(self.PerennialBranches, branches) != 0 {
-		return gitconfig.SetPerennialBranches(runner, branches, configdomain.ConfigScopeLocal)
+		err = gitconfig.SetPerennialBranches(runner, branches, configdomain.ConfigScopeLocal)
 	}
-	return nil
+	self.PerennialBranches = branches
+	return err
 }
 
 // remoteURLString provides the URL for the given remote.

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -21,23 +21,6 @@ type NormalConfig struct {
 	GitVersion git.Version // version of the installed Git executable
 }
 
-// removes the given branch from the lineage, and updates its children
-func (self *NormalConfig) CleanupBranchFromLineage(runner subshelldomain.Runner, branch gitdomain.LocalBranchName) {
-	parent, hasParent := self.Git.Lineage.Parent(branch).Get()
-	children := self.Git.Lineage.Children(branch)
-	for _, child := range children {
-		if hasParent {
-			self.Git.Lineage = self.Git.Lineage.Set(child, parent)
-			_ = gitconfig.SetParent(runner, child, parent)
-		} else {
-			self.Git.Lineage = self.Git.Lineage.RemoveBranch(child)
-			_ = gitconfig.RemoveParent(runner, parent)
-		}
-	}
-	self.Git.Lineage = self.Git.Lineage.RemoveBranch(branch)
-	_ = gitconfig.RemoveParent(runner, branch)
-}
-
 // DevURL provides the URL for the development remote.
 // Tests can stub this through the GIT_TOWN_REMOTE environment variable.
 // Caches its result so can be called repeatedly.
@@ -65,15 +48,15 @@ func (self *NormalConfig) RemoteURL(querier subshelldomain.Querier, remote gitdo
 
 // RemoveParent removes the parent branch entry for the given branch from the Git configuration.
 func (self *NormalConfig) RemoveParent(runner subshelldomain.Runner, branch gitdomain.LocalBranchName) {
-	self.Git.Lineage = self.Git.Lineage.RemoveBranch(branch)
+	self.Lineage = self.Lineage.RemoveBranch(branch)
 	_ = gitconfig.RemoveParent(runner, branch)
 }
 
 func (self *NormalConfig) RemovePerennialAncestors(runner subshelldomain.Runner, finalMessages stringslice.Collector) {
 	for _, perennialBranch := range self.PerennialBranches {
-		if self.Git.Lineage.Parent(perennialBranch).IsSome() {
+		if self.Lineage.Parent(perennialBranch).IsSome() {
 			_ = gitconfig.RemoveParent(runner, perennialBranch)
-			self.Git.Lineage = self.Git.Lineage.RemoveBranch(perennialBranch)
+			self.Lineage = self.Lineage.RemoveBranch(perennialBranch)
 			finalMessages.Add(fmt.Sprintf(messages.PerennialBranchRemovedParentEntry, perennialBranch))
 		}
 	}
@@ -85,14 +68,14 @@ func (self *NormalConfig) SetParent(runner subshelldomain.Runner, branch, parent
 	if self.DryRun {
 		return nil
 	}
-	self.Git.Lineage = self.Git.Lineage.Set(branch, parentBranch)
+	self.Lineage = self.Lineage.Set(branch, parentBranch)
 	return gitconfig.SetParent(runner, branch, parentBranch)
 }
 
 // SetPerennialBranches marks the given branches as perennial branches.
 func (self *NormalConfig) SetPerennialBranches(runner subshelldomain.Runner, branches gitdomain.LocalBranchNames) error {
 	self.PerennialBranches = branches
-	if slices.Compare(self.Git.PerennialBranches, branches) != 0 {
+	if slices.Compare(self.PerennialBranches, branches) != 0 {
 		return gitconfig.SetPerennialBranches(runner, branches, configdomain.ConfigScopeLocal)
 	}
 	return nil

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -14,6 +14,7 @@ import (
 
 type UnvalidatedConfig struct {
 	File              Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
+	Git               configdomain.PartialConfig         // configuration data taken from Git metadata, in particular the unscoped Git metadata
 	NormalConfig      NormalConfig
 	UnvalidatedConfig configdomain.UnvalidatedConfigData
 }
@@ -51,9 +52,9 @@ func (self *UnvalidatedConfig) Reload(backend subshelldomain.RunnerQuerier) (glo
 		file: self.File,
 		git:  unscopedGitConfig,
 	})
+	self.Git = unscopedGitConfig
 	self.UnvalidatedConfig = unvalidatedConfig
 	self.NormalConfig = NormalConfig{
-		Git:              unscopedGitConfig,
 		GitVersion:       self.NormalConfig.GitVersion,
 		NormalConfigData: normalConfig,
 	}
@@ -61,7 +62,7 @@ func (self *UnvalidatedConfig) Reload(backend subshelldomain.RunnerQuerier) (glo
 }
 
 func (self *UnvalidatedConfig) RemoveMainBranch(runner subshelldomain.Runner) {
-	if self.NormalConfig.Git.MainBranch.IsSome() {
+	if self.Git.MainBranch.IsSome() {
 		_ = gitconfig.RemoveMainBranch(runner)
 	}
 }
@@ -93,8 +94,8 @@ func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {
 	})
 	return UnvalidatedConfig{
 		File: args.ConfigFile,
+		Git:  args.GitConfig,
 		NormalConfig: NormalConfig{
-			Git:              args.GitConfig,
 			GitVersion:       args.GitVersion,
 			NormalConfigData: normalConfig,
 		},

--- a/internal/config/unvalidated_config_test.go
+++ b/internal/config/unvalidated_config_test.go
@@ -22,7 +22,7 @@ func TestUnvalidatedConfig(t *testing.T) {
 			want := configdomain.NewLineageWith(configdomain.LineageData{
 				"branch": "main",
 			})
-			must.Eq(t, want, repo.Config.NormalConfig.Git.Lineage)
+			must.Eq(t, want, repo.Config.NormalConfig.Lineage)
 		})
 		t.Run("contribution branches changed", func(t *testing.T) {
 			t.Parallel()

--- a/internal/config/validated_config.go
+++ b/internal/config/validated_config.go
@@ -64,7 +64,7 @@ func (self *ValidatedConfig) RemoveDeletedBranchesFromLineage(branchInfos gitdom
 	for _, nonExistingBranch := range nonExistingBranches {
 		self.NormalConfig.CleanupBranchFromLineage(runner, nonExistingBranch)
 	}
-	for _, entry := range self.NormalConfig.Git.Lineage.Entries() {
+	for _, entry := range self.NormalConfig.Lineage.Entries() {
 		childDoesntExist := nonExistingBranches.Contains(entry.Child)
 		parentDoesntExist := nonExistingBranches.Contains(entry.Parent)
 		if childDoesntExist || parentDoesntExist {

--- a/internal/config/validated_config.go
+++ b/internal/config/validated_config.go
@@ -19,46 +19,6 @@ func EmptyValidatedConfig() ValidatedConfig {
 	return ValidatedConfig{} //exhaustruct:ignore
 }
 
-// removes the given branch from the lineage, and updates its children
-func (self *ValidatedConfig) CleanupBranchFromLineage(runner subshelldomain.Runner, branch gitdomain.LocalBranchName) {
-	parent, hasParent := self.NormalConfig.Lineage.Parent(branch).Get()
-	children := self.NormalConfig.Lineage.Children(branch)
-	for _, child := range children {
-		if hasParent {
-			self.NormalConfig.Lineage = self.NormalConfig.Lineage.Set(child, parent)
-			_ = gitconfig.SetParent(runner, child, parent)
-		} else {
-			self.NormalConfig.Lineage = self.NormalConfig.Lineage.RemoveBranch(child)
-			_ = gitconfig.RemoveParent(runner, parent)
-		}
-	}
-	self.NormalConfig.Lineage = self.NormalConfig.Lineage.RemoveBranch(branch)
-	_ = gitconfig.RemoveParent(runner, branch)
-}
-
-func (self *ValidatedConfig) RemoveDeletedBranchesFromLineage(branchInfos gitdomain.BranchInfos, nonExistingBranches gitdomain.LocalBranchNames, runner subshelldomain.Runner) {
-	for _, nonExistingBranch := range nonExistingBranches {
-		self.CleanupBranchFromLineage(runner, nonExistingBranch)
-	}
-	for _, entry := range self.NormalConfig.Lineage.Entries() {
-		childDoesntExist := nonExistingBranches.Contains(entry.Child)
-		parentDoesntExist := nonExistingBranches.Contains(entry.Parent)
-		if childDoesntExist || parentDoesntExist {
-			self.NormalConfig.RemoveParent(runner, entry.Child)
-		}
-		childExists := branchInfos.HasBranch(entry.Child)
-		parentExists := branchInfos.HasBranch(entry.Parent)
-		if !childExists || !parentExists {
-			self.NormalConfig.RemoveParent(runner, entry.Child)
-		}
-	}
-}
-
-func (self *ValidatedConfig) CleanupLineage(branchInfos gitdomain.BranchInfos, nonExistingBranches gitdomain.LocalBranchNames, finalMessages stringslice.Collector, runner subshelldomain.Runner) {
-	self.RemoveDeletedBranchesFromLineage(branchInfos, nonExistingBranches, runner)
-	self.NormalConfig.RemovePerennialAncestors(runner, finalMessages)
-}
-
 func (self *ValidatedConfig) BranchType(branch gitdomain.LocalBranchName) configdomain.BranchType {
 	if self.ValidatedConfigData.IsMainBranch(branch) {
 		return configdomain.BranchTypeMainBranch
@@ -84,6 +44,28 @@ func (self *ValidatedConfig) BranchesOfType(branches gitdomain.LocalBranchNames,
 	return result
 }
 
+// removes the given branch from the lineage, and updates its children
+func (self *ValidatedConfig) CleanupBranchFromLineage(runner subshelldomain.Runner, branch gitdomain.LocalBranchName) {
+	parent, hasParent := self.NormalConfig.Lineage.Parent(branch).Get()
+	children := self.NormalConfig.Lineage.Children(branch)
+	for _, child := range children {
+		if hasParent {
+			self.NormalConfig.Lineage = self.NormalConfig.Lineage.Set(child, parent)
+			_ = gitconfig.SetParent(runner, child, parent)
+		} else {
+			self.NormalConfig.Lineage = self.NormalConfig.Lineage.RemoveBranch(child)
+			_ = gitconfig.RemoveParent(runner, parent)
+		}
+	}
+	self.NormalConfig.Lineage = self.NormalConfig.Lineage.RemoveBranch(branch)
+	_ = gitconfig.RemoveParent(runner, branch)
+}
+
+func (self *ValidatedConfig) CleanupLineage(branchInfos gitdomain.BranchInfos, nonExistingBranches gitdomain.LocalBranchNames, finalMessages stringslice.Collector, runner subshelldomain.Runner) {
+	self.RemoveDeletedBranchesFromLineage(branchInfos, nonExistingBranches, runner)
+	self.NormalConfig.RemovePerennialAncestors(runner, finalMessages)
+}
+
 // IsMainOrPerennialBranch indicates whether the branch with the given name
 // is the main branch or a perennial branch of the repository.
 func (self *ValidatedConfig) IsMainOrPerennialBranch(branch gitdomain.LocalBranchName) bool {
@@ -93,6 +75,24 @@ func (self *ValidatedConfig) IsMainOrPerennialBranch(branch gitdomain.LocalBranc
 
 func (self *ValidatedConfig) MainAndPerennials() gitdomain.LocalBranchNames {
 	return append(gitdomain.LocalBranchNames{self.ValidatedConfigData.MainBranch}, self.NormalConfig.PerennialBranches...)
+}
+
+func (self *ValidatedConfig) RemoveDeletedBranchesFromLineage(branchInfos gitdomain.BranchInfos, nonExistingBranches gitdomain.LocalBranchNames, runner subshelldomain.Runner) {
+	for _, nonExistingBranch := range nonExistingBranches {
+		self.CleanupBranchFromLineage(runner, nonExistingBranch)
+	}
+	for _, entry := range self.NormalConfig.Lineage.Entries() {
+		childDoesntExist := nonExistingBranches.Contains(entry.Child)
+		parentDoesntExist := nonExistingBranches.Contains(entry.Parent)
+		if childDoesntExist || parentDoesntExist {
+			self.NormalConfig.RemoveParent(runner, entry.Child)
+		}
+		childExists := branchInfos.HasBranch(entry.Child)
+		parentExists := branchInfos.HasBranch(entry.Parent)
+		if !childExists || !parentExists {
+			self.NormalConfig.RemoveParent(runner, entry.Child)
+		}
+	}
 }
 
 // provides this collection without the perennial branch at the root

--- a/internal/config/validated_config_test.go
+++ b/internal/config/validated_config_test.go
@@ -52,7 +52,7 @@ func TestValidatedConfig(t *testing.T) {
 		repo.CreateFeatureBranch("feature1", "main")
 		repo.CreateFeatureBranch("feature2", "main")
 		repo.Config.Reload(repo.TestRunner)
-		have := repo.Config.NormalConfig.Git.Lineage
+		have := repo.Config.NormalConfig.Lineage
 		want := configdomain.NewLineageWith(configdomain.LineageData{
 			"feature1": "main",
 			"feature2": "main",

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -90,7 +90,7 @@ func (self *TestCommands) CommitStagedChanges(message gitdomain.CommitMessage) {
 
 // Commits provides a list of the commits in this Git repository with the given fields.
 func (self *TestCommands) Commits(fields []string, mainBranch gitdomain.BranchName, lineage configdomain.Lineage) []testgit.Commit {
-	// NOTE: This method uses the provided lineage instead of self.Config.NormalConfig.Git.Lineage
+	// NOTE: This method uses the provided lineage instead of self.Config.NormalConfig.Lineage
 	//       because it might determine the commits on a remote repo, and that repo has no lineage information.
 	//       We therefore always provide the lineage of the local repo.
 	branches, branchesInOtherWorktree := asserts.NoError2(self.LocalBranchesMainFirst(mainBranch.LocalName()))

--- a/internal/test/commands/test_commands_test.go
+++ b/internal/test/commands/test_commands_test.go
@@ -47,7 +47,7 @@ func TestTestCommands(t *testing.T) {
 			FileName:    "file2",
 			Message:     "second commit",
 		})
-		commits := runtime.Commits([]string{"FILE NAME", "FILE CONTENT"}, "initial", runtime.Config.NormalConfig.Git.Lineage)
+		commits := runtime.Commits([]string{"FILE NAME", "FILE CONTENT"}, "initial", runtime.Config.NormalConfig.Lineage)
 		must.Len(t, 2, commits)
 		must.EqOp(t, "initial", commits[0].Branch)
 		must.EqOp(t, "file1", commits[0].FileName)
@@ -111,7 +111,7 @@ func TestTestCommands(t *testing.T) {
 				FileName:    "hello.txt",
 				Message:     "test commit",
 			})
-			commits := runtime.Commits([]string{"FILE NAME", "FILE CONTENT"}, "initial", runtime.Config.NormalConfig.Git.Lineage)
+			commits := runtime.Commits([]string{"FILE NAME", "FILE CONTENT"}, "initial", runtime.Config.NormalConfig.Lineage)
 			must.Len(t, 1, commits)
 			must.EqOp(t, "hello.txt", commits[0].FileName)
 			must.EqOp(t, "hello world", commits[0].FileContent)
@@ -129,7 +129,7 @@ func TestTestCommands(t *testing.T) {
 				FileName:    "hello.txt",
 				Message:     "test commit",
 			})
-			commits := runtime.Commits([]string{"FILE NAME", "FILE CONTENT"}, "initial", runtime.Config.NormalConfig.Git.Lineage)
+			commits := runtime.Commits([]string{"FILE NAME", "FILE CONTENT"}, "initial", runtime.Config.NormalConfig.Lineage)
 			must.Len(t, 1, commits)
 			must.EqOp(t, "hello.txt", commits[0].FileName)
 			must.EqOp(t, "hello world", commits[0].FileContent)
@@ -145,7 +145,7 @@ func TestTestCommands(t *testing.T) {
 		runtime.CreateFeatureBranch("f1", "main")
 		runtime.Config.Reload(runtime.TestRunner)
 		must.False(t, runtime.Config.IsMainOrPerennialBranch("f1"))
-		lineageHave := runtime.Config.NormalConfig.Git.Lineage
+		lineageHave := runtime.Config.NormalConfig.Lineage
 		lineageWant := configdomain.NewLineageWith(configdomain.LineageData{
 			"f1": "main",
 		})
@@ -208,7 +208,7 @@ func TestTestCommands(t *testing.T) {
 		runtime.CreateFile("f2.txt", "two")
 		runtime.StageFiles("f1.txt", "f2.txt")
 		runtime.CommitStagedChanges("stuff")
-		commits := runtime.Commits([]string{}, "initial", runtime.Config.NormalConfig.Git.Lineage)
+		commits := runtime.Commits([]string{}, "initial", runtime.Config.NormalConfig.Lineage)
 		must.Len(t, 2, commits)
 		fileNames := runtime.FilesInCommit(commits[1].SHA)
 		must.Eq(t, []string{"f1.txt", "f2.txt"}, fileNames)

--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -1414,7 +1414,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^the main branch is (?:now|still) not set$`, func(ctx context.Context) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		have := devRepo.Config.NormalConfig.Git.MainBranch
+		have := devRepo.Config.Git.MainBranch
 		if branch, has := have.Get(); has {
 			return fmt.Errorf("unexpected main branch setting %q", branch)
 		}
@@ -1459,7 +1459,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^there are (?:now|still) no perennial branches$`, func(ctx context.Context) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		branches := devRepo.Config.NormalConfig.Git.PerennialBranches
+		branches := devRepo.Config.Git.PerennialBranches
 		if len(branches) > 0 {
 			return fmt.Errorf("expected no perennial branches, got %q", branches)
 		}

--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -315,7 +315,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
 		branch := gitdomain.NewLocalBranchName(branchText)
-		parent := devRepo.Config.NormalConfig.Git.Lineage.Parent(branch).GetOrPanic()
+		parent := devRepo.Config.NormalConfig.Lineage.Parent(branch).GetOrPanic()
 		sha := devRepo.CommitSHA(devRepo, title, branch, parent.BranchName())
 		have := asserts.NoError1(devRepo.Git.CommitMessage(devRepo, sha)).String()
 		want := expected.Content
@@ -926,8 +926,8 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^no lineage exists now$`, func(ctx context.Context) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		if devRepo.Config.NormalConfig.Git.Lineage.Len() > 0 {
-			lineage := devRepo.Config.NormalConfig.Git.Lineage
+		if devRepo.Config.NormalConfig.Lineage.Len() > 0 {
+			lineage := devRepo.Config.NormalConfig.Lineage
 			return fmt.Errorf("unexpected Git Town lineage information: %+v", lineage)
 		}
 		return nil

--- a/internal/test/fixture/fixture.go
+++ b/internal/test/fixture/fixture.go
@@ -128,7 +128,7 @@ func (self *Fixture) Branches() datatable.DataTable {
 // CommitTable provides a table for all commits in this Git environment containing only the given fields.
 func (self *Fixture) CommitTable(fields []string) datatable.DataTable {
 	builder := datatable.NewCommitTableBuilder()
-	lineage := self.DevRepo.Value.Config.NormalConfig.Git.Lineage
+	lineage := self.DevRepo.Value.Config.NormalConfig.Lineage
 	var mainBranch gitdomain.BranchName
 	mainIsLocal := self.DevRepo.Value.Git.BranchExists(self.DevRepo.Value, "main")
 	if mainIsLocal {

--- a/internal/test/fixture/fixture_test.go
+++ b/internal/test/fixture/fixture_test.go
@@ -165,7 +165,7 @@ func TestFixture(t *testing.T) {
 			},
 		})
 		// verify local commits
-		commits := cloned.DevRepo.GetOrPanic().Commits([]string{"FILE NAME", "FILE CONTENT"}, "main", cloned.DevRepo.Value.Config.NormalConfig.Git.Lineage)
+		commits := cloned.DevRepo.GetOrPanic().Commits([]string{"FILE NAME", "FILE CONTENT"}, "main", cloned.DevRepo.Value.Config.NormalConfig.Lineage)
 		must.Len(t, 2, commits)
 		must.EqOp(t, "local and origin commit", commits[0].Message)
 		must.EqOp(t, "loc-rem-file", commits[0].FileName)
@@ -174,7 +174,7 @@ func TestFixture(t *testing.T) {
 		must.EqOp(t, "local-file", commits[1].FileName)
 		must.EqOp(t, "local content", commits[1].FileContent)
 		// verify origin commits
-		commits = cloned.OriginRepo.GetOrPanic().Commits([]string{"FILE NAME", "FILE CONTENT"}, "main", cloned.DevRepo.Value.Config.NormalConfig.Git.Lineage)
+		commits = cloned.OriginRepo.GetOrPanic().Commits([]string{"FILE NAME", "FILE CONTENT"}, "main", cloned.DevRepo.Value.Config.NormalConfig.Lineage)
 		must.Len(t, 2, commits)
 		must.EqOp(t, "local and origin commit", commits[0].Message)
 		must.EqOp(t, "loc-rem-file", commits[0].FileName)

--- a/internal/undo/undobranches/branch_changes_test.go
+++ b/internal/undo/undobranches/branch_changes_test.go
@@ -72,10 +72,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PushHook:          false,
 					PerennialBranches: gitdomain.LocalBranchNames{},
 				},
@@ -168,10 +166,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
 				},
@@ -266,10 +262,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
 				},
@@ -411,10 +405,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
 				},
@@ -514,10 +506,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          true,
 				},
@@ -642,10 +632,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					UnknownBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
@@ -766,10 +754,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					UnknownBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
@@ -864,10 +850,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
 				},
@@ -1001,10 +985,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					UnknownBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          true,
@@ -1104,10 +1086,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					UnknownBranchType: configdomain.BranchTypeFeatureBranch,
 				},
 			},
@@ -1197,10 +1177,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					UnknownBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
@@ -1298,10 +1276,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
 				},
@@ -1402,10 +1378,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					UnknownBranchType: configdomain.BranchTypeFeatureBranch,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
@@ -1494,10 +1468,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
 				},
@@ -1581,10 +1553,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.LocalBranchNames{},
 					PushHook:          false,
 				},
@@ -1683,10 +1653,8 @@ func TestChanges(t *testing.T) {
 				MainBranch: "main",
 			},
 			NormalConfig: config.NormalConfig{
-				Git: configdomain.PartialConfig{
-					Lineage: lineage,
-				},
 				NormalConfigData: configdomain.NormalConfigData{
+					Lineage:           lineage,
 					PerennialBranches: gitdomain.NewLocalBranchNames("perennial-branch"),
 					PushHook:          false,
 				},

--- a/internal/validate/config.go
+++ b/internal/validate/config.go
@@ -56,7 +56,7 @@ func Config(args ConfigArgs) (config.ValidatedConfig, dialogdomain.Exit, error) 
 		Connector:         args.Connector,
 		DefaultChoice:     mainBranch,
 		DialogTestInputs:  args.TestInputs,
-		Lineage:           args.Unvalidated.Value.NormalConfig.Git.Lineage,
+		Lineage:           args.Unvalidated.Value.NormalConfig.Lineage,
 		LocalBranches:     args.LocalBranches,
 		MainBranch:        mainBranch,
 		PerennialBranches: args.Unvalidated.Value.NormalConfig.PerennialBranches,

--- a/internal/vm/opcodes/branch_current_reset_to_parent.go
+++ b/internal/vm/opcodes/branch_current_reset_to_parent.go
@@ -13,7 +13,7 @@ type BranchCurrentResetToParent struct {
 }
 
 func (self *BranchCurrentResetToParent) Run(args shared.RunArgs) error {
-	parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.CurrentBranch).Get()
+	parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(self.CurrentBranch).Get()
 	if !hasParent {
 		return nil
 	}

--- a/internal/vm/opcodes/branch_delete_if_empty_at_runtime.go
+++ b/internal/vm/opcodes/branch_delete_if_empty_at_runtime.go
@@ -12,7 +12,7 @@ type BranchDeleteIfEmptyAtRuntime struct {
 }
 
 func (self *BranchDeleteIfEmptyAtRuntime) Run(args shared.RunArgs) error {
-	parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.Branch).Get()
+	parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(self.Branch).Get()
 	if !hasParent {
 		return nil
 	}

--- a/internal/vm/opcodes/branch_local_delete_content.go
+++ b/internal/vm/opcodes/branch_local_delete_content.go
@@ -18,7 +18,7 @@ func (self *BranchLocalDeleteContent) Run(args shared.RunArgs) error {
 	switch args.Config.Value.NormalConfig.SyncFeatureStrategy {
 	case configdomain.SyncFeatureStrategyRebase:
 		opcodes := []shared.Opcode{}
-		descendents := args.Config.Value.NormalConfig.Git.Lineage.Descendants(self.BranchToDelete)
+		descendents := args.Config.Value.NormalConfig.Lineage.Descendants(self.BranchToDelete)
 		if len(descendents) > 0 {
 			opcodes = append(opcodes, &RebaseOntoRemoveDeleted{
 				BranchToRebaseOnto: self.BranchToRebaseOnto,

--- a/internal/vm/opcodes/branch_with_remote_gone_delete_if_empty_at_runtime.go
+++ b/internal/vm/opcodes/branch_with_remote_gone_delete_if_empty_at_runtime.go
@@ -15,7 +15,7 @@ type BranchWithRemoteGoneDeleteIfEmptyAtRuntime struct {
 }
 
 func (self *BranchWithRemoteGoneDeleteIfEmptyAtRuntime) Run(args shared.RunArgs) error {
-	parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.Branch).Get()
+	parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(self.Branch).Get()
 	if !hasParent {
 		return nil
 	}

--- a/internal/vm/opcodes/checkout_parent_or_main.go
+++ b/internal/vm/opcodes/checkout_parent_or_main.go
@@ -13,7 +13,7 @@ type CheckoutParentOrMain struct {
 }
 
 func (self *CheckoutParentOrMain) Run(args shared.RunArgs) error {
-	parent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.Branch).GetOrElse(args.Config.Value.ValidatedConfigData.MainBranch)
+	parent := args.Config.Value.NormalConfig.Lineage.Parent(self.Branch).GetOrElse(args.Config.Value.ValidatedConfigData.MainBranch)
 	args.PrependOpcodes(&CheckoutIfNeeded{Branch: parent})
 	return nil
 }

--- a/internal/vm/opcodes/commit_revert_if_needed.go
+++ b/internal/vm/opcodes/commit_revert_if_needed.go
@@ -20,7 +20,7 @@ func (self *CommitRevertIfNeeded) Run(args shared.RunArgs) error {
 	if err != nil {
 		return err
 	}
-	parent := args.Config.Value.NormalConfig.Git.Lineage.Parent(currentBranch)
+	parent := args.Config.Value.NormalConfig.Lineage.Parent(currentBranch)
 	commitsInCurrentBranch, err := args.Git.CommitsInBranch(args.Backend, currentBranch, parent)
 	if err != nil {
 		return err

--- a/internal/vm/opcodes/lineage_branch_remove.go
+++ b/internal/vm/opcodes/lineage_branch_remove.go
@@ -11,8 +11,8 @@ type LineageBranchRemove struct {
 }
 
 func (self *LineageBranchRemove) Run(args shared.RunArgs) error {
-	parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.Branch).Get()
-	children := args.Config.Value.NormalConfig.Git.Lineage.Children(self.Branch)
+	parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(self.Branch).Get()
+	children := args.Config.Value.NormalConfig.Lineage.Children(self.Branch)
 	for _, child := range children {
 		if !hasParent {
 			args.PrependOpcodes(&LineageParentRemove{Branch: child})
@@ -21,6 +21,6 @@ func (self *LineageBranchRemove) Run(args shared.RunArgs) error {
 		}
 	}
 	args.PrependOpcodes(&LineageParentRemove{Branch: self.Branch})
-	args.Config.Value.NormalConfig.Git.Lineage = args.Config.Value.NormalConfig.Git.Lineage.RemoveBranch(self.Branch)
+	args.Config.Value.NormalConfig.Lineage = args.Config.Value.NormalConfig.Lineage.RemoveBranch(self.Branch)
 	return nil
 }

--- a/internal/vm/opcodes/lineage_parent_set_to_grandparent.go
+++ b/internal/vm/opcodes/lineage_parent_set_to_grandparent.go
@@ -12,11 +12,11 @@ type LineageParentSetToGrandParent struct {
 }
 
 func (self *LineageParentSetToGrandParent) Run(args shared.RunArgs) error {
-	parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.Branch).Get()
+	parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(self.Branch).Get()
 	if !hasParent {
 		return nil
 	}
-	if grandParent, hasGrandParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(parent).Get(); hasGrandParent {
+	if grandParent, hasGrandParent := args.Config.Value.NormalConfig.Lineage.Parent(parent).Get(); hasGrandParent {
 		args.PrependOpcodes(&LineageParentSet{
 			Branch: self.Branch,
 			Parent: grandParent,

--- a/internal/vm/opcodes/proposal_create.go
+++ b/internal/vm/opcodes/proposal_create.go
@@ -20,7 +20,7 @@ type ProposalCreate struct {
 }
 
 func (self *ProposalCreate) Run(args shared.RunArgs) error {
-	parentBranch, hasParentBranch := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.Branch).Get()
+	parentBranch, hasParentBranch := args.Config.Value.NormalConfig.Lineage.Parent(self.Branch).Get()
 	if !hasParentBranch {
 		return fmt.Errorf(messages.ProposalNoParent, self.Branch)
 	}

--- a/internal/vm/opcodes/proposal_update_target_to_grandparent.go
+++ b/internal/vm/opcodes/proposal_update_target_to_grandparent.go
@@ -17,7 +17,7 @@ type ProposalUpdateTargetToGrandParent struct {
 }
 
 func (self *ProposalUpdateTargetToGrandParent) Run(args shared.RunArgs) error {
-	parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.OldTarget).Get()
+	parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(self.OldTarget).Get()
 	if !hasParent {
 		return fmt.Errorf("branch %q has no parent", self.Branch)
 	}

--- a/internal/vm/opcodes/rebase_parents_until_local.go
+++ b/internal/vm/opcodes/rebase_parents_until_local.go
@@ -21,7 +21,7 @@ func (self *RebaseParentsUntilLocal) Run(args shared.RunArgs) error {
 	}
 	branch := self.Branch
 	for {
-		parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(branch).Get()
+		parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(branch).Get()
 		if !hasParent {
 			break
 		}

--- a/internal/vm/opcodes/sync_feature_branch_compress.go
+++ b/internal/vm/opcodes/sync_feature_branch_compress.go
@@ -22,7 +22,7 @@ type SyncFeatureBranchCompress struct {
 func (self *SyncFeatureBranchCompress) Run(args shared.RunArgs) error {
 	opcodes := []shared.Opcode{}
 	commitsInBranch := gitdomain.Commits{}
-	if parentLocalName, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(self.CurrentBranch).Get(); hasParent {
+	if parentLocalName, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(self.CurrentBranch).Get(); hasParent {
 		parentName := determineParentBranchName(parentLocalName, args.BranchInfos, args.Config.Value.NormalConfig.DevRemote)
 		inSyncWithParent, err := args.Git.BranchInSyncWithParent(args.Backend, self.CurrentBranch, parentName)
 		if err != nil {

--- a/internal/vm/opcodes/sync_feature_branch_merge.go
+++ b/internal/vm/opcodes/sync_feature_branch_merge.go
@@ -24,7 +24,7 @@ func (self *SyncFeatureBranchMerge) Run(args shared.RunArgs) error {
 	}
 	branch := self.Branch
 	for {
-		parent, hasParent := args.Config.Value.NormalConfig.Git.Lineage.Parent(branch).Get()
+		parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(branch).Get()
 		if !hasParent {
 			break
 		}

--- a/tools/print_config_exhaustive/lint_test.go
+++ b/tools/print_config_exhaustive/lint_test.go
@@ -192,8 +192,8 @@ func printConfig(config config.UnvalidatedConfig) {
 	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
 	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
 	fmt.Println()
-	if config.NormalConfig.Git.Lineage.Len() > 0 {
-		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Git.Lineage))
+	if config.NormalConfig.Lineage.Len() > 0 {
+		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
 	}
 }
 `
@@ -205,8 +205,8 @@ func printConfig(config config.UnvalidatedConfig) {
 	print.Entry("contribution regex", format.OptionalStringerSetting(config.NormalConfig.ContributionRegex))
 	print.Entry("feature regex", format.OptionalStringerSetting(config.NormalConfig.FeatureRegex))
 	fmt.Println()
-	if config.NormalConfig.Git.Lineage.Len() > 0 {
-		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Git.Lineage))
+	if config.NormalConfig.Lineage.Len() > 0 {
+		print.LabelAndValue("Branch Lineage", format.BranchLineage(config.NormalConfig.Lineage))
 	`
 	must.EqOp(t, want, have)
 }


### PR DESCRIPTION
ValidatedConfig is for commands to operate on. It shouldn't contain parts of the
information that was used to synthesize it. 
