### PR TITLE
enhance(internal/forge): Github forge should find Proposals regardless of state but prioritize open PRs

### DIFF
--- a/internal/messages/en.go
+++ b/internal/messages/en.go
@@ -222,7 +222,6 @@ Please upgrade to the new format: create.new-branch-type = "prototype"`
 	ProposalMultipleFromToFound           = "found %d proposals from branch %q to branch %q"
 	ProposalNoNumberGiven                 = "no proposal number given"
 	ProposalNoParent                      = "branch %q has no parent and can therefore not be proposed"
-	ProposalNotFoundForBranch             = "cannot determine proposal for branch %q: %w"
 	ProposalSourceCannotUpdate            = "cannot update the proposal source branch on your forge"
 	ProposalsShowLineageInvalid           = "invalid value for whether proposals should show the lineage: %q. Valid values are: none, ci, cli"
 	ProposalTargetBranchUpdateProblem     = "cannot update the target branch of proposal %d on your forge"


### PR DESCRIPTION
This matches the behavior of the gh cli being able to find even closed pull-requests. This is also needed if a stack of pull-requests are not shipped all at once and you still need to sync and keep track of the proposals in the stack in the lineage comment.
