### PR TITLE
Remove obsolete todo

### DIFF
--- a/features/sync/stack/rebase_sync_strategy/sibling_shipped/conflicting_changes.feature
+++ b/features/sync/stack/rebase_sync_strategy/sibling_shipped/conflicting_changes.feature
@@ -60,7 +60,6 @@ Feature: conflicting sibling branches, one gets shipped, the other syncs afterwa
       |          |               | commit 1    | file      | line 1: branch-1 content\nline 2                   |
       | branch-1 | local         | commit 1    | file      | line 1: branch-1 content\nline 2                   |
       | branch-2 | local, origin | commit 2    | file      | line 1: branch-1 content\nline 2: branch-2 content |
-    # TODO: this should remove the local branch-1, but doesn't
     And this lineage exists now
       | BRANCH   | PARENT |
       | branch-1 | main   |


### PR DESCRIPTION
This E2E test only runs "git-town sync", which syncs only the current branch. It
doesn't clean up the sibling branch because it shouldn't do that in this
situation.
