### PR TITLE
setup assistant: enter character-based fields

### DIFF
--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -41,7 +41,6 @@ Feature: change existing information in Git metadata
       | ship delete tracking branch | down enter             |
       | config storage              | enter                  |
 
-  @this
   Scenario: result
     Then Git Town runs the commands
       | COMMAND                                                  |

--- a/features/config/setup/change_git_metadata.feature
+++ b/features/config/setup/change_git_metadata.feature
@@ -19,16 +19,16 @@ Feature: change existing information in Git metadata
       | aliases                     | a enter                |
       | main branch                 | enter                  |
       | perennial branches          | space down space enter |
-      | perennial regex             | 3 3 6 6 enter          |
-      | feature regex               | u s e r enter          |
-      | contribution regex          | 1 1 1 1 enter          |
-      | observed regex              | 2 2 2 2 enter          |
+      | perennial regex             | p e r enter            |
+      | feature regex               | f e a t enter          |
+      | contribution regex          | c o n t enter          |
+      | observed regex              | o b s enter            |
       | new branch type             | down enter             |
       | unknown branch type         | down enter             |
       | origin hostname             | c o d e enter          |
       | forge type                  | up up enter            |
       | github connector type       | enter                  |
-      | github token                | 1 2 3 4 5 6 enter      |
+      | github token                | g h - t o k enter      |
       | token scope                 | enter                  |
       | sync feature strategy       | down enter             |
       | sync perennial strategy     | down enter             |
@@ -41,6 +41,7 @@ Feature: change existing information in Git metadata
       | ship delete tracking branch | down enter             |
       | config storage              | enter                  |
 
+  @this
   Scenario: result
     Then Git Town runs the commands
       | COMMAND                                                  |
@@ -59,17 +60,17 @@ Feature: change existing information in Git metadata
       | git config --global alias.set-parent "town set-parent"   |
       | git config --global alias.ship "town ship"               |
       | git config --global alias.sync "town sync"               |
-      | git config git-town.github-token 123456                  |
+      | git config git-town.github-token gh-tok                  |
       | git config git-town.new-branch-type prototype            |
       | git config git-town.forge-type github                    |
       | git config git-town.github-connector api                 |
       | git config git-town.hosting-origin-hostname code         |
       | git config git-town.perennial-branches "production qa"   |
-      | git config git-town.perennial-regex 3366                 |
+      | git config git-town.perennial-regex per                  |
       | git config git-town.unknown-branch-type observed         |
-      | git config git-town.feature-regex user                   |
-      | git config git-town.contribution-regex 1111              |
-      | git config git-town.observed-regex 2222                  |
+      | git config git-town.feature-regex feat                   |
+      | git config git-town.contribution-regex cont              |
+      | git config git-town.observed-regex obs                   |
       | git config git-town.push-hook true                       |
       | git config git-town.share-new-branches push              |
       | git config git-town.ship-strategy fast-forward           |
@@ -95,17 +96,17 @@ Feature: change existing information in Git metadata
     And local Git setting "git-town.dev-remote" still doesn't exist
     And local Git setting "git-town.new-branch-type" is now "prototype"
     And local Git setting "git-town.forge-type" is now "github"
-    And local Git setting "git-town.github-token" is now "123456"
+    And local Git setting "git-town.github-token" is now "gh-tok"
     And local Git setting "git-town.hosting-origin-hostname" is now "code"
     And local Git setting "git-town.sync-feature-strategy" is now "rebase"
     And local Git setting "git-town.sync-perennial-strategy" is now "ff-only"
     And local Git setting "git-town.sync-prototype-strategy" is now "rebase"
     And local Git setting "git-town.sync-upstream" is now "false"
     And local Git setting "git-town.sync-tags" is now "true"
-    And local Git setting "git-town.perennial-regex" is now "3366"
-    And local Git setting "git-town.feature-regex" is now "user"
-    And local Git setting "git-town.contribution-regex" is now "1111"
-    And local Git setting "git-town.observed-regex" is now "2222"
+    And local Git setting "git-town.perennial-regex" is now "per"
+    And local Git setting "git-town.feature-regex" is now "feat"
+    And local Git setting "git-town.contribution-regex" is now "cont"
+    And local Git setting "git-town.observed-regex" is now "obs"
     And local Git setting "git-town.unknown-branch-type" is now "observed"
     And local Git setting "git-town.share-new-branches" is now "push"
     And local Git setting "git-town.push-hook" is now "true"

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -7,34 +7,34 @@ Feature: enter the Codeberg API token
   Scenario: auto-detected Codeberg platform
     Given my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | new branch type             | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type                  | enter             |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | enter             |                                             |
