### PR TITLE
delete: rebase onto the correct branch

### DIFF
--- a/features/delete/stack/rebase_sync_strategy/dependent_changes.feature
+++ b/features/delete/stack/rebase_sync_strategy/dependent_changes.feature
@@ -29,17 +29,17 @@ Feature: deleting a branch from a stack with dependent changes
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                                    |
-      | branch-2 | git fetch --prune --tags                                   |
-      |          | git push origin :branch-2                                  |
-      |          | git checkout branch-3                                      |
-      | branch-3 | git pull                                                   |
-      |          | git -c rebase.updateRefs=false rebase --onto main branch-2 |
-      |          | git checkout --theirs file                                 |
-      |          | git add file                                               |
-      |          | GIT_EDITOR=true git rebase --continue                      |
-      |          | git push --force-with-lease                                |
-      |          | git branch -D branch-2                                     |
+      | BRANCH   | COMMAND                                                        |
+      | branch-2 | git fetch --prune --tags                                       |
+      |          | git push origin :branch-2                                      |
+      |          | git checkout branch-3                                          |
+      | branch-3 | git pull                                                       |
+      |          | git -c rebase.updateRefs=false rebase --onto branch-1 branch-2 |
+      |          | git checkout --theirs file                                     |
+      |          | git add file                                                   |
+      |          | GIT_EDITOR=true git rebase --continue                          |
+      |          | git push --force-with-lease                                    |
+      |          | git branch -D branch-2                                         |
     And the branches are now
       | REPOSITORY    | BRANCHES                 |
       | local, origin | main, branch-1, branch-3 |

--- a/features/delete/stack/rebase_sync_strategy/independent_changes.feature
+++ b/features/delete/stack/rebase_sync_strategy/independent_changes.feature
@@ -29,22 +29,19 @@ Feature: deleting a branch from a stack with independent changes
 
   Scenario: result
     Then Git Town runs the commands
-      | BRANCH   | COMMAND                                                    |
-      | branch-2 | git fetch --prune --tags                                   |
-      |          | git push origin :branch-2                                  |
-      |          | git checkout branch-3                                      |
-      | branch-3 | git pull                                                   |
-      |          | git -c rebase.updateRefs=false rebase --onto main branch-2 |
-      |          | git push --force-with-lease                                |
-      |          | git branch -D branch-2                                     |
-    # TODO: these commits are wrong.
-    # After removing branch-2, branch-3 no longer contains changes from branch-1.
-    # This is because it wrongly rebases branch-3 onto main, when it should rebase onto branch-1.
+      | BRANCH   | COMMAND                                                        |
+      | branch-2 | git fetch --prune --tags                                       |
+      |          | git push origin :branch-2                                      |
+      |          | git checkout branch-3                                          |
+      | branch-3 | git pull                                                       |
+      |          | git -c rebase.updateRefs=false rebase --onto branch-1 branch-2 |
+      |          | git push --force-with-lease                                    |
+      |          | git branch -D branch-2                                         |
     And these commits exist now
-      | BRANCH   | LOCATION      | MESSAGE         | FILE NAME | FILE CONTENT                                                         |
-      | main     | local, origin | main commit     | file      | line 0: main content\n\nline 1\n\nline 2\n\nline 3                   |
-      | branch-1 | local, origin | branch-1 commit | file      | line 0: main content\n\nline 1: branch-1 content\n\nline 2\n\nline 3 |
-      | branch-3 | local, origin | branch-3 commit | file      | line 0: main content\n\nline 1\n\nline 2\n\nline 3: branch-3 content |
+      | BRANCH   | LOCATION      | MESSAGE         | FILE NAME | FILE CONTENT                                                                           |
+      | main     | local, origin | main commit     | file      | line 0: main content\n\nline 1\n\nline 2\n\nline 3                                     |
+      | branch-1 | local, origin | branch-1 commit | file      | line 0: main content\n\nline 1: branch-1 content\n\nline 2\n\nline 3                   |
+      | branch-3 | local, origin | branch-3 commit | file      | line 0: main content\n\nline 1: branch-1 content\n\nline 2\n\nline 3: branch-3 content |
     And the branches are now
       | REPOSITORY    | BRANCHES                 |
       | local, origin | main, branch-1, branch-3 |

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -351,12 +351,16 @@ func deleteLocalBranch(prog, finalUndoProgram Mutable[program.Program], data del
 			descendents := data.config.NormalConfig.Lineage.Descendants(localBranchToDelete)
 			for _, descendent := range descendents {
 				if branchInfo, hasBranchInfo := data.branchesSnapshot.Branches.FindByLocalName(descendent).Get(); hasBranchInfo {
+					parent := data.config.NormalConfig.Lineage.Parent(descendent).GetOrElse(data.config.ValidatedConfigData.MainBranch)
+					if parent == localBranchToDelete {
+						parent = data.config.NormalConfig.Lineage.Parent(parent).GetOrElse(data.config.ValidatedConfigData.MainBranch)
+					}
 					sync.RemoveAncestorCommits(sync.RemoveAncestorCommitsArgs{
 						Ancestor:          localBranchToDelete.BranchName(),
 						Branch:            descendent,
 						HasTrackingBranch: branchInfo.HasTrackingBranch(),
 						Program:           prog,
-						RebaseOnto:        data.config.ValidatedConfigData.MainBranch,
+						RebaseOnto:        parent,
 					})
 				}
 			}


### PR DESCRIPTION
Removing commits when deleting a branch from a stack rebased onto the wrong
parent branch. This PR fixes that.
