### PR TITLE
Rename UnvalidatedConfig.Git to .GitUnscoped

### DIFF
--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -75,7 +75,7 @@ func executeConfigSetup(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	if err = saveAll(enterDataResult, repo.UnvalidatedConfig.Git, data.configFile, data, repo.Frontend); err != nil {
+	if err = saveAll(enterDataResult, repo.UnvalidatedConfig.GitUnscoped, data.configFile, data, repo.Frontend); err != nil {
 		return err
 	}
 	return configinterpreter.Finished(configinterpreter.FinishedArgs{

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -13,7 +13,7 @@ import (
 
 type UnvalidatedConfig struct {
 	File              Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
-	Git               configdomain.PartialConfig         // configuration data taken from Git metadata, in particular the unscoped Git metadata
+	GitUnscoped       configdomain.PartialConfig         // configuration data taken from Git metadata, in particular the unscoped Git metadata
 	NormalConfig      NormalConfig
 	UnvalidatedConfig configdomain.UnvalidatedConfigData
 }
@@ -51,7 +51,7 @@ func (self *UnvalidatedConfig) Reload(backend subshelldomain.RunnerQuerier) (glo
 		file: self.File,
 		git:  unscopedGitConfig,
 	})
-	self.Git = unscopedGitConfig
+	self.GitUnscoped = unscopedGitConfig
 	self.UnvalidatedConfig = unvalidatedConfig
 	self.NormalConfig = normalConfig
 	return globalSnapshot, localSnapshot, unscopedSnapshot
@@ -84,7 +84,7 @@ func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {
 	})
 	return UnvalidatedConfig{
 		File:              args.ConfigFile,
-		Git:               args.GitConfig,
+		GitUnscoped:       args.GitConfig,
 		NormalConfig:      normalConfig,
 		UnvalidatedConfig: unvalidatedConfig,
 	}

--- a/internal/test/cucumber/steps.go
+++ b/internal/test/cucumber/steps.go
@@ -1414,7 +1414,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^the main branch is (?:now|still) not set$`, func(ctx context.Context) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		have := devRepo.Config.Git.MainBranch
+		have := devRepo.Config.GitUnscoped.MainBranch
 		if branch, has := have.Get(); has {
 			return fmt.Errorf("unexpected main branch setting %q", branch)
 		}
@@ -1459,7 +1459,7 @@ func defineSteps(sc *godog.ScenarioContext) {
 	sc.Step(`^there are (?:now|still) no perennial branches$`, func(ctx context.Context) error {
 		state := ctx.Value(keyScenarioState).(*ScenarioState)
 		devRepo := state.fixture.DevRepo.GetOrPanic()
-		branches := devRepo.Config.Git.PerennialBranches
+		branches := devRepo.Config.GitUnscoped.PerennialBranches
 		if len(branches) > 0 {
 			return fmt.Errorf("expected no perennial branches, got %q", branches)
 		}


### PR DESCRIPTION
Make the name of the unscoped Git more precise to make room for adding local and
global Git to this struct later.