-      | sync feature strategy       | enter             |                                             |
-      | sync perennial strategy     | enter             |                                             |
-      | sync prototype strategy     | enter             |                                             |
-      | sync upstream               | enter             |                                             |
-      | sync tags                   | enter             |                                             |
-      | share new branches          | enter             |                                             |
-      | push hook                   | enter             |                                             |
-      | ship strategy               | enter             |                                             |
-      | ship delete tracking branch | enter             |                                             |
-      | config storage              | enter             |                                             |
+      | DIALOG                      | KEYS                   | DESCRIPTION                                 |
+      | welcome                     | enter                  |                                             |
+      | aliases                     | enter                  |                                             |
+      | main branch                 | enter                  |                                             |
+      | perennial branches          |                        | no input here since the dialog doesn't show |
+      | perennial regex             | enter                  |                                             |
+      | feature regex               | enter                  |                                             |
+      | contribution regex          | enter                  |                                             |
+      | observed regex              | enter                  |                                             |
+      | new branch type             | enter                  |                                             |
+      | unknown branch type         | enter                  |                                             |
+      | origin hostname             | enter                  |                                             |
+      | forge type                  | enter                  |                                             |
+      | codeberg token              | c o d e - t o k  enter |                                             |
+      | token scope                 | enter                  |                                             |
+      | sync feature strategy       | enter                  |                                             |
+      | sync perennial strategy     | enter                  |                                             |
+      | sync prototype strategy     | enter                  |                                             |
+      | sync upstream               | enter                  |                                             |
+      | sync tags                   | enter                  |                                             |
+      | share new branches          | enter                  |                                             |
+      | push hook                   | enter                  |                                             |
+      | ship strategy               | enter                  |                                             |
+      | ship delete tracking branch | enter                  |                                             |
+      | config storage              | enter                  |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config git-town.codeberg-token 123456            |
+      | git config git-town.codeberg-token code-tok          |
       | git config git-town.new-branch-type feature          |
       | git config git-town.unknown-branch-type feature      |
       | git config git-town.push-hook true                   |
@@ -51,34 +51,34 @@ Feature: enter the Codeberg API token
 
   Scenario: select Codeberg manually
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS                 | DESCRIPTION                                 |
-      | welcome                     | enter                |                                             |
-      | aliases                     | enter                |                                             |
-      | main branch                 | enter                |                                             |
-      | perennial branches          |                      | no input here since the dialog doesn't show |
-      | perennial regex             | enter                |                                             |
-      | feature regex               | enter                |                                             |
-      | contribution regex          | enter                |                                             |
-      | observed regex              | enter                |                                             |
-      | new branch type             | enter                |                                             |
-      | unknown branch type         | enter                |                                             |
-      | origin hostname             | enter                |                                             |
-      | forge type                  | down down down enter |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter    |                                             |
-      | token scope                 | enter                |                                             |
-      | sync feature strategy       | enter                |                                             |
-      | sync perennial strategy     | enter                |                                             |
-      | sync prototype strategy     | enter                |                                             |
-      | sync upstream               | enter                |                                             |
-      | sync tags                   | enter                |                                             |
-      | share new branches          | enter                |                                             |
-      | push hook                   | enter                |                                             |
-      | ship strategy               | enter                |                                             |
-      | ship delete tracking branch | enter                |                                             |
-      | config storage              | enter                |                                             |
+      | DIALOG                      | KEYS                   | DESCRIPTION                                 |
+      | welcome                     | enter                  |                                             |
+      | aliases                     | enter                  |                                             |
+      | main branch                 | enter                  |                                             |
+      | perennial branches          |                        | no input here since the dialog doesn't show |
+      | perennial regex             | enter                  |                                             |
+      | feature regex               | enter                  |                                             |
+      | contribution regex          | enter                  |                                             |
+      | observed regex              | enter                  |                                             |
+      | new branch type             | enter                  |                                             |
+      | unknown branch type         | enter                  |                                             |
+      | origin hostname             | enter                  |                                             |
+      | forge type                  | down down down enter   |                                             |
+      | codeberg token              | c o d e - t o k  enter |                                             |
+      | token scope                 | enter                  |                                             |
+      | sync feature strategy       | enter                  |                                             |
+      | sync perennial strategy     | enter                  |                                             |
+      | sync prototype strategy     | enter                  |                                             |
+      | sync upstream               | enter                  |                                             |
+      | sync tags                   | enter                  |                                             |
+      | share new branches          | enter                  |                                             |
+      | push hook                   | enter                  |                                             |
+      | ship strategy               | enter                  |                                             |
+      | ship delete tracking branch | enter                  |                                             |
+      | config storage              | enter                  |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config git-town.codeberg-token 123456            |
+      | git config git-town.codeberg-token code-tok          |
       | git config git-town.new-branch-type feature          |
       | git config git-town.forge-type codeberg              |
       | git config git-town.unknown-branch-type feature      |
