### PR TITLE
setup assistant: Move new-branch-type above unknown-branch-type

### DIFF
--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -15,6 +15,7 @@ Feature: override an existing Git alias
       | feature regex               | enter      |
       | contribution regex          | enter      |
       | observed regex              | enter      |
+      | new branch type             | enter      |
       | unknown branch type         | enter      |
       | origin hostname             | enter      |
       | forge type                  | enter      |
@@ -25,7 +26,6 @@ Feature: override an existing Git alias
       | sync tags                   | enter      |
       | share new branches          | enter      |
       | push hook                   | enter      |
-      | new branch type             | enter      |
       | ship strategy               | enter      |
       | ship delete tracking branch | enter      |
       | config storage              | down enter |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -19,15 +19,16 @@ Feature: change existing information in Git metadata
       | aliases                     | a enter                |
       | main branch                 | enter                  |
       | perennial branches          | space down space enter |
-      | perennial regex             | 3 3 6 6 enter          |
+      | perennial regex             |          3 3 6 6 enter |
       | feature regex               | u s e r enter          |
-      | contribution regex          | 1 1 1 1 enter          |
-      | observed regex              | 2 2 2 2 enter          |
+      | contribution regex          |          1 1 1 1 enter |
+      | observed regex              |          2 2 2 2 enter |
+      | new branch type             | down enter             |
       | unknown branch type         | down enter             |
       | origin hostname             | c o d e enter          |
       | forge type                  | up up enter            |
       | github connector type       | enter                  |
-      | github token                | 1 2 3 4 5 6 enter      |
+      | github token                |      1 2 3 4 5 6 enter |
       | token scope                 | enter                  |
       | sync feature strategy       | down enter             |
       | sync perennial strategy     | down enter             |
@@ -36,7 +37,6 @@ Feature: change existing information in Git metadata
       | sync tags                   | down enter             |
       | share-new-branches          | down enter             |
       | push hook                   | down enter             |
-      | new branch type             | down enter             |
       | ship strategy               | down down enter        |
       | ship delete tracking branch | down enter             |
       | config storage              | enter                  |

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -16,6 +16,7 @@ Feature: enter the Codeberg API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -28,7 +29,6 @@ Feature: enter the Codeberg API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             |                                             |
@@ -60,10 +60,11 @@ Feature: enter the Codeberg API token
       | feature regex               | enter                |                                             |
       | contribution regex          | enter                |                                             |
       | observed regex              | enter                |                                             |
+      | new branch type             | enter                |                                             |
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | down down down enter |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
+      | codeberg token              |    1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                |                                             |
       | sync feature strategy       | enter                |                                             |
       | sync perennial strategy     | enter                |                                             |
@@ -72,7 +73,6 @@ Feature: enter the Codeberg API token
       | sync tags                   | enter                |                                             |
       | share new branches          | enter                |                                             |
       | push hook                   | enter                |                                             |
-      | new branch type             | enter                |                                             |
       | ship strategy               | enter                |                                             |
       | ship delete tracking branch | enter                |                                             |
       | config storage              | enter                |                                             |
@@ -106,6 +106,7 @@ Feature: enter the Codeberg API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -118,7 +119,6 @@ Feature: enter the Codeberg API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             |                                             |
@@ -151,6 +151,7 @@ Feature: enter the Codeberg API token
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
       | observed regex              | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
@@ -163,7 +164,6 @@ Feature: enter the Codeberg API token
       | sync tags                   | enter                                     |                                             |
       | share new branches          | enter                                     |                                             |
       | push hook                   | enter                                     |                                             |
-      | new branch type             | enter                                     |                                             |
       | ship strategy               | enter                                     |                                             |
       | ship delete tracking branch | enter                                     |                                             |
       | config storage              | enter                                     |                                             |

--- a/features/config/setup/default_values.feature
+++ b/features/config/setup/default_values.feature
@@ -19,6 +19,7 @@ Feature: Accepting all default values leads to a working setup
       | feature regex               | enter      |
       | contribution regex          | enter      |
       | observed regex              | enter      |
