### PR TITLE
setup assistant: correctly handle global Git config for mainbranch

### DIFF
--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -1,6 +1,7 @@
 @messyoutput
 Feature: setup a new repo when I have configured some things in global Git metadata
 
+  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured
@@ -24,7 +25,6 @@ Feature: setup a new repo when I have configured some things in global Git metad
       | DIALOG                      | KEYS  |
       | welcome                     | enter |
       | aliases                     | enter |
-      | main branch                 | enter |
       | perennial branches          | enter |
       | perennial regex             | enter |
       | feature regex               | enter |

--- a/features/config/setup/unconfigured_with_global_settings.feature
+++ b/features/config/setup/unconfigured_with_global_settings.feature
@@ -1,7 +1,6 @@
 @messyoutput
 Feature: setup a new repo when I have configured some things in global Git metadata
 
-  @debug @this
   Scenario:
     Given a Git repo with origin
     And Git Town is not configured

--- a/internal/cli/dialog/main_and_perennial.go
+++ b/internal/cli/dialog/main_and_perennial.go
@@ -21,7 +21,13 @@ func MainAndPerennials(args MainAndPerennialsArgs) (mainBranch gitdomain.LocalBr
 		return unvalidatedMain, args.UnvalidatedPerennials, false, errors.New(messages.ConfigMainbranchInConfigFile)
 	}
 	fmt.Print(messages.ConfigNeeded)
-	mainBranch, exit, err = MainBranch(args.LocalBranches, args.GetDefaultBranch(args.Backend), args.DialogInputs)
+	mainBranch, exit, err = MainBranch(MainBranchArgs{
+		GitStandardBranch:     Option[gitdomain.LocalBranchName]{},
+		Inputs:                dialogcomponents.TestInputs{},
+		LocalBranches:         gitdomain.LocalBranchNames{},
+		LocalGitMainBranch:    Option[gitdomain.LocalBranchName]{},
+		UnscopedGitMainBranch: Option[gitdomain.LocalBranchName]{},
+	}, args.LocalBranches, args.GetDefaultBranch(args.Backend), args.DialogInputs)
 	if err != nil || exit {
 		return mainBranch, args.UnvalidatedPerennials, exit, err
 	}