@@ -97,34 +97,34 @@ Feature: enter the Codeberg API token
   Scenario: store Codeberge API token globally
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main-branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | new branch type             | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type                  | enter             |                                             |
-      | codeberg token              | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | down enter        |                                             |
-      | sync feature strategy       | enter             |                                             |
-      | sync perennial strategy     | enter             |                                             |
-      | sync prototype strategy     | enter             |                                             |
-      | sync upstream               | enter             |                                             |
-      | sync tags                   | enter             |                                             |
-      | share new branches          | enter             |                                             |
-      | push hook                   | enter             |                                             |
-      | ship strategy               | enter             |                                             |
-      | ship delete tracking branch | enter             |                                             |
-      | config storage              | enter             |                                             |
+      | DIALOG                      | KEYS                   | DESCRIPTION                                 |
+      | welcome                     | enter                  |                                             |
+      | aliases                     | enter                  |                                             |
+      | main-branch                 | enter                  |                                             |
+      | perennial branches          |                        | no input here since the dialog doesn't show |
+      | perennial regex             | enter                  |                                             |
+      | feature regex               | enter                  |                                             |
+      | contribution regex          | enter                  |                                             |
+      | observed regex              | enter                  |                                             |
+      | new branch type             | enter                  |                                             |
+      | unknown branch type         | enter                  |                                             |
+      | origin hostname             | enter                  |                                             |
+      | forge type                  | enter                  |                                             |
+      | codeberg token              | c o d e - t o k  enter |                                             |
+      | token scope                 | down enter             |                                             |
+      | sync feature strategy       | enter                  |                                             |
+      | sync perennial strategy     | enter                  |                                             |
+      | sync prototype strategy     | enter                  |                                             |
+      | sync upstream               | enter                  |                                             |
+      | sync tags                   | enter                  |                                             |
+      | share new branches          | enter                  |                                             |
+      | push hook                   | enter                  |                                             |
+      | ship strategy               | enter                  |                                             |
+      | ship delete tracking branch | enter                  |                                             |
+      | config storage              | enter                  |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config --global git-town.codeberg-token 123456   |
+      | git config --global git-town.codeberg-token code-tok |
       | git config git-town.new-branch-type feature          |
       | git config git-town.unknown-branch-type feature      |
       | git config git-town.push-hook true                   |
@@ -138,9 +138,10 @@ Feature: enter the Codeberg API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.codeberg-token" is now "123456"
 
+  @this
   Scenario: edit global Codeberge API token
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
-    Given global Git setting "git-town.codeberg-token" is "123"
+    Given global Git setting "git-town.codeberg-token" is "code123"
     When I run "git-town config setup" and enter into the dialog:
       | DIALOG                      | KEYS                                      | DESCRIPTION                                 |
       | welcome                     | enter                                     |                                             |
@@ -169,7 +170,7 @@ Feature: enter the Codeberg API token
       | config storage              | enter                                     |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config --global git-town.codeberg-token 456      |
+      | git config --global git-town.codeberg-token code456  |
       | git config git-town.new-branch-type feature          |
       | git config git-town.unknown-branch-type feature      |
       | git config git-town.push-hook true                   |
@@ -181,4 +182,4 @@ Feature: enter the Codeberg API token
       | git config git-town.sync-prototype-strategy merge    |
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
-    And global Git setting "git-town.codeberg-token" is now "456"
+    And global Git setting "git-town.codeberg-token" is now "code456"

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -138,7 +138,6 @@ Feature: enter the Codeberg API token
       | git config git-town.sync-tags true                   |
     And global Git setting "git-town.codeberg-token" is now "123456"
 
-  @this
   Scenario: edit global Codeberge API token
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"
     Given global Git setting "git-town.codeberg-token" is "code123"

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -136,7 +136,7 @@ Feature: enter the Codeberg API token
       | git config git-town.sync-prototype-strategy merge    |
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
-    And global Git setting "git-town.codeberg-token" is now "123456"
+    And global Git setting "git-town.codeberg-token" is now "code-tok"
 
   Scenario: edit global Codeberge API token
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -47,7 +47,7 @@ Feature: enter the Codeberg API token
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
     And local Git setting "git-town.forge-type" still doesn't exist
-    And local Git setting "git-town.codeberg-token" is now "123456"
+    And local Git setting "git-town.codeberg-token" is now "code-tok"
 
   Scenario: select Codeberg manually
     When I run "git-town config setup" and enter into the dialog:

--- a/features/config/setup/codeberg_token.feature
+++ b/features/config/setup/codeberg_token.feature
@@ -92,7 +92,7 @@ Feature: enter the Codeberg API token
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
     And local Git setting "git-town.forge-type" is now "codeberg"
-    And local Git setting "git-town.codeberg-token" is now "123456"
+    And local Git setting "git-town.codeberg-token" is now "code-tok"
 
   Scenario: store Codeberge API token globally
     And my repo's "origin" remote is "git@codeberg.org:git-town/docs.git"

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -64,7 +64,7 @@ Feature: enter the Gitea API token
       | unknown branch type         | enter                     |                                             |
       | origin hostname             | enter                     |                                             |
       | forge type                  | down down down down enter |                                             |
-      | gitea token                 | 1 2 3 4 5 6 enter         |                                             |
+      | gitea token                 |         1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                     |                                             |
       | sync feature strategy       | enter                     |                                             |
       | sync perennial strategy     | enter                     |                                             |
@@ -97,34 +97,34 @@ Feature: enter the Gitea API token
   Scenario: store Gitea API token globally
     And my repo's "origin" remote is "git@gitea.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | new branch type             | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type                  | enter             |                                             |