+      | new branch type             | enter      |
       | unknown branch type         | enter      |
       | origin hostname             | enter      |
       | forge type                  | enter      |
@@ -29,7 +30,6 @@ Feature: Accepting all default values leads to a working setup
       | sync tags                   | enter      |
       | share new branches          | enter      |
       | push hook                   | enter      |
-      | new branch type             | enter      |
       | ship strategy               | enter      |
       | ship delete tracking branch | enter      |
       | config storage              | down enter |
@@ -60,21 +60,21 @@ Feature: Accepting all default values leads to a working setup
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/fresh_default_values.feature
+++ b/features/config/setup/fresh_default_values.feature
@@ -13,6 +13,7 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       | feature regex               | enter      |
       | contribution regex          | enter      |
       | observed regex              | enter      |
+      | new branch type             | enter      |
       | unknown branch type         | enter      |
       | origin hostname             | enter      |
       | forge type                  | enter      |
@@ -23,7 +24,6 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
       | sync tags                   | enter      |
       | share new branches          | enter      |
       | push hook                   | enter      |
-      | new branch type             | enter      |
       | ship strategy               | enter      |
       | ship delete tracking branch | enter      |
       | config storage              | down enter |
@@ -54,21 +54,21 @@ Feature: Accepting all default values in a brand-new Git repo leads to a working
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "initial"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "origin"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -16,6 +16,7 @@ Feature: enter the Gitea API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             | auto-detect                                 |
@@ -28,7 +29,6 @@ Feature: enter the Gitea API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             | git metadata                                |
@@ -60,10 +60,11 @@ Feature: enter the Gitea API token
       | feature regex               | enter                     |                                             |
       | contribution regex          | enter                     |                                             |
       | observed regex              | enter                     |                                             |
+      | new branch type             | enter                     |                                             |
       | unknown branch type         | enter                     |                                             |
       | origin hostname             | enter                     |                                             |
       | forge type                  | down down down down enter |                                             |
-      | gitea token                 | 1 2 3 4 5 6 enter         |                                             |
+      | gitea token                 |         1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                     |                                             |
       | sync feature strategy       | enter                     |                                             |
       | sync perennial strategy     | enter                     |                                             |
@@ -72,7 +73,6 @@ Feature: enter the Gitea API token
       | sync tags                   | enter                     |                                             |
       | share new branches          | enter                     |                                             |
       | push hook                   | enter                     |                                             |
-      | new branch type             | enter                     |                                             |
       | ship strategy               | enter                     |                                             |
       | ship delete tracking branch | enter                     |                                             |
       | config storage              | enter                     | git metadata                                |
@@ -106,6 +106,7 @@ Feature: enter the Gitea API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -118,7 +119,6 @@ Feature: enter the Gitea API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             | git metadata                                |
@@ -151,6 +151,7 @@ Feature: enter the Gitea API token
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
       | observed regex              | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
@@ -163,7 +164,6 @@ Feature: enter the Gitea API token
       | sync tags                   | enter                                     |                                             |
       | share new branches          | enter                                     |                                             |
       | push hook                   | enter                                     |                                             |
-      | new branch type             | enter                                     |                                             |
       | ship strategy               | enter                                     |                                             |
       | ship delete tracking branch | enter                                     |                                             |
       | config storage              | enter                                     | git metadata                                |

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -16,6 +16,7 @@ Feature: enter the GitHub API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -29,7 +30,6 @@ Feature: enter the GitHub API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             |                                             |
@@ -62,11 +62,12 @@ Feature: enter the GitHub API token
       | feature regex               | enter                          |                                             |
       | contribution regex          | enter                          |                                             |
       | observed regex              | enter                          |                                             |
+      | new branch type             | enter                          |                                             |
       | unknown branch type         | enter                          |                                             |
       | origin hostname             | enter                          |                                             |
       | forge type                  | down down down down down enter |                                             |
       | github connector type       | enter                          |                                             |
