### PR TITLE
Remove OpenRepoResult data from command data

### DIFF
--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -177,7 +177,6 @@ type appendFeatureData struct {
 	connector                 Option[forgedomain.Connector]
 	detached                  configdomain.Detached
 	dialogTestInputs          dialogcomponents.TestInputs
-	dryRun                    configdomain.DryRun
 	hasOpenChanges            bool
 	initialBranch             gitdomain.LocalBranchName
 	initialBranchInfo         *gitdomain.BranchInfo
@@ -319,7 +318,6 @@ func determineAppendData(cliConfig cliconfig.CliConfig, targetBranch gitdomain.L
 		connector:                 connector,
 		detached:                  detached,
 		dialogTestInputs:          dialogTestInputs,
-		dryRun:                    cliConfig.DryRun,
 		hasOpenChanges:            repoStatus.OpenChanges,
 		initialBranch:             initialBranch,
 		initialBranchInfo:         initialBranchInfo,
@@ -415,7 +413,7 @@ func appendProgram(frontend subshelldomain.Runner, data appendFeatureData, final
 	} else {
 		previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.initialBranch), data.previousBranch}
 		cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-			DryRun:                   data.dryRun,
+			DryRun:                   data.config.NormalConfig.DryRun,
 			InitialStashSize:         data.stashSize,
 			RunInGitRoot:             true,
 			StashOpenChanges:         data.hasOpenChanges,

--- a/internal/cmd/branch.go
+++ b/internal/cmd/branch.go
@@ -65,7 +65,7 @@ func executeBranch(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	entries := SwitchBranchEntries(data.branchInfos, []configdomain.BranchType{}, data.branchesAndTypes, data.lineage, data.unknownBranchType, false, []*regexp.Regexp{})
+	entries := SwitchBranchEntries(data.branchInfos, []configdomain.BranchType{}, data.branchesAndTypes, repo.UnvalidatedConfig.NormalConfig.Lineage, repo.UnvalidatedConfig.NormalConfig.UnknownBranchType, false, []*regexp.Regexp{})
 	fmt.Print(branchLayout(entries, data))
 	return nil
 }
@@ -105,26 +105,21 @@ func determineBranchData(repo execute.OpenRepoResult, cliConfig cliconfig.CliCon
 			initialBranchOpt = Some(initialBranch)
 		}
 	}