-      | gitea token                 | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | down enter        |                                             |
-      | sync feature strategy       | enter             |                                             |
-      | sync perennial strategy     | enter             |                                             |
-      | sync prototype strategy     | enter             |                                             |
-      | sync upstream               | enter             |                                             |
-      | sync tags                   | enter             |                                             |
-      | share new branches          | enter             |                                             |
-      | push hook                   | enter             |                                             |
-      | ship strategy               | enter             |                                             |
-      | ship delete tracking branch | enter             |                                             |
-      | config storage              | enter             | git metadata                                |
+      | DIALOG                      | KEYS                    | DESCRIPTION                                 |
+      | welcome                     | enter                   |                                             |
+      | aliases                     | enter                   |                                             |
+      | main branch                 | enter                   |                                             |
+      | perennial branches          |                         | no input here since the dialog doesn't show |
+      | perennial regex             | enter                   |                                             |
+      | feature regex               | enter                   |                                             |
+      | contribution regex          | enter                   |                                             |
+      | observed regex              | enter                   |                                             |
+      | new branch type             | enter                   |                                             |
+      | unknown branch type         | enter                   |                                             |
+      | origin hostname             | enter                   |                                             |
+      | forge type                  | enter                   |                                             |
+      | gitea token                 | g i t e a - t o k enter |                                             |
+      | token scope                 | down enter              |                                             |
+      | sync feature strategy       | enter                   |                                             |
+      | sync perennial strategy     | enter                   |                                             |
+      | sync prototype strategy     | enter                   |                                             |
+      | sync upstream               | enter                   |                                             |
+      | sync tags                   | enter                   |                                             |
+      | share new branches          | enter                   |                                             |
+      | push hook                   | enter                   |                                             |
+      | ship strategy               | enter                   |                                             |
+      | ship delete tracking branch | enter                   |                                             |
+      | config storage              | enter                   | git metadata                                |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config --global git-town.gitea-token 123456      |
+      | git config --global git-town.gitea-token gitea-tok   |
       | git config git-town.new-branch-type feature          |
       | git config git-town.unknown-branch-type feature      |
       | git config git-town.push-hook true                   |

--- a/features/config/setup/gitea_token.feature
+++ b/features/config/setup/gitea_token.feature
@@ -136,7 +136,7 @@ Feature: enter the Gitea API token
       | git config git-town.sync-prototype-strategy merge    |
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
-    And global Git setting "git-town.gitea-token" is now "123456"
+    And global Git setting "git-town.gitea-token" is now "gitea-tok"
 
   Scenario: edit global Gitea token
     Given my repo's "origin" remote is "git@gitea.com:git-town/git-town.git"

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -189,7 +189,7 @@ Feature: enter the GitHub API token
       | git config git-town.sync-prototype-strategy merge    |
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
-    And global Git setting "git-town.github-token" is now "123456"
+    And global Git setting "git-town.github-token" is now "ghtok"
 
   Scenario: edit global GitHub token
     Given my repo's "origin" remote is "git@github.com:git-town/git-town.git"

--- a/features/config/setup/github_token.feature
+++ b/features/config/setup/github_token.feature
@@ -67,7 +67,7 @@ Feature: enter the GitHub API token
       | origin hostname             | enter                          |                                             |
       | forge type                  | down down down down down enter |                                             |
       | github connector type       | enter                          |                                             |
-      | github token                | 1 2 3 4 5 6 enter              |                                             |
+      | github token                |              1 2 3 4 5 6 enter |                                             |
       | token scope                 | enter                          |                                             |
       | sync feature strategy       | enter                          |                                             |
       | sync perennial strategy     | enter                          |                                             |
@@ -148,35 +148,35 @@ Feature: enter the GitHub API token
   Scenario: store GitHub token globally
     Given my repo's "origin" remote is "git@github.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | new branch type             | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type                  | enter             |                                             |
-      | github connector type       | enter             |                                             |
-      | github token                | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | down enter        |                                             |
-      | sync feature strategy       | enter             |                                             |
-      | sync perennial strategy     | enter             |                                             |
-      | sync prototype strategy     | enter             |                                             |
-      | sync upstream               | enter             |                                             |
-      | sync tags                   | enter             |                                             |
-      | share new branches          | enter             |                                             |
-      | push hook                   | enter             |                                             |
-      | ship strategy               | enter             |                                             |
-      | ship delete tracking branch | enter             |                                             |
-      | config storage              | enter             |                                             |
+      | DIALOG                      | KEYS            | DESCRIPTION                                 |
+      | welcome                     | enter           |                                             |
+      | aliases                     | enter           |                                             |
+      | main branch                 | enter           |                                             |
+      | perennial branches          |                 | no input here since the dialog doesn't show |
+      | perennial regex             | enter           |                                             |
+      | feature regex               | enter           |                                             |
+      | contribution regex          | enter           |                                             |
+      | observed regex              | enter           |                                             |
+      | new branch type             | enter           |                                             |
+      | unknown branch type         | enter           |                                             |
+      | origin hostname             | enter           |                                             |
+      | forge type                  | enter           |                                             |
+      | github connector type       | enter           |                                             |
+      | github token                | g h t o k enter |                                             |
+      | token scope                 | down enter      |                                             |
+      | sync feature strategy       | enter           |                                             |
+      | sync perennial strategy     | enter           |                                             |
+      | sync prototype strategy     | enter           |                                             |
+      | sync upstream               | enter           |                                             |
+      | sync tags                   | enter           |                                             |
+      | share new branches          | enter           |                                             |
+      | push hook                   | enter           |                                             |
+      | ship strategy               | enter           |                                             |
+      | ship delete tracking branch | enter           |                                             |
+      | config storage              | enter           |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config --global git-town.github-token 123456     |
+      | git config --global git-town.github-token ghtok      |
       | git config git-town.new-branch-type feature          |
       | git config git-town.github-connector api             |
       | git config git-town.unknown-branch-type feature      |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -100,35 +100,35 @@ Feature: enter the GitLab API token
   Scenario: store GitLab API token globally
     Given my repo's "origin" remote is "git@gitlab.com:git-town/git-town.git"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | new branch type             | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type                  | enter             |                                             |
