### PR TITLE
More generic verbose E2E runner

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -75,7 +75,7 @@ func findVerboseFiles() []string {
 		if err != nil {
 			return err
 		}
-		if dir.Name() == "verbose.feature" {
+		if strings.Contains(dir.Name(), "verbose") {
 			result = append(result, path)
 		}
 		return nil


### PR DESCRIPTION
Some verbose E2E tests are in a folder called "verbose". This updated test
runner finds those tests as well.
