### PR TITLE
Make bool parsing generic

### DIFF
--- a/internal/cli/flags/auto_resolve.go
+++ b/internal/cli/flags/auto_resolve.go
@@ -24,8 +24,7 @@ func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
 		if err != nil {
 			return None[configdomain.AutoResolve](), err
 		}
-		parsed, err := gohacks.ParseBool[configdomain.AutoResolve](text, autoResolveLong)
-		return Some(configdomain.AutoResolve(parsed)), err
+		return gohacks.ParseBoolOpt[configdomain.AutoResolve](text, autoResolveLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/auto_resolve.go
+++ b/internal/cli/flags/auto_resolve.go
@@ -24,7 +24,7 @@ func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
 		if err != nil {
 			return None[configdomain.AutoResolve](), err
 		}
-		parsed, err := gohacks.ParseBool(text, autoResolveLong)
+		parsed, err := gohacks.ParseBool[configdomain.AutoResolve](text, autoResolveLong)
 		return Some(configdomain.AutoResolve(parsed)), err
 	}
 	return addFlag, readFlag

--- a/internal/cmd/offline.go
+++ b/internal/cmd/offline.go
@@ -94,6 +94,6 @@ func setOfflineStatus(text string, runner subshelldomain.Runner) error {
 	if err != nil {
 		return fmt.Errorf(messages.ValueInvalid, configdomain.KeyOffline, text)
 	}
-	return gitconfig.SetOffline(runner, configdomain.Offline(value))
+	return gitconfig.SetOffline(runner, value)
 	// in the future, we could remove the offline setting here
 }