-      | gitlab connector type       | enter             | api                                         |
-      | gitlab token                | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | down enter        |                                             |
-      | sync feature strategy       | enter             |                                             |
-      | sync perennial strategy     | enter             |                                             |
-      | sync prototype strategy     | enter             |                                             |
-      | sync upstream               | enter             |                                             |
-      | sync tags                   | enter             |                                             |
-      | share new branches          | enter             |                                             |
-      | push hook                   | enter             |                                             |
-      | ship strategy               | enter             |                                             |
-      | ship delete tracking branch | enter             |                                             |
-      | config storage              | enter             | git metadata                                |
+      | DIALOG                      | KEYS            | DESCRIPTION                                 |
+      | welcome                     | enter           |                                             |
+      | aliases                     | enter           |                                             |
+      | main branch                 | enter           |                                             |
+      | perennial branches          |                 | no input here since the dialog doesn't show |
+      | perennial regex             | enter           |                                             |
+      | feature regex               | enter           |                                             |
+      | contribution regex          | enter           |                                             |
+      | observed regex              | enter           |                                             |
+      | new branch type             | enter           |                                             |
+      | unknown branch type         | enter           |                                             |
+      | origin hostname             | enter           |                                             |
+      | forge type                  | enter           |                                             |
+      | gitlab connector type       | enter           | api                                         |
+      | gitlab token                | g l t o k enter |                                             |
+      | token scope                 | down enter      |                                             |
+      | sync feature strategy       | enter           |                                             |
+      | sync perennial strategy     | enter           |                                             |
+      | sync prototype strategy     | enter           |                                             |
+      | sync upstream               | enter           |                                             |
+      | sync tags                   | enter           |                                             |
+      | share new branches          | enter           |                                             |
+      | push hook                   | enter           |                                             |
+      | ship strategy               | enter           |                                             |
+      | ship delete tracking branch | enter           |                                             |
+      | config storage              | enter           | git metadata                                |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config --global git-town.gitlab-token 123456     |
+      | git config --global git-town.gitlab-token gltok      |
       | git config git-town.new-branch-type feature          |
       | git config git-town.gitlab-connector api             |
       | git config git-town.unknown-branch-type feature      |

--- a/features/config/setup/gitlab_token.feature
+++ b/features/config/setup/gitlab_token.feature
@@ -141,7 +141,7 @@ Feature: enter the GitLab API token
       | git config git-town.sync-prototype-strategy merge    |
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
-    And global Git setting "git-town.gitlab-token" is now "123456"
+    And global Git setting "git-town.gitlab-token" is now "gltok"
 
   Scenario: edit global GitLab token
     Given my repo's "origin" remote is "git@gitlab.com:git-town/git-town.git"

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -6,35 +6,35 @@ Feature: a global API token of another forge exists
     And my repo's "origin" remote is "git@github.com:git-town/git-town.git"
     And global Git setting "git-town.gitlab-token" is "987654"
     When I run "git-town config setup" and enter into the dialog:
-      | DIALOG                      | KEYS              | DESCRIPTION                                 |
-      | welcome                     | enter             |                                             |
-      | aliases                     | enter             |                                             |
-      | main branch                 | enter             |                                             |
-      | perennial branches          |                   | no input here since the dialog doesn't show |
-      | perennial regex             | enter             |                                             |
-      | feature regex               | enter             |                                             |
-      | contribution regex          | enter             |                                             |
-      | observed regex              | enter             |                                             |
-      | new branch type             | enter             |                                             |
-      | unknown branch type         | enter             |                                             |
-      | origin hostname             | enter             |                                             |
-      | forge type                  | enter             |                                             |
-      | github connector type       | enter             |                                             |
-      | github token                | 1 2 3 4 5 6 enter |                                             |
-      | token scope                 | enter             |                                             |
-      | sync feature strategy       | enter             |                                             |
-      | sync perennial strategy     | enter             |                                             |
-      | sync prototype strategy     | enter             |                                             |
-      | sync upstream               | enter             |                                             |
-      | sync tags                   | enter             |                                             |
-      | share new branches          | enter             |                                             |
-      | push hook                   | enter             |                                             |
-      | ship strategy               | enter             |                                             |
-      | ship delete tracking branch | enter             |                                             |
-      | config storage              | enter             |                                             |
+      | DIALOG                      | KEYS            | DESCRIPTION                                 |
+      | welcome                     | enter           |                                             |
+      | aliases                     | enter           |                                             |
+      | main branch                 | enter           |                                             |
+      | perennial branches          |                 | no input here since the dialog doesn't show |
+      | perennial regex             | enter           |                                             |
+      | feature regex               | enter           |                                             |
+      | contribution regex          | enter           |                                             |
+      | observed regex              | enter           |                                             |
+      | new branch type             | enter           |                                             |
+      | unknown branch type         | enter           |                                             |
+      | origin hostname             | enter           |                                             |
+      | forge type                  | enter           |                                             |
+      | github connector type       | enter           |                                             |
+      | github token                | g h t o k enter |                                             |
+      | token scope                 | enter           |                                             |
+      | sync feature strategy       | enter           |                                             |
+      | sync perennial strategy     | enter           |                                             |
+      | sync prototype strategy     | enter           |                                             |
+      | sync upstream               | enter           |                                             |
+      | sync tags                   | enter           |                                             |
+      | share new branches          | enter           |                                             |
+      | push hook                   | enter           |                                             |
+      | ship strategy               | enter           |                                             |
+      | ship delete tracking branch | enter           |                                             |
+      | config storage              | enter           |                                             |
     Then Git Town runs the commands
       | COMMAND                                              |
