### PR TITLE
setup assistant: allow using global setting for unknown-branch-type

### DIFF
--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: setup a new repo when I have configured some things in global Git metadata
 
-  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -20,7 +19,6 @@ Feature: setup a new repo when I have configured some things in global Git metad
     And global Git setting "git-town.sync-tags" is "false"
     And global Git setting "git-town.sync-upstream" is "false"
     And global Git setting "git-town.unknown-branch-type" is "observed"
-    # And inspect the repo
     When I run "git-town config setup" and enter into the dialogs:
       | DIALOG                      | KEYS        |
       | welcome                     | enter       |
@@ -45,9 +43,19 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | ship delete tracking branch | enter       |
       | config storage              | enter       |
     Then Git Town runs the commands
-      | COMMAND                                            |
-      | git config git-town.perennial-regex 111            |
-      | git config git-town.unknown-branch-type feature    |
-      | git config git-town.feature-regex ^kg-222          |
-      | git config git-town.contribution-regex release-333 |
-      | git config git-town.observed-regex staging-444     |
+      | COMMAND                                               |
+      | git config git-town.new-branch-type prototype         |
+      | git config git-town.main-branch main                  |
+      | git config git-town.perennial-regex 111               |
+      | git config git-town.feature-regex ^kg-222             |
+      | git config git-town.contribution-regex release-333    |
+      | git config git-town.observed-regex staging-444        |
+      | git config git-town.push-hook false                   |
+      | git config git-town.share-new-branches push           |
+      | git config git-town.ship-strategy api                 |
+      | git config git-town.ship-delete-tracking-branch false |
+      | git config git-town.sync-feature-strategy rebase      |
+      | git config git-town.sync-perennial-strategy ff-only   |
+      | git config git-town.sync-prototype-strategy compress  |
+      | git config git-town.sync-upstream false               |
+      | git config git-town.sync-tags false                   |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -20,6 +20,7 @@ Feature: setup a new repo when I have configured some things in global Git metad
     And global Git setting "git-town.sync-tags" is "false"
     And global Git setting "git-town.sync-upstream" is "false"
     And global Git setting "git-town.unknown-branch-type" is "observed"
+    And inspect the repo
     When I run "git-town config setup" and enter into the dialogs:
       | DIALOG                      | KEYS        |
       | welcome                     | enter       |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -1,0 +1,49 @@
+@messyoutput
+Feature: setup a new repo when I have configured some things in global Git metadata
+
+  @this
+  Scenario:
+    Given a Git repo with origin
+    And Git Town is not configured
+    And global Git setting "git-town.main-branch" is "main"
+    And global Git setting "git-town.sync-feature-strategy" is "rebase"
+    And global Git setting "git-town.sync-perennial-strategy" is "ff-only"
+    And global Git setting "git-town.sync-prototype-strategy" is "compress"
+    And global Git setting "git-town.unknown-branch-type" is "observed"
+    When I run "git-town config setup" and enter into the dialogs:
+      | DIALOG                      | KEYS        |
+      | welcome                     | enter       |
+      | aliases                     | enter       |
+      | main branch                 | enter       |
+      | perennial regex             | 1 1 1 enter |
+      | feature regex               | 2 2 2 enter |
+      | contribution regex          | 3 3 3 enter |
+      | observed regex              | 4 4 4 enter |
+      | unknown branch type         | enter       |
+      | origin hostname             | enter       |
+      | forge type                  | enter       |
+      | sync feature strategy       | enter       |
+      | sync perennial strategy     | enter       |
+      | sync prototype strategy     | enter       |
+      | sync upstream               | enter       |
+      | sync tags                   | enter       |
+      | share new branches          | enter       |
+      | push hook                   | enter       |
+      | new branch type             | enter       |
+      | ship strategy               | enter       |
+      | ship delete tracking branch | enter       |
+      | config storage              | enter       |
+    Then Git Town runs the commands
+      | COMMAND                                              |
+      | git config git-town.new-branch-type feature          |
+      | git config git-town.perennial-regex 111              |
+      | git config git-town.unknown-branch-type feature      |
+      | git config git-town.feature-regex 222                |
+      | git config git-town.contribution-regex 333           |
+      | git config git-town.observed-regex 444               |
+      | git config git-town.push-hook true                   |
+      | git config git-town.share-new-branches no            |
+      | git config git-town.ship-strategy api                |
+      | git config git-town.ship-delete-tracking-branch true |
+      | git config git-town.sync-upstream true               |
+      | git config git-town.sync-tags true                   |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -5,10 +5,20 @@ Feature: setup a new repo when I have configured some things in global Git metad
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
+    And global Git setting "git-town.feature-regex" is "^kg-"
+    And global Git setting "git-town.contribution-regex" is "release-"
+    And global Git setting "git-town.observed-regex" is "staging-"
     And global Git setting "git-town.main-branch" is "main"
