### PR TITLE
setup assistant: correctly remove all values

### DIFF
--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -4,7 +4,7 @@ Feature: override an existing Git alias
   Background:
     Given a Git repo with origin
     And I ran "git config --global alias.append checkout"
-    And local Git setting "git-town.unknown-branch-type" is "feature"
+    And global Git setting "git-town.unknown-branch-type" is "feature"
     When I run "git-town config setup" and enter into the dialogs:
       | DIALOG                      | KEYS       |
       | welcome                     | enter      |
@@ -30,7 +30,6 @@ Feature: override an existing Git alias
       | ship delete tracking branch | enter      |
       | config storage              | down enter |
 
-  @debug @this
   Scenario: result
     Then Git Town runs the commands
       | COMMAND                                        |

--- a/features/config/setup/alias_override.feature
+++ b/features/config/setup/alias_override.feature
@@ -30,6 +30,7 @@ Feature: override an existing Git alias
       | ship delete tracking branch | enter      |
       | config storage              | down enter |
 
+  @debug @this
   Scenario: result
     Then Git Town runs the commands
       | COMMAND                                        |

--- a/features/config/setup/migrate_git_to_file.feature
+++ b/features/config/setup/migrate_git_to_file.feature
@@ -49,9 +49,12 @@ Feature: migrate existing configuration in Git metadata to a config file
   Scenario: result
     Then Git Town runs the commands
       | COMMAND                                                 |
+      | git config --unset git-town.contribution-regex          |
       | git config --unset git-town.dev-remote                  |
+      | git config --unset git-town.feature-regex               |
       | git config --unset git-town.main-branch                 |
       | git config --unset git-town.new-branch-type             |
+      | git config --unset git-town.observed-regex              |
       | git config --unset git-town.perennial-branches          |
       | git config --unset git-town.perennial-regex             |
       | git config --unset git-town.share-new-branches          |
@@ -62,6 +65,7 @@ Feature: migrate existing configuration in Git metadata to a config file
       | git config --unset git-town.sync-perennial-strategy     |
       | git config --unset git-town.sync-upstream               |
       | git config --unset git-town.sync-tags                   |
+      | git config --unset git-town.unknown-branch-type         |
     And the main branch is now not set
     And there are now no perennial branches
     And local Git setting "git-town.forge-type" now doesn't exist
@@ -71,10 +75,10 @@ Feature: migrate existing configuration in Git metadata to a config file
     And local Git setting "git-town.sync-upstream" now doesn't exist
     And local Git setting "git-town.sync-tags" now doesn't exist
     And local Git setting "git-town.perennial-regex" now doesn't exist
-    And local Git setting "git-town.feature-regex" is still "user-.*"
-    And local Git setting "git-town.contribution-regex" is still "coworker-.*"
-    And local Git setting "git-town.observed-regex" is still "other-.*"
-    And local Git setting "git-town.unknown-branch-type" is still "observed"
+    And local Git setting "git-town.feature-regex" now doesn't exist
+    And local Git setting "git-town.contribution-regex" now doesn't exist
+    And local Git setting "git-town.observed-regex" now doesn't exist
+    And local Git setting "git-town.unknown-branch-type" now doesn't exist
     And local Git setting "git-town.share-new-branches" now doesn't exist
     And local Git setting "git-town.push-hook" now doesn't exist
     And local Git setting "git-town.new-branch-type" now doesn't exist

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -1316,14 +1316,23 @@ func saveToFile(userInput userInput, gitConfig configdomain.PartialConfig, runne
 	if err := configfile.Save(userInput.data); err != nil {
 		return err
 	}
+	if gitConfig.ContributionRegex.IsSome() {
+		_ = gitconfig.RemoveContributionRegex(runner)
+	}
 	if gitConfig.DevRemote.IsSome() {
 		_ = gitconfig.RemoveDevRemote(runner)
+	}
+	if gitConfig.FeatureRegex.IsSome() {
+		_ = gitconfig.RemoveFeatureRegex(runner)
 	}
 	if gitConfig.MainBranch.IsSome() {
 		_ = gitconfig.RemoveMainBranch(runner)
 	}
 	if gitConfig.NewBranchType.IsSome() {
 		_ = gitconfig.RemoveNewBranchType(runner)
+	}
+	if gitConfig.ObservedRegex.IsSome() {
+		_ = gitconfig.RemoveObservedRegex(runner)
 	}
 	if len(gitConfig.PerennialBranches) > 0 {
 		_ = gitconfig.RemovePerennialBranches(runner)
@@ -1358,9 +1367,11 @@ func saveToFile(userInput userInput, gitConfig configdomain.PartialConfig, runne
 	if gitConfig.SyncTags.IsSome() {
 		_ = gitconfig.RemoveSyncTags(runner)
 	}
+	if gitConfig.UnknownBranchType.IsSome() {
+		_ = gitconfig.RemoveUnknownBranchType(runner)
+	}
 	if err := saveUnknownBranchType(userInput.data.UnknownBranchType, gitConfig.UnknownBranchType, runner); err != nil {
 		return err
 	}
-	// TODO: also save ObservedRegex ContributionRegex NewBranchType
 	return saveFeatureRegex(userInput.data.FeatureRegex, gitConfig.FeatureRegex, runner)
 }

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -24,8 +24,6 @@ import (
 // They don't change the user's repo, execute instantaneously, and Git Town needs to know their output.
 // They are invisible to the end user unless the "verbose" option is set.
 type Commands struct {
-	// TODO: convert the methods of this struct to stand-alone function.
-	// Provide the CurrentBranchCache or RemotesCache as an additional function argument if needed.
 	CurrentBranchCache *cache.WithPrevious[gitdomain.LocalBranchName] // caches the currently checked out Git branch
 	RemotesCache       *cache.Cache[gitdomain.Remotes]                // caches Git remotes
 }


### PR DESCRIPTION
The setup assistant didn't remove some values when the user chooses to use the global values.

part of #5201