-      | git config git-town.github-token 123456              |
+      | git config git-town.github-token ghtok               |
       | git config git-town.new-branch-type feature          |
       | git config git-town.github-connector api             |
       | git config git-town.unknown-branch-type feature      |

--- a/features/config/setup/global_token_other_forge.feature
+++ b/features/config/setup/global_token_other_forge.feature
@@ -48,6 +48,6 @@ Feature: a global API token of another forge exists
       | git config git-town.sync-upstream true               |
       | git config git-town.sync-tags true                   |
     And local Git setting "git-town.forge-type" still doesn't exist
-    And local Git setting "git-town.github-token" is now "123456"
+    And local Git setting "git-town.github-token" is now "ghtok"
     And local Git setting "git-town.gitlab-token" now doesn't exist
     And global Git setting "git-town.gitlab-token" is still "987654"

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -83,23 +83,23 @@ Feature: migrate existing configuration in Git metadata to a config file
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
       perennials = ["qa"]
       perennial-regex = "release-.*"
-
+      
       [create]
       new-branch-type = "prototype"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = false
       strategy = "squash-merge"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/multiple_remotes.feature
+++ b/features/config/setup/multiple_remotes.feature
@@ -38,21 +38,21 @@ Feature: Configure a different development remote
     And the configuration file is now:
       """
       # More info around this file at https://www.git-town.com/configuration-file
-
+      
       [branches]
       main = "main"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "no"
-
+      
       [hosting]
       dev-remote = "fork"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"

--- a/features/config/setup/unconfigured_with_complete_config_file.feature
+++ b/features/config/setup/unconfigured_with_complete_config_file.feature
@@ -14,27 +14,27 @@ Feature: don't ask for information already provided by the config file
       perennial-regex = "release-"
       perennials = ["staging"]
       unknown-type = "observed"
-
+      
       [create]
       new-branch-type = "feature"
       share-new-branches = "propose"
-
+      
       [hosting]
       dev-remote = "something"
       origin-hostname = "github.com"
       forge-type = "github"
-
+      
       [ship]
       delete-tracking-branch = true
       strategy = "api"
-
+      
       [sync]
       feature-strategy = "merge"
       perennial-strategy = "rebase"
       push-hook = true
       tags = true
       upstream = true
-
+      
       [sync-strategy]
       feature-branches = "rebase"
       prototype-branches = "merge"
@@ -45,10 +45,10 @@ Feature: don't ask for information already provided by the config file
       | welcome               | enter             |
       | aliases               | enter             |
       | github connector type | enter             |
-      | github token          | 1 2 3 4 5 6 enter |
+      | github token          | g h - t o k enter |
       | token scope           | enter             |
       | config storage        | enter             |
     Then Git Town runs the commands
       | COMMAND                                  |
-      | git config git-town.github-token 123456  |
+      | git config git-town.github-token gh-tok  |
       | git config git-town.github-connector api |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -1,6 +1,7 @@
 @messyoutput
 Feature: setup a new repo when I have configured some things in global Git metadata
 
+  @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -21,38 +22,37 @@ Feature: setup a new repo when I have configured some things in global Git metad
     And global Git setting "git-town.sync-upstream" is "false"
     And global Git setting "git-town.unknown-branch-type" is "observed"
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG                      | KEYS        |
-      | welcome                     | enter       |
-      | aliases                     | enter       |
-      | main branch                 | enter       |
-      | perennial branches          | enter       |
-      | perennial regex             | p p p enter |
-      | feature regex               | f f f enter |
-      | contribution regex          | c c c enter |
-      | observed regex              | o o o enter |
-      | new branch type             | enter       |
-      | unknown branch type         | enter       |
-      | origin hostname             | enter       |
-      | forge type                  | enter       |
-      | sync feature strategy       | enter       |
-      | sync perennial strategy     | enter       |
-      | sync prototype strategy     | enter       |
-      | sync upstream               | enter       |
-      | sync tags                   | enter       |
-      | share new branches          | enter       |
-      | push hook                   | enter       |
-      | ship strategy               | enter       |
-      | ship delete tracking branch | enter       |
-      | config storage              | enter       |
+      | DIALOG                      | KEYS  |
+      | welcome                     | enter |
+      | aliases                     | enter |
+      | main branch                 | enter |
+      | perennial branches          | enter |
+      | perennial regex             | enter |
+      | feature regex               | enter |
+      | contribution regex          | enter |
+      | observed regex              | enter |
+      | new branch type             | enter |
+      | unknown branch type         | enter |
+      | origin hostname             | enter |
+      | forge type                  | enter |
+      | sync feature strategy       | enter |
+      | sync perennial strategy     | enter |
+      | sync prototype strategy     | enter |
+      | sync upstream               | enter |
+      | sync tags                   | enter |
+      | share new branches          | enter |
+      | push hook                   | enter |
+      | ship strategy               | enter |
+      | ship delete tracking branch | enter |
+      | config storage              | enter |
     Then Git Town runs the commands
       | COMMAND                                               |
       | git config git-town.new-branch-type prototype         |
       | git config git-town.main-branch main                  |
       | git config git-town.perennial-branches public         |
-      | git config git-town.perennial-regex ppp               |
-      | git config git-town.feature-regex ^kg-222             |
-      | git config git-town.contribution-regex release-333    |
-      | git config git-town.observed-regex staging-444        |
+      | git config git-town.feature-regex ^kg-                |
+      | git config git-town.contribution-regex release-       |
+      | git config git-town.observed-regex staging-           |
       | git config git-town.push-hook false                   |
       | git config git-town.share-new-branches push           |
       | git config git-town.ship-strategy api                 |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -26,10 +26,10 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | aliases                     | enter       |
       | main branch                 | enter       |
       | perennial branches          | enter       |
-      | perennial regex             | 1 1 1 enter |
-      | feature regex               | 2 2 2 enter |
-      | contribution regex          | 3 3 3 enter |
-      | observed regex              | 4 4 4 enter |
+      | perennial regex             | p p p enter |
+      | feature regex               | f f f enter |
+      | contribution regex          | c c c enter |
+      | observed regex              | o o o enter |
       | new branch type             | enter       |
       | unknown branch type         | enter       |
       | origin hostname             | enter       |
@@ -49,7 +49,7 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | git config git-town.new-branch-type prototype         |
       | git config git-town.main-branch main                  |
       | git config git-town.perennial-branches public         |
-      | git config git-town.perennial-regex 111               |
+      | git config git-town.perennial-regex ppp               |
       | git config git-town.feature-regex ^kg-222             |
       | git config git-town.contribution-regex release-333    |
       | git config git-town.observed-regex staging-444        |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: setup a new repo when I have configured some things in global Git metadata
 
-  @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: ask for information not provided by the config file
 
-  @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -1,7 +1,7 @@
 @messyoutput
 Feature: ask for information not provided by the config file
 
-  @debug @this
+  @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -23,35 +23,35 @@ Feature: ask for information not provided by the config file
       upstream = false
       """
     When I run "git-town config setup" and enter into the dialogs:
-      | DIALOG                  | KEYS        |
-      | welcome                 | enter       |
-      | aliases                 | enter       |
-      | perennial regex         | p p p enter |
-      | feature regex           | f f f enter |
-      | contribution regex      | c c c enter |
-      | observed regex          | o o o enter |
-      | new branch type         | enter       |
-      | unknown branch type     | enter       |
-      | github connector type   | enter       |
-      | github token            | g g g enter |
-      | token scope             | enter       |
-      | sync feature strategy   | enter       |
-      | sync perennial strategy | enter       |
-      | sync prototype strategy | enter       |
-      | share new branches      | enter       |
-      | push hook               | enter       |
-      | ship strategy           | enter       |
-      | config storage          | enter       |
+      | DIALOG                  | KEYS                  |
+      | welcome                 | enter                 |
+      | aliases                 | enter                 |
+      | perennial regex         | p e r e n enter       |
+      | feature regex           | f e a t enter         |
+      | contribution regex      | c o n t enter         |
+      | observed regex          | o b s enter           |
+      | new branch type         | enter                 |
+      | unknown branch type     | enter                 |
+      | github connector type   | enter                 |
+      | github token            | g h - t o k e n enter |
+      | token scope             | enter                 |
+      | sync feature strategy   | enter                 |
+      | sync perennial strategy | enter                 |
+      | sync prototype strategy | enter                 |
+      | share new branches      | enter                 |
+      | push hook               | enter                 |
+      | ship strategy           | enter                 |
+      | config storage          | enter                 |
     Then Git Town runs the commands
       | COMMAND                                            |
-      | git config git-town.github-token ggg               |
+      | git config git-town.github-token gh-token          |
       | git config git-town.new-branch-type feature        |
       | git config git-town.github-connector api           |
-      | git config git-town.perennial-regex ppp            |
+      | git config git-town.perennial-regex peren          |
       | git config git-town.unknown-branch-type feature    |
