### PR TITLE
Move function reading config data into SingleSnapshot

### DIFF
--- a/internal/config/configdomain/single_snapshot.go
+++ b/internal/config/configdomain/single_snapshot.go
@@ -1,5 +1,11 @@
 package configdomain
 
+import (
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	"github.com/git-town/git-town/v21/internal/subshell/subshelldomain"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
+)
+
 // SingleSnapshot contains all of the local or global Git metadata config settings.
 type SingleSnapshot map[Key]string
 
@@ -33,6 +39,15 @@ func (self SingleSnapshot) BranchTypeOverrideEntries() map[BranchTypeOverrideKey
 		}
 	}
 	return result
+}
+
+// TODO: make this a method of SingleSnapshot?
+func (self SingleSnapshot) DefaultBranch(querier subshelldomain.Querier) Option[gitdomain.LocalBranchName] {
+	text, has := self["init.defaultbranch"]
+	if !has {
+		return None[gitdomain.LocalBranchName]()
+	}
+	return Some(gitdomain.LocalBranchName(text))
 }
 
 // provides all the keys that describe lineage entries

--- a/internal/config/configdomain/single_snapshot.go
+++ b/internal/config/configdomain/single_snapshot.go
@@ -2,7 +2,6 @@ package configdomain
 
 import (
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
-	"github.com/git-town/git-town/v21/internal/subshell/subshelldomain"
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
@@ -41,7 +40,7 @@ func (self SingleSnapshot) BranchTypeOverrideEntries() map[BranchTypeOverrideKey
 	return result
 }
 
-func (self SingleSnapshot) DefaultBranch(querier subshelldomain.Querier) Option[gitdomain.LocalBranchName] {
+func (self SingleSnapshot) DefaultBranch() Option[gitdomain.LocalBranchName] {
 	text, has := self["init.defaultbranch"]
 	if !has {
 		return None[gitdomain.LocalBranchName]()

--- a/internal/config/configdomain/single_snapshot.go
+++ b/internal/config/configdomain/single_snapshot.go
@@ -41,7 +41,6 @@ func (self SingleSnapshot) BranchTypeOverrideEntries() map[BranchTypeOverrideKey
 	return result
 }
 
-// TODO: make this a method of SingleSnapshot?
 func (self SingleSnapshot) DefaultBranch(querier subshelldomain.Querier) Option[gitdomain.LocalBranchName] {
 	text, has := self["init.defaultbranch"]
 	if !has {

--- a/internal/config/configdomain/single_snapshot_test.go
+++ b/internal/config/configdomain/single_snapshot_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 func TestSingleSnapshot(t *testing.T) {
+	t.Parallel()
 	t.Run("DefaultBranch", func(t *testing.T) {
 		t.Parallel()
 		runtime := testruntime.Create(t)
 		runtime.SetDefaultGitBranch("custom")
 		snapshot := asserts.NoError1(gitconfig.LoadSnapshot(runtime.TestRunner, Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedNo))
-		have := snapshot.DefaultBranch(runtime)
+		have := snapshot.DefaultBranch()
 		want := gitdomain.NewLocalBranchNameOption("main")
 		must.Eq(t, want, have)
 	})

--- a/internal/config/configdomain/single_snapshot_test.go
+++ b/internal/config/configdomain/single_snapshot_test.go
@@ -1,0 +1,21 @@
+package configdomain_test
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	"github.com/git-town/git-town/v21/internal/test/testruntime"
+	"github.com/shoenig/test/must"
+)
+
+func TestSingleSnapshot(t *testing.T) {
+
+	t.Run("DefaultBranch", func(t *testing.T) {
+		t.Parallel()
+		runtime := testruntime.Create(t)
+		runtime.SetDefaultGitBranch("main")
+		have := gitconfig.DefaultBranch(runtime)
+		want := gitdomain.NewLocalBranchNameOption("main")
+		must.Eq(t, want, have)
+	})
+}

--- a/internal/config/configdomain/single_snapshot_test.go
+++ b/internal/config/configdomain/single_snapshot_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestSingleSnapshot(t *testing.T) {
-
 	t.Run("DefaultBranch", func(t *testing.T) {
 		t.Parallel()
 		runtime := testruntime.Create(t)

--- a/internal/config/configdomain/single_snapshot_test.go
+++ b/internal/config/configdomain/single_snapshot_test.go
@@ -3,8 +3,12 @@ package configdomain_test
 import (
 	"testing"
 
+	"github.com/git-town/git-town/v21/internal/config/configdomain"
+	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/test/testruntime"
+	"github.com/git-town/git-town/v21/pkg/asserts"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/shoenig/test/must"
 )
 
@@ -13,8 +17,9 @@ func TestSingleSnapshot(t *testing.T) {
 	t.Run("DefaultBranch", func(t *testing.T) {
 		t.Parallel()
 		runtime := testruntime.Create(t)
-		runtime.SetDefaultGitBranch("main")
-		have := gitconfig.DefaultBranch(runtime)
+		runtime.SetDefaultGitBranch("custom")
+		snapshot := asserts.NoError1(gitconfig.LoadSnapshot(runtime.TestRunner, Some(configdomain.ConfigScopeLocal), configdomain.UpdateOutdatedNo))
+		have := snapshot.DefaultBranch(runtime)
 		want := gitdomain.NewLocalBranchNameOption("main")
 		must.Eq(t, want, have)
 	})

--- a/internal/config/gitconfig/high_level.go
+++ b/internal/config/gitconfig/high_level.go
@@ -2,27 +2,12 @@ package gitconfig
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
 	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/subshell/subshelldomain"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
-
-// TODO: make this a method of SingleSnapshot?
-func DefaultBranch(querier subshelldomain.Querier) Option[gitdomain.LocalBranchName] {
-	name, err := querier.QueryTrim("git", "config", "--get", "init.defaultbranch")
-	if err != nil {
-		return None[gitdomain.LocalBranchName]()
-	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return None[gitdomain.LocalBranchName]()
-	}
-	return Some(gitdomain.LocalBranchName(name))
-}
 
 // TODO: make this a method of SingleSnapshot?
 func DefaultRemote(querier subshelldomain.Querier) gitdomain.Remote {

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
-	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/gohacks"
 	"github.com/git-town/git-town/v21/internal/gohacks/cache"
@@ -797,8 +796,8 @@ func (self *Commands) StageFiles(runner subshelldomain.Runner, names ...string) 
 }
 
 // determines the branch that is configured in Git as the default branch
-func (self *Commands) StandardBranch(querier subshelldomain.Querier) Option[gitdomain.LocalBranchName] {
-	if defaultBranch, has := gitconfig.DefaultBranch(querier).Get(); has {
+func (self *Commands) StandardBranch(querier subshelldomain.Querier, snapshot configdomain.SingleSnapshot) Option[gitdomain.LocalBranchName] {
+	if defaultBranch, has := snapshot.DefaultBranch(querier).Get(); has {
 		return Some(defaultBranch)
 	}
 	return self.OriginHead(querier)

--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -797,7 +797,7 @@ func (self *Commands) StageFiles(runner subshelldomain.Runner, names ...string) 
 
 // determines the branch that is configured in Git as the default branch
 func (self *Commands) StandardBranch(querier subshelldomain.Querier, snapshot configdomain.SingleSnapshot) Option[gitdomain.LocalBranchName] {
-	if defaultBranch, has := snapshot.DefaultBranch(querier).Get(); has {
+	if defaultBranch, has := snapshot.DefaultBranch().Get(); has {
 		return Some(defaultBranch)
 	}
 	return self.OriginHead(querier)

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
-	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/git"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
 	"github.com/git-town/git-town/v21/internal/gohacks"
@@ -970,15 +969,6 @@ func TestBackendCommands(t *testing.T) {
 			have := repo.Git.CurrentBranchHasTrackingBranch(repo)
 			must.False(t, have)
 		})
-	})
-
-	t.Run("DefaultBranch", func(t *testing.T) {
-		t.Parallel()
-		runtime := testruntime.Create(t)
-		runtime.SetDefaultGitBranch("main")
-		have := gitconfig.DefaultBranch(runtime)
-		want := gitdomain.NewLocalBranchNameOption("main")
-		must.Eq(t, want, have)
 	})
 
 	t.Run("DetectPhantomMergeConflicts", func(t *testing.T) {

--- a/internal/setup/enter.go
+++ b/internal/setup/enter.go
@@ -423,7 +423,7 @@ func enterMainBranch(data Data) (userChoice Option[gitdomain.LocalBranchName], a
 		Inputs:         data.Inputs,
 		Local:          data.Config.GitLocal.MainBranch,
 		LocalBranches:  data.LocalBranches,
-		StandardBranch: data.Git.StandardBranch(data.Backend, data.Snapshot),
+		StandardBranch: data.Git.StandardBranch(data.Backend, data.Snapshot.Unscoped),
 		Unscoped:       data.Config.GitUnscoped.MainBranch,
 	})
 }

--- a/internal/setup/enter.go
+++ b/internal/setup/enter.go
@@ -423,7 +423,7 @@ func enterMainBranch(data Data) (userChoice Option[gitdomain.LocalBranchName], a
 		Inputs:         data.Inputs,
 		Local:          data.Config.GitLocal.MainBranch,
 		LocalBranches:  data.LocalBranches,
-		StandardBranch: data.Git.StandardBranch(data.Backend),
+		StandardBranch: data.Git.StandardBranch(data.Backend, data.Snapshot),
 		Unscoped:       data.Config.GitUnscoped.MainBranch,
 	})
 }

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -108,10 +108,11 @@ func continueRunstate(runState runstate.RunState, args UnfinishedStateArgs) (dia
 		return false, errors.New(messages.ContinueUnresolvedConflicts)
 	}
 	validatedConfig, exit, err := quickValidateConfig(quickValidateConfigArgs{
-		backend:     args.Backend,
-		git:         args.Git,
-		inputs:      args.Inputs,
-		unvalidated: NewMutable(&args.UnvalidatedConfig),
+		backend:          args.Backend,
+		git:              args.Git,
+		inputs:           args.Inputs,
+		unscopedSnapshot: runState.BeginConfigSnapshot.Unscoped,
+		unvalidated:      NewMutable(&args.UnvalidatedConfig),
 	})
 	if err != nil || exit {
 		return exit, err
@@ -196,10 +197,11 @@ func skipRunstate(args UnfinishedStateArgs, runState runstate.RunState) (dialogd
 		return false, err
 	}
 	validatedConfig, exit, err := quickValidateConfig(quickValidateConfigArgs{
-		backend:     args.Backend,
-		git:         args.Git,
-		inputs:      args.Inputs,
-		unvalidated: NewMutable(&args.UnvalidatedConfig),
+		backend:          args.Backend,
+		git:              args.Git,
+		inputs:           args.Inputs,
+		unscopedSnapshot: runState.BeginConfigSnapshot.Unscoped,
+		unvalidated:      NewMutable(&args.UnvalidatedConfig),
 	})
 	if err != nil || exit {
 		return exit, err
@@ -223,10 +225,11 @@ func skipRunstate(args UnfinishedStateArgs, runState runstate.RunState) (dialogd
 
 func undoRunState(args UnfinishedStateArgs, runState runstate.RunState) (dialogdomain.Exit, error) {
 	validatedConfig, exit, err := quickValidateConfig(quickValidateConfigArgs{
-		backend:     args.Backend,
-		git:         args.Git,
-		inputs:      args.Inputs,
-		unvalidated: NewMutable(&args.UnvalidatedConfig),
+		backend:          args.Backend,
+		git:              args.Git,
+		inputs:           args.Inputs,
+		unscopedSnapshot: runState.BeginConfigSnapshot.Unscoped,
+		unvalidated:      NewMutable(&args.UnvalidatedConfig),
 	})
 	if err != nil || exit {
 		return exit, err

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -142,6 +142,14 @@ func discardRunstate(rootDir gitdomain.RepoRootDir) (dialogdomain.Exit, error) {
 	return false, err
 }
 
+type quickValidateConfigArgs struct {
+	backend          subshelldomain.RunnerQuerier
+	git              git.Commands
+	inputs           dialogcomponents.Inputs
+	unscopedSnapshot configdomain.SingleSnapshot
+	unvalidated      Mutable[config.UnvalidatedConfig]
+}
+
 // quickly provides a ValidatedConfig instance in situations where we continue runstate.
 // It is expected that all data exists.
 // This doesn't change lineage since we are in the middle of an ongoing Git Town operation.
@@ -158,7 +166,7 @@ func quickValidateConfig(args quickValidateConfigArgs) (config.ValidatedConfig, 
 			Inputs:         args.inputs,
 			Local:          args.unvalidated.Value.GitGlobal.MainBranch,
 			LocalBranches:  localBranches,
-			StandardBranch: args.git.StandardBranch(args.backend),
+			StandardBranch: args.git.StandardBranch(args.backend, args.unscopedSnapshot),
 			Unscoped:       args.unvalidated.Value.GitUnscoped.MainBranch,
 		})
 		if err != nil || exit {
@@ -237,11 +245,4 @@ func undoRunState(args UnfinishedStateArgs, runState runstate.RunState) (dialogd
 		RootDir:          args.RootDir,
 		RunState:         runState,
 	})
-}
-
-type quickValidateConfigArgs struct {
-	backend     subshelldomain.RunnerQuerier
-	git         git.Commands
-	inputs      dialogcomponents.Inputs
-	unvalidated Mutable[config.UnvalidatedConfig]
 }


### PR DESCRIPTION
This avoids unnecessary calls to Git.
