### PR TITLE
refactor: move swap cmd to dedicated folder

### DIFF
--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -5,6 +5,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/cmd/config"
 	"github.com/git-town/git-town/v21/internal/cmd/ship"
 	"github.com/git-town/git-town/v21/internal/cmd/status"
+	"github.com/git-town/git-town/v21/internal/cmd/swap"
 	"github.com/git-town/git-town/v21/internal/cmd/sync"
 )
 
@@ -37,7 +38,7 @@ func Execute() error {
 	rootCmd.AddCommand(setParentCommand())
 	rootCmd.AddCommand(ship.Cmd())
 	rootCmd.AddCommand(skipCmd())
-	rootCmd.AddCommand(swapCommand())
+	rootCmd.AddCommand(swap.Cmd())
 	rootCmd.AddCommand(switchCmd())
 	rootCmd.AddCommand(sync.Cmd())
 	rootCmd.AddCommand(undoCmd())

--- a/internal/cmd/swap/doc.go
+++ b/internal/cmd/swap/doc.go
@@ -1,2 +1,2 @@
-// Package swap provides functionality around swap Git branches.
+// Package swap implements the Git Town command to change the position of a Git branch within its stack.
 package swap

--- a/internal/cmd/swap/doc.go
+++ b/internal/cmd/swap/doc.go
@@ -1,0 +1,2 @@
+// Package swap provides functionality around swap Git branches.
+package swap

--- a/internal/cmd/swap/swap_git_operations_program.go
+++ b/internal/cmd/swap/swap_git_operations_program.go
@@ -1,0 +1,71 @@
+package swap
+
+import (
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	"github.com/git-town/git-town/v21/internal/vm/opcodes"
+	"github.com/git-town/git-town/v21/internal/vm/program"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
+)
+
+type swapGitOperationsProgramArgs struct {
+	branchToSwap        gitdomain.BranchInfo
+	childBranchesToSwap []swapChildBranch
+	grandParentBranch   gitdomain.LocalBranchName
+	parentBranch        gitdomain.BranchInfo
+	program             Mutable[program.Program]
+}
+
+func swapGitOperationsProgram(args swapGitOperationsProgramArgs) {
+	args.program.Value.Add(
+		&opcodes.RebaseOnto{
+			BranchToRebaseOnto: args.grandParentBranch.BranchName(),
+			CommitsToRemove:    args.parentBranch.LocalBranchName().Location(),
+		},
+	)
+
+	if args.branchToSwap.HasTrackingBranch() {
+		args.program.Value.Add(
+			&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: args.branchToSwap.LocalBranchName(), ForceIfIncludes: true},
+		)
+	}
+	args.program.Value.Add(
+		&opcodes.Checkout{
+			Branch: args.parentBranch.LocalBranchName(),
+		},
+		&opcodes.RebaseOnto{
+			BranchToRebaseOnto: args.branchToSwap.LocalBranchName().BranchName(),
+			CommitsToRemove:    args.grandParentBranch.Location(),
+		},
+	)
+	if args.parentBranch.HasTrackingBranch() {
+		args.program.Value.Add(
+			&opcodes.PushCurrentBranchForceIfNeeded{CurrentBranch: args.parentBranch.LocalBranchName(), ForceIfIncludes: true},
+		)
+	}
+	for _, child := range args.childBranchesToSwap {
+		args.program.Value.Add(
+			&opcodes.Checkout{
+				Branch: child.name,
+			},
+		)
+		oldBranchSHA, hasOldBranchSHA := args.branchToSwap.LocalSHA.Get()
+		if !hasOldBranchSHA {
+			oldBranchSHA = args.branchToSwap.RemoteSHA.GetOrDefault()
+		}
+		args.program.Value.Add(
+			&opcodes.RebaseOnto{
+				BranchToRebaseOnto: args.parentBranch.LocalBranchName().BranchName(),
+				CommitsToRemove:    oldBranchSHA.Location(),
+			},
+		)
+		if child.info.HasTrackingBranch() {
+			args.program.Value.Add(
+				&opcodes.PushCurrentBranchForceIfNeeded{
+					CurrentBranch:   child.name,
+					ForceIfIncludes: true,
+				},
+			)
+		}
+	}
+	args.program.Value.Add(&opcodes.CheckoutIfNeeded{Branch: args.branchToSwap.LocalBranchName()})
+}

--- a/internal/cmd/swap/swap_lineage_sets_program.go
+++ b/internal/cmd/swap/swap_lineage_sets_program.go
@@ -1,0 +1,37 @@
+package swap
+
+import (
+	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	"github.com/git-town/git-town/v21/internal/vm/opcodes"
+	"github.com/git-town/git-town/v21/internal/vm/program"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
+)
+
+type swapLineageParentSetsProgramArg struct {
+	branchToSwap      gitdomain.LocalBranchName
+	childBranches     []swapChildBranch
+	grandParentBranch gitdomain.LocalBranchName
+	parentBranch      gitdomain.LocalBranchName
+	program           Mutable[program.Program]
+}
+
+func swapLineageParentSetsProgram(args swapLineageParentSetsProgramArg) {
+	args.program.Value.Add(
+		&opcodes.LineageParentSet{
+			Branch: args.branchToSwap,
+			Parent: args.grandParentBranch,
+		},
+		&opcodes.LineageParentSet{
+			Branch: args.parentBranch,
+			Parent: args.branchToSwap,
+		},
+	)
+	for _, child := range args.childBranches {
+		args.program.Value.Add(
+			&opcodes.LineageParentSet{
+				Branch: child.name,
+				Parent: args.parentBranch,
+			},
+		)
+	}
+}


### PR DESCRIPTION
Refactors swap command under dedicated folder. Follow up PRs will add two more program methods that update proposal targets and proposal body with lineage information after a swap occurs

## Changes
- Moved swap command from `internal/cmd/swap.go` to `internal/cmd/swap/cmd.go`
- Extracted git operations logic into `swap_git_operations_program.go`
- Extracted lineage parent set logic into `swap_lineage_sets_program.go`
- Updated function visibility (exported `Cmd()` instead of internal `swapCommand()`)

## Testing
Existing tests pass. No functionality changes.

<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5401 :point_left:
     - https://github.com/git-town/git-town/pull/5423
       - https://github.com/git-town/git-town/pull/5424

Stack generated by [Git-Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->