### PR TITLE
Verify dialog test input usage at program end

### DIFF
--- a/features/append/on_feature_branch/missing_lineage/unknown_parent.feature
+++ b/features/append/on_feature_branch/missing_lineage/unknown_parent.feature
@@ -4,13 +4,13 @@ Feature: ask for missing parent branch information
   Scenario:
     Given a Git repo with origin
     And the branches
-      | NAME    | TYPE    | PARENT | LOCATIONS     |
-      | feature | feature | main   | local, origin |
-    And the current branch is "feature"
+      | NAME   | TYPE   | PARENT | LOCATIONS     |
+      | branch | (none) |        | local, origin |
+    And the current branch is "branch"
     When I run "git-town append new" and enter into the dialog:
-      | DIALOG                      | KEYS  |
-      | parent branch for "feature" | enter |
+      | DIALOG                     | KEYS  |
+      | parent branch for "branch" | enter |
     Then this lineage exists now
-      | BRANCH  | PARENT  |
-      | feature | main    |
-      | new     | feature |
+      | BRANCH | PARENT |
+      | branch | main   |
+      | new    | branch |

--- a/features/rename/branch_type/overridden_branch_type.feature
+++ b/features/rename/branch_type/overridden_branch_type.feature
@@ -5,7 +5,7 @@ Feature: rename a branch that has an overridden branch type
     Given a Git repo with origin
     And the branches
       | NAME | TYPE         | PARENT | LOCATIONS     |
-      | old  | contribution | main   | local, origin |
+      | old  | contribution |        | local, origin |
     And the commits
       | BRANCH | LOCATION      | MESSAGE     |
       | main   | local, origin | main commit |

--- a/internal/cli/dialog/dialogcomponents/test_inputs.go
+++ b/internal/cli/dialog/dialogcomponents/test_inputs.go
@@ -34,6 +34,12 @@ func (self TestInputs) Next() Option[TestInput] {
 	return Some(result)
 }
 
+func (self TestInputs) VerifyAllUsed() {
+	if !self.IsEmpty() {
+		panic("unused dialog inputs")
+	}
+}
+
 // LoadTestInputs provides the TestInputs to use in an end-to-end test,
 // taken from the given environment variable snapshot.
 func LoadTestInputs(environmenttVariables []string) TestInputs {

--- a/internal/cli/dialog/dialogcomponents/test_inputs.go
+++ b/internal/cli/dialog/dialogcomponents/test_inputs.go
@@ -18,7 +18,7 @@ type TestInputs struct {
 }
 
 func (self TestInputs) IsEmpty() bool {
-	return *self.cursor.Value == self.len
+	return self.cursor.Immutable() == self.len
 }
 
 // Next provides the TestInput for the next dialog in an end-to-end test.

--- a/internal/setup/enter.go
+++ b/internal/setup/enter.go
@@ -246,9 +246,6 @@ EnterForgeData:
 		GitUserName:  "", // the setup assistant doesn't ask for this
 		MainBranch:   actualMainBranch,
 	}
-	if !data.DialogInputs.IsEmpty() {
-		panic("unused dialog inputs")
-	}
 	return UserInput{normalData, actualForgeType, tokenScope, configStorage, validatedData}, false, nil
 }
 

--- a/internal/vm/interpreter/fullinterpreter/errored.go
+++ b/internal/vm/interpreter/fullinterpreter/errored.go
@@ -82,6 +82,6 @@ func errored(failedOpcode shared.Opcode, runErr error, args ExecuteArgs) error {
 		}
 	}
 	message += "\n"
-	args.DialogTestInputs.IsEmpty()
+	args.DialogTestInputs.VerifyAllUsed()
 	return errors.New(message)
 }

--- a/internal/vm/interpreter/fullinterpreter/errored.go
+++ b/internal/vm/interpreter/fullinterpreter/errored.go
@@ -82,8 +82,6 @@ func errored(failedOpcode shared.Opcode, runErr error, args ExecuteArgs) error {
 		}
 	}
 	message += "\n"
-	if !args.DialogTestInputs.IsEmpty() {
-		panic("unused dialog inputs")
-	}
+	args.DialogTestInputs.IsEmpty()
 	return errors.New(message)
 }

