### PR TITLE
More specific name for conflict info struct

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -473,21 +473,21 @@ func (self *Commands) FetchUpstream(runner subshelldomain.Runner, branch gitdoma
 	return runner.Run("git", "fetch", gitdomain.RemoteUpstream.String(), branch.String())
 }
 
-func (self *Commands) FileConflictFullInfo(querier subshelldomain.Querier, quickInfo FileConflictQuickInfo, parentLocation gitdomain.Location, rootBranch gitdomain.LocalBranchName) (FileConflictFullInfo, error) {
+func (self *Commands) FileConflictFullInfo(querier subshelldomain.Querier, quickInfo FileConflictQuickInfo, parentLocation gitdomain.Location, rootBranch gitdomain.LocalBranchName) (MergeConflictFullInfo, error) {
 	rootBlob := None[BlobInfo]()
 	parentBlob := None[BlobInfo]()
 	if currentBranchBlobInfo, has := quickInfo.CurrentBranchChange.Get(); has {
 		var err error
 		rootBlob, err = self.ContentBlobInfo(querier, rootBranch.Location(), currentBranchBlobInfo.FilePath)
 		if err != nil {
-			return FileConflictFullInfo{}, err
+			return MergeConflictFullInfo{}, err
 		}
 		parentBlob, err = self.ContentBlobInfo(querier, parentLocation, currentBranchBlobInfo.FilePath)
 		if err != nil {
-			return FileConflictFullInfo{}, err
+			return MergeConflictFullInfo{}, err
 		}
 	}
-	result := FileConflictFullInfo{
+	result := MergeConflictFullInfo{
 		Current: quickInfo.CurrentBranchChange,
 		Parent:  parentBlob,
 		Root:    rootBlob,
@@ -495,8 +495,8 @@ func (self *Commands) FileConflictFullInfo(querier subshelldomain.Querier, quick
 	return result, nil
 }
 
-func (self *Commands) FileConflictFullInfos(querier subshelldomain.Querier, quickInfos []FileConflictQuickInfo, parentLocation gitdomain.Location, rootBranch gitdomain.LocalBranchName) ([]FileConflictFullInfo, error) {
-	result := make([]FileConflictFullInfo, len(quickInfos))
+func (self *Commands) FileConflictFullInfos(querier subshelldomain.Querier, quickInfos []FileConflictQuickInfo, parentLocation gitdomain.Location, rootBranch gitdomain.LocalBranchName) ([]MergeConflictFullInfo, error) {
+	result := make([]MergeConflictFullInfo, len(quickInfos))
 	for q, quickInfo := range quickInfos {
 		fullInfo, err := self.FileConflictFullInfo(querier, quickInfo, parentLocation, rootBranch)
 		if err != nil {

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -985,7 +985,7 @@ func TestBackendCommands(t *testing.T) {
 		t.Parallel()
 		t.Run("legit phantom merge conflict", func(t *testing.T) {
 			t.Parallel()
-			fullInfos := []git.FileConflictFullInfo{
+			fullInfos := []git.MergeConflictFullInfo{
 				{
 					Root: Some(git.BlobInfo{
 						FilePath:   "file",
@@ -1015,7 +1015,7 @@ func TestBackendCommands(t *testing.T) {
 		})
 		t.Run("permissions differ", func(t *testing.T) {
 			t.Parallel()
-			fullInfos := []git.FileConflictFullInfo{
+			fullInfos := []git.MergeConflictFullInfo{
 				{
 					Root: Some(git.BlobInfo{
 						FilePath:   "file",
@@ -1040,7 +1040,7 @@ func TestBackendCommands(t *testing.T) {
 		})
 		t.Run("file checksums between parent and main differ", func(t *testing.T) {
 			t.Parallel()
-			fullInfos := []git.FileConflictFullInfo{
+			fullInfos := []git.MergeConflictFullInfo{
 				{
 					Root: Some(git.BlobInfo{
 						FilePath:   "file",
@@ -1065,7 +1065,7 @@ func TestBackendCommands(t *testing.T) {
 		})
 		t.Run("file names between parent and main differ", func(t *testing.T) {
 			t.Parallel()
-			fullInfos := []git.FileConflictFullInfo{
+			fullInfos := []git.MergeConflictFullInfo{
 				{
 					Root: Some(git.BlobInfo{
 						FilePath:   "file-1",

--- a/internal/git/phantom_merge_conflict.go
+++ b/internal/git/phantom_merge_conflict.go
@@ -44,7 +44,7 @@ var UnmergedStages = []UnmergedStage{
 // Everything Git Town needs to know about a file merge conflict to determine whether this is a phantom merge conflict.
 // Includes the FileConflictQuickInfo as well as information that only Git Town knows,
 // like how this file looks at the root branch of the stack on which the conflict occurs.
-type FileConflictFullInfo struct {
+type MergeConflictFullInfo struct {
 	Current Option[BlobInfo] // info about the file on the current branch
 	Parent  Option[BlobInfo] // info about the file on the original parent
 	Root    Option[BlobInfo] // info about the file on the root branch
@@ -56,7 +56,7 @@ type PhantomConflict struct {
 	Resolution gitdomain.ConflictResolution
 }
 
-func DetectPhantomMergeConflicts(conflictInfos []FileConflictFullInfo, parentBranchOpt Option[gitdomain.LocalBranchName], rootBranch gitdomain.LocalBranchName) []PhantomConflict {
+func DetectPhantomMergeConflicts(conflictInfos []MergeConflictFullInfo, parentBranchOpt Option[gitdomain.LocalBranchName], rootBranch gitdomain.LocalBranchName) []PhantomConflict {
 	parentBranch, hasParentBranch := parentBranchOpt.Get()
 	if !hasParentBranch || parentBranch == rootBranch {
 		// branches that don't have a parent or whose parent is the root branch cannot have phantom merge conflicts


### PR DESCRIPTION
The `FileConflictFullInfo` struct is only useful for merge conflicts, so this PR adjusts its name to reflect that.