+    And global Git setting "git-town.new-branch-type" is "prototype"
+    And global Git setting "git-town.push-hook" is "false"
+    And global Git setting "git-town.share-new-branches" is "push"
+    And global Git setting "git-town.ship-strategy" is "api"
+    And global Git setting "git-town.ship-delete-tracking-branch" is "false"
     And global Git setting "git-town.sync-feature-strategy" is "rebase"
     And global Git setting "git-town.sync-perennial-strategy" is "ff-only"
     And global Git setting "git-town.sync-prototype-strategy" is "compress"
+    And global Git setting "git-town.sync-tags" is "false"
+    And global Git setting "git-town.sync-upstream" is "false"
     And global Git setting "git-town.unknown-branch-type" is "observed"
     When I run "git-town config setup" and enter into the dialogs:
       | DIALOG                      | KEYS        |
@@ -34,16 +44,9 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | ship delete tracking branch | enter       |
       | config storage              | enter       |
     Then Git Town runs the commands
-      | COMMAND                                              |
-      | git config git-town.new-branch-type feature          |
-      | git config git-town.perennial-regex 111              |
-      | git config git-town.unknown-branch-type feature      |
-      | git config git-town.feature-regex 222                |
-      | git config git-town.contribution-regex 333           |
-      | git config git-town.observed-regex 444               |
-      | git config git-town.push-hook true                   |
-      | git config git-town.share-new-branches no            |
-      | git config git-town.ship-strategy api                |
-      | git config git-town.ship-delete-tracking-branch true |
-      | git config git-town.sync-upstream true               |
-      | git config git-town.sync-tags true                   |
+      | COMMAND                                            |
+      | git config git-town.perennial-regex 111            |
+      | git config git-town.unknown-branch-type feature    |
+      | git config git-town.feature-regex ^kg-222          |
+      | git config git-town.contribution-regex release-333 |
+      | git config git-town.observed-regex staging-444     |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -1,7 +1,7 @@
 @messyoutput
 Feature: setup a new repo when I have configured some things in global Git metadata
 
-  @this
+  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -20,7 +20,7 @@ Feature: setup a new repo when I have configured some things in global Git metad
     And global Git setting "git-town.sync-tags" is "false"
     And global Git setting "git-town.sync-upstream" is "false"
     And global Git setting "git-town.unknown-branch-type" is "observed"
-    And inspect the repo
+    # And inspect the repo
     When I run "git-town config setup" and enter into the dialogs:
       | DIALOG                      | KEYS        |
       | welcome                     | enter       |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -9,6 +9,7 @@ Feature: setup a new repo when I have configured some things in global Git metad
     And global Git setting "git-town.observed-regex" is "staging-"
     And global Git setting "git-town.main-branch" is "main"
     And global Git setting "git-town.new-branch-type" is "prototype"
+    And global Git setting "git-town.perennial-branches" is "public"
     And global Git setting "git-town.push-hook" is "false"
     And global Git setting "git-town.share-new-branches" is "push"
     And global Git setting "git-town.ship-strategy" is "api"
@@ -24,6 +25,7 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | welcome                     | enter       |
       | aliases                     | enter       |
       | main branch                 | enter       |
+      | perennial branches          | enter       |
       | perennial regex             | 1 1 1 enter |
       | feature regex               | 2 2 2 enter |
       | contribution regex          | 3 3 3 enter |
@@ -46,6 +48,7 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | COMMAND                                               |
       | git config git-town.new-branch-type prototype         |
       | git config git-town.main-branch main                  |
+      | git config git-town.perennial-branches public         |
       | git config git-town.perennial-regex 111               |
       | git config git-town.feature-regex ^kg-222             |
       | git config git-town.contribution-regex release-333    |
@@ -59,3 +62,4 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | git config git-town.sync-prototype-strategy compress  |
       | git config git-town.sync-upstream false               |
       | git config git-town.sync-tags false                   |
