### PR TITLE
Move creating switch branch entries into the dialog package

### DIFF
--- a/internal/cli/dialog/switch_branch.go
+++ b/internal/cli/dialog/switch_branch.go
@@ -1,6 +1,8 @@
 package dialog
 
 import (
+	"regexp"
+	"slices"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,6 +14,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/gohacks/slice"
 	"github.com/git-town/git-town/v21/internal/messages"
+	"github.com/git-town/git-town/v21/internal/regexes"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/muesli/termenv"
 )
@@ -216,4 +219,127 @@ func newSwitchBranchListEntries(switchBranchEntries []SwitchBranchEntry) list.En
 		}
 	}
 	return result
+}
+
+// NewSwitchBranchEntries provides the entries for the "switch branch" components.
+func NewSwitchBranchEntries(args NewSwitchBranchEntriesArgs) SwitchBranchEntries {
+	entries := make(SwitchBranchEntries, 0, args.Lineage.Len())
+	roots := args.Lineage.Roots()
+	// add all entries from the lineage
+	for _, root := range roots {
+		layoutBranches(layoutBranchesArgs{
+			branch:            root,
+			branchInfos:       args.BranchInfos,
+			branchTypes:       args.BranchTypes,
+			branchesAndTypes:  args.BranchesAndTypes,
+			excludeBranches:   args.ExcludeBranches,
+			indentation:       "",
+			lineage:           args.Lineage,
+			regexes:           args.Regexes,
+			result:            &entries,
+			showAllBranches:   args.ShowAllBranches,
+			unknownBranchType: args.UnknownBranchType,
+		})
+	}
+	// add branches not in the lineage
+	branchesInLineage := args.Lineage.BranchesWithParents()
+	for _, branchInfo := range args.BranchInfos {
+		localBranch := branchInfo.LocalBranchName()
+		if slices.Contains(roots, localBranch) {
+			continue
+		}
+		if slices.Contains(branchesInLineage, localBranch) {
+			continue
+		}
+		if entries.ContainsBranch(localBranch) {
+			continue
+		}
+		layoutBranches(layoutBranchesArgs{
+			branch:            localBranch,
+			branchInfos:       args.BranchInfos,
+			branchTypes:       args.BranchTypes,
+			branchesAndTypes:  args.BranchesAndTypes,
+			excludeBranches:   args.ExcludeBranches,
+			indentation:       "",
+			lineage:           args.Lineage,
+			regexes:           args.Regexes,
+			result:            &entries,
+			showAllBranches:   args.ShowAllBranches,
+			unknownBranchType: args.UnknownBranchType,
+		})
+	}
+	return entries
+}
+
+type NewSwitchBranchEntriesArgs struct {
+	BranchInfos       gitdomain.BranchInfos
+	BranchTypes       []configdomain.BranchType
+	BranchesAndTypes  configdomain.BranchesAndTypes
+	ExcludeBranches   gitdomain.LocalBranchNames
+	Lineage           configdomain.Lineage
+	Regexes           []*regexp.Regexp
+	ShowAllBranches   configdomain.AllBranches
+	UnknownBranchType configdomain.UnknownBranchType
+}
+
+// layoutBranches adds entries for the given branch and its children to the given entry list.
+// The entries are indented according to their position in the given lineage.
+func layoutBranches(args layoutBranchesArgs) {
+	if args.excludeBranches.Contains(args.branch) {
+		return
+	}
+	if args.branchInfos.HasLocalBranch(args.branch) || args.showAllBranches.Enabled() {
+		var otherWorktree bool
+		if branchInfo, hasBranchInfo := args.branchInfos.FindByLocalName(args.branch).Get(); hasBranchInfo {
+			otherWorktree = branchInfo.SyncStatus == gitdomain.SyncStatusOtherWorktree
+		} else {
+			otherWorktree = false
+		}
+		branchType, hasBranchType := args.branchesAndTypes[args.branch]
+		if !hasBranchType && len(args.branchTypes) > 0 {
+			branchType = args.unknownBranchType.BranchType()
+		}
+		var hasCorrectBranchType bool
+		if len(args.branchTypes) == 0 || slices.Contains(args.branchTypes, branchType) {
+			hasCorrectBranchType = true
+		}
+		matchesRegex := args.regexes.Matches(args.branch.String())
+		if hasCorrectBranchType && matchesRegex {
+			*args.result = append(*args.result, SwitchBranchEntry{
+				Branch:        args.branch,
+				Indentation:   args.indentation,
+				OtherWorktree: otherWorktree,
+				Type:          branchType,
+			})
+		}
+	}
+	for _, child := range args.lineage.Children(args.branch) {
+		layoutBranches(layoutBranchesArgs{
+			branch:            child,
+			branchInfos:       args.branchInfos,
+			branchTypes:       args.branchTypes,
+			branchesAndTypes:  args.branchesAndTypes,
+			excludeBranches:   args.excludeBranches,
+			indentation:       args.indentation + "  ",
+			lineage:           args.lineage,
+			regexes:           args.regexes,
+			result:            args.result,
+			showAllBranches:   args.showAllBranches,
+			unknownBranchType: args.unknownBranchType,
+		})
+	}
+}
+
+type layoutBranchesArgs struct {
+	branch            gitdomain.LocalBranchName
+	branchInfos       gitdomain.BranchInfos
+	branchTypes       []configdomain.BranchType
+	branchesAndTypes  configdomain.BranchesAndTypes
+	excludeBranches   gitdomain.LocalBranchNames
+	indentation       string
+	lineage           configdomain.Lineage
+	regexes           regexes.Regexes
+	result            *SwitchBranchEntries
+	showAllBranches   configdomain.AllBranches
+	unknownBranchType configdomain.UnknownBranchType
 }

