### PR TITLE
Specialize FileConflictFullInfo to MergeConflict

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -565,27 +565,26 @@ func (self *Commands) MergeBranchNoEdit(runner subshelldomain.Runner, branch git
 
 // loads the information needed to determine which of the given file conflicts are phantom merge conflicts
 func (self *Commands) MergeConflicts(querier subshelldomain.Querier, fileConflicts FileConflicts, parentLocation gitdomain.Location, rootBranch gitdomain.LocalBranchName) (MergeConflicts, error) {
-	result := make([]MergeConflict, len(fileConflicts))
+	result := make(MergeConflicts, len(fileConflicts))
 	for f, fileConflict := range fileConflicts {
 		rootBlob := None[Blob]()
 		parentBlob := None[Blob]()
-		if currentBranchBlobInfo, has := fileConflict.CurrentBranchChange.Get(); has {
+		if currentBranchBlob, has := fileConflict.CurrentBranchChange.Get(); has {
 			var err error
-			rootBlob, err = self.ContentBlobInfo(querier, rootBranch.Location(), currentBranchBlobInfo.FilePath)
+			rootBlob, err = self.ContentBlobInfo(querier, rootBranch.Location(), currentBranchBlob.FilePath)
 			if err != nil {
 				return result, err
 			}
-			parentBlob, err = self.ContentBlobInfo(querier, parentLocation, currentBranchBlobInfo.FilePath)
+			parentBlob, err = self.ContentBlobInfo(querier, parentLocation, currentBranchBlob.FilePath)
 			if err != nil {
 				return result, err
 			}
 		}
-		mergeConflict := MergeConflict{
+		result[f] = MergeConflict{
 			Current: fileConflict.CurrentBranchChange,
 			Parent:  parentBlob,
 			Root:    rootBlob,
 		}
-		result[f] = mergeConflict
 	}
 	return result, nil
 }

--- a/internal/git/file_conflicts.go
+++ b/internal/git/file_conflicts.go
@@ -1,11 +1,3 @@
 package git
 
-import "github.com/git-town/git-town/v21/internal/subshell/subshelldomain"
-
 type FileConflicts []FileConflict
-
-func (self FileConflicts) Debug(querier subshelldomain.Querier) {
-	for _, fileConflict := range self {
-		fileConflict.Debug(querier)
-	}
-}

--- a/internal/git/file_conflicts.go
+++ b/internal/git/file_conflicts.go
@@ -1,0 +1,11 @@
+package git
+
+import "github.com/git-town/git-town/v21/internal/subshell/subshelldomain"
+
+type FileConflicts []FileConflict
+
+func (self FileConflicts) Debug(querier subshelldomain.Querier) {
+	for _, fileConflict := range self {
+		fileConflict.Debug(querier)
+	}
+}

--- a/internal/git/merge_conflict.go
+++ b/internal/git/merge_conflict.go
@@ -8,5 +8,3 @@ type MergeConflict struct {
 	Parent  Option[Blob] // info about the file on the original parent
 	Root    Option[Blob] // info about the file on the root branch
 }
-
-type MergeConflicts []MergeConflict

--- a/internal/git/merge_conflict.go
+++ b/internal/git/merge_conflict.go
@@ -8,3 +8,5 @@ type MergeConflict struct {
 	Parent  Option[Blob] // info about the file on the original parent
 	Root    Option[Blob] // info about the file on the root branch
 }
+
+type MergeConflicts []MergeConflict

--- a/internal/git/merge_conflicts.go
+++ b/internal/git/merge_conflicts.go
@@ -1,0 +1,3 @@
+package git
+
+type MergeConflicts []MergeConflict

--- a/internal/vm/opcodes/conflict_merge_phantom_resolve_all.go
+++ b/internal/vm/opcodes/conflict_merge_phantom_resolve_all.go
@@ -39,7 +39,7 @@ func (self *ConflictMergePhantomResolveAll) Run(args shared.RunArgs) error {
 		return err
 	}
 	rootBranch := args.Config.Value.NormalConfig.Lineage.Root(self.CurrentBranch)
-	fullInfos, err := args.Git.FileConflictFullInfos(args.Backend, quickInfos, parentSHA.Location(), rootBranch)
+	fullInfos, err := args.Git.MergeConflicts(args.Backend, quickInfos, parentSHA.Location(), rootBranch)
 	if err != nil {
 		return err
 	}

--- a/internal/vm/opcodes/conflict_merge_phantom_resolve_all.go
+++ b/internal/vm/opcodes/conflict_merge_phantom_resolve_all.go
@@ -39,11 +39,11 @@ func (self *ConflictMergePhantomResolveAll) Run(args shared.RunArgs) error {
 		return err
 	}
 	rootBranch := args.Config.Value.NormalConfig.Lineage.Root(self.CurrentBranch)
-	fullInfos, err := args.Git.MergeConflicts(args.Backend, quickInfos, parentSHA.Location(), rootBranch)
+	mergeConflits, err := args.Git.MergeConflicts(args.Backend, quickInfos, parentSHA.Location(), rootBranch)
 	if err != nil {
 		return err
 	}
-	phantomMergeConflicts := git.DetectPhantomMergeConflicts(fullInfos, self.ParentBranch, rootBranch)
+	phantomMergeConflicts := git.DetectPhantomMergeConflicts(mergeConflits, self.ParentBranch, rootBranch)
 	newOpcodes := []shared.Opcode{}
 	for _, phantomMergeConflict := range phantomMergeConflicts {
 		newOpcodes = append(newOpcodes, &ConflictPhantomResolve{


### PR DESCRIPTION
This entire logic is only for detecting and resolving merge conflicts. In the future, we'll detect and handle rebase conflicts separately.