-      | github token                | 1 2 3 4 5 6 enter              |                                             |
+      | github token                |              1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                          |                                             |
       | sync feature strategy       | enter                          |                                             |
       | sync perennial strategy     | enter                          |                                             |
@@ -75,7 +76,6 @@ Feature: enter the GitHub API token
       | sync tags                   | enter                          |                                             |
       | share new branches          | enter                          |                                             |
       | push hook                   | enter                          |                                             |
-      | new branch type             | enter                          |                                             |
       | ship strategy               | enter                          |                                             |
       | ship delete tracking branch | enter                          |                                             |
       | config storage              | enter                          |                                             |
@@ -111,6 +111,7 @@ Feature: enter the GitHub API token
       | feature regex               | enter                               |                                             |
       | contribution regex          | enter                               |                                             |
       | observed regex              | enter                               |                                             |
+      | new branch type             | enter                               |                                             |
       | unknown branch type         | enter                               |                                             |
       | origin hostname             | enter                               |                                             |
       | forge type                  | enter                               |                                             |
@@ -123,7 +124,6 @@ Feature: enter the GitHub API token
       | sync tags                   | enter                               |                                             |
       | share new branches          | enter                               |                                             |
       | push hook                   | enter                               |                                             |
-      | new branch type             | enter                               |                                             |
       | ship strategy               | enter                               |                                             |
       | ship delete tracking branch | enter                               |                                             |
       | config storage              | enter                               |                                             |
@@ -157,6 +157,7 @@ Feature: enter the GitHub API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -170,7 +171,6 @@ Feature: enter the GitHub API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             |                                             |
@@ -204,6 +204,7 @@ Feature: enter the GitHub API token
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
       | observed regex              | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
@@ -217,7 +218,6 @@ Feature: enter the GitHub API token
       | sync tags                   | enter                                     |                                             |
       | share new branches          | enter                                     |                                             |
       | push hook                   | enter                                     |                                             |
-      | new branch type             | enter                                     |                                             |
       | ship strategy               | enter                                     |                                             |
       | ship delete tracking branch | enter                                     |                                             |
       | config storage              | enter                                     |                                             |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -16,6 +16,7 @@ Feature: enter the GitLab API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -29,7 +30,6 @@ Feature: enter the GitLab API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             |                                             |
@@ -61,6 +61,7 @@ Feature: enter the GitLab API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | up enter          |                                             |
@@ -74,7 +75,6 @@ Feature: enter the GitLab API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             |                                             |
@@ -109,6 +109,7 @@ Feature: enter the GitLab API token
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -122,7 +123,6 @@ Feature: enter the GitLab API token
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             | git metadata                                |
@@ -156,6 +156,7 @@ Feature: enter the GitLab API token
       | feature regex               | enter                                     |                                             |
       | contribution regex          | enter                                     |                                             |
       | observed regex              | enter                                     |                                             |
+      | new branch type             | enter                                     |                                             |
       | unknown branch type         | enter                                     |                                             |
       | origin hostname             | enter                                     |                                             |
       | forge type                  | enter                                     |                                             |
@@ -169,7 +170,6 @@ Feature: enter the GitLab API token
       | sync tags                   | enter                                     |                                             |
       | share new branches          | enter                                     |                                             |
       | push hook                   | enter                                     |                                             |
-      | new branch type             | enter                                     |                                             |
       | ship strategy               | enter                                     |                                             |
       | ship delete tracking branch | enter                                     |                                             |
       | config storage              | enter                                     |                                             |

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -15,6 +15,7 @@ Feature: a global API token of another forge exists
       | feature regex               | enter             |                                             |
       | contribution regex          | enter             |                                             |
       | observed regex              | enter             |                                             |
+      | new branch type             | enter             |                                             |
       | unknown branch type         | enter             |                                             |
       | origin hostname             | enter             |                                             |
       | forge type                  | enter             |                                             |