+      # TODO: don't save the perennial branches locally here

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -62,4 +62,4 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | git config git-town.sync-prototype-strategy compress  |
       | git config git-town.sync-upstream false               |
       | git config git-town.sync-tags false                   |
-      # TODO: don't save the perennial branches locally here
+  # TODO: don't save the perennial branches locally here

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: ask for information not provided by the config file
 
-  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -8,15 +8,15 @@ Feature: ask for information not provided by the config file
       """
       [branches]
       main = "main"
-      
+
       [hosting]
       dev-remote = "something"
       forge-type = "github"
       origin-hostname = "github.com"
-      
+
       [ship]
       delete-tracking-branch = false
-      
+
       [sync]
       tags = false
       upstream = false

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -1,6 +1,7 @@
 @messyoutput
 Feature: ask for information not provided by the config file
 
+  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -8,15 +9,15 @@ Feature: ask for information not provided by the config file
       """
       [branches]
       main = "main"
-
+      
       [hosting]
       dev-remote = "something"
       forge-type = "github"
       origin-hostname = "github.com"
-
+      
       [ship]
       delete-tracking-branch = false
-
+      
       [sync]
       tags = false
       upstream = false

--- a/internal/cli/dialog/dialogcomponents/colors.go
+++ b/internal/cli/dialog/dialogcomponents/colors.go
@@ -1,8 +1,11 @@
 package dialogcomponents
 
 import (
+	"fmt"
+
 	"github.com/git-town/git-town/v21/internal/cli/colors"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
 // FormattedToken provides the given API token in a printable format.
@@ -25,4 +28,15 @@ func FormattedSelection(selection string, exit dialogdomain.Exit) string {
 		return colors.Green().Styled("(not provided)")
 	}
 	return colors.Green().Styled(selection)
+}
+
+// FormattedSelection provides the given dialog choice in a printable format.
+func FormattedOptionalSelection(selection Option[fmt.Stringer], exit dialogdomain.Exit) string {
+	if exit {
+		return colors.Red().Styled("(aborted)")
+	}
+	if selected, has := selection.Get(); has {
+		return colors.Green().Styled(selected.String())
+	}
+	return colors.Green().Styled("(use global setting)")
 }

--- a/internal/cli/dialog/dialogcomponents/colors.go
+++ b/internal/cli/dialog/dialogcomponents/colors.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/cli/colors"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
 // FormattedToken provides the given API token in a printable format.
@@ -31,12 +30,12 @@ func FormattedSelection(selection string, exit dialogdomain.Exit) string {
 }
 
 // FormattedSelection provides the given dialog choice in a printable format.
