### PR TITLE
Move named args defs above the functions that use them

### DIFF
--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -128,7 +128,7 @@ func appendCmd() *cobra.Command {
 type executeAppendArgs struct {
 	arg           string
 	beam          configdomain.Beam
-	cliConfig     cliconfig.CliConfig
+	cliConfig     configdomain.PartialConfig
 	commit        configdomain.Commit
 	commitMessage Option[gitdomain.CommitMessage]
 	detached      configdomain.Detached

--- a/internal/cmd/append.go
+++ b/internal/cmd/append.go
@@ -125,6 +125,17 @@ func appendCmd() *cobra.Command {
 	return &cmd
 }
 
+type executeAppendArgs struct {
+	arg           string
+	beam          configdomain.Beam
+	cliConfig     cliconfig.CliConfig
+	commit        configdomain.Commit
+	commitMessage Option[gitdomain.CommitMessage]
+	detached      configdomain.Detached
+	propose       configdomain.Propose
+	prototype     configdomain.Prototype
+}
+
 func executeAppend(args executeAppendArgs) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		CliConfig:        args.cliConfig,
@@ -182,17 +193,6 @@ func executeAppend(args executeAppendArgs) error {
 		RootDir:                 repo.RootDir,
 		RunState:                runState,
 	})
-}
-
-type executeAppendArgs struct {
-	arg           string
-	beam          configdomain.Beam
-	cliConfig     configdomain.PartialConfig
-	commit        configdomain.Commit
-	commitMessage Option[gitdomain.CommitMessage]
-	detached      configdomain.Detached
-	propose       configdomain.Propose
-	prototype     configdomain.Prototype
 }
 
 type appendFeatureData struct {

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -130,7 +130,7 @@ func hackCmd() *cobra.Command {
 type hackArgs struct {
 	argv          []string
 	beam          configdomain.Beam
-	cliConfig     cliconfig.CliConfig
+	cliConfig     configdomain.PartialConfig
 	commit        configdomain.Commit
 	commitMessage Option[gitdomain.CommitMessage]
 	detached      configdomain.Detached

--- a/internal/cmd/hack.go
+++ b/internal/cmd/hack.go
@@ -127,6 +127,17 @@ func hackCmd() *cobra.Command {
 	return &cmd
 }
 
+type hackArgs struct {
+	argv          []string
+	beam          configdomain.Beam
+	cliConfig     cliconfig.CliConfig
+	commit        configdomain.Commit
+	commitMessage Option[gitdomain.CommitMessage]
+	detached      configdomain.Detached
+	propose       configdomain.Propose
+	prototype     configdomain.Prototype
+}
+
 func executeHack(args hackArgs) error {
 	repo, err := execute.OpenRepo(execute.OpenRepoArgs{
 		CliConfig:        args.cliConfig,
@@ -180,6 +191,21 @@ type convertToFeatureData struct {
 	targetBranches configdomain.BranchesAndTypes
 }
 
+type createFeatureBranchArgs struct {
+	appendData            appendFeatureData
+	backend               subshelldomain.RunnerQuerier
+	beginBranchesSnapshot gitdomain.BranchesSnapshot
+	beginConfigSnapshot   undoconfig.ConfigSnapshot
+	beginStashSize        gitdomain.StashSize
+	branchInfosLastRun    Option[gitdomain.BranchInfos]
+	commandsCounter       Mutable[gohacks.Counter]
+	dryRun                configdomain.DryRun
+	finalMessages         stringslice.Collector
+	frontend              subshelldomain.Runner
+	git                   git.Commands
+	rootDir               gitdomain.RepoRootDir
+}
+
 func createFeatureBranch(args createFeatureBranchArgs) error {
 	runProgram := appendProgram(args.backend, args.appendData, args.finalMessages, true)
 	runState := runstate.RunState{
@@ -215,21 +241,6 @@ func createFeatureBranch(args createFeatureBranchArgs) error {
 		RootDir:                 args.rootDir,
 		RunState:                runState,
 	})
-}
-
-type createFeatureBranchArgs struct {
-	appendData            appendFeatureData
-	backend               subshelldomain.RunnerQuerier
-	beginBranchesSnapshot gitdomain.BranchesSnapshot
-	beginConfigSnapshot   undoconfig.ConfigSnapshot
-	beginStashSize        gitdomain.StashSize
-	branchInfosLastRun    Option[gitdomain.BranchInfos]
-	commandsCounter       Mutable[gohacks.Counter]
-	dryRun                configdomain.DryRun
-	finalMessages         stringslice.Collector
-	frontend              subshelldomain.Runner
-	git                   git.Commands
-	rootDir               gitdomain.RepoRootDir
 }
 
 func determineHackData(args hackArgs, repo execute.OpenRepoResult) (data hackData, exit dialogdomain.Exit, err error) {
@@ -398,15 +409,11 @@ func determineHackData(args hackArgs, repo execute.OpenRepoResult) (data hackDat
 	return data, false, err
 }
 
-type hackArgs struct {
-	argv          []string
-	beam          configdomain.Beam
-	cliConfig     configdomain.PartialConfig
-	commit        configdomain.Commit
-	commitMessage Option[gitdomain.CommitMessage]
-	detached      configdomain.Detached
-	propose       configdomain.Propose
-	prototype     configdomain.Prototype
+type convertToFeatureBranchArgs struct {
+	beginConfigSnapshot undoconfig.ConfigSnapshot
+	config              config.ValidatedConfig
+	makeFeatureData     convertToFeatureData
+	verbose             configdomain.Verbose
 }
 
 func convertToFeatureBranch(repo execute.OpenRepoResult, args convertToFeatureBranchArgs) error {
@@ -441,11 +448,4 @@ func convertToFeatureBranch(repo execute.OpenRepoResult, args convertToFeatureBr
 		TouchedBranches:       args.makeFeatureData.targetBranches.Keys().BranchNames(),
 		Verbose:               args.verbose,
 	})
-}
-
-type convertToFeatureBranchArgs struct {
-	beginConfigSnapshot undoconfig.ConfigSnapshot
-	config              config.ValidatedConfig
-	makeFeatureData     convertToFeatureData
-	verbose             configdomain.Verbose
 }

--- a/internal/forge/codeberg/connector.go
+++ b/internal/forge/codeberg/connector.go
@@ -255,6 +255,12 @@ func FilterPullRequests2(pullRequests []*forgejo.PullRequest, branch gitdomain.L
 	return result
 }
 
+type NewConnectorArgs struct {
+	APIToken  Option[forgedomain.CodebergToken]
+	Log       print.Logger
+	RemoteURL giturl.Parts
+}
+
 // NewConnector provides a new connector instance.
 func NewConnector(args NewConnectorArgs) (Connector, error) {
 	codebergClient, err := forgejo.NewClient("https://"+args.RemoteURL.Host, forgejo.SetToken(args.APIToken.String()))
@@ -268,12 +274,6 @@ func NewConnector(args NewConnectorArgs) (Connector, error) {
 		client: codebergClient,
 		log:    args.Log,
 	}, err
-}
-
-type NewConnectorArgs struct {
-	APIToken  Option[forgedomain.CodebergToken]
-	Log       print.Logger
-	RemoteURL giturl.Parts
 }
 
 func parsePullRequest(pullRequest *forgejo.PullRequest) forgedomain.ProposalData {

--- a/internal/forge/gitea/connector.go
+++ b/internal/forge/gitea/connector.go
@@ -255,6 +255,12 @@ func FilterPullRequests2(pullRequests []*gitea.PullRequest, branch gitdomain.Loc
 	return result
 }
 
+type NewConnectorArgs struct {
+	APIToken  Option[forgedomain.GiteaToken]
+	Log       print.Logger
+	RemoteURL giturl.Parts
+}
+
 // NewGiteaConfig provides Gitea configuration data if the current repo is hosted on Gitea,
 // otherwise nil.
 func NewConnector(args NewConnectorArgs) Connector {
@@ -271,12 +277,6 @@ func NewConnector(args NewConnectorArgs) Connector {
 		client: giteaClient,
 		log:    args.Log,
 	}
-}
-
-type NewConnectorArgs struct {
-	APIToken  Option[forgedomain.GiteaToken]
-	Log       print.Logger
-	RemoteURL giturl.Parts
 }
 
 func parsePullRequest(pullRequest *gitea.PullRequest) forgedomain.ProposalData {

--- a/internal/forge/github/connector.go
+++ b/internal/forge/github/connector.go
@@ -242,6 +242,12 @@ func DefaultProposalMessage(data forgedomain.ProposalData) string {
 	return forgedomain.CommitBody(data, fmt.Sprintf("%s (#%d)", data.Title, data.Number))
 }
 
+type NewConnectorArgs struct {
+	APIToken  Option[forgedomain.GitHubToken]
+	Log       print.Logger
+	RemoteURL giturl.Parts
+}
+
 func NewConnector(args NewConnectorArgs) (Connector, error) {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: args.APIToken.String()})
 	httpClient := oauth2.NewClient(context.Background(), tokenSource)
@@ -264,12 +270,6 @@ func NewConnector(args NewConnectorArgs) (Connector, error) {
 		client: githubClient,
 		log:    args.Log,
 	}, nil
-}
-
-type NewConnectorArgs struct {
-	APIToken  Option[forgedomain.GitHubToken]
-	Log       print.Logger
-	RemoteURL giturl.Parts
 }
 
 func RepositoryURL(hostNameWithStandardPort string, organization string, repository string) string {

--- a/internal/forge/gitlab/connector.go
+++ b/internal/forge/gitlab/connector.go
@@ -218,6 +218,12 @@ func (self Connector) updateProposalTarget(proposalData forgedomain.ProposalInte
 	return nil
 }
 
+type NewConnectorArgs struct {
+	APIToken  Option[forgedomain.GitLabToken]
+	Log       print.Logger
+	RemoteURL giturl.Parts
+}
+
 func NewConnector(args NewConnectorArgs) (Connector, error) {
 	gitlabData := Data{
 		APIToken: args.APIToken,
@@ -237,12 +243,6 @@ func NewConnector(args NewConnectorArgs) (Connector, error) {
 		log:    args.Log,
 	}
 	return connector, nil
-}
-
-type NewConnectorArgs struct {
-	APIToken  Option[forgedomain.GitLabToken]
-	Log       print.Logger
-	RemoteURL giturl.Parts
 }
 
 func parseMergeRequest(mergeRequest *gitlab.BasicMergeRequest) forgedomain.ProposalData {

--- a/internal/skip/execute.go
+++ b/internal/skip/execute.go
@@ -23,6 +23,22 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
+type ExecuteArgs struct {
+	Backend         subshelldomain.RunnerQuerier
+	CommandsCounter Mutable[gohacks.Counter]
+	Config          config.ValidatedConfig
+	Connector       Option[forgedomain.Connector]
+	Detached        configdomain.Detached
+	FinalMessages   stringslice.Collector
+	Frontend        subshelldomain.Runner
+	Git             git.Commands
+	HasOpenChanges  bool
+	InitialBranch   gitdomain.LocalBranchName
+	Inputs          dialogcomponents.Inputs
+	RootDir         gitdomain.RepoRootDir
+	RunState        runstate.RunState
+}
+
 // executes the "skip" command at the given runstate
 func Execute(args ExecuteArgs) error {
 	lightinterpreter.Execute(lightinterpreter.ExecuteArgs{
@@ -59,22 +75,6 @@ func Execute(args ExecuteArgs) error {
 		RootDir:                 args.RootDir,
 		RunState:                args.RunState,
 	})
-}
-
-type ExecuteArgs struct {
-	Backend         subshelldomain.RunnerQuerier
-	CommandsCounter Mutable[gohacks.Counter]
-	Config          config.ValidatedConfig
-	Connector       Option[forgedomain.Connector]
-	Detached        configdomain.Detached
-	FinalMessages   stringslice.Collector
-	Frontend        subshelldomain.Runner
-	Git             git.Commands
-	HasOpenChanges  bool
-	InitialBranch   gitdomain.LocalBranchName
-	Inputs          dialogcomponents.Inputs
-	RootDir         gitdomain.RepoRootDir
-	RunState        runstate.RunState
 }
 
 // removes the remaining opcodes for the current branch from the given program

--- a/internal/undo/execute.go
+++ b/internal/undo/execute.go
@@ -19,6 +19,21 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
+type ExecuteArgs struct {
+	Backend          subshelldomain.RunnerQuerier
+	CommandsCounter  Mutable[gohacks.Counter]
+	Config           config.ValidatedConfig
+	Connector        Option[forgedomain.Connector]
+	Detached         configdomain.Detached
+	FinalMessages    stringslice.Collector
+	Frontend         subshelldomain.Runner
+	Git              git.Commands
+	HasOpenChanges   bool
+	InitialStashSize gitdomain.StashSize
+	RootDir          gitdomain.RepoRootDir
+	RunState         runstate.RunState
+}
+
 // undoes the persisted runstate
 func Execute(args ExecuteArgs) error {
 	if args.RunState.DryRun {
@@ -50,19 +65,4 @@ func Execute(args ExecuteArgs) error {
 	}
 	print.Footer(args.Config.NormalConfig.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
 	return nil
-}
-
-type ExecuteArgs struct {
-	Backend          subshelldomain.RunnerQuerier
-	CommandsCounter  Mutable[gohacks.Counter]
-	Config           config.ValidatedConfig
-	Connector        Option[forgedomain.Connector]
-	Detached         configdomain.Detached
-	FinalMessages    stringslice.Collector
-	Frontend         subshelldomain.Runner
-	Git              git.Commands
-	HasOpenChanges   bool
-	InitialStashSize gitdomain.StashSize
-	RootDir          gitdomain.RepoRootDir
-	RunState         runstate.RunState
 }

--- a/internal/vm/interpreter/configinterpreter/finished.go
+++ b/internal/vm/interpreter/configinterpreter/finished.go
@@ -15,6 +15,19 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
+type FinishedArgs struct {
+	Backend               subshelldomain.RunnerQuerier
+	BeginBranchesSnapshot Option[gitdomain.BranchesSnapshot]
+	BeginConfigSnapshot   undoconfig.ConfigSnapshot
+	Command               string
+	CommandsCounter       Mutable[gohacks.Counter]
+	FinalMessages         stringslice.Collector
+	Git                   git.Commands
+	RootDir               gitdomain.RepoRootDir
+	TouchedBranches       []gitdomain.BranchName
+	Verbose               configdomain.Verbose
+}
+
 // Finished is called when a Git Town command that only changes configuration has finished successfully.
 func Finished(args FinishedArgs) error {
 	var endBranchesSnapshot Option[gitdomain.BranchesSnapshot]
@@ -57,17 +70,4 @@ func Finished(args FinishedArgs) error {
 	}
 	print.Footer(args.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
 	return runstate.Save(runState, args.RootDir)
-}
-
-type FinishedArgs struct {
-	Backend               subshelldomain.RunnerQuerier
-	BeginBranchesSnapshot Option[gitdomain.BranchesSnapshot]
-	BeginConfigSnapshot   undoconfig.ConfigSnapshot
-	Command               string
-	CommandsCounter       Mutable[gohacks.Counter]
-	FinalMessages         stringslice.Collector
-	Git                   git.Commands
-	RootDir               gitdomain.RepoRootDir
-	TouchedBranches       []gitdomain.BranchName
-	Verbose               configdomain.Verbose
 }

--- a/internal/vm/interpreter/fullinterpreter/execute.go
+++ b/internal/vm/interpreter/fullinterpreter/execute.go
@@ -18,6 +18,26 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
+type ExecuteArgs struct {
+	Backend                 subshelldomain.RunnerQuerier
+	CommandsCounter         Mutable[gohacks.Counter]
+	Config                  config.ValidatedConfig
+	Connector               Option[forgedomain.Connector]
+	Detached                configdomain.Detached
+	FinalMessages           stringslice.Collector
+	Frontend                subshelldomain.Runner
+	Git                     git.Commands
+	HasOpenChanges          bool
+	InitialBranch           gitdomain.LocalBranchName
+	InitialBranchesSnapshot gitdomain.BranchesSnapshot
+	InitialConfigSnapshot   undoconfig.ConfigSnapshot
+	InitialStashSize        gitdomain.StashSize
+	Inputs                  dialogcomponents.Inputs
+	PendingCommand          Option[string]
+	RootDir                 gitdomain.RepoRootDir
+	RunState                runstate.RunState
+}
+
 // Execute runs the commands in the given runstate.
 func Execute(args ExecuteArgs) error {
 	if err := runlog.Write(runlog.EventStart, args.InitialBranchesSnapshot.Branches, args.PendingCommand, args.RootDir); err != nil {
@@ -59,24 +79,4 @@ func Execute(args ExecuteArgs) error {
 		}
 		args.RunState.UndoAPIProgram = append(args.RunState.UndoAPIProgram, nextStep.UndoExternalChanges()...)
 	}
-}
-
-type ExecuteArgs struct {
-	Backend                 subshelldomain.RunnerQuerier
-	CommandsCounter         Mutable[gohacks.Counter]
-	Config                  config.ValidatedConfig
-	Connector               Option[forgedomain.Connector]
-	Detached                configdomain.Detached
-	FinalMessages           stringslice.Collector
-	Frontend                subshelldomain.Runner
-	Git                     git.Commands
-	HasOpenChanges          bool
-	InitialBranch           gitdomain.LocalBranchName
-	InitialBranchesSnapshot gitdomain.BranchesSnapshot
-	InitialConfigSnapshot   undoconfig.ConfigSnapshot
-	InitialStashSize        gitdomain.StashSize
-	Inputs                  dialogcomponents.Inputs
-	PendingCommand          Option[string]
-	RootDir                 gitdomain.RepoRootDir
-	RunState                runstate.RunState
 }

--- a/internal/vm/interpreter/fullinterpreter/finished.go
+++ b/internal/vm/interpreter/fullinterpreter/finished.go
@@ -19,6 +19,17 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
+type finishedArgs struct {
+	Backend         subshelldomain.RunnerQuerier
+	CommandsCounter Mutable[gohacks.Counter]
+	FinalMessages   stringslice.Collector
+	Git             git.Commands
+	Inputs          dialogcomponents.Inputs
+	RootDir         gitdomain.RepoRootDir
+	RunState        runstate.RunState
+	Verbose         configdomain.Verbose
+}
+
 // finished is called when executing all steps has successfully finished.
 func finished(args finishedArgs) error {
 	endBranchesSnapshot, err := args.Git.BranchesSnapshot(args.Backend)
@@ -52,15 +63,4 @@ func finished(args finishedArgs) error {
 	print.Footer(args.Verbose, args.CommandsCounter.Immutable(), args.FinalMessages.Result())
 	args.Inputs.VerifyAllUsed()
 	return nil
-}
-
-type finishedArgs struct {
-	Backend         subshelldomain.RunnerQuerier
-	CommandsCounter Mutable[gohacks.Counter]
-	FinalMessages   stringslice.Collector
-	Git             git.Commands
-	Inputs          dialogcomponents.Inputs
-	RootDir         gitdomain.RepoRootDir
-	RunState        runstate.RunState
-	Verbose         configdomain.Verbose
 }


### PR DESCRIPTION
This is the location where they are the most useful because they are technically a part of the function declaration.