### PR TITLE
Support for deleted files in E2E tests

### DIFF
--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -25,7 +25,7 @@ import (
 const (
 	ConfigFileCommitMessage = "persisted config file"
 	FileCommitMessage       = "persisted file"
-	deleted                 = "(deleted)"
+	deletedText             = "(deleted)"
 )
 
 // TestCommands defines Git commands used only in test code.
@@ -146,7 +146,7 @@ func (self *TestCommands) CommitsInBranch(branch gitdomain.LocalBranchName, pare
 				var err error
 				filecontent, err = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
 				if err != nil {
-					filecontent = deleted
+					filecontent = deletedText
 				}
 			}
 			commit.FileContent = filecontent
@@ -304,7 +304,7 @@ func (self *TestCommands) FilesInBranches(mainBranch gitdomain.LocalBranchName) 
 		for _, file := range files {
 			content, err := self.FileContentInCommit(branch.Location(), file)
 			if err != nil {
-				content = deleted
+				content = deletedText
 			}
 			if branch == lastBranch {
 				result.AddRow("", file, content)

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -143,9 +143,9 @@ func (self *TestCommands) CommitsInBranch(branch gitdomain.LocalBranchName, pare
 		if slices.Contains(fields, "FILE CONTENT") {
 			filecontent := ""
 			if commit.FileName != "" {
-				var err error
-				filecontent, err = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
-				if err != nil {
+				var deleted bool
+				filecontent, deleted = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
+				if deleted {
 					filecontent = deletedText
 				}
 			}
@@ -276,8 +276,13 @@ func (self *TestCommands) FileContentErr(filename string) (string, error) {
 }
 
 // FileContentInCommit provides the content of the file with the given name in the commit with the given SHA.
-func (self *TestCommands) FileContentInCommit(location gitdomain.Location, filename string) (string, error) {
-	return self.Query("git", "show", location.String()+":"+filename)
+// If the file was deleted, the return content is empty and the bool return variable is set.
+func (self *TestCommands) FileContentInCommit(location gitdomain.Location, filename string) (content string, deleted bool) {
+	output, err := self.Query("git", "show", location.String()+":"+filename)
+	if err != nil {
+		return "", true
+	}
+	return output, false
 }
 
 // FilesInBranch provides the list of the files present in the given branch.
@@ -302,8 +307,8 @@ func (self *TestCommands) FilesInBranches(mainBranch gitdomain.LocalBranchName) 
 	for _, branch := range branches {
 		files := self.FilesInBranch(branch)
 		for _, file := range files {
-			content, err := self.FileContentInCommit(branch.Location(), file)
-			if err != nil {
+			content, deleted := self.FileContentInCommit(branch.Location(), file)
+			if deleted {
 				content = deletedText
 			}
 			if branch == lastBranch {

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -142,7 +142,11 @@ func (self *TestCommands) CommitsInBranch(branch gitdomain.LocalBranchName, pare
 		if slices.Contains(fields, "FILE CONTENT") {
 			filecontent := ""
 			if commit.FileName != "" {
-				filecontent = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
+				var err error
+				filecontent, err = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
+				if err != nil {
+					filecontent = "(deleted)"
+				}
 			}
 			commit.FileContent = filecontent
 		}
@@ -271,9 +275,8 @@ func (self *TestCommands) FileContentErr(filename string) (string, error) {
 }
 
 // FileContentInCommit provides the content of the file with the given name in the commit with the given SHA.
-func (self *TestCommands) FileContentInCommit(location gitdomain.Location, filename string) string {
-	output := self.MustQuery("git", "show", location.String()+":"+filename)
-	return output
+func (self *TestCommands) FileContentInCommit(location gitdomain.Location, filename string) (string, error) {
+	return self.Query("git", "show", location.String()+":"+filename)
 }
 
 // FilesInBranch provides the list of the files present in the given branch.
@@ -298,7 +301,10 @@ func (self *TestCommands) FilesInBranches(mainBranch gitdomain.LocalBranchName) 
 	for _, branch := range branches {
 		files := self.FilesInBranch(branch)
 		for _, file := range files {
-			content := self.FileContentInCommit(branch.Location(), file)
+			content, err := self.FileContentInCommit(branch.Location(), file)
+			if err != nil {
+				content = "(deleted)"
+			}
 			if branch == lastBranch {
 				result.AddRow("", file, content)
 			} else {

--- a/internal/test/commands/test_commands.go
+++ b/internal/test/commands/test_commands.go
@@ -25,6 +25,7 @@ import (
 const (
 	ConfigFileCommitMessage = "persisted config file"
 	FileCommitMessage       = "persisted file"
+	deleted                 = "(deleted)"
 )
 
 // TestCommands defines Git commands used only in test code.
@@ -145,7 +146,7 @@ func (self *TestCommands) CommitsInBranch(branch gitdomain.LocalBranchName, pare
 				var err error
 				filecontent, err = self.FileContentInCommit(commit.SHA.Location(), commit.FileName)
 				if err != nil {
-					filecontent = "(deleted)"
+					filecontent = deleted
 				}
 			}
 			commit.FileContent = filecontent
@@ -303,7 +304,7 @@ func (self *TestCommands) FilesInBranches(mainBranch gitdomain.LocalBranchName) 
 		for _, file := range files {
 			content, err := self.FileContentInCommit(branch.Location(), file)
 			if err != nil {
-				content = "(deleted)"
+				content = deleted
 			}
 			if branch == lastBranch {
 				result.AddRow("", file, content)

--- a/internal/test/commands/test_commands_test.go
+++ b/internal/test/commands/test_commands_test.go
@@ -191,7 +191,8 @@ func TestTestCommands(t *testing.T) {
 		})
 		commits := runtime.CommitsInBranch("initial", None[gitdomain.BranchName](), []string{})
 		must.Len(t, 1, commits)
-		content := runtime.FileContentInCommit(commits[0].SHA.Location(), "hello.txt")
+		content, err := runtime.FileContentInCommit(commits[0].SHA.Location(), "hello.txt")
+		must.NoError(t, err)
 		must.EqOp(t, "hello world", content)
 	})
 

--- a/internal/test/commands/test_commands_test.go
+++ b/internal/test/commands/test_commands_test.go
@@ -191,8 +191,8 @@ func TestTestCommands(t *testing.T) {
 		})
 		commits := runtime.CommitsInBranch("initial", None[gitdomain.BranchName](), []string{})
 		must.Len(t, 1, commits)
-		content, err := runtime.FileContentInCommit(commits[0].SHA.Location(), "hello.txt")
-		must.NoError(t, err)
+		content, deleted := runtime.FileContentInCommit(commits[0].SHA.Location(), "hello.txt")
+		must.False(t, deleted)
 		must.EqOp(t, "hello world", content)
 	})
 

--- a/internal/test/subshell/test_runner.go
+++ b/internal/test/subshell/test_runner.go
@@ -209,9 +209,7 @@ func (self *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string)
 	subProcess.Env = opts.Env
 	var outputBuf bytes.Buffer
 	subProcess.Stdout = &outputBuf
-	if !opts.IgnoreStdErr {
-		subProcess.Stderr = &outputBuf
-	}
+	subProcess.Stderr = &outputBuf
 	if input, hasInput := opts.Input.Get(); hasInput {
 		var stdin io.WriteCloser
 		stdin, err = subProcess.StdinPipe()
@@ -310,9 +308,6 @@ type Options struct {
 
 	// when set, captures the output and returns it
 	IgnoreOutput bool `exhaustruct:"optional"`
-
-	// when set, captures only StdOut
-	IgnoreStdErr bool `exhaustruct:"optional"`
 
 	// input to pipe into STDIN
 	Input Option[string] `exhaustruct:"optional"`

--- a/internal/test/subshell/test_runner.go
+++ b/internal/test/subshell/test_runner.go
@@ -209,7 +209,9 @@ func (self *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string)
 	subProcess.Env = opts.Env
 	var outputBuf bytes.Buffer
 	subProcess.Stdout = &outputBuf
-	subProcess.Stderr = &outputBuf
+	if !opts.IgnoreStdErr {
+		subProcess.Stderr = &outputBuf
+	}
 	if input, hasInput := opts.Input.Get(); hasInput {
 		var stdin io.WriteCloser
 		stdin, err = subProcess.StdinPipe()
@@ -308,6 +310,9 @@ type Options struct {
 
 	// when set, captures the output and returns it
 	IgnoreOutput bool `exhaustruct:"optional"`
+
+	// when set, captures only StdOut
+	IgnoreStdErr bool `exhaustruct:"optional"`
 
 	// input to pipe into STDIN
 	Input Option[string] `exhaustruct:"optional"`


### PR DESCRIPTION
In order to evaluate all possible phantom merge conflicts, the E2E tests need to
be able to represent commits that delete files. This PR adds support for them.