-func FormattedOptionalSelection(selection Option[fmt.Stringer], exit dialogdomain.Exit) string {
+func FormattedOptionalSelection(value fmt.Stringer, has bool, exit dialogdomain.Exit) string {
 	if exit {
 		return colors.Red().Styled("(aborted)")
 	}
-	if selected, has := selection.Get(); has {
-		return colors.Green().Styled(selected.String())
+	if has {
+		return colors.Green().Styled(value.String())
 	}
 	return colors.Green().Styled("(use global setting)")
 }

--- a/internal/cli/dialog/dialogcomponents/colors.go
+++ b/internal/cli/dialog/dialogcomponents/colors.go
@@ -7,6 +7,17 @@ import (
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogdomain"
 )
 
+// FormattedOptionalSelection provides the given optional dialog choice in a printable format.
+func FormattedOptionalSelection(value fmt.Stringer, has bool, exit dialogdomain.Exit) string {
+	if exit {
+		return colors.Red().Styled("(aborted)")
+	}
+	if has {
+		return colors.Green().Styled(value.String())
+	}
+	return colors.Green().Styled("(use global setting)")
+}
+
 // FormattedToken provides the given API token in a printable format.
 func FormattedSecret(secret string, exit dialogdomain.Exit) string {
 	if exit {
@@ -27,15 +38,4 @@ func FormattedSelection(selection string, exit dialogdomain.Exit) string {
 		return colors.Green().Styled("(not provided)")
 	}
 	return colors.Green().Styled(selection)
-}
-
-// FormattedOptionalSelection provides the given optional dialog choice in a printable format.
-func FormattedOptionalSelection(value fmt.Stringer, has bool, exit dialogdomain.Exit) string {
-	if exit {
-		return colors.Red().Styled("(aborted)")
-	}
-	if has {
-		return colors.Green().Styled(value.String())
-	}
-	return colors.Green().Styled("(use global setting)")
 }

--- a/internal/cli/dialog/dialogcomponents/colors.go
+++ b/internal/cli/dialog/dialogcomponents/colors.go
@@ -29,7 +29,7 @@ func FormattedSelection(selection string, exit dialogdomain.Exit) string {
 	return colors.Green().Styled(selection)
 }
 
-// FormattedSelection provides the given dialog choice in a printable format.
+// FormattedOptionalSelection provides the given optional dialog choice in a printable format.
 func FormattedOptionalSelection(value fmt.Stringer, has bool, exit dialogdomain.Exit) string {
 	if exit {
 		return colors.Red().Styled("(aborted)")

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -34,9 +34,9 @@ func UnknownBranchType(unvalidatedConfig config.UnvalidatedConfig, inputs dialog
 	entries = appendEntry(entries, configdomain.BranchTypeObservedBranch)
 	entries = appendEntry(entries, configdomain.BranchTypeParkedBranch)
 	entries = appendEntry(entries, configdomain.BranchTypePrototypeBranch)
-	defaultPos := determinePos(entries, unvalidatedConfig.GitLocal.UnknownBranchType)
+	defaultPos := determinePos(entries, unvalidatedConfig)
 	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs, "unknown-branch-type")
-	fmt.Printf(messages.UnknownBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
+	fmt.Printf(messages.ShareNewBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }
 
@@ -47,9 +47,12 @@ func appendEntry(entries list.Entries[Option[configdomain.UnknownBranchType]], b
 	})
 }
 
-func determinePos(entries list.Entries[Option[configdomain.UnknownBranchType]], localGitValue Option[configdomain.UnknownBranchType]) int {
-	if localValue, has := localGitValue.Get(); has {
+func determinePos(entries list.Entries[Option[configdomain.UnknownBranchType]], unvalidatedConfig config.UnvalidatedConfig) int {
+	if localValue, has := unvalidatedConfig.GitLocal.UnknownBranchType.Get(); has {
 		return entries.IndexOf(Some(localValue))
 	}
-	return 0
+	if unvalidatedConfig.GitGlobal.UnknownBranchType.IsSome() {
+		return 0
+	}
+	return entries.IndexOf(Some(unvalidatedConfig.Defaults.UnknownBranchType))
 }

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -23,7 +23,9 @@ Git Town cannot determine their type any other way.
 
 func UnknownBranchType(unvalidatedConfig config.UnvalidatedConfig, inputs dialogcomponents.TestInputs) (Option[configdomain.UnknownBranchType], dialogdomain.Exit, error) {
 	entries := make(list.Entries[Option[configdomain.UnknownBranchType]], 0, 5)
+	fmt.Println("11111111111111111111111111111", unvalidatedConfig.GitGlobal.UnknownBranchType)
 	if globalValue, has := unvalidatedConfig.GitGlobal.UnknownBranchType.Get(); has {
+		fmt.Println("22222222222222", globalValue)
 		entries = append(entries, list.Entry[Option[configdomain.UnknownBranchType]]{
 			Data: None[configdomain.UnknownBranchType](),
 			Text: fmt.Sprintf("use global value (%s)", globalValue),
@@ -36,7 +38,7 @@ func UnknownBranchType(unvalidatedConfig config.UnvalidatedConfig, inputs dialog
 	entries = appendEntry(entries, configdomain.BranchTypePrototypeBranch)
 	defaultPos := determinePos(entries, unvalidatedConfig)
 	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs, "unknown-branch-type")
-	fmt.Printf(messages.ShareNewBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
+	fmt.Printf(messages.UnknownBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }
 

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -23,12 +23,10 @@ Git Town cannot determine their type any other way.
 
 func UnknownBranchType(unvalidatedConfig config.UnvalidatedConfig, inputs dialogcomponents.TestInputs) (Option[configdomain.UnknownBranchType], dialogdomain.Exit, error) {
 	entries := make(list.Entries[Option[configdomain.UnknownBranchType]], 0, 5)
-	fmt.Println("11111111111111111111111111111", unvalidatedConfig.GitGlobal.UnknownBranchType)
 	if globalValue, has := unvalidatedConfig.GitGlobal.UnknownBranchType.Get(); has {
-		fmt.Println("22222222222222", globalValue)
 		entries = append(entries, list.Entry[Option[configdomain.UnknownBranchType]]{
 			Data: None[configdomain.UnknownBranchType](),
-			Text: fmt.Sprintf("use global value (%s)", globalValue),
+			Text: fmt.Sprintf("use global setting (%s)", globalValue),
 		})
 	}
 	entries = appendEntry(entries, configdomain.BranchTypeContributionBranch)
@@ -38,7 +36,8 @@ func UnknownBranchType(unvalidatedConfig config.UnvalidatedConfig, inputs dialog
 	entries = appendEntry(entries, configdomain.BranchTypePrototypeBranch)
 	defaultPos := determinePos(entries, unvalidatedConfig)
 	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs, "unknown-branch-type")
-	fmt.Printf(messages.UnknownBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
+	value, has := selection.Get()
+	fmt.Printf(messages.UnknownBranchType, dialogcomponents.FormattedOptionalSelection(value, has, exit))
 	return selection, exit, err
 }
 

--- a/internal/cli/dialog/unknown_branch_type.go
+++ b/internal/cli/dialog/unknown_branch_type.go
@@ -23,7 +23,7 @@ Git Town cannot determine their type any other way.
 
 func UnknownBranchType(unvalidatedConfig config.UnvalidatedConfig, inputs dialogcomponents.TestInputs) (Option[configdomain.UnknownBranchType], dialogdomain.Exit, error) {
 	entries := make(list.Entries[Option[configdomain.UnknownBranchType]], 0, 5)
-	if globalValue, has := config.G.Get(); has {
+	if globalValue, has := unvalidatedConfig.GitGlobal.UnknownBranchType.Get(); has {
 		entries = append(entries, list.Entry[Option[configdomain.UnknownBranchType]]{
 			Data: None[configdomain.UnknownBranchType](),
 			Text: fmt.Sprintf("use global value (%s)", globalValue),
@@ -34,9 +34,9 @@ func UnknownBranchType(unvalidatedConfig config.UnvalidatedConfig, inputs dialog
 	entries = appendEntry(entries, configdomain.BranchTypeObservedBranch)
 	entries = appendEntry(entries, configdomain.BranchTypeParkedBranch)
 	entries = appendEntry(entries, configdomain.BranchTypePrototypeBranch)
-	defaultPos := determinePos(entries, localGitValue)
-	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, shareNewBranchesTitle, ShareNewBranchesHelp, inputs, "share-new-branches")
-	fmt.Printf(messages.ShareNewBranches, dialogcomponents.FormattedSelection(selection.String(), exit))
+	defaultPos := determinePos(entries, unvalidatedConfig.GitLocal.UnknownBranchType)
+	selection, exit, err := dialogcomponents.RadioList(entries, defaultPos, unknownBranchTypeTitle, UnknownBranchTypeHelp, inputs, "unknown-branch-type")
+	fmt.Printf(messages.UnknownBranchType, dialogcomponents.FormattedSelection(selection.String(), exit))
 	return selection, exit, err
 }
 

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -173,9 +173,9 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 			return emptyResult, exit, err
 		}
 	}
-	unknownBranchType := repo.UnvalidatedConfig.NormalConfig.UnknownBranchType
+	unknownBranchType := None[configdomain.UnknownBranchType]()
 	if configFile.UnknownBranchType.IsNone() {
-		unknownBranchType, exit, err = dialog.UnknownBranchType(unknownBranchType, data.dialogInputs)
+		unknownBranchType, exit, err = dialog.UnknownBranchType(repo.UnvalidatedConfig, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -75,7 +75,7 @@ func executeConfigSetup(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	if err = saveAll(enterDataResult, repo.UnvalidatedConfig.GitLocal, data.configFile, data, repo.Frontend); err != nil {
+	if err = saveAll(enterDataResult, repo.UnvalidatedConfig, data.configFile, data, repo.Frontend); err != nil {
 		return err
 	}
 	return configinterpreter.Finished(configinterpreter.FinishedArgs{
@@ -603,35 +603,35 @@ func loadSetupData(repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig) (
 	}, exit, nil
 }
 
-func saveAll(userInput userInput, existingGitConfig configdomain.PartialConfig, configFile Option[configdomain.PartialConfig], data setupData, frontend subshelldomain.Runner) error {
+func saveAll(userInput userInput, unvalidatedConfig config.UnvalidatedConfig, configFile Option[configdomain.PartialConfig], data setupData, frontend subshelldomain.Runner) error {
 	fc := gohacks.ErrorCollector{}
 	fc.Check(
-		saveAliases(userInput.data.Aliases, existingGitConfig.Aliases, frontend),
+		saveAliases(userInput.data.Aliases, unvalidatedConfig.GitGlobal.Aliases, frontend),
 	)
 	if forgeType, hasForgeType := userInput.determinedForgeType.Get(); hasForgeType {
 		switch forgeType {
 		case forgedomain.ForgeTypeBitbucket, forgedomain.ForgeTypeBitbucketDatacenter:
 			fc.Check(
-				saveBitbucketUsername(userInput.data.BitbucketUsername, existingGitConfig.BitbucketUsername, userInput.scope, frontend),
+				saveBitbucketUsername(userInput.data.BitbucketUsername, unvalidatedConfig.GitLocal.BitbucketUsername, userInput.scope, frontend),
 			)
 			fc.Check(
-				saveBitbucketAppPassword(userInput.data.BitbucketAppPassword, existingGitConfig.BitbucketAppPassword, userInput.scope, frontend),
+				saveBitbucketAppPassword(userInput.data.BitbucketAppPassword, unvalidatedConfig.GitLocal.BitbucketAppPassword, userInput.scope, frontend),
 			)
 		case forgedomain.ForgeTypeCodeberg:
 			fc.Check(
-				saveCodebergToken(userInput.data.CodebergToken, existingGitConfig.CodebergToken, userInput.scope, frontend),
+				saveCodebergToken(userInput.data.CodebergToken, unvalidatedConfig.GitLocal.CodebergToken, userInput.scope, frontend),
 			)
 		case forgedomain.ForgeTypeGitHub:
 			fc.Check(
-				saveGitHubToken(userInput.data.GitHubToken, existingGitConfig.GitHubToken, userInput.scope, userInput.data.GitHubConnectorType, frontend),
+				saveGitHubToken(userInput.data.GitHubToken, unvalidatedConfig.GitLocal.GitHubToken, userInput.scope, userInput.data.GitHubConnectorType, frontend),
 			)
 		case forgedomain.ForgeTypeGitLab:
 			fc.Check(
-				saveGitLabToken(userInput.data.GitLabToken, existingGitConfig.GitLabToken, userInput.scope, userInput.data.GitLabConnectorType, frontend),
+				saveGitLabToken(userInput.data.GitLabToken, unvalidatedConfig.GitLocal.GitLabToken, userInput.scope, userInput.data.GitLabConnectorType, frontend),
 			)
 		case forgedomain.ForgeTypeGitea:
 			fc.Check(
-				saveGiteaToken(userInput.data.GiteaToken, existingGitConfig.GiteaToken, userInput.scope, frontend),
+				saveGiteaToken(userInput.data.GiteaToken, unvalidatedConfig.GitLocal.GiteaToken, userInput.scope, frontend),
 			)
 		}
 	}
@@ -640,9 +640,9 @@ func saveAll(userInput userInput, existingGitConfig configdomain.PartialConfig, 
 	}
 	switch userInput.storageLocation {
 	case dialog.ConfigStorageOptionFile:
-		return saveToFile(userInput, existingGitConfig, frontend)
+		return saveToFile(userInput, unvalidatedConfig.GitLocal, frontend)
 	case dialog.ConfigStorageOptionGit:
-		return saveToGit(userInput, existingGitConfig, configFile, data, frontend)
+		return saveToGit(userInput, unvalidatedConfig.GitLocal, configFile, data, frontend)
 	}
 	return nil
 }

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -400,7 +400,7 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		SyncPrototypeStrategy:    Some(syncPrototypeStrategy),
 		SyncTags:                 Some(syncTags),
 		SyncUpstream:             Some(syncUpstream),
-		UnknownBranchType:        Some(unknownBranchType),
+		UnknownBranchType:        unknownBranchType,
 		Verbose:                  None[configdomain.Verbose](), // the setup assistant doesn't ask for this
 	}
 	validatedData := configdomain.ValidatedConfigData{

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -75,7 +75,7 @@ func executeConfigSetup(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	if err = saveAll(enterDataResult, repo.UnvalidatedConfig.GitUnscoped, data.configFile, data, repo.Frontend); err != nil {
+	if err = saveAll(enterDataResult, repo.UnvalidatedConfig.GitLocal, data.configFile, data, repo.Frontend); err != nil {
 		return err
 	}
 	return configinterpreter.Finished(configinterpreter.FinishedArgs{

--- a/internal/cmd/debug/enter_unknown_branch.go
+++ b/internal/cmd/debug/enter_unknown_branch.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog"
 	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
-	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/cliconfig"
+	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/spf13/cobra"
 )
 
@@ -13,8 +14,21 @@ func enterUnknownBranch() *cobra.Command {
 	return &cobra.Command{
 		Use: "unknown-branch-type",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			repo, err := execute.OpenRepo(execute.OpenRepoArgs{
+				CliConfig: cliconfig.CliConfig{
+					DryRun:  false,
+					Verbose: false,
+				},
+				PrintBranchNames: false,
+				PrintCommands:    true,
+				ValidateGitRepo:  true,
+				ValidateIsOnline: false,
+			})
+			if err != nil {
+				return err
+			}
 			dialogTestInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.UnknownBranchType(configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch), dialogTestInputs)
+			_, _, err = dialog.UnknownBranchType(repo.UnvalidatedConfig, dialogTestInputs)
 			return err
 		},
 	}

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -99,8 +99,8 @@ type NewUnvalidatedConfigArgs struct {
 	ConfigFile    Option[configdomain.PartialConfig]
 	EnvConfig     configdomain.PartialConfig
 	FinalMessages stringslice.Collector
-	GitLocal      configdomain.PartialConfig
 	GitGlobal     configdomain.PartialConfig
+	GitLocal      configdomain.PartialConfig
 	GitUnscoped   configdomain.PartialConfig
 }
 

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -13,7 +13,9 @@ import (
 
 type UnvalidatedConfig struct {
 	File              Option[configdomain.PartialConfig] // content of git-town.toml, nil = no config file exists
-	GitUnscoped       configdomain.PartialConfig         // configuration data taken from Git metadata, in particular the unscoped Git metadata
+	GitGlobal         configdomain.PartialConfig
+	GitLocal          configdomain.PartialConfig
+	GitUnscoped       configdomain.PartialConfig // configuration data taken from Git metadata, in particular the unscoped Git metadata
 	NormalConfig      NormalConfig
 	UnvalidatedConfig configdomain.UnvalidatedConfigData
 }

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -82,11 +82,13 @@ func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {
 		cli:  args.CliConfig,
 		env:  args.EnvConfig,
 		file: args.ConfigFile,
-		git:  args.GitConfig,
+		git:  args.GitUnscoped,
 	})
 	return UnvalidatedConfig{
 		File:              args.ConfigFile,
-		GitUnscoped:       args.GitConfig,
+		GitGlobal:         args.GitLocal,
+		GitLocal:          args.GitLocal,
+		GitUnscoped:       args.GitUnscoped,
 		NormalConfig:      normalConfig,
 		UnvalidatedConfig: unvalidatedConfig,
 	}
@@ -97,7 +99,9 @@ type NewUnvalidatedConfigArgs struct {
 	ConfigFile    Option[configdomain.PartialConfig]
 	EnvConfig     configdomain.PartialConfig
 	FinalMessages stringslice.Collector
-	GitConfig     configdomain.PartialConfig
+	GitLocal      configdomain.PartialConfig
+	GitGlobal     configdomain.PartialConfig
+	GitUnscoped   configdomain.PartialConfig
 }
 
 func mergeConfigs(args mergeConfigsArgs) (configdomain.UnvalidatedConfigData, NormalConfig) {
@@ -116,5 +120,5 @@ type mergeConfigsArgs struct {
 	cli  cliconfig.CliConfig
 	env  configdomain.PartialConfig         // configuration data taken from environment variables
 	file Option[configdomain.PartialConfig] // data of the configuration file
-	git  configdomain.PartialConfig         // data from the unscoped Git configuration
+	git  configdomain.PartialConfig
 }

--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -90,7 +90,7 @@ func NewUnvalidatedConfig(args NewUnvalidatedConfigArgs) UnvalidatedConfig {
 	return UnvalidatedConfig{
 		Defaults:          args.Defaults,
 		File:              args.ConfigFile,
-		GitGlobal:         args.GitLocal,
+		GitGlobal:         args.GitGlobal,
 		GitLocal:          args.GitLocal,
 		GitUnscoped:       args.GitUnscoped,
 		NormalConfig:      normalConfig,

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -104,6 +104,7 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	unvalidatedConfig := config.NewUnvalidatedConfig(config.NewUnvalidatedConfigArgs{
 		CliConfig:     args.CliConfig,
 		ConfigFile:    configFile,
+		Defaults:      config.DefaultNormalConfig(),
 		EnvConfig:     envconfig.Load(),
 		FinalMessages: finalMessages,
 		GitGlobal:     globalConfig,

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -70,6 +70,14 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
+	globalConfig, err := config.NewPartialConfigFromSnapshot(globalSnapshot, true, backendRunner)
+	if err != nil {
+		return emptyOpenRepoResult(), err
+	}
+	localConfig, err := config.NewPartialConfigFromSnapshot(localSnapshot, true, backendRunner)
+	if err != nil {
+		return emptyOpenRepoResult(), err
+	}
 	unscopedSnapshot, err := gitconfig.LoadSnapshot(backendRunner, None[configdomain.ConfigScope](), configdomain.UpdateOutdatedNo)
 	if err != nil {
 		return emptyOpenRepoResult(), err
@@ -98,7 +106,9 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 		ConfigFile:    configFile,
 		EnvConfig:     envconfig.Load(),
 		FinalMessages: finalMessages,
-		GitConfig:     unscopedConfig,
+		GitGlobal:     globalConfig,
+		GitLocal:      localConfig,
+		GitUnscoped:   unscopedConfig,
 	})
 	frontEndRunner := newFrontendRunner(newFrontendRunnerArgs{
 		backend:          backendRunner,

--- a/internal/execute/open_repo.go
+++ b/internal/execute/open_repo.go
@@ -66,11 +66,11 @@ func OpenRepo(args OpenRepoArgs) (OpenRepoResult, error) {
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
-	localSnapshot, err := gitconfig.LoadSnapshot(backendRunner, Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedYes)
+	globalConfig, err := config.NewPartialConfigFromSnapshot(globalSnapshot, true, backendRunner)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}
-	globalConfig, err := config.NewPartialConfigFromSnapshot(globalSnapshot, true, backendRunner)
+	localSnapshot, err := gitconfig.LoadSnapshot(backendRunner, Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedYes)
 	if err != nil {
 		return emptyOpenRepoResult(), err
 	}

--- a/internal/test/testruntime/test_runtime.go
+++ b/internal/test/testruntime/test_runtime.go
@@ -99,6 +99,7 @@ func New(workingDir, homeDir, binDir string) commands.TestCommands {
 			Verbose: false,
 		},
 		ConfigFile:    None[configdomain.PartialConfig](),
+		Defaults:      config.DefaultNormalConfig(),
 		EnvConfig:     configdomain.EmptyPartialConfig(),
 		FinalMessages: stringslice.NewCollector(),
 		GitGlobal:     configdomain.EmptyPartialConfig(),

--- a/internal/test/testruntime/test_runtime.go
+++ b/internal/test/testruntime/test_runtime.go
@@ -101,6 +101,8 @@ func New(workingDir, homeDir, binDir string) commands.TestCommands {
 		ConfigFile:    None[configdomain.PartialConfig](),
 		EnvConfig:     configdomain.EmptyPartialConfig(),
 		FinalMessages: stringslice.NewCollector(),
+		GitGlobal:     configdomain.EmptyPartialConfig(),
+		GitLocal:      configdomain.EmptyPartialConfig(),
 		GitUnscoped:   configdomain.EmptyPartialConfig(),
 	})
 	unvalidatedConfig.UnvalidatedConfig.MainBranch = gitdomain.NewLocalBranchNameOption("main")

--- a/internal/test/testruntime/test_runtime.go
+++ b/internal/test/testruntime/test_runtime.go
@@ -101,7 +101,7 @@ func New(workingDir, homeDir, binDir string) commands.TestCommands {
 		ConfigFile:    None[configdomain.PartialConfig](),
 		EnvConfig:     configdomain.EmptyPartialConfig(),
 		FinalMessages: stringslice.NewCollector(),
-		GitConfig:     configdomain.EmptyPartialConfig(),
+		GitUnscoped:   configdomain.EmptyPartialConfig(),
 	})
 	unvalidatedConfig.UnvalidatedConfig.MainBranch = gitdomain.NewLocalBranchNameOption("main")
 	testCommands := commands.TestCommands{


### PR DESCRIPTION
This PR supports the following use case:

- You have set up Git Town settings that you want to use on all your repos
- You clone a new repo
- You run the setup assistant

In this situation, the setup assistant should offer you to use the globally
configured values. 

This PR enables this for the unknown-branch-type setting.