-	unknownBranchType := repo.UnvalidatedConfig.NormalConfig.UnknownBranchType
 	colors := colors.NewDialogColors()
 	branchesAndTypes := repo.UnvalidatedConfig.UnvalidatedBranchesAndTypes(branchesSnapshot.Branches.Names())
 	return branchData{
-		branchInfos:       branchesSnapshot.Branches,
-		branchesAndTypes:  branchesAndTypes,
-		colors:            colors,
-		initialBranchOpt:  initialBranchOpt,
-		lineage:           repo.UnvalidatedConfig.NormalConfig.Lineage,
-		unknownBranchType: unknownBranchType,
+		branchInfos:      branchesSnapshot.Branches,
+		branchesAndTypes: branchesAndTypes,
+		colors:           colors,
+		initialBranchOpt: initialBranchOpt,
 	}, false, err
 }
 
 type branchData struct {
-	branchInfos       gitdomain.BranchInfos
-	branchesAndTypes  configdomain.BranchesAndTypes
-	colors            colors.DialogColors
-	initialBranchOpt  Option[gitdomain.LocalBranchName]
-	lineage           configdomain.Lineage
-	unknownBranchType configdomain.UnknownBranchType
+	branchInfos      gitdomain.BranchInfos
+	branchesAndTypes configdomain.BranchesAndTypes
+	colors           colors.DialogColors
+	initialBranchOpt Option[gitdomain.LocalBranchName]
 }
 
 func branchLayout(entries dialog.SwitchBranchEntries, data branchData) string {

--- a/internal/cmd/compress.go
+++ b/internal/cmd/compress.go
@@ -159,7 +159,6 @@ type compressBranchesData struct {
 	branchesToCompress []compressBranchData
 	config             config.ValidatedConfig
 	dialogTestInputs   dialogcomponents.TestInputs
-	dryRun             configdomain.DryRun
 	hasOpenChanges     bool
 	initialBranch      gitdomain.LocalBranchName
 	previousBranch     Option[gitdomain.LocalBranchName]
@@ -310,7 +309,6 @@ func determineCompressBranchesData(repo execute.OpenRepoResult, cliConfig clicon
 		branchesToCompress: branchesToCompress,
 		config:             validatedConfig,
 		dialogTestInputs:   dialogTestInputs,
-		dryRun:             cliConfig.DryRun,
 		hasOpenChanges:     repoStatus.OpenChanges,
 		initialBranch:      initialBranch,
 		previousBranch:     previousBranch,
@@ -326,7 +324,7 @@ func compressProgram(data compressBranchesData, commitHook configdomain.CommitHo
 	prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: data.initialBranch})
 	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{data.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-		DryRun:                   data.dryRun,
+		DryRun:                   data.config.NormalConfig.DryRun,
 		InitialStashSize:         data.stashSize,
 		RunInGitRoot:             true,
 		StashOpenChanges:         data.hasOpenChanges,

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -75,7 +75,7 @@ func executeConfigSetup(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	if err = saveAll(enterDataResult, repo.UnvalidatedConfig, data.configFile, data, repo.Frontend); err != nil {
+	if err = saveAll(enterDataResult, repo.UnvalidatedConfig, repo.UnvalidatedConfig.File, data, repo.Frontend); err != nil {
 		return err
 	}
 	return configinterpreter.Finished(configinterpreter.FinishedArgs{
@@ -94,8 +94,6 @@ func executeConfigSetup(cliConfig cliconfig.CliConfig) error {
 
 type setupData struct {
 	backend       subshelldomain.Querier
-	config        config.UnvalidatedConfig
-	configFile    configdomain.PartialConfig
 	dialogInputs  dialogcomponents.TestInputs
 	localBranches gitdomain.BranchInfos
 	remotes       gitdomain.Remotes
@@ -126,7 +124,7 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		return emptyResult, exit, err
 	}
 	perennialBranches := repo.UnvalidatedConfig.NormalConfig.PerennialBranches
-	if len(data.configFile.PerennialBranches) == 0 {
+	if len(repo.UnvalidatedConfig.File.PerennialBranches) == 0 {
 		perennialBranches, exit, err = dialog.PerennialBranches(data.localBranches.Names(), perennialBranches, actualMainBranch, data.dialogInputs)
 		if err != nil || exit {
 			return emptyResult, exit, err
@@ -187,7 +185,7 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 	bitbucketUsername := repo.UnvalidatedConfig.NormalConfig.BitbucketUsername
 	bitbucketAppPassword := repo.UnvalidatedConfig.NormalConfig.BitbucketAppPassword
 	codebergToken := repo.UnvalidatedConfig.NormalConfig.CodebergToken
-	devURL := data.config.NormalConfig.DevURL(data.backend)
+	devURL := repo.UnvalidatedConfig.NormalConfig.DevURL(data.backend)
 	giteaToken := repo.UnvalidatedConfig.NormalConfig.GiteaToken
 	githubConnectorTypeOpt := repo.UnvalidatedConfig.NormalConfig.GitHubConnectorType
 	githubToken := repo.UnvalidatedConfig.NormalConfig.GitHubToken
@@ -261,7 +259,7 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 			gitlabConnectorType:  gitlabConnectorTypeOpt,
 			gitlabToken:          gitlabToken,
 			inputs:               data.dialogInputs,
-			remoteURL:            data.config.NormalConfig.RemoteURL(data.backend, devRemote),
+			remoteURL:            repo.UnvalidatedConfig.NormalConfig.RemoteURL(data.backend, devRemote),
 		})
 		if err != nil || exit {
 			return emptyResult, exit, err
@@ -275,7 +273,7 @@ func enterData(repo execute.OpenRepoResult, data setupData) (userInput, dialogdo
 		bitbucketUsername:    bitbucketUsername,
 		codebergToken:        codebergToken,
 		determinedForgeType:  actualForgeType,
-		existingConfig:       data.config.NormalConfig,
+		existingConfig:       repo.UnvalidatedConfig.NormalConfig,
 		giteaToken:           giteaToken,
 		githubToken:          githubToken,
 		gitlabToken:          gitlabToken,
@@ -595,8 +593,6 @@ func loadSetupData(repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig) (
 	}
 	return setupData{
 		backend:       repo.Backend,
-		config:        repo.UnvalidatedConfig,
-		configFile:    repo.UnvalidatedConfig.File,
 		dialogInputs:  dialogTestInputs,
 		localBranches: branchesSnapshot.Branches,
 		remotes:       remotes,

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -158,7 +158,6 @@ type deleteData struct {
 	config                   config.ValidatedConfig
 	connector                Option[forgedomain.Connector]
 	dialogTestInputs         dialogcomponents.TestInputs
-	dryRun                   configdomain.DryRun
 	hasOpenChanges           bool
 	initialBranch            gitdomain.LocalBranchName
 	nonExistingBranches      gitdomain.LocalBranchNames // branches that are listed in the lineage information, but don't exist in the repo, neither locally nor remotely
@@ -272,7 +271,6 @@ func determineDeleteData(args []string, repo execute.OpenRepoResult, cliConfig c
 		config:                   validatedConfig,
 		connector:                connector,
 		dialogTestInputs:         dialogTestInputs,
-		dryRun:                   cliConfig.DryRun,
 		hasOpenChanges:           repoStatus.OpenChanges,
 		initialBranch:            initialBranch,
 		nonExistingBranches:      nonExistingBranches,
@@ -310,7 +308,7 @@ func deleteProgram(repo execute.OpenRepoResult, data deleteData, finalMessages s
 	}
 	localBranchNameToDelete, hasLocalBranchToDelete := data.branchToDeleteInfo.LocalName.Get()
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-		DryRun:                   data.dryRun,
+		DryRun:                   data.config.NormalConfig.DryRun,
 		InitialStashSize:         data.stashSize,
 		RunInGitRoot:             true,
 		StashOpenChanges:         hasLocalBranchToDelete && data.initialBranch != localBranchNameToDelete && data.hasOpenChanges,
@@ -364,7 +362,7 @@ func deleteLocalBranch(prog, finalUndoProgram Mutable[program.Program], data del
 		prog.Value.Add(&opcodes.BranchLocalDelete{
 			Branch: localBranchToDelete,
 		})
-		if !data.dryRun {
+		if !data.config.NormalConfig.DryRun {
 			sync.RemoveBranchConfiguration(sync.RemoveBranchConfigurationArgs{
 				Branch:  localBranchToDelete,
 				Lineage: data.config.NormalConfig.Lineage,

--- a/internal/cmd/detach.go
+++ b/internal/cmd/detach.go
@@ -163,7 +163,6 @@ type detachData struct {
 	connector           Option[forgedomain.Connector]
 	descendents         []detachChildBranch
 	dialogTestInputs    dialogcomponents.TestInputs
-	dryRun              configdomain.DryRun
 	hasOpenChanges      bool
 	initialBranch       gitdomain.LocalBranchName
 	nonExistingBranches gitdomain.LocalBranchNames // branches that are listed in the lineage information, but don't exist in the repo, neither locally nor remotely
@@ -317,7 +316,6 @@ func determineDetachData(args []string, repo execute.OpenRepoResult, cliConfig c
 		connector:           connector,
 		descendents:         descendents,
 		dialogTestInputs:    dialogTestInputs,
-		dryRun:              cliConfig.DryRun,
 		hasOpenChanges:      repoStatus.OpenChanges,
 		initialBranch:       initialBranch,
 		nonExistingBranches: nonExistingBranches,
@@ -359,7 +357,7 @@ func detachProgram(repo execute.OpenRepoResult, data detachData, finalMessages s
 		lastParent = descendent.name
 	}
 	prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: data.initialBranch})
-	if !data.dryRun {
+	if !data.config.NormalConfig.DryRun {
 		prog.Value.Add(
 			&opcodes.LineageParentSet{
 				Branch: data.branchToDetachName,
@@ -376,7 +374,7 @@ func detachProgram(repo execute.OpenRepoResult, data detachData, finalMessages s
 		}
 	}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-		DryRun:                   data.dryRun,
+		DryRun:                   data.config.NormalConfig.DryRun,
 		InitialStashSize:         data.stashSize,
 		RunInGitRoot:             true,
 		StashOpenChanges:         false,

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -375,7 +375,6 @@ func determineHackData(args []string, repo execute.OpenRepoResult, cliConfig cli
 		connector:                 connector,
 		detached:                  detached,
 		dialogTestInputs:          dialogTestInputs,
-		dryRun:                    cliConfig.DryRun,
 		hasOpenChanges:            repoStatus.OpenChanges,
 		initialBranch:             initialBranch,
 		initialBranchInfo:         initialBranchInfo,

--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -187,7 +187,6 @@ type prependData struct {
 	config              config.ValidatedConfig
 	connector           Option[forgedomain.Connector]
 	dialogTestInputs    dialogcomponents.TestInputs
-	dryRun              configdomain.DryRun
 	existingParent      gitdomain.LocalBranchName
 	hasOpenChanges      bool
 	initialBranch       gitdomain.LocalBranchName
@@ -342,7 +341,6 @@ func determinePrependData(args []string, repo execute.OpenRepoResult, cliConfig 
 		config:              validatedConfig,
 		connector:           connector,
 		dialogTestInputs:    dialogTestInputs,
-		dryRun:              cliConfig.DryRun,
 		existingParent:      ancestor,
 		hasOpenChanges:      repoStatus.OpenChanges,
 		initialBranch:       initialBranch,
@@ -441,7 +439,7 @@ func prependProgram(repo execute.OpenRepoResult, data prependData, finalMessages
 	} else {
 		previousBranchCandidates := []Option[gitdomain.LocalBranchName]{data.previousBranch}
 		cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-			DryRun:                   data.dryRun,
+			DryRun:                   repo.UnvalidatedConfig.NormalConfig.DryRun,
 			InitialStashSize:         data.stashSize,
 			RunInGitRoot:             true,
 			StashOpenChanges:         data.hasOpenChanges,

--- a/internal/cmd/propose.go
+++ b/internal/cmd/propose.go
@@ -155,7 +155,6 @@ type proposeData struct {
 	config              config.ValidatedConfig
 	connector           Option[forgedomain.Connector]
 	dialogTestInputs    dialogcomponents.TestInputs
-	dryRun              configdomain.DryRun
 	hasOpenChanges      bool
 	initialBranch       gitdomain.LocalBranchName
 	nonExistingBranches gitdomain.LocalBranchNames // branches that are listed in the lineage information, but don't exist in the repo, neither locally nor remotely
@@ -336,7 +335,6 @@ func determineProposeData(repo execute.OpenRepoResult, cliConfig cliconfig.CliCo
 		config:              validatedConfig,
 		connector:           connectorOpt,
 		dialogTestInputs:    dialogTestInputs,
-		dryRun:              cliConfig.DryRun,
 		hasOpenChanges:      repoStatus.OpenChanges,
 		initialBranch:       initialBranch,
 		nonExistingBranches: nonExistingBranches,
@@ -382,7 +380,7 @@ func proposeProgram(repo execute.OpenRepoResult, data proposeData) program.Progr
 		})
 		previousBranchCandidates := []Option[gitdomain.LocalBranchName]{data.previousBranch}
 		cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-			DryRun:                   data.dryRun,
+			DryRun:                   data.config.NormalConfig.DryRun,
 			InitialStashSize:         data.stashSize,
 			RunInGitRoot:             true,
 			StashOpenChanges:         data.hasOpenChanges,

--- a/internal/cmd/rename.go
+++ b/internal/cmd/rename.go
@@ -128,7 +128,6 @@ type renameData struct {
 	config                   config.ValidatedConfig
 	connector                Option[forgedomain.Connector]
 	dialogTestInputs         dialogcomponents.TestInputs
-	dryRun                   configdomain.DryRun
 	hasOpenChanges           bool
 	initialBranch            gitdomain.LocalBranchName
 	newBranch                gitdomain.LocalBranchName
@@ -264,7 +263,6 @@ func determineRenameData(args []string, cliConfig cliconfig.CliConfig, force con
 		config:                   validatedConfig,
 		connector:                connector,
 		dialogTestInputs:         dialogTestInputs,
-		dryRun:                   cliConfig.DryRun,
 		hasOpenChanges:           repoStatus.OpenChanges,
 		initialBranch:            initialBranch,
 		newBranch:                newBranchName,
@@ -288,7 +286,7 @@ func renameProgram(repo execute.OpenRepoResult, data renameData, finalMessages s
 	if data.initialBranch == oldLocalBranch {
 		prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: data.newBranch})
 	}
-	if !data.dryRun {
+	if !data.config.NormalConfig.DryRun {
 		if override, hasBranchTypeOverride := data.config.NormalConfig.BranchTypeOverrides[oldLocalBranch]; hasBranchTypeOverride {
 			prog.Value.Add(
 				&opcodes.ConfigSet{
@@ -329,7 +327,7 @@ func renameProgram(repo execute.OpenRepoResult, data renameData, finalMessages s
 	}
 	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{Some(data.newBranch), data.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-		DryRun:                   data.dryRun,
+		DryRun:                   data.config.NormalConfig.DryRun,
 		InitialStashSize:         data.stashSize,
 		RunInGitRoot:             false,
 		StashOpenChanges:         false,

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -116,7 +116,7 @@ func executeSetParent(args []string, cliConfig cliconfig.CliConfig) error {
 			Inputs:        data.dialogTestInputs,
 			Lineage:       data.config.NormalConfig.Lineage,
 			LocalBranches: data.branchesSnapshot.Branches.LocalBranches().Names(),
-			MainBranch:    data.mainBranch,
+			MainBranch:    data.config.ValidatedConfigData.MainBranch,
 		})
 		if err != nil {
 			return err
@@ -171,7 +171,6 @@ type setParentData struct {
 	dialogTestInputs   dialogcomponents.TestInputs
 	hasOpenChanges     bool
 	initialBranch      gitdomain.LocalBranchName
-	mainBranch         gitdomain.LocalBranchName
 	proposal           Option[forgedomain.Proposal]
 	stashSize          gitdomain.StashSize
 }
@@ -268,7 +267,6 @@ func determineSetParentData(repo execute.OpenRepoResult, cliConfig cliconfig.Cli
 		dialogTestInputs:   dialogTestInputs,
 		hasOpenChanges:     repoStatus.OpenChanges,
 		initialBranch:      initialBranch,
-		mainBranch:         mainBranch,
 		proposal:           proposalOpt,
 		stashSize:          stashSize,
 	}, false, nil

--- a/internal/cmd/ship/always_merge.go
+++ b/internal/cmd/ship/always_merge.go
@@ -2,13 +2,14 @@ package ship
 
 import (
 	"github.com/git-town/git-town/v21/internal/cmd/cmdhelpers"
+	"github.com/git-town/git-town/v21/internal/execute"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/vm/opcodes"
 	"github.com/git-town/git-town/v21/internal/vm/program"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
-func shipProgramAlwaysMerge(prog Mutable[program.Program], sharedData sharedShipData, mergeData shipDataMerge, commitMessage Option[gitdomain.CommitMessage]) {
+func shipProgramAlwaysMerge(prog Mutable[program.Program], repo execute.OpenRepoResult, sharedData sharedShipData, mergeData shipDataMerge, commitMessage Option[gitdomain.CommitMessage]) {
 	prog.Value.Add(&opcodes.BranchEnsureShippableChanges{Branch: sharedData.branchNameToShip, Parent: sharedData.targetBranchName})
 	if sharedData.initialBranch != sharedData.targetBranchName {
 		prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: sharedData.targetBranchName})
@@ -37,7 +38,7 @@ func shipProgramAlwaysMerge(prog Mutable[program.Program], sharedData sharedShip
 	prog.Value.Add(&opcodes.BranchLocalDelete{Branch: sharedData.branchNameToShip})
 	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{sharedData.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-		DryRun:                   sharedData.dryRun,
+		DryRun:                   repo.UnvalidatedConfig.NormalConfig.DryRun,
 		InitialStashSize:         sharedData.stashSize,
 		RunInGitRoot:             true,
 		StashOpenChanges:         !sharedData.isShippingInitialBranch && sharedData.hasOpenChanges,

--- a/internal/cmd/ship/cmd.go
+++ b/internal/cmd/ship/cmd.go
@@ -104,7 +104,7 @@ func executeShip(args []string, cliConfig cliconfig.CliConfig, message Option[gi
 		if err != nil {
 			return err
 		}
-		if err = shipAPIProgram(prog, sharedData, apiData, message); err != nil {
+		if err = shipAPIProgram(prog, repo, sharedData, apiData, message); err != nil {
 			return err
 		}
 	case configdomain.ShipStrategyAlwaysMerge:
@@ -112,19 +112,19 @@ func executeShip(args []string, cliConfig cliconfig.CliConfig, message Option[gi
 		if err != nil {
 			return err
 		}
-		shipProgramAlwaysMerge(prog, sharedData, mergeData, message)
+		shipProgramAlwaysMerge(prog, repo, sharedData, mergeData, message)
 	case configdomain.ShipStrategyFastForward:
 		mergeData, err := determineMergeData(repo, sharedData.branchNameToShip, sharedData.targetBranchName)
 		if err != nil {
 			return err
 		}
-		shipProgramFastForward(prog, sharedData, mergeData)
+		shipProgramFastForward(prog, repo, sharedData, mergeData)
 	case configdomain.ShipStrategySquashMerge:
 		squashMergeData, err := determineMergeData(repo, sharedData.branchNameToShip, sharedData.targetBranchName)
 		if err != nil {
 			return err
 		}
-		shipProgramSquashMerge(prog, sharedData, squashMergeData, message)
+		shipProgramSquashMerge(prog, repo, sharedData, squashMergeData, message)
 	}
 	optimizedProgram := optimizer.Optimize(prog.Immutable())
 	runState := runstate.RunState{

--- a/internal/cmd/ship/shared.go
+++ b/internal/cmd/ship/shared.go
@@ -30,7 +30,6 @@ type sharedShipData struct {
 	config                   config.ValidatedConfig
 	connector                Option[forgedomain.Connector]
 	dialogTestInputs         dialogcomponents.TestInputs
-	dryRun                   configdomain.DryRun
 	hasOpenChanges           bool
 	initialBranch            gitdomain.LocalBranchName
 	isShippingInitialBranch  bool
@@ -163,7 +162,6 @@ func determineSharedShipData(args []string, repo execute.OpenRepoResult, cliConf
 		config:                   validatedConfig,
 		connector:                connector,
 		dialogTestInputs:         dialogTestInputs,
-		dryRun:                   cliConfig.DryRun,
 		hasOpenChanges:           repoStatus.OpenChanges,
 		initialBranch:            initialBranch,
 		isShippingInitialBranch:  isShippingInitialBranch,

--- a/internal/cmd/ship/squash_merge.go
+++ b/internal/cmd/ship/squash_merge.go
@@ -26,7 +26,7 @@ func determineMergeData(repo execute.OpenRepoResult, branch, parent gitdomain.Lo
 	}, err
 }
 
-func shipProgramSquashMerge(prog Mutable[program.Program], sharedData sharedShipData, squashMergeData shipDataMerge, commitMessage Option[gitdomain.CommitMessage]) {
+func shipProgramSquashMerge(prog Mutable[program.Program], repo execute.OpenRepoResult, sharedData sharedShipData, squashMergeData shipDataMerge, commitMessage Option[gitdomain.CommitMessage]) {
 	prog.Value.Add(&opcodes.BranchEnsureShippableChanges{Branch: sharedData.branchNameToShip, Parent: sharedData.targetBranchName})
 	localTargetBranch, _ := sharedData.targetBranch.LocalName.Get()
 	if sharedData.initialBranch != sharedData.targetBranchName {
@@ -49,7 +49,7 @@ func shipProgramSquashMerge(prog Mutable[program.Program], sharedData sharedShip
 	for _, child := range sharedData.childBranches {
 		prog.Value.Add(&opcodes.LineageParentSetToGrandParent{Branch: child})
 	}
-	if !sharedData.dryRun {
+	if !repo.UnvalidatedConfig.NormalConfig.DryRun {
 		prog.Value.Add(&opcodes.LineageParentRemove{Branch: sharedData.branchNameToShip})
 	}
 	if !sharedData.isShippingInitialBranch {
@@ -58,7 +58,7 @@ func shipProgramSquashMerge(prog Mutable[program.Program], sharedData sharedShip
 	prog.Value.Add(&opcodes.BranchLocalDelete{Branch: sharedData.branchNameToShip})
 	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{sharedData.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-		DryRun:                   sharedData.dryRun,
+		DryRun:                   repo.UnvalidatedConfig.NormalConfig.DryRun,
 		InitialStashSize:         sharedData.stashSize,
 		RunInGitRoot:             true,
 		StashOpenChanges:         !sharedData.isShippingInitialBranch && sharedData.hasOpenChanges,

--- a/internal/cmd/swap.go
+++ b/internal/cmd/swap.go
@@ -157,7 +157,6 @@ type swapData struct {
 	config              config.ValidatedConfig
 	connector           Option[forgedomain.Connector]
 	dialogTestInputs    dialogcomponents.TestInputs
-	dryRun              configdomain.DryRun
 	grandParentBranch   gitdomain.LocalBranchName
 	hasOpenChanges      bool
 	initialBranch       gitdomain.LocalBranchName
@@ -316,7 +315,6 @@ func determineSwapData(args []string, repo execute.OpenRepoResult, cliConfig cli
 		config:              validatedConfig,
 		connector:           connector,
 		dialogTestInputs:    dialogTestInputs,
-		dryRun:              cliConfig.DryRun,
 		grandParentBranch:   grandParentBranch,
 		hasOpenChanges:      repoStatus.OpenChanges,
 		initialBranch:       initialBranch,
@@ -386,7 +384,7 @@ func swapProgram(repo execute.OpenRepoResult, data swapData, finalMessages strin
 		}
 	}
 	prog.Value.Add(&opcodes.CheckoutIfNeeded{Branch: data.branchToSwapName})
-	if !data.dryRun {
+	if !data.config.NormalConfig.DryRun {
 		prog.Value.Add(
 			&opcodes.LineageParentSet{
 				Branch: data.branchToSwapName,
@@ -407,7 +405,7 @@ func swapProgram(repo execute.OpenRepoResult, data swapData, finalMessages strin
 		}
 	}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
-		DryRun:                   data.dryRun,
+		DryRun:                   data.config.NormalConfig.DryRun,
 		InitialStashSize:         data.stashSize,
 		RunInGitRoot:             true,
 		StashOpenChanges:         false,


### PR DESCRIPTION
The data loaded for commands should not redundantly contain data that is already available in OpenRepoResult.