@@ -28,7 +29,6 @@ Feature: a global API token of another forge exists
       | sync tags                   | enter             |                                             |
       | share new branches          | enter             |                                             |
       | push hook                   | enter             |                                             |
-      | new branch type             | enter             |                                             |
       | ship strategy               | enter             |                                             |
       | ship delete tracking branch | enter             |                                             |
       | config storage              | enter             |                                             |

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -30,6 +30,7 @@ Feature: migrate existing configuration in Git metadata to a config file
       | feature regex               | enter      |
       | contribution regex          | enter      |
       | observed regex              | enter      |
+      | new branch type             | enter      |
       | unknown branch type         | enter      |
       | dev-remote                  |            |
       | origin hostname             | enter      |
@@ -41,7 +42,6 @@ Feature: migrate existing configuration in Git metadata to a config file
       | sync tags                   | enter      |
       | share new branches          | enter      |
       | push hook                   | enter      |
-      | new branch type             | enter      |
       | ship strategy               | enter      |
       | ship delete tracking branch | enter      |
       | config storage              | down enter |
@@ -83,23 +83,23 @@ Feature: migrate existing configuration in Git metadata to a config file
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
       perennials = ["qa"]
       perennial-regex = "release-.*"
-
+      
       [create]
       new-branch-type = "prototype"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = false
       strategy = "squash-merge"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -14,6 +14,7 @@ Feature: Configure a different development remote
       | feature regex               | enter      |
       | contribution regex          | enter      |
       | observed regex              | enter      |
+      | new branch type             | enter      |
       | unknown branch type         | enter      |
       | dev-remote                  | up enter   |
       | origin hostname             | enter      |
@@ -25,7 +26,6 @@ Feature: Configure a different development remote
       | sync tags                   | enter      |
       | share new branches          | enter      |
       | push hook                   | enter      |
-      | new branch type             | enter      |
       | ship strategy               | enter      |
       | ship delete tracking branch | enter      |
       | config storage              | down enter |
@@ -38,21 +38,21 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/remove_git_metadata.feature
+++ b/features/config/setup/remove_git_metadata.feature
@@ -54,6 +54,7 @@ Feature: remove existing configuration in Git metadata
       | feature regex               | backspace backspace backspace backspace backspace backspace enter           |                     |
       | contribution regex          | backspace backspace backspace backspace backspace backspace backspace enter |                     |
       | observed regex              | backspace backspace backspace backspace backspace enter                     |                     |
+      | new branch type             | up enter                                                                    |                     |
       | unknown branch type         | up enter                                                                    |                     |
       | origin hostname             | backspace backspace backspace backspace enter                               | remove the override |
       | forge type                  | up up up up up enter                                                        | remove the override |
@@ -64,7 +65,6 @@ Feature: remove existing configuration in Git metadata
       | sync tags                   | down enter                                                                  |                     |
       | share new branches          | up enter                                                                    | enable              |
       | push hook                   | down enter                                                                  | enable              |
-      | new branch type             | up enter                                                                    |                     |
       | ship strategy               | down enter                                                                  |                     |
       | ship delete tracking branch | down enter                                                                  | disable             |
       | config storage              | enter                                                                       | git metadata        |

--- a/features/config/setup/remove_hosting_override.feature
+++ b/features/config/setup/remove_hosting_override.feature
@@ -14,6 +14,7 @@ Feature: remove an existing forge type override
       | feature regex               | enter                |                                             |
       | contribution regex          | enter                |                                             |
       | observed regex              | enter                |                                             |
+      | new branch type             | enter                |                                             |
       | unknown branch type         | enter                |                                             |
       | origin hostname             | enter                |                                             |
       | forge type                  | up up up up up enter |                                             |
@@ -24,7 +25,6 @@ Feature: remove an existing forge type override
       | sync tags                   | enter                |                                             |
       | share new branches          | enter                |                                             |
       | push hook                   | enter                |                                             |
-      | new branch type             | enter                |                                             |
       | ship strategy               | enter                |                                             |
       | ship delete tracking branch | enter                |                                             |
       | config storage              | enter                |                                             |