-      | git config git-town.feature-regex fff              |
-      | git config git-town.contribution-regex ccc         |
-      | git config git-town.observed-regex ooo             |
+      | git config git-town.feature-regex feat             |
+      | git config git-town.contribution-regex cont        |
+      | git config git-town.observed-regex obs             |
       | git config git-town.push-hook true                 |
       | git config git-town.share-new-branches no          |
       | git config git-town.ship-strategy api              |

--- a/features/config/setup/unconfigured_with_partial_config_file.feature
+++ b/features/config/setup/unconfigured_with_partial_config_file.feature
@@ -1,6 +1,7 @@
 @messyoutput
 Feature: ask for information not provided by the config file
 
+  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -8,15 +9,15 @@ Feature: ask for information not provided by the config file
       """
       [branches]
       main = "main"
-
+      
       [hosting]
       dev-remote = "something"
       forge-type = "github"
       origin-hostname = "github.com"
-
+      
       [ship]
       delete-tracking-branch = false
-
+      
       [sync]
       tags = false
       upstream = false
@@ -25,14 +26,14 @@ Feature: ask for information not provided by the config file
       | DIALOG                  | KEYS        |
       | welcome                 | enter       |
       | aliases                 | enter       |
-      | perennial regex         | 1 1 1 enter |
-      | feature regex           | 2 2 2 enter |
-      | contribution regex      | 3 3 3 enter |
-      | observed regex          | 4 4 4 enter |
+      | perennial regex         | p p p enter |
+      | feature regex           | f f f enter |
+      | contribution regex      | c c c enter |
+      | observed regex          | o o o enter |
       | new branch type         | enter       |
       | unknown branch type     | enter       |
       | github connector type   | enter       |
-      | github token            | 9 9 9 enter |
+      | github token            | g g g enter |
       | token scope             | enter       |
       | sync feature strategy   | enter       |
       | sync perennial strategy | enter       |
@@ -43,14 +44,14 @@ Feature: ask for information not provided by the config file
       | config storage          | enter       |
     Then Git Town runs the commands
       | COMMAND                                            |
-      | git config git-town.github-token 999               |
+      | git config git-town.github-token ggg               |
       | git config git-town.new-branch-type feature        |
       | git config git-town.github-connector api           |
-      | git config git-town.perennial-regex 111            |
+      | git config git-town.perennial-regex ppp            |
       | git config git-town.unknown-branch-type feature    |
-      | git config git-town.feature-regex 222              |
-      | git config git-town.contribution-regex 333         |
-      | git config git-town.observed-regex 444             |
+      | git config git-town.feature-regex fff              |
+      | git config git-town.contribution-regex ccc         |
+      | git config git-town.observed-regex ooo             |
       | git config git-town.push-hook true                 |
       | git config git-town.share-new-branches no          |
       | git config git-town.ship-strategy api              |

--- a/internal/cli/dialog/dialogcomponents/test_input.go
+++ b/internal/cli/dialog/dialogcomponents/test_input.go
@@ -74,14 +74,30 @@ func recognizeTestInput(input string) tea.Msg { //nolint:ireturn
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}} //exhaustruct:ignore
 	case "a":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}} //exhaustruct:ignore
+	case "b":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}} //exhaustruct:ignore
 	case "c":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}} //exhaustruct:ignore
 	case "d":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}} //exhaustruct:ignore
 	case "e":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}} //exhaustruct:ignore
+	case "f":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}} //exhaustruct:ignore
+	case "g":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}} //exhaustruct:ignore
+	case "h":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}} //exhaustruct:ignore
+	case "i":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}} //exhaustruct:ignore
+	case "j":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}} //exhaustruct:ignore
 	case "k":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}} //exhaustruct:ignore
+	case "l":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}} //exhaustruct:ignore
+	case "m":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}} //exhaustruct:ignore
 	case "n":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}} //exhaustruct:ignore
 	case "o":
@@ -94,8 +110,20 @@ func recognizeTestInput(input string) tea.Msg { //nolint:ireturn
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}} //exhaustruct:ignore
 	case "s":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}} //exhaustruct:ignore
+	case "t":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}} //exhaustruct:ignore
 	case "u":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}} //exhaustruct:ignore
+	case "v":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}} //exhaustruct:ignore
+	case "w":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}} //exhaustruct:ignore
+	case "x":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}} //exhaustruct:ignore
+	case "y":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}} //exhaustruct:ignore
+	case "z":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}} //exhaustruct:ignore
 	}
 	panic("unknown test input: " + input)
 }

--- a/internal/cli/dialog/dialogcomponents/test_input.go
+++ b/internal/cli/dialog/dialogcomponents/test_input.go
@@ -124,6 +124,10 @@ func recognizeTestInput(input string) tea.Msg { //nolint:ireturn
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}} //exhaustruct:ignore
 	case "z":
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}} //exhaustruct:ignore
+	case "^":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'^'}} //exhaustruct:ignore
+	case "-":
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'-'}} //exhaustruct:ignore
 	}
 	panic("unknown test input: " + input)
 }


### PR DESCRIPTION
An ongoing pain point is that the Cucumber VSCode plugin formats table fields
that start with a number right-aligned, which deviates how the CLI Gherkin
formatter sees this. This PR changes all numeric inputs to characters.