--- a/internal/vm/interpreter/fullinterpreter/errored.go
+++ b/internal/vm/interpreter/fullinterpreter/errored.go
@@ -82,5 +82,8 @@ func errored(failedOpcode shared.Opcode, runErr error, args ExecuteArgs) error {
 		}
 	}
 	message += "\n"
+	if !args.DialogTestInputs.IsEmpty() {
+		panic("unused dialog inputs")
+	}
 	return errors.New(message)
 }

--- a/internal/vm/interpreter/fullinterpreter/execute.go
+++ b/internal/vm/interpreter/fullinterpreter/execute.go
@@ -31,6 +31,7 @@ func Execute(args ExecuteArgs) error {
 				CommandsCounter: args.CommandsCounter,
 				FinalMessages:   args.FinalMessages,
 				Git:             args.Git,
+				Inputs:          args.DialogTestInputs,
 				RootDir:         args.RootDir,
 				RunState:        args.RunState,
 				Verbose:         args.Verbose,

--- a/internal/vm/interpreter/fullinterpreter/exit_to_shell.go
+++ b/internal/vm/interpreter/fullinterpreter/exit_to_shell.go
@@ -48,5 +48,8 @@ func exitToShell(args ExecuteArgs) error {
 	}
 	args.FinalMessages.Add(`Run "git town continue" to go to the next branch.`)
 	print.Footer(args.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
+	if !args.DialogTestInputs.IsEmpty() {
+		panic("unused dialog inputs")
+	}
 	return nil
 }

--- a/internal/vm/interpreter/fullinterpreter/exit_to_shell.go
+++ b/internal/vm/interpreter/fullinterpreter/exit_to_shell.go
@@ -48,8 +48,6 @@ func exitToShell(args ExecuteArgs) error {
 	}
 	args.FinalMessages.Add(`Run "git town continue" to go to the next branch.`)
 	print.Footer(args.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
-	if !args.DialogTestInputs.IsEmpty() {
-		panic("unused dialog inputs")
-	}
+	args.DialogTestInputs.VerifyAllUsed()
 	return nil
 }

--- a/internal/vm/interpreter/fullinterpreter/finished.go
+++ b/internal/vm/interpreter/fullinterpreter/finished.go
@@ -50,7 +50,7 @@ func finished(args finishedArgs) error {
 		return fmt.Errorf(messages.RunstateSaveProblem, err)
 	}
 	print.Footer(args.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
-	args.Inputs.IsEmpty()
+	args.Inputs.VerifyAllUsed()
 	return nil
 }
 

--- a/internal/vm/interpreter/fullinterpreter/finished.go
+++ b/internal/vm/interpreter/fullinterpreter/finished.go
@@ -50,9 +50,7 @@ func finished(args finishedArgs) error {
 		return fmt.Errorf(messages.RunstateSaveProblem, err)
 	}
 	print.Footer(args.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
-	if !args.Inputs.IsEmpty() {
-		panic("unused dialog inputs")
-	}
+	args.Inputs.IsEmpty()
 	return nil
 }
 

--- a/internal/vm/interpreter/fullinterpreter/finished.go
+++ b/internal/vm/interpreter/fullinterpreter/finished.go
@@ -3,6 +3,7 @@ package fullinterpreter
 import (
 	"fmt"
 
+	"github.com/git-town/git-town/v21/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v21/internal/cli/print"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
@@ -49,6 +50,9 @@ func finished(args finishedArgs) error {
 		return fmt.Errorf(messages.RunstateSaveProblem, err)
 	}
 	print.Footer(args.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
+	if !args.Inputs.IsEmpty() {
+		panic("unused dialog inputs")
+	}
 	return nil
 }
 
@@ -57,6 +61,7 @@ type finishedArgs struct {
 	CommandsCounter Mutable[gohacks.Counter]
 	FinalMessages   stringslice.Collector
 	Git             git.Commands
+	Inputs          dialogcomponents.TestInputs
 	RootDir         gitdomain.RepoRootDir
 	RunState        runstate.RunState
 	Verbose         configdomain.Verbose


### PR DESCRIPTION
Currently we check for unused test input at the end of the setup assistant.
There are tests where inputs are required two times: for the setup assistant and
then for the parent branch. This doesn't currently work. This test moves the
unused input check to the end of the execution. This surfaces a few bugs in the
E2E tests, which this PR also fixes.
