### PR TITLE
Make RebaseOntoRemoveDeleted continuable

### DIFF
--- a/internal/state/runstate/save_load_test.go
+++ b/internal/state/runstate/save_load_test.go
@@ -92,6 +92,8 @@ func TestLoadSave(t *testing.T) {
 				&opcodes.ExecuteShellCommand{Args: []string{"arg1", "arg2"}, Executable: "executable"},
 				&opcodes.ExitToShell{},
 				&opcodes.FetchUpstream{Branch: "branch"},
+				&opcodes.FileRemove{FilePath: "file"},
+				&opcodes.FileStage{FilePath: "file"},
 				&opcodes.LineageBranchRemove{Branch: "branch"},
 				&opcodes.LineageParentRemove{Branch: "branch"},
 				&opcodes.LineageParentSet{Branch: "branch", Parent: "parent"},
@@ -465,6 +467,18 @@ func TestLoadSave(t *testing.T) {
         "Branch": "branch"
       },
       "type": "FetchUpstream"
+    },
+    {
+      "data": {
+        "FilePath": "file"
+      },
+      "type": "FileRemove"
+    },
+    {
+      "data": {
+        "FilePath": "file"
+      },
+      "type": "FileStage"
     },
     {
       "data": {

--- a/internal/vm/opcodes/all.go
+++ b/internal/vm/opcodes/all.go
@@ -59,6 +59,8 @@ func All() []shared.Opcode {
 		&ExecuteShellCommand{},
 		&ExitToShell{},
 		&FetchUpstream{},
+		&FileRemove{},
+		&FileStage{},
 		&LineageBranchRemove{},
 		&LineageParentRemove{},
 		&LineageParentSetFirstExisting{},

--- a/internal/vm/opcodes/file_remove.go
+++ b/internal/vm/opcodes/file_remove.go
@@ -1,0 +1,12 @@
+package opcodes
+
+import "github.com/git-town/git-town/v21/internal/vm/shared"
+
+type FileRemove struct {
+	FilePath                string
+	undeclaredOpcodeMethods `exhaustruct:"optional"`
+}
+
+func (self *FileRemove) Run(args shared.RunArgs) error {
+	return args.Git.RemoveFile(args.Frontend, self.FilePath)
+}

--- a/internal/vm/opcodes/file_stage.go
+++ b/internal/vm/opcodes/file_stage.go
@@ -1,0 +1,12 @@
+package opcodes
+
+import "github.com/git-town/git-town/v21/internal/vm/shared"
+
+type FileStage struct {
+	FilePath                string
+	undeclaredOpcodeMethods `exhaustruct:"optional"`
+}
+
+func (self *FileStage) Run(args shared.RunArgs) error {
+	return args.Git.StageFiles(args.Frontend, self.FilePath)
+}

--- a/internal/vm/opcodes/rebase_onto_remove_deleted.go
+++ b/internal/vm/opcodes/rebase_onto_remove_deleted.go
@@ -42,14 +42,25 @@ func (self *RebaseOntoRemoveDeleted) Run(args shared.RunArgs) error {
 	if err != nil {
 		return fmt.Errorf("cannot determine conflicting files after rebase: %w", err)
 	}
+	opcodes := []shared.Opcode{}
 	for _, conflictingFile := range conflictingFiles {
 		if conflictingChange, has := conflictingFile.CurrentBranchChange.Get(); has {
-			_ = args.Git.ResolveConflict(args.Frontend, conflictingChange.FilePath, gitdomain.ConflictResolutionTheirs)
-			_ = args.Git.StageFiles(args.Frontend, conflictingChange.FilePath)
+			opcodes = append(opcodes,
+				&ConflictResolve{
+					FilePath:   conflictingChange.FilePath,
+					Resolution: gitdomain.ConflictResolutionTheirs,
+				},
+				&FileStage{
+					FilePath: conflictingChange.FilePath,
+				},
+			)
 		} else if baseChange, has := conflictingFile.BaseChange.Get(); has {
-			_ = args.Git.RemoveFile(args.Frontend, baseChange.FilePath)
+			opcodes = append(opcodes, &FileRemove{
+				FilePath: baseChange.FilePath,
+			})
 		}
 	}
-	_ = args.Git.ContinueRebase(args.Frontend)
+	opcodes = append(opcodes, &RebaseContinue{})
+	args.PrependOpcodes(opcodes...)
 	return nil
 }


### PR DESCRIPTION
This helps protect against concurrently running Git operations.