--- a/internal/cli/dialog/switch_branch.go
+++ b/internal/cli/dialog/switch_branch.go
@@ -164,63 +164,6 @@ func (self SwitchModel) View() string {
 	return s.String()
 }
 
-func ShouldDisplayBranchType(branchType configdomain.BranchType) bool {
-	switch branchType {
-	case
-		configdomain.BranchTypeMainBranch,
-		configdomain.BranchTypeFeatureBranch:
-		return false
-	case
-		configdomain.BranchTypeContributionBranch,
-		configdomain.BranchTypeObservedBranch,
-		configdomain.BranchTypeParkedBranch,
-		configdomain.BranchTypePerennialBranch,
-		configdomain.BranchTypePrototypeBranch:
-		return true
-	}
-	panic("unhandled branch type:" + branchType.String())
-}
-
-func SwitchBranch(args SwitchBranchArgs) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
-	initialBranchPos := None[int]()
-	if currentBranch, has := args.CurrentBranch.Get(); has {
-		initialBranchPos = Some(args.Entries.IndexOf(currentBranch))
-	}
-	dialogProgram := tea.NewProgram(SwitchModel{
-		DisplayBranchTypes: args.DisplayBranchTypes,
-		InitialBranchPos:   initialBranchPos,
-		List:               list.NewList(newSwitchBranchListEntries(args.Entries), args.Cursor),
-		UncommittedChanges: args.UncommittedChanges,
-	})
-	dialogcomponents.SendInputs(args.InputName, args.Inputs.Next(), dialogProgram)
-	dialogResult, err := dialogProgram.Run()
-	result := dialogResult.(SwitchModel)
-	selectedData := result.List.SelectedData()
-	return selectedData.Branch, result.Aborted(), err
-}
-
-type SwitchBranchArgs struct {
-	CurrentBranch      Option[gitdomain.LocalBranchName]
-	Cursor             int
-	DisplayBranchTypes configdomain.DisplayTypes
-	Entries            SwitchBranchEntries
-	InputName          string
-	Inputs             dialogcomponents.Inputs
-	UncommittedChanges bool
-}
-
-func newSwitchBranchListEntries(switchBranchEntries []SwitchBranchEntry) list.Entries[SwitchBranchEntry] {
-	result := make(list.Entries[SwitchBranchEntry], len(switchBranchEntries))
-	for e, entry := range switchBranchEntries {
-		result[e] = list.Entry[SwitchBranchEntry]{
-			Data:     entry,
-			Disabled: entry.OtherWorktree,
-			Text:     entry.String(),
-		}
-	}
-	return result
-}
-
 // NewSwitchBranchEntries provides the entries for the "switch branch" components.
 func NewSwitchBranchEntries(args NewSwitchBranchEntriesArgs) SwitchBranchEntries {
 	entries := make(SwitchBranchEntries, 0, args.Lineage.Len())
@@ -280,6 +223,51 @@ type NewSwitchBranchEntriesArgs struct {
 	Regexes           []*regexp.Regexp
 	ShowAllBranches   configdomain.AllBranches
 	UnknownBranchType configdomain.UnknownBranchType
+}
+
+func ShouldDisplayBranchType(branchType configdomain.BranchType) bool {
+	switch branchType {
+	case
+		configdomain.BranchTypeMainBranch,
+		configdomain.BranchTypeFeatureBranch:
+		return false
+	case
+		configdomain.BranchTypeContributionBranch,
+		configdomain.BranchTypeObservedBranch,
+		configdomain.BranchTypeParkedBranch,
+		configdomain.BranchTypePerennialBranch,
+		configdomain.BranchTypePrototypeBranch:
+		return true
+	}
+	panic("unhandled branch type:" + branchType.String())
+}
+
+func SwitchBranch(args SwitchBranchArgs) (gitdomain.LocalBranchName, dialogdomain.Exit, error) {
+	initialBranchPos := None[int]()
+	if currentBranch, has := args.CurrentBranch.Get(); has {
+		initialBranchPos = Some(args.Entries.IndexOf(currentBranch))
+	}
+	dialogProgram := tea.NewProgram(SwitchModel{
+		DisplayBranchTypes: args.DisplayBranchTypes,
+		InitialBranchPos:   initialBranchPos,
+		List:               list.NewList(newSwitchBranchListEntries(args.Entries), args.Cursor),
+		UncommittedChanges: args.UncommittedChanges,
+	})
+	dialogcomponents.SendInputs(args.InputName, args.Inputs.Next(), dialogProgram)
+	dialogResult, err := dialogProgram.Run()
+	result := dialogResult.(SwitchModel)
+	selectedData := result.List.SelectedData()
+	return selectedData.Branch, result.Aborted(), err
+}
+
+type SwitchBranchArgs struct {
+	CurrentBranch      Option[gitdomain.LocalBranchName]
+	Cursor             int
+	DisplayBranchTypes configdomain.DisplayTypes
+	Entries            SwitchBranchEntries
+	InputName          string
+	Inputs             dialogcomponents.Inputs
+	UncommittedChanges bool
 }
 
 // layoutBranches adds entries for the given branch and its children to the given entry list.
@@ -342,4 +330,16 @@ type layoutBranchesArgs struct {
 	result            *SwitchBranchEntries
 	showAllBranches   configdomain.AllBranches
 	unknownBranchType configdomain.UnknownBranchType
+}
+
+func newSwitchBranchListEntries(switchBranchEntries []SwitchBranchEntry) list.Entries[SwitchBranchEntry] {
+	result := make(list.Entries[SwitchBranchEntry], len(switchBranchEntries))
+	for e, entry := range switchBranchEntries {
+		result[e] = list.Entry[SwitchBranchEntry]{
+			Data:     entry,
+			Disabled: entry.OtherWorktree,
+			Text:     entry.String(),
+		}
+	}
+	return result
 }

--- a/internal/cmd/branch.go
+++ b/internal/cmd/branch.go
@@ -65,7 +65,7 @@ func executeBranch(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	entries := SwitchBranchEntries(SwitchBranchArgs{
+	entries := NewSwitchBranchEntries(SwitchBranchArgs{
 		BranchInfos:       data.branchInfos,
 		BranchTypes:       []configdomain.BranchType{},
 		BranchesAndTypes:  data.branchesAndTypes,

--- a/internal/cmd/branch.go
+++ b/internal/cmd/branch.go
@@ -65,7 +65,7 @@ func executeBranch(cliConfig cliconfig.CliConfig) error {
 	if err != nil || exit {
 		return err
 	}
-	entries := NewSwitchBranchEntries(SwitchBranchArgs{
+	entries := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 		BranchInfos:       data.branchInfos,
 		BranchTypes:       []configdomain.BranchType{},
 		BranchesAndTypes:  data.branchesAndTypes,

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -110,7 +110,7 @@ func executeSetParent(args []string, cliConfig cliconfig.CliConfig) error {
 			gitdomain.LocalBranchNames{data.initialBranch},
 			data.config.NormalConfig.Lineage.Children(data.initialBranch)...,
 		)
-		entries := NewSwitchBranchEntries(SwitchBranchArgs{
+		entries := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 			BranchInfos:       data.branchesSnapshot.Branches,
 			BranchTypes:       []configdomain.BranchType{},
 			BranchesAndTypes:  repo.UnvalidatedConfig.UnvalidatedBranchesAndTypes(data.branchesSnapshot.Branches.Names()),

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -110,7 +110,7 @@ func executeSetParent(args []string, cliConfig cliconfig.CliConfig) error {
 			gitdomain.LocalBranchNames{data.initialBranch},
 			data.config.NormalConfig.Lineage.Children(data.initialBranch)...,
 		)
-		entries := SwitchBranchEntries(SwitchBranchArgs{
+		entries := NewSwitchBranchEntries(SwitchBranchArgs{
 			BranchInfos:       data.branchesSnapshot.Branches,
 			BranchTypes:       []configdomain.BranchType{},
 			BranchesAndTypes:  repo.UnvalidatedConfig.UnvalidatedBranchesAndTypes(data.branchesSnapshot.Branches.Names()),

--- a/internal/cmd/switch.go
+++ b/internal/cmd/switch.go
@@ -80,7 +80,7 @@ func executeSwitch(args []string, cliConfig cliconfig.CliConfig, allBranches con
 	}
 	branchesAndTypes := repo.UnvalidatedConfig.UnvalidatedBranchesAndTypes(data.branchNames)
 	unknownBranchType := repo.UnvalidatedConfig.NormalConfig.UnknownBranchType
-	entries := SwitchBranchEntries(SwitchBranchArgs{
+	entries := NewSwitchBranchEntries(SwitchBranchArgs{
 		BranchInfos:       data.branchesSnapshot.Branches,
 		BranchTypes:       branchTypes,
 		BranchesAndTypes:  branchesAndTypes,
@@ -180,8 +180,8 @@ func determineSwitchData(args []string, repo execute.OpenRepoResult, cliConfig c
 	}, false, err
 }
 
-// SwitchBranchEntries provides the entries for the "switch branch" components.
-func SwitchBranchEntries(args SwitchBranchArgs) dialog.SwitchBranchEntries {
+// NewSwitchBranchEntries provides the entries for the "switch branch" components.
+func NewSwitchBranchEntries(args SwitchBranchArgs) dialog.SwitchBranchEntries {
 	entries := make(dialog.SwitchBranchEntries, 0, args.Lineage.Len())
 	roots := args.Lineage.Roots()
 	// add all entries from the lineage

--- a/internal/cmd/switch_test.go
+++ b/internal/cmd/switch_test.go
@@ -40,7 +40,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -71,7 +71,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -106,7 +106,7 @@ func TestSwitchBranch(t *testing.T) {
 			branchesAndTypes := configdomain.BranchesAndTypes{}
 			unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 			regexes := []*regexp.Regexp{}
-			have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+			have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 				BranchInfos:       branchInfos,
 				BranchTypes:       branchTypes,
 				BranchesAndTypes:  branchesAndTypes,
@@ -140,7 +140,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -174,7 +174,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -205,7 +205,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -247,7 +247,7 @@ func TestSwitchBranch(t *testing.T) {
 				}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -287,7 +287,7 @@ func TestSwitchBranch(t *testing.T) {
 				}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -324,7 +324,7 @@ func TestSwitchBranch(t *testing.T) {
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes, err := regexes.NewRegexes([]string{})
 				must.NoError(t, err)
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -359,7 +359,7 @@ func TestSwitchBranch(t *testing.T) {
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes, err := regexes.NewRegexes([]string{"observed-"})
 				must.NoError(t, err)
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -391,7 +391,7 @@ func TestSwitchBranch(t *testing.T) {
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes, err := regexes.NewRegexes([]string{"observed-", "main"})
 				must.NoError(t, err)
-				have := cmd.SwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,

--- a/internal/cmd/switch_test.go
+++ b/internal/cmd/switch_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v21/internal/cli/dialog"
-	"github.com/git-town/git-town/v21/internal/cmd"
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/regexes"
@@ -40,7 +39,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -71,7 +70,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -106,7 +105,7 @@ func TestSwitchBranch(t *testing.T) {
 			branchesAndTypes := configdomain.BranchesAndTypes{}
 			unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 			regexes := []*regexp.Regexp{}
-			have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+			have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 				BranchInfos:       branchInfos,
 				BranchTypes:       branchTypes,
 				BranchesAndTypes:  branchesAndTypes,
@@ -140,7 +139,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -174,7 +173,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -205,7 +204,7 @@ func TestSwitchBranch(t *testing.T) {
 				branchesAndTypes := configdomain.BranchesAndTypes{}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -247,7 +246,7 @@ func TestSwitchBranch(t *testing.T) {
 				}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -287,7 +286,7 @@ func TestSwitchBranch(t *testing.T) {
 				}
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes := []*regexp.Regexp{}
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -324,7 +323,7 @@ func TestSwitchBranch(t *testing.T) {
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes, err := regexes.NewRegexes([]string{})
 				must.NoError(t, err)
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -359,7 +358,7 @@ func TestSwitchBranch(t *testing.T) {
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes, err := regexes.NewRegexes([]string{"observed-"})
 				must.NoError(t, err)
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,
@@ -391,7 +390,7 @@ func TestSwitchBranch(t *testing.T) {
 				unknownBranchType := configdomain.UnknownBranchType(configdomain.BranchTypeFeatureBranch)
 				regexes, err := regexes.NewRegexes([]string{"observed-", "main"})
 				must.NoError(t, err)
-				have := cmd.NewSwitchBranchEntries(cmd.SwitchBranchArgs{
+				have := dialog.NewSwitchBranchEntries(dialog.NewSwitchBranchEntriesArgs{
 					BranchInfos:       branchInfos,
 					BranchTypes:       branchTypes,
 					BranchesAndTypes:  branchesAndTypes,


### PR DESCRIPTION
This functionality is going to be needed in both cmd and dialog packages in the
future, so the dialog package seems the right place for it. Plus, it creates
dialog related data.
