### PR TITLE
Store local branch names directly

### DIFF
--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -119,7 +119,7 @@ func LoadData(repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig) (data 
 		Config:        repo.UnvalidatedConfig,
 		DialogInputs:  dialogTestInputs,
 		Git:           repo.Git,
-		LocalBranches: branchesSnapshot.Branches,
+		LocalBranches: branchesSnapshot.Branches.Names(),
 		Remotes:       remotes,
 		Snapshot:      repo.ConfigSnapshot,
 	}, exit, nil

--- a/internal/cmd/config/setup.go
+++ b/internal/cmd/config/setup.go
@@ -119,7 +119,7 @@ func LoadData(repo execute.OpenRepoResult, cliConfig cliconfig.CliConfig) (data 
 		Config:        repo.UnvalidatedConfig,
 		DialogInputs:  dialogTestInputs,
 		Git:           repo.Git,
-		LocalBranches: branchesSnapshot.Branches.Names(),
+		LocalBranches: branchesSnapshot.Branches.LocalBranches().Names(),
 		Remotes:       remotes,
 		Snapshot:      repo.ConfigSnapshot,
 	}, exit, nil

--- a/internal/setup/enter.go
+++ b/internal/setup/enter.go
@@ -423,7 +423,7 @@ func enterMainBranch(data Data) (userChoice Option[gitdomain.LocalBranchName], a
 	return dialog.MainBranch(dialog.MainBranchArgs{
 		Inputs:         data.DialogInputs,
 		Local:          data.Config.GitLocal.MainBranch,
-		LocalBranches:  data.LocalBranches.Names(),
+		LocalBranches:  data.LocalBranches,
 		StandardBranch: data.Git.StandardBranch(data.Backend),
 		Unscoped:       data.Config.GitUnscoped.MainBranch,
 	})
@@ -469,7 +469,7 @@ func enterPerennialBranches(data Data, mainBranch gitdomain.LocalBranchName) (gi
 	return dialog.PerennialBranches(dialog.PerennialBranchesArgs{
 		ImmutableGitPerennials: immutablePerennials,
 		Inputs:                 data.DialogInputs,
-		LocalBranches:          data.LocalBranches.Names(),
+		LocalBranches:          data.LocalBranches,
 		LocalGitPerennials:     data.Config.GitLocal.PerennialBranches,
 		MainBranch:             mainBranch,
 	})

--- a/internal/setup/load.go
+++ b/internal/setup/load.go
@@ -14,7 +14,7 @@ type Data struct {
 	Config        config.UnvalidatedConfig
 	DialogInputs  dialogcomponents.TestInputs
 	Git           git.Commands
-	LocalBranches gitdomain.BranchInfos
+	LocalBranches gitdomain.LocalBranchNames
 	Remotes       gitdomain.Remotes
 	Snapshot      undoconfig.ConfigSnapshot
 }


### PR DESCRIPTION
No need to store an entire branch snapshot when all we need is the branch names from it.