--- a/internal/cli/dialog/main_branch.go
+++ b/internal/cli/dialog/main_branch.go
@@ -27,10 +27,9 @@ This is typically the branch called
 
 // MainBranch lets the user select a new main branch for this repo.
 func MainBranch(args MainBranchArgs) (Option[gitdomain.LocalBranchName], dialogdomain.Exit, error) {
-	// if mainbranch is configured in unscoped Git config but not in local: add option "use global setting" with None
-	// if set in local config: don't add None option, preselect local setting
-	// if no local config: don't add None option, keep existing preselect nothing
-	// if global and local: add global option but preselect the local one
+	// if local: don't add None option, preselect local setting
+	// if no local and unscoped: add None option and preselect it
+	// if local and different unscoped: add None option but preselect the local one
 	entries := list.Entries[Option[gitdomain.LocalBranchName]]{}
 	if unscopedMain, hasUnscoped := args.UnscopedGitMainBranch.Get(); hasUnscoped {
 		if args.LocalGitMainBranch.IsNone() {

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -435,12 +435,12 @@ func enterMainBranch(repo execute.OpenRepoResult, data setupData) (userInput Opt
 		Inputs:                data.dialogInputs,
 		LocalBranches:         data.localBranches.Names(),
 		LocalGitMainBranch:    repo.UnvalidatedConfig.GitLocal.MainBranch,
-		UnscopedGitMainBranch: repo.UnvalidatedConfig.NormalConfig.Git.MainBranch,
+		UnscopedGitMainBranch: repo.UnvalidatedConfig.GitUnscoped.MainBranch,
 	})
 	if err != nil || exit {
 		return None[gitdomain.LocalBranchName](), "", exit, err
 	}
-	actualMainBranch = userInput.Or(repo.UnvalidatedConfig.NormalConfig.Git.MainBranch).GetOrPanic()
+	actualMainBranch = userInput.Or(repo.UnvalidatedConfig.GitUnscoped.MainBranch).GetOrPanic()
 	return userInput, actualMainBranch, false, nil
 }
 

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -444,6 +444,14 @@ func enterMainBranch(repo execute.OpenRepoResult, data setupData) (userInput Opt
 	return userInput, actualMainBranch, false, nil
 }
 
+// determines the branch that is configured in Git as the default branch
+func determineGitRepoDefaultBranch(repo execute.OpenRepoResult) Option[gitdomain.LocalBranchName] {
+	if defaultBranch, has := gitconfig.DefaultBranch(repo.Backend).Get(); has {
+		return Some(defaultBranch)
+	}
+	return repo.Git.OriginHead(repo.Backend)
+}
+
 func testForgeAuth(args testForgeAuthArgs) (repeat bool, exit dialogdomain.Exit, err error) {
 	if _, inTest := os.LookupEnv(subshell.TestToken); inTest {
 		return false, false, nil

--- a/internal/cmd/debug/enter_main_branch.go
+++ b/internal/cmd/debug/enter_main_branch.go
@@ -17,7 +17,13 @@ func enterMainBranchCmd() *cobra.Command {
 			localBranches := gitdomain.NewLocalBranchNames("main", "branch-1", "branch-2", "branch-3", "branch-4", "branch-5", "branch-6", "branch-7", "branch-8", "branch-9", "branch-A", "branch-B")
 			main := gitdomain.NewLocalBranchName("main")
 			dialogInputs := dialogcomponents.LoadTestInputs(os.Environ())
-			_, _, err := dialog.MainBranch(localBranches, Some(main), dialogInputs)
+			_, _, err := dialog.MainBranch(dialog.MainBranchArgs{
+				GitStandardBranch:     Some(gitdomain.NewLocalBranchName("main")),
+				Inputs:                dialogInputs,
+				LocalBranches:         localBranches,
+				LocalGitMainBranch:    Some(main),
+				UnscopedGitMainBranch: None[gitdomain.LocalBranchName](),
+			})
 			return err
 		},
 	}

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -166,10 +166,10 @@ func quickValidateConfig(args quickValidateConfigArgs) (config.ValidatedConfig, 
 		if err != nil || exit {
 			return config.EmptyValidatedConfig(), exit, err
 		}
-		if err = args.unvalidated.Value.SetMainBranch(validatedMain, args.backend); err != nil {
+		if err = args.unvalidated.Value.SetMainBranch(validatedMain.GetOrPanic(), args.backend); err != nil {
 			return config.EmptyValidatedConfig(), false, err
 		}
-		mainBranch = validatedMain
+		mainBranch = validatedMain.GetOrPanic()
 	}
 	gitUserEmail, gitUserName, err := GitUser(args.unvalidated.Value.UnvalidatedConfig)
 	if err != nil {

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -156,7 +156,13 @@ func quickValidateConfig(args quickValidateConfigArgs) (config.ValidatedConfig, 
 			return config.EmptyValidatedConfig(), false, err
 		}
 		localBranches := branchesSnapshot.Branches.LocalBranches().Names()
-		validatedMain, exit, err := dialog.MainBranch(localBranches, gitconfig.DefaultBranch(args.backend), args.dialogInputs)
+		validatedMain, exit, err := dialog.MainBranch(dialog.MainBranchArgs{
+			GitStandardBranch:     gitconfig.DefaultBranch(args.backend),
+			Inputs:                args.dialogInputs,
+			LocalBranches:         localBranches,
+			LocalGitMainBranch:    args.unvalidated.Value.GitGlobal.MainBranch,
+			UnscopedGitMainBranch: args.unvalidated.Value.GitUnscoped.MainBranch,
+		})
 		if err != nil || exit {
 			return config.EmptyValidatedConfig(), exit, err
 		}


### PR DESCRIPTION
Part of the effort to make the setup assistant more correct so that we can
automatically display it when configuration data is missing. This PR adds an
option to use the globally defined main branch to the setup assistant.