--- a/features/config/setup/skip_perennials.feature
+++ b/features/config/setup/skip_perennials.feature
@@ -14,6 +14,7 @@ Feature: don't ask for perennial branches if no branches that could be perennial
       | feature regex               | enter      |                                             |
       | contribution regex          | enter      |                                             |
       | observed regex              | enter      |                                             |
+      | new branch type             | enter      |                                             |
       | unknown branch type         | enter      |                                             |
       | origin hostname             | enter      |                                             |
       | forge type                  | enter      |                                             |
@@ -24,7 +25,6 @@ Feature: don't ask for perennial branches if no branches that could be perennial
       | sync tags                   | enter      |                                             |
       | share new branches          | enter      |                                             |
       | push hook                   | enter      |                                             |
-      | new branch type             | enter      |                                             |
       | ship strategy               | enter      |                                             |
       | ship delete tracking branch | enter      |                                             |
       | config storage              | enter      |                                             |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -30,6 +30,7 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | feature regex               | 2 2 2 enter |
       | contribution regex          | 3 3 3 enter |
       | observed regex              | 4 4 4 enter |
+      | new branch type             | enter       |
       | unknown branch type         | enter       |
       | origin hostname             | enter       |
       | forge type                  | enter       |
@@ -40,7 +41,6 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | sync tags                   | enter       |
       | share new branches          | enter       |
       | push hook                   | enter       |
-      | new branch type             | enter       |
       | ship strategy               | enter       |
       | ship delete tracking branch | enter       |
       | config storage              | enter       |

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -8,15 +8,15 @@ Feature: ask for information not provided by the config file
       """
       [branches]
       main = "main"
-
+      
       [hosting]
       dev-remote = "something"
       forge-type = "github"
       origin-hostname = "github.com"
-
+      
       [ship]
       delete-tracking-branch = false
-
+      
       [sync]
       tags = false
       upstream = false
@@ -29,6 +29,7 @@ Feature: ask for information not provided by the config file
       | feature regex           | 2 2 2 enter |
       | contribution regex      | 3 3 3 enter |
       | observed regex          | 4 4 4 enter |
+      | new branch type         | enter       |
       | unknown branch type     | enter       |
       | github connector type   | enter       |
       | github token            | 9 9 9 enter |
@@ -38,7 +39,6 @@ Feature: ask for information not provided by the config file
       | sync prototype strategy | enter       |
       | share new branches      | enter       |
       | push hook               | enter       |
-      | new branch type         | enter       |
       | ship strategy           | enter       |
       | config storage          | enter       |
     Then Git Town runs the commands

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -173,6 +173,13 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 			return emptyResult, exit, err
 		}
 	}
+	newBranchType := repo.UnvalidatedConfig.NormalConfig.NewBranchType
+	if configFile.NewBranchType.IsNone() {
+		newBranchType, exit, err = dialog.NewBranchType(newBranchType, data.dialogInputs)
+		if err != nil || exit {
+			return emptyResult, exit, err
+		}
+	}
 	unknownBranchType := None[configdomain.UnknownBranchType]()
 	if configFile.UnknownBranchType.IsNone() {
 		unknownBranchType, exit, err = dialog.UnknownBranchType(repo.UnvalidatedConfig, data.dialogInputs)
@@ -336,13 +343,6 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 	pushHook := repo.UnvalidatedConfig.NormalConfig.PushHook
 	if configFile.PushHook.IsNone() {
 		pushHook, exit, err = dialog.PushHook(pushHook, data.dialogInputs)
-		if err != nil || exit {
-			return emptyResult, exit, err
-		}
-	}
-	newBranchType := repo.UnvalidatedConfig.NormalConfig.NewBranchType
-	if configFile.NewBranchType.IsNone() {
-		newBranchType, exit, err = dialog.NewBranchType(newBranchType, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
 		}


### PR DESCRIPTION
Allowing the user to enter all branch-related things together helps make better sense of things.
