### PR TITLE
More precise entry type checks

### DIFF
--- a/internal/cli/dialog/dialogcomponents/checklist.go
+++ b/internal/cli/dialog/dialogcomponents/checklist.go
@@ -11,7 +11,7 @@ import (
 )
 
 // lets the user select zero, one, or many of the given entries
-func CheckList[S comparable](entries list.Entries[S], selections []int, title, help string, inputs TestInputs, dialogName string) (selected []S, exit dialogdomain.Exit, err error) {
+func CheckList[S any](entries list.Entries[S], selections []int, title, help string, inputs TestInputs, dialogName string) (selected []S, exit dialogdomain.Exit, err error) {
 	cursor := entries.FirstEnabled()
 	program := tea.NewProgram(CheckListModel[S]{
 		List:       list.NewList(entries, cursor),
@@ -25,7 +25,7 @@ func CheckList[S comparable](entries list.Entries[S], selections []int, title, h
 	return result.CheckedEntries(), result.Aborted(), err
 }
 
-type CheckListModel[S comparable] struct {
+type CheckListModel[S any] struct {
 	list.List[S]
 	Selections []int
 	help       string // help text to display before the checklist

--- a/internal/cli/dialog/dialogcomponents/list/entries.go
+++ b/internal/cli/dialog/dialogcomponents/list/entries.go
@@ -61,9 +61,3 @@ func (self Entries[S]) IndexOfFunc(needle S, equalFn func(a, b S) bool) int {
 	}
 	return 0
 }
-
-// narrower type needed to use the NewEntries convenience function
-type ComparableStringer interface {
-	comparable
-	fmt.Stringer
-}

--- a/internal/cli/dialog/dialogcomponents/list/entries.go
+++ b/internal/cli/dialog/dialogcomponents/list/entries.go
@@ -2,13 +2,15 @@ package list
 
 import (
 	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // Entries provides methods for a collection of Entry instances.
-type Entries[S comparable] []Entry[S]
+type Entries[S any] []Entry[S]
 
 // creates an Entries instance containing the given records
-func NewEntries[S ComparableStringer](records ...S) Entries[S] {
+func NewEntries[S fmt.Stringer](records ...S) Entries[S] {
 	result := make([]Entry[S], len(records))
 	for r, record := range records {
 		result[r] = Entry[S]{
@@ -43,7 +45,7 @@ func (self Entries[S]) FirstEnabled() int {
 // provides the position of the given needle in this list
 func (self Entries[S]) IndexOf(needle S) int {
 	for e, entry := range self {
-		if entry.Data == needle {
+		if cmp.Equal(entry.Data, needle) {
 			return e
 		}
 	}

--- a/internal/cli/dialog/dialogcomponents/list/entries_test.go
+++ b/internal/cli/dialog/dialogcomponents/list/entries_test.go
@@ -89,7 +89,7 @@ func TestEntries(t *testing.T) {
 			want := 1
 			must.EqOp(t, want, have)
 		})
-		t.Run("does not work with options", func(t *testing.T) {
+		t.Run("works with options", func(t *testing.T) {
 			t.Parallel()
 			entries := list.Entries[Option[forgedomain.ForgeType]]{
 				{
@@ -106,12 +106,7 @@ func TestEntries(t *testing.T) {
 				},
 			}
 			have := entries.IndexOf(Some(forgedomain.ForgeTypeGitHub))
-			want := 0 // this should be 1 if comparing options would work
-			must.EqOp(t, want, have)
-			have = entries.IndexOfFunc(Some(forgedomain.ForgeTypeGitHub), func(a, b Option[forgedomain.ForgeType]) bool {
-				return a.Equal(b)
-			})
-			want = 1
+			want := 1
 			must.EqOp(t, want, have)
 		})
 	})

--- a/internal/cli/dialog/dialogcomponents/list/entries_test.go
+++ b/internal/cli/dialog/dialogcomponents/list/entries_test.go
@@ -73,7 +73,7 @@ func TestEntries(t *testing.T) {
 
 	t.Run("IndexOf", func(t *testing.T) {
 		t.Parallel()
-		t.Run("works with correctly comparable types", func(t *testing.T) {
+		t.Run("works with comparable types", func(t *testing.T) {
 			t.Parallel()
 			entries := list.Entries[forgedomain.ForgeType]{
 				{

--- a/internal/cli/dialog/dialogcomponents/list/entry.go
+++ b/internal/cli/dialog/dialogcomponents/list/entry.go
@@ -1,7 +1,7 @@
 package list
 
 // Entry is an entry in a List instance.
-type Entry[S comparable] struct {
+type Entry[S any] struct {
 	Data     S
 	Disabled bool `exhaustruct:"optional"`
 	Text     string

--- a/internal/cli/dialog/dialogcomponents/list/list.go
+++ b/internal/cli/dialog/dialogcomponents/list/list.go
@@ -11,7 +11,7 @@ import (
 )
 
 // List contains elements and operations common to all BubbleTea-based list implementations.
-type List[S comparable] struct {
+type List[S any] struct {
 	Colors       colors.DialogColors // colors to use for help text
 	Cursor       int                 // index of the currently selected row
 	Entries      Entries[S]          // the entries to select from
@@ -21,7 +21,7 @@ type List[S comparable] struct {
 	Status       Status
 }
 
-func NewList[S comparable](entries Entries[S], cursor int) List[S] {
+func NewList[S any](entries Entries[S], cursor int) List[S] {
 	numberLen := gohacks.NumberLength(len(entries))
 	return List[S]{
 		Status:       StatusActive,

--- a/internal/cli/dialog/dialogcomponents/radiolist.go
+++ b/internal/cli/dialog/dialogcomponents/radiolist.go
@@ -13,7 +13,7 @@ import (
 const WindowSize = 9
 
 // RadioList lets the user select one of the given entries.
-func RadioList[S comparable](entries list.Entries[S], cursor int, title, help string, inputs TestInputs, dialogName string) (selected S, exit dialogdomain.Exit, err error) { //nolint:ireturn
+func RadioList[S any](entries list.Entries[S], cursor int, title, help string, inputs TestInputs, dialogName string) (selected S, exit dialogdomain.Exit, err error) { //nolint:ireturn
 	program := tea.NewProgram(radioListModel[S]{
 		List:  list.NewList(entries, cursor),
 		help:  help,
@@ -25,7 +25,7 @@ func RadioList[S comparable](entries list.Entries[S], cursor int, title, help st
 	return result.SelectedData(), result.Aborted(), err
 }
 
-type radioListModel[S comparable] struct {
+type radioListModel[S any] struct {
 	list.List[S]
 	help  string // help text to display before the radio list
 	title string // title to display before the help text

--- a/internal/test/helpers/ordered_set.go
+++ b/internal/test/helpers/ordered_set.go
@@ -3,15 +3,17 @@ package helpers
 import (
 	"fmt"
 	"strings"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // OrderedSet is a Set that provides its elements in the order they were received.
-type OrderedSet[T comparable] struct {
+type OrderedSet[T any] struct {
 	elements []T
 }
 
 // NewOrderedSet provides instances of OrderedSet populated with the given elements.
-func NewOrderedSet[T comparable](elements ...T) OrderedSet[T] {
+func NewOrderedSet[T any](elements ...T) OrderedSet[T] {
 	return OrderedSet[T]{elements}
 }
 
@@ -27,7 +29,7 @@ func (self OrderedSet[T]) Add(element T) OrderedSet[T] {
 // Contains indicates whether this Set contains the given element.
 func (self OrderedSet[T]) Contains(element T) bool {
 	for _, existing := range self.elements {
-		if element == existing {
+		if cmp.Equal(element, existing) {
 			return true
 		}
 	}

--- a/pkg/prelude/option.go
+++ b/pkg/prelude/option.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // Option provides infrastructure for optional (nullable) values
@@ -134,9 +136,9 @@ func (self *Option[T]) UnmarshalJSON(b []byte) error {
 }
 
 // Creates a new Option containing None if the given value is the zero value, otherwise Some.
-func NewOption[T comparable](value T) Option[T] {
+func NewOption[T any](value T) Option[T] {
 	var zero T
-	if value == zero {
+	if cmp.Equal(value, zero) {
 		return None[T]()
 	}
 	return Some(value)


### PR DESCRIPTION
Relying on comparable isn't sufficient here. Go happily compares Options, which
return the wrong result when compared via ==. Not having the comparable
constraint enforces using cmp.Equal, which uses the Equal method if one exists.
