### PR TITLE
[internal/cmd/swap] enhance: update proposal stack lineage during git-town swap

### DIFF
--- a/internal/cmd/swap/cmd.go
+++ b/internal/cmd/swap/cmd.go
@@ -378,6 +378,17 @@ func swapProgram(repo execute.OpenRepoResult, data swapData, finalMessages strin
 			program:     prog,
 		})
 	}
+	connector, hasConnector := data.connector.Get()
+	if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
+		swapUpdateProposalStackLineagesProgram(
+			prog,
+			forge.ProposalStackLineageArgs{
+				Connector:                connector,
+				CurrentBranch:            data.currentBranchName,
+				Lineage:                  data.config.NormalConfig.Lineage,
+				MainAndPerennialBranches: data.config.MainAndPerennials(),
+			})
+	}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.config.NormalConfig.DryRun,
 		InitialStashSize:         data.stashSize,

--- a/internal/cmd/swap/cmd.go
+++ b/internal/cmd/swap/cmd.go
@@ -380,16 +380,13 @@ func swapProgram(repo execute.OpenRepoResult, data swapData, finalMessages strin
 	}
 	connector, hasConnector := data.connector.Get()
 	if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
-		proposalFinder, canFindProposals := connector.(forgedomain.ProposalFinder)
-		if canFindProposals {
-			swapUpdateProposalStackLineagesProgram(
-				prog,
-				forge.ProposalStackLineageArgs{
-					Connector:                proposalFinder,
-					CurrentBranch:            data.currentBranchName,
-					Lineage:                  data.config.NormalConfig.Lineage,
-					MainAndPerennialBranches: data.config.MainAndPerennials(),
-				})
+		if proposalFinder, canFindProposals := connector.(forgedomain.ProposalFinder); canFindProposals {
+			swapUpdateProposalStackLineagesProgram(prog, forge.ProposalStackLineageArgs{
+				Connector:                proposalFinder,
+				CurrentBranch:            data.currentBranchName,
+				Lineage:                  data.config.NormalConfig.Lineage,
+				MainAndPerennialBranches: data.config.MainAndPerennials(),
+			})
 		}
 	}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{

--- a/internal/cmd/swap/cmd.go
+++ b/internal/cmd/swap/cmd.go
@@ -380,14 +380,17 @@ func swapProgram(repo execute.OpenRepoResult, data swapData, finalMessages strin
 	}
 	connector, hasConnector := data.connector.Get()
 	if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
-		swapUpdateProposalStackLineagesProgram(
-			prog,
-			forge.ProposalStackLineageArgs{
-				Connector:                connector,
-				CurrentBranch:            data.currentBranchName,
-				Lineage:                  data.config.NormalConfig.Lineage,
-				MainAndPerennialBranches: data.config.MainAndPerennials(),
-			})
+		proposalFinder, canFindProposals := connector.(forgedomain.ProposalFinder)
+		if canFindProposals {
+			swapUpdateProposalStackLineagesProgram(
+				prog,
+				forge.ProposalStackLineageArgs{
+					Connector:                proposalFinder,
+					CurrentBranch:            data.currentBranchName,
+					Lineage:                  data.config.NormalConfig.Lineage,
+					MainAndPerennialBranches: data.config.MainAndPerennials(),
+				})
+		}
 	}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.config.NormalConfig.DryRun,

--- a/internal/cmd/swap/swap_update_proposal_stack_lineages_program.go
+++ b/internal/cmd/swap/swap_update_proposal_stack_lineages_program.go
@@ -1,0 +1,34 @@
+package swap
+
+import (
+	"github.com/git-town/git-town/v21/internal/forge"
+	"github.com/git-town/git-town/v21/internal/vm/opcodes"
+	"github.com/git-town/git-town/v21/internal/vm/program"
+	. "github.com/git-town/git-town/v21/pkg/prelude"
+)
+
+func swapUpdateProposalStackLineagesProgram(program Mutable[program.Program], proposalStackLineageArgs forge.ProposalStackLineageArgs) {
+	// TODO: the proposal stack lineage builder executes its own GetProposalFn calls. Some of
+	// these calls are duplicative because similar calls are completed upstream. A separate
+	// enhancement is needed to reduce duplicative GetProposalFn calls through the forge
+	// connectors.
+	//
+	// NOTE: NewProposalStackLineageBuilder method stores all the proposals found in the stack lineage
+	// in map for fast retrieve through the GetProposals used below.
+	builder, hasBuilder := forge.NewProposalStackLineageBuilder(proposalStackLineageArgs).Get()
+	if !hasBuilder {
+		return
+	}
+
+	for _, proposal := range builder.GetProposals() {
+		program.Value.Add(&opcodes.ProposalUpdateBody{
+			Proposal: proposal,
+			UpdatedBody: forge.ProposalBodyUpdateWithStackLineage(proposal.Data.Data().Body.GetOrDefault(), builder.Build(forge.ProposalStackLineageArgs{
+				Connector:                proposalStackLineageArgs.Connector,
+				CurrentBranch:            proposal.Data.Data().Source,
+				Lineage:                  proposalStackLineageArgs.Lineage,
+				MainAndPerennialBranches: proposalStackLineageArgs.MainAndPerennialBranches,
+			})),
+		})
+	}
+}


### PR DESCRIPTION
## Context

Add opcode to update proposal stack lineage in proposal bodies impacted by the swap command

## Test Plan

- [x] Stack lineage updated on proposals with branches that were swapped
- [x] Stack lineage is updated for all other proposals involved in the stack lineage


<div>
    <a href="https://www.loom.com/share/75648fe270664094aceb877106e55828">
      <p>GitSwap: Updating Proposals and Lineage in Your Development Workflow 🚀 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/75648fe270664094aceb877106e55828">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/75648fe270664094aceb877106e55828-5069338798209661-full-play.gif">
    </a>
  </div>

<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5424 :point_left:

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->