--- a/internal/cmd/offline.go
+++ b/internal/cmd/offline.go
@@ -90,7 +90,7 @@ func displayOfflineStatus(config config.UnvalidatedConfig) {
 }
 
 func setOfflineStatus(text string, runner subshelldomain.Runner) error {
-	value, err := gohacks.ParseBool(text, "offline status")
+	value, err := gohacks.ParseBool[configdomain.Offline](text, "offline status")
 	if err != nil {
 		return fmt.Errorf(messages.ValueInvalid, configdomain.KeyOffline, text)
 	}

--- a/internal/config/configdomain/auto_resolve.go
+++ b/internal/config/configdomain/auto_resolve.go
@@ -1,10 +1,5 @@
 package configdomain
 
-import (
-	"github.com/git-town/git-town/v21/internal/gohacks"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
-)
-
 // indicates whether a Git Town command should not auto-resolve phantom merge conflicts
 type AutoResolve bool
 
@@ -14,12 +9,4 @@ func (self AutoResolve) NoAutoResolve() bool {
 
 func (self AutoResolve) ShouldAutoResolve() bool {
 	return bool(self)
-}
-
-func ParseAutoResolve(value string, source Key) (Option[AutoResolve], error) {
-	parsedOpt, err := gohacks.ParseBoolOpt(value, source.String())
-	if parsed, has := parsedOpt.Get(); has {
-		return Some(AutoResolve(parsed)), err
-	}
-	return None[AutoResolve](), err
 }

--- a/internal/config/configdomain/offline.go
+++ b/internal/config/configdomain/offline.go
@@ -2,9 +2,6 @@ package configdomain
 
 import (
 	"strconv"
-
-	"github.com/git-town/git-town/v21/internal/gohacks"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
 // Offline is a new-type for the "offline" configuration setting.
@@ -20,12 +17,4 @@ func (self Offline) IsOnline() bool {
 
 func (self Offline) String() string {
 	return strconv.FormatBool(self.IsOffline())
-}
-
-func ParseOffline(value string, source Key) (Option[Offline], error) {
-	parsedOpt, err := gohacks.ParseBoolOpt(value, source.String())
-	if parsed, has := parsedOpt.Get(); has {
-		return Some(Offline(parsed)), err
-	}
-	return None[Offline](), err
 }

--- a/internal/config/configdomain/push_hook.go
+++ b/internal/config/configdomain/push_hook.go
@@ -1,11 +1,6 @@
 package configdomain
 
-import (
-	"strconv"
-
-	"github.com/git-town/git-town/v21/internal/gohacks"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
-)
+import "strconv"
 
 // PushHook contains the push-hook configuration setting.
 type PushHook bool
@@ -21,14 +16,6 @@ func (self PushHook) Negate() NoPushHook {
 
 func (self PushHook) String() string {
 	return strconv.FormatBool(bool(self))
-}
-
-func ParsePushHook(value string, source Key) (Option[PushHook], error) {
-	parsedOpt, err := gohacks.ParseBoolOpt(value, source.String())
-	if parsed, has := parsedOpt.Get(); has {
-		return Some(PushHook(parsed)), err
-	}
-	return None[PushHook](), err
 }
 
 // NoPushHook helps using the type checker to verify correct negation of the push-hook configuration setting.

--- a/internal/config/configdomain/ship_delete_tracking_branch.go
+++ b/internal/config/configdomain/ship_delete_tracking_branch.go
@@ -1,11 +1,6 @@
 package configdomain
 
-import (
-	"strconv"
-
-	"github.com/git-town/git-town/v21/internal/gohacks"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
-)
+import "strconv"
 
 // ShipDeleteTrackingBranch contains the configuration setting about whether to delete the tracking branch when shipping.
 type ShipDeleteTrackingBranch bool
@@ -16,12 +11,4 @@ func (self ShipDeleteTrackingBranch) IsTrue() bool {
 
 func (self ShipDeleteTrackingBranch) String() string {
 	return strconv.FormatBool(bool(self))
-}
-
-func ParseShipDeleteTrackingBranch(value string, source Key) (Option[ShipDeleteTrackingBranch], error) {
-	parsedOpt, err := gohacks.ParseBoolOpt(value, source.String())
-	if parsed, has := parsedOpt.Get(); has {
-		return Some(ShipDeleteTrackingBranch(parsed)), err
-	}
-	return None[ShipDeleteTrackingBranch](), err
 }

--- a/internal/config/configdomain/ship_delete_tracking_branch_test.go
+++ b/internal/config/configdomain/ship_delete_tracking_branch_test.go
@@ -4,41 +4,17 @@ import (
 	"testing"
 
 	"github.com/git-town/git-town/v21/internal/config/configdomain"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
 	"github.com/shoenig/test/must"
 )
 
 func TestShipDeleteTrackingBranch(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Bool", func(t *testing.T) {
+	t.Run("IsTrue", func(t *testing.T) {
 		t.Parallel()
 		give := configdomain.ShipDeleteTrackingBranch(true)
 		have := give.IsTrue()
 		must.True(t, have)
-	})
-
-	t.Run("ParseShipDeleteTrackingBranch", func(t *testing.T) {
-		t.Parallel()
-		t.Run("parsable value", func(t *testing.T) {
-			t.Parallel()
-			have, err := configdomain.ParseShipDeleteTrackingBranch("yes", "test")
-			must.NoError(t, err)
-			want := Some(configdomain.ShipDeleteTrackingBranch(true))
-			must.Eq(t, want, have)
-		})
-		t.Run("empty value", func(t *testing.T) {
-			t.Parallel()
-			have, err := configdomain.ParseShipDeleteTrackingBranch("", "test")
-			must.NoError(t, err)
-			want := None[configdomain.ShipDeleteTrackingBranch]()
-			must.Eq(t, want, have)
-		})
-		t.Run("invalid value", func(t *testing.T) {
-			t.Parallel()
-			_, err := configdomain.ParseShipDeleteTrackingBranch("zonk", "local config")
-			must.EqOp(t, `invalid value for local config: "zonk". Please provide either "yes" or "no"`, err.Error())
-		})
 	})
 
 	t.Run("String", func(t *testing.T) {

--- a/internal/config/configdomain/sync_tags.go
+++ b/internal/config/configdomain/sync_tags.go
@@ -1,11 +1,6 @@
 package configdomain
 
-import (
-	"strconv"
-
-	"github.com/git-town/git-town/v21/internal/gohacks"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
-)
+import "strconv"
 
 // SyncTags contains the configuration setting whether to sync Git tags.
 type SyncTags bool
@@ -20,12 +15,4 @@ func (self SyncTags) IsTrue() bool {
 
 func (self SyncTags) String() string {
 	return strconv.FormatBool(self.IsTrue())
-}
-
-func ParseSyncTags(value string, source Key) (Option[SyncTags], error) {
-	parsedOpt, err := gohacks.ParseBoolOpt(value, source.String())
-	if parsed, has := parsedOpt.Get(); has {
-		return Some(SyncTags(parsed)), err
-	}
-	return None[SyncTags](), err
 }

--- a/internal/config/configdomain/sync_upstream.go
+++ b/internal/config/configdomain/sync_upstream.go
@@ -1,11 +1,6 @@
 package configdomain
 
-import (
-	"strconv"
-
-	"github.com/git-town/git-town/v21/internal/gohacks"
-	. "github.com/git-town/git-town/v21/pkg/prelude"
-)
+import "strconv"
 
 // SyncUpstream contains the configuration setting whether to sync with the upstream remote.
 type SyncUpstream bool
@@ -16,12 +11,4 @@ func (self SyncUpstream) IsTrue() bool {
 
 func (self SyncUpstream) String() string {
 	return strconv.FormatBool(bool(self))
-}
-
-func ParseSyncUpstream(value string, source Key) (Option[SyncUpstream], error) {
-	parsedOpt, err := gohacks.ParseBoolOpt(value, source.String())
-	if parsed, has := parsedOpt.Get(); has {
-		return Some(SyncUpstream(parsed)), err
-	}
-	return None[SyncUpstream](), err
 }

--- a/internal/config/parse_snapshot.go
+++ b/internal/config/parse_snapshot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/git-town/git-town/v21/internal/config/gitconfig"
 	"github.com/git-town/git-town/v21/internal/forge/forgedomain"
 	"github.com/git-town/git-town/v21/internal/git/gitdomain"
+	"github.com/git-town/git-town/v21/internal/gohacks"
 	"github.com/git-town/git-town/v21/internal/messages"
 	"github.com/git-town/git-town/v21/internal/subshell/subshelldomain"
 	"github.com/git-town/git-town/v21/pkg/colors"
@@ -77,7 +78,7 @@ func NewLineageFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated
 
 func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOutdated bool, runner subshelldomain.Runner) (configdomain.PartialConfig, error) {
 	aliases := snapshot.Aliases()
-	autoResolve, errAutoResolve := configdomain.ParseAutoResolve(snapshot[configdomain.KeyAutoResolve], configdomain.KeyAutoResolve)
+	autoResolve, errAutoResolve := gohacks.ParseBoolOpt[configdomain.AutoResolve](snapshot[configdomain.KeyAutoResolve], configdomain.KeyAutoResolve.String())
 	branchTypeOverrides, errBranchTypeOverride := NewBranchTypeOverridesInSnapshot(snapshot, runner)
 	contributionRegex, errContributionRegex := configdomain.ParseContributionRegex(snapshot[configdomain.KeyContributionRegex])
 	featureRegex, errFeatureRegex := configdomain.ParseFeatureRegex(snapshot[configdomain.KeyFeatureRegex])
@@ -88,18 +89,18 @@ func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOu
 	newBranchTypeValue, errNewBranchType := configdomain.ParseBranchType(snapshot[configdomain.KeyNewBranchType])
 	newBranchType := configdomain.NewBranchTypeOpt(newBranchTypeValue)
 	observedRegex, errObservedRegex := configdomain.ParseObservedRegex(snapshot[configdomain.KeyObservedRegex])
-	offline, errOffline := configdomain.ParseOffline(snapshot[configdomain.KeyOffline], configdomain.KeyOffline)
+	offline, errOffline := gohacks.ParseBoolOpt[configdomain.Offline](snapshot[configdomain.KeyOffline], configdomain.KeyOffline.String())
 	perennialRegex, errPerennialRegex := configdomain.ParsePerennialRegex(snapshot[configdomain.KeyPerennialRegex])
 	proposalsShowLineage, errProposalsShowLineage := forgedomain.ParseProposalsShowLineage(snapshot[configdomain.KeyProposalsShowLineage])
-	pushHook, errPushHook := configdomain.ParsePushHook(snapshot[configdomain.KeyPushHook], configdomain.KeyPushHook)
+	pushHook, errPushHook := gohacks.ParseBoolOpt[configdomain.PushHook](snapshot[configdomain.KeyPushHook], configdomain.KeyPushHook.String())
 	shareNewBranches, errShareNewBranches := configdomain.ParseShareNewBranches(snapshot[configdomain.KeyShareNewBranches], configdomain.KeyShareNewBranches)
-	shipDeleteTrackingBranch, errShipDeleteTrackingBranch := configdomain.ParseShipDeleteTrackingBranch(snapshot[configdomain.KeyShipDeleteTrackingBranch], configdomain.KeyShipDeleteTrackingBranch)
+	shipDeleteTrackingBranch, errShipDeleteTrackingBranch := gohacks.ParseBoolOpt[configdomain.ShipDeleteTrackingBranch](snapshot[configdomain.KeyShipDeleteTrackingBranch], configdomain.KeyShipDeleteTrackingBranch.String())
 	shipStrategy, errShipStrategy := configdomain.ParseShipStrategy(snapshot[configdomain.KeyShipStrategy])
 	syncFeatureStrategy, errSyncFeatureStrategy := configdomain.ParseSyncFeatureStrategy(snapshot[configdomain.KeySyncFeatureStrategy])
 	syncPerennialStrategy, errSyncPerennialStrategy := configdomain.ParseSyncPerennialStrategy(snapshot[configdomain.KeySyncPerennialStrategy])
 	syncPrototypeStrategy, errSyncPrototypeStrategy := configdomain.ParseSyncPrototypeStrategy(snapshot[configdomain.KeySyncPrototypeStrategy])
-	syncTags, errSyncTags := configdomain.ParseSyncTags(snapshot[configdomain.KeySyncTags], configdomain.KeySyncTags)
-	syncUpstream, errSyncUpstream := configdomain.ParseSyncUpstream(snapshot[configdomain.KeySyncUpstream], configdomain.KeySyncUpstream)
+	syncTags, errSyncTags := gohacks.ParseBoolOpt[configdomain.SyncTags](snapshot[configdomain.KeySyncTags], configdomain.KeySyncTags.String())
+	syncUpstream, errSyncUpstream := gohacks.ParseBoolOpt[configdomain.SyncUpstream](snapshot[configdomain.KeySyncUpstream], configdomain.KeySyncUpstream.String())
 	unknownBranchTypeValue, errUnknownBranchType := configdomain.ParseBranchType(snapshot[configdomain.KeyUnknownBranchType])
 	unknownBranchType := configdomain.UnknownBranchTypeOpt(unknownBranchTypeValue)
 	err := cmp.Or(

--- a/internal/forge/forgedomain/proposals_show_lineage.go
+++ b/internal/forge/forgedomain/proposals_show_lineage.go
@@ -33,7 +33,7 @@ func ParseProposalsShowLineage(value string) (Option[ProposalsShowLineage], erro
 	case ProposalsShowLineageCLI.String():
 		return Some(ProposalsShowLineageCLI), nil
 	}
-	parsedOpt, err := gohacks.ParseBoolOpt(value, "proposals-show-lineage")
+	parsedOpt, err := gohacks.ParseBoolOpt[bool](value, "proposals-show-lineage")
 	if err != nil {
 		return None[ProposalsShowLineage](), fmt.Errorf(messages.ProposalsShowLineageInvalid, value)
 	}

--- a/internal/gohacks/parse_bool.go
+++ b/internal/gohacks/parse_bool.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
-func ParseBool(text, source string) (bool, error) {
+func ParseBool[T ~bool](text, source string) (T, error) {
 	switch strings.ToLower(text) {
 	case "":
 		return false, fmt.Errorf(messages.ValueInvalid, source, text)
@@ -18,17 +18,17 @@ func ParseBool(text, source string) (bool, error) {
 	case "no", "n", "off", "disable", "disabled":
 		return false, nil
 	}
-	result, err := strconv.ParseBool(text)
+	parsed, err := strconv.ParseBool(text)
 	if err != nil {
 		return false, fmt.Errorf(messages.ValueInvalid, source, text)
 	}
-	return result, nil
+	return T(parsed), nil
 }
 
-func ParseBoolOpt(text, source string) (Option[bool], error) {
+func ParseBoolOpt[T ~bool](text, source string) (Option[T], error) {
 	if text == "" {
-		return None[bool](), nil
+		return None[T](), nil
 	}
-	result, err := ParseBool(text, source)
-	return Some(result), err
+	parsed, err := ParseBool[T](text, source)
+	return Some(T(parsed)), err
 }

--- a/internal/gohacks/parse_bool.go
+++ b/internal/gohacks/parse_bool.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/git-town/git-town/v21/pkg/prelude"
 )
 
-func ParseBool[T ~bool](text, source string) (T, error) {
+func ParseBool[T ~bool](text, source string) (T, error) { //nolint:ireturn
 	switch strings.ToLower(text) {
 	case "":
 		return false, fmt.Errorf(messages.ValueInvalid, source, text)
@@ -30,5 +30,5 @@ func ParseBoolOpt[T ~bool](text, source string) (Option[T], error) {
 		return None[T](), nil
 	}
 	parsed, err := ParseBool[T](text, source)
-	return Some(T(parsed)), err
+	return Some(parsed), err
 }

--- a/internal/gohacks/parse_bool_test.go
+++ b/internal/gohacks/parse_bool_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/shoenig/test/must"
 )
 
+type MyBool bool
+
 func TestParseBool(t *testing.T) {
 	t.Parallel()
 
@@ -15,7 +17,7 @@ func TestParseBool(t *testing.T) {
 		t.Parallel()
 		t.Run("valid inputs", func(t *testing.T) {
 			t.Parallel()
-			tests := map[string]bool{
+			tests := map[string]MyBool{
 				"y":        true,
 				"Y":        true,
 				"yes":      true,
@@ -36,7 +38,7 @@ func TestParseBool(t *testing.T) {
 				"0":        false,
 			}
 			for give, want := range tests {
-				have, err := gohacks.ParseBool(give, "test")
+				have, err := gohacks.ParseBool[MyBool](give, "test")
 				must.NoError(t, err)
 				must.Eq(t, want, have)
 			}
@@ -46,7 +48,7 @@ func TestParseBool(t *testing.T) {
 			t.Parallel()
 			tests := []string{"", "zonk"}
 			for _, give := range tests {
-				_, err := gohacks.ParseBool(give, "test")
+				_, err := gohacks.ParseBool[MyBool](give, "test")
 				must.Error(t, err)
 			}
 		})
@@ -54,32 +56,32 @@ func TestParseBool(t *testing.T) {
 
 	t.Run("ParseBoolOpt", func(t *testing.T) {
 		t.Parallel()
-		tests := map[string]Option[bool]{
-			"":         None[bool](),
-			"yes":      Some(true),
-			"Yes":      Some(true),
-			"YES":      Some(true),
-			"no":       Some(false),
-			"on":       Some(true),
-			"off":      Some(false),
-			"true":     Some(true),
-			"false":    Some(false),
-			"enable":   Some(true),
-			"enabled":  Some(true),
-			"disable":  Some(false),
-			"disabled": Some(false),
-			"1":        Some(true),
-			"0":        Some(false),
+		tests := map[string]Option[MyBool]{
+			"":         None[MyBool](),
+			"yes":      Some(MyBool(true)),
+			"Yes":      Some(MyBool(true)),
+			"YES":      Some(MyBool(true)),
+			"no":       Some(MyBool(false)),
+			"on":       Some(MyBool(true)),
+			"off":      Some(MyBool(false)),
+			"true":     Some(MyBool(true)),
+			"false":    Some(MyBool(false)),
+			"enable":   Some(MyBool(true)),
+			"enabled":  Some(MyBool(true)),
+			"disable":  Some(MyBool(false)),
+			"disabled": Some(MyBool(false)),
+			"1":        Some(MyBool(true)),
+			"0":        Some(MyBool(false)),
 		}
 		for give, want := range tests {
-			have, err := gohacks.ParseBoolOpt(give, "test")
+			have, err := gohacks.ParseBoolOpt[MyBool](give, "test")
 			must.NoError(t, err)
 			must.Eq(t, want, have)
 		}
 
 		t.Run("invalid input", func(t *testing.T) {
 			t.Parallel()
-			_, err := gohacks.ParseBoolOpt("zonk", "test")
+			_, err := gohacks.ParseBoolOpt[MyBool]("zonk", "test")
 			must.Error(t, err)
 		})
 	})


### PR DESCRIPTION
This allows us to get rid of the repetitive and low-level parse methods for all
the bool newtypes.
