### PR TITLE
Flag helper functions

### DIFF
--- a/internal/cli/flags/all.go
+++ b/internal/cli/flags/all.go
@@ -13,8 +13,7 @@ func All(desc string) (AddFunc, ReadAllFlagFunc) {
 		cmd.Flags().BoolP(allLong, "a", false, desc)
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.AllBranches, error) {
-		value, err := cmd.Flags().GetBool(allLong)
-		return configdomain.AllBranches(value), err
+		return readBoolFlag[configdomain.AllBranches](cmd.Flags(), allLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/all.go
+++ b/internal/cli/flags/all.go
@@ -13,7 +13,7 @@ func All(desc string) (AddFunc, ReadAllFlagFunc) {
 		cmd.Flags().BoolP(allLong, "a", false, desc)
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.AllBranches, error) {
-		return readBoolFlag[configdomain.AllBranches](cmd.Flags(), allLong)
+		return readBoolFlag[configdomain.AllBranches](cmd, allLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/auto_resolve.go
+++ b/internal/cli/flags/auto_resolve.go
@@ -14,14 +14,7 @@ const (
 // type-safe access to the CLI arguments of type configdomain.AutoResolve
 func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		// Defining a string flag here, even though this is technically a bool flag,
-		// so that we can parse it using our expanded bool syntax.
-		flags := cmd.Flags()
-		flags.Bool(autoResolveLong, true, "whether to auto-resolve phantom merge conflicts")
-		flags.Bool(noAutoResolve, false, "")
-		if err := flags.MarkHidden(noAutoResolve); err != nil {
-			panic(err)
-		}
+		defineNegatableBoolFlag(cmd.Flags(), autoResolveLong)
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.AutoResolve], error) {
 		flags := cmd.Flags()

--- a/internal/cli/flags/auto_resolve.go
+++ b/internal/cli/flags/auto_resolve.go
@@ -6,10 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	autoResolveLong = "auto-resolve"
-	noAutoResolve   = "no-" + autoResolveLong
-)
+const autoResolveLong = "auto-resolve"
 
 // type-safe access to the CLI arguments of type configdomain.AutoResolve
 func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
@@ -17,22 +14,7 @@ func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
 		defineNegatableBoolFlag(cmd.Flags(), autoResolveLong)
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.AutoResolve], error) {
-		flags := cmd.Flags()
-		if flags.Changed(autoResolveLong) {
-			value, err := flags.GetBool(autoResolveLong)
-			if err != nil {
-				return None[configdomain.AutoResolve](), err
-			}
-			return Some(configdomain.AutoResolve(value)), nil
-		}
-		if flags.Changed(noAutoResolve) {
-			value, err := flags.GetBool(noAutoResolve)
-			if err != nil {
-				return None[configdomain.AutoResolve](), err
-			}
-			return Some(configdomain.AutoResolve(!value)), nil
-		}
-		return None[configdomain.AutoResolve](), nil
+		return readNegatableBoolFlag[configdomain.AutoResolve](cmd.Flags(), autoResolveLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/auto_resolve.go
+++ b/internal/cli/flags/auto_resolve.go
@@ -16,7 +16,6 @@ func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
 		cmd.Flags().Bool(autoResolveLong, autoResolveDefault, "whether to auto-resolve phantom merge conflicts")
 		defineNegatedFlag(cmd.Flags(), autoResolveLong, autoResolveDefault)
-
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.AutoResolve], error) {
 		return readNegatableFlag[configdomain.AutoResolve](cmd.Flags(), autoResolveLong)

--- a/internal/cli/flags/auto_resolve.go
+++ b/internal/cli/flags/auto_resolve.go
@@ -6,13 +6,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const autoResolveLong = "auto-resolve"
+const (
+	autoResolveLong    = "auto-resolve"
+	autoResolveDefault = true
+)
 
 // type-safe access to the CLI arguments of type configdomain.AutoResolve
 func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.Flags().Bool(autoResolveLong, true, "whether to auto-resolve phantom merge conflicts")
-		defineNegatedFlag(cmd.Flags(), autoResolveLong)
+		cmd.Flags().Bool(autoResolveLong, autoResolveDefault, "whether to auto-resolve phantom merge conflicts")
+		defineNegatedFlag(cmd.Flags(), autoResolveLong, autoResolveDefault)
 
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.AutoResolve], error) {

--- a/internal/cli/flags/auto_resolve.go
+++ b/internal/cli/flags/auto_resolve.go
@@ -11,10 +11,12 @@ const autoResolveLong = "auto-resolve"
 // type-safe access to the CLI arguments of type configdomain.AutoResolve
 func AutoResolve() (AddFunc, ReadAutoResolveFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		defineNegatableBoolFlag(cmd.Flags(), autoResolveLong)
+		cmd.Flags().Bool(autoResolveLong, true, "whether to auto-resolve phantom merge conflicts")
+		defineNegatedFlag(cmd.Flags(), autoResolveLong)
+
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.AutoResolve], error) {
-		return readNegatableBoolFlag[configdomain.AutoResolve](cmd.Flags(), autoResolveLong)
+		return readNegatableFlag[configdomain.AutoResolve](cmd.Flags(), autoResolveLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/beam.go
+++ b/internal/cli/flags/beam.go
@@ -13,8 +13,7 @@ func Beam() (AddFunc, ReadBeamFlagFunc) {
 		cmd.Flags().BoolP(beamLong, "b", false, "beam some commits from this branch to the new branch")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.Beam, error) {
-		value, err := cmd.Flags().GetBool(beamLong)
-		return configdomain.Beam(value), err
+		return readBoolFlag[configdomain.Beam](cmd, beamLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/commit.go
+++ b/internal/cli/flags/commit.go
@@ -13,8 +13,7 @@ func Commit() (AddFunc, ReadCommitFlagFunc) {
 		cmd.Flags().BoolP(commitLong, "c", false, "commit the stashed changes into the new branch")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.Commit, error) {
-		value, err := cmd.Flags().GetBool(commitLong)
-		return configdomain.Commit(value), err
+		return readBoolFlag[configdomain.Commit](cmd, commitLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/commit_message.go
+++ b/internal/cli/flags/commit_message.go
@@ -17,11 +17,7 @@ func CommitMessage(desc string) (AddFunc, ReadCommitMessageFlagFunc) {
 		cmd.Flags().StringP(commitMessageLong, commitMessageShort, "", desc)
 	}
 	readFlag := func(cmd *cobra.Command) (Option[gitdomain.CommitMessage], error) {
-		value, err := cmd.Flags().GetString(commitMessageLong)
-		if err != nil || value == "" {
-			return None[gitdomain.CommitMessage](), err
-		}
-		return Some(gitdomain.CommitMessage(value)), nil
+		return readStringOptFlag[gitdomain.CommitMessage](cmd.Flags(), commitMessageLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/commit_message_file.go
+++ b/internal/cli/flags/commit_message_file.go
@@ -17,8 +17,7 @@ func CommitMessageFile() (AddFunc, ReadCommitMessageFileFlagFunc) {
 		cmd.Flags().StringP(commitMessageFileLong, commitMessageFileShort, "", "Read the commit message from the given file (use \"-\" to read from STDIN)")
 	}
 	readFlag := func(cmd *cobra.Command) (Option[gitdomain.CommitMessageFile], error) {
-		value, err := cmd.Flags().GetString(commitMessageFileLong)
-		return NewOption(gitdomain.CommitMessageFile(value)), err
+		return readStringOptFlag[gitdomain.CommitMessageFile](cmd.Flags(), commitMessageFileLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/detached.go
+++ b/internal/cli/flags/detached.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	detachedLong    = "detached"
-	noDetached      = "no-" + detachedLong
 	detachedDefault = false
 )
 
@@ -19,15 +18,7 @@ func Detached() (AddFunc, ReadDetachedFlagFunc) {
 		defineNegatedFlag(cmd.Flags(), detachedLong, detachedDefault)
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.Detached], error) {
-		if cmd.Flags().Changed(detachedLong) {
-			value, err := cmd.Flags().GetBool(detachedLong)
-			return Some(configdomain.Detached(value)), err
-		}
-		if cmd.Flags().Changed(noDetached) {
-			value, err := cmd.Flags().GetBool(noDetached)
-			return Some(configdomain.Detached(!value)), err
-		}
-		return None[configdomain.Detached](), nil
+		return readNegatableFlag[configdomain.Detached](cmd.Flags(), detachedLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/detached.go
+++ b/internal/cli/flags/detached.go
@@ -7,15 +7,16 @@ import (
 )
 
 const (
-	detachedLong = "detached"
-	noDetached   = "no-" + detachedLong
+	detachedLong    = "detached"
+	noDetached      = "no-" + detachedLong
+	detachedDefault = false
 )
 
 // type-safe access to the CLI arguments of type configdomain.Detached
 func Detached() (AddFunc, ReadDetachedFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.Flags().BoolP(detachedLong, "d", false, "don't update the perennial root branch")
-		cmd.Flags().Bool(noDetached, true, "")
+		cmd.Flags().BoolP(detachedLong, "d", detachedDefault, "don't update the perennial root branch")
+		defineNegatedFlag(cmd.Flags(), detachedLong, detachedDefault)
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.Detached], error) {
 		if cmd.Flags().Changed(detachedLong) {

--- a/internal/cli/flags/display_types.go
+++ b/internal/cli/flags/display_types.go
@@ -13,8 +13,7 @@ func Displaytypes() (AddFunc, ReadDisplayTypesFlagFunc) {
 		cmd.Flags().BoolP(displayTypesLong, "d", false, "display the branch types")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.DisplayTypes, error) {
-		value, err := cmd.Flags().GetBool(displayTypesLong)
-		return configdomain.DisplayTypes(value), err
+		return readBoolFlag[configdomain.DisplayTypes](cmd, displayTypesLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -20,6 +20,8 @@ func defineNegatedFlag(flags *pflag.FlagSet, name string, nonNegatedDefault bool
 	negateName := negate + name
 	flags.Bool(negateName, !nonNegatedDefault, "")
 	if err := flags.MarkHidden(negateName); err != nil {
+		// this will never panic in production,
+		// since our tests will catch when we provide a wrong flag name
 		panic(err)
 	}
 }

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -21,7 +21,7 @@ func defineNegatedFlag(flags *pflag.FlagSet, name string, nonNegatedDefault bool
 	flags.Bool(negateName, !nonNegatedDefault, "")
 	if err := flags.MarkHidden(negateName); err != nil {
 		// this will never panic in production,
-		// since our tests will catch when we provide a wrong flag name
+		// our tests will fail if we provide a non-existing flag name here
 		panic(err)
 	}
 }

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -29,8 +29,11 @@ func readBoolFlag[T ~bool](cmd *cobra.Command, name string) (T, error) { //nolin
 }
 
 func readBoolOptFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {
-	value, err := flags.GetBool(name)
-	return NewOption(T(value)), err
+	if flags.Changed(name) {
+		value, err := flags.GetBool(name)
+		return Some(T(value)), err
+	}
+	return None[T](), nil
 }
 
 func readNegatableBoolFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -14,8 +14,7 @@ const negate = "no-"
 // AddFunc defines the type signature for helper functions that add a CLI flag to a Cobra command.
 type AddFunc func(*cobra.Command)
 
-func defineNegatableBoolFlag(flags *pflag.FlagSet, name string) {
-	flags.Bool(name, true, "whether to auto-resolve phantom merge conflicts")
+func defineNegatedFlag(flags *pflag.FlagSet, name string) {
 	negateName := negate + name
 	flags.Bool(negateName, false, "")
 	if err := flags.MarkHidden(negateName); err != nil {
@@ -36,7 +35,7 @@ func readBoolOptFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], err
 	return None[T](), nil
 }
 
-func readNegatableBoolFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {
+func readNegatableFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {
 	if value, err := readBoolOptFlag[T](flags, name); value.IsSome() || err != nil {
 		return value, err
 	}

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -18,7 +18,9 @@ func defineNegatableBoolFlag(flags *pflag.FlagSet, name string) {
 	flags.Bool(name, true, "whether to auto-resolve phantom merge conflicts")
 	negateName := negate + name
 	flags.Bool(negateName, false, "")
-	_ = flags.MarkHidden(negateName)
+	if err := flags.MarkHidden(negateName); err != nil {
+		panic(err)
+	}
 }
 
 func readBoolFlag[T ~bool](cmd *cobra.Command, name string) (T, error) { //nolint:ireturn

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -21,8 +21,8 @@ func defineNegatableBoolFlag(flags *pflag.FlagSet, name string) {
 	_ = flags.MarkHidden(negateName)
 }
 
-func readBoolFlag[T ~bool](flags *pflag.FlagSet, name string) (T, error) { //nolint:ireturn
-	value, err := flags.GetBool(name)
+func readBoolFlag[T ~bool](cmd *cobra.Command, name string) (T, error) { //nolint:ireturn
+	value, err := cmd.Flags().GetBool(name)
 	return T(value), err
 }
 

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -3,7 +3,46 @@
 // enforces that the programmer didn't forget to define or read the flag.
 package flags
 
-import "github.com/spf13/cobra"
+import (
+	. "github.com/git-town/git-town/v21/pkg/prelude"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const negate = "no-"
 
 // AddFunc defines the type signature for helper functions that add a CLI flag to a Cobra command.
 type AddFunc func(*cobra.Command)
+
+func defineNegatableBoolFlag(flags *pflag.FlagSet, name string) {
+	flags.Bool(name, true, "whether to auto-resolve phantom merge conflicts")
+	negateName := negate + name
+	flags.Bool(negateName, false, "")
+	_ = flags.MarkHidden(negateName)
+}
+
+func readBoolFlag[T ~bool](flags *pflag.FlagSet, name string) (T, error) { //nolint:ireturn
+	value, err := flags.GetBool(name)
+	return T(value), err
+}
+
+func readBoolOptFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {
+	value, err := flags.GetBool(name)
+	return NewOption(T(value)), err
+}
+
+func readNegatableBoolFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {
+	if value, err := readBoolOptFlag[T](flags, name); value.IsSome() || err != nil {
+		return value, err
+	}
+	valueOpt, err := readBoolOptFlag[T](flags, negate+name)
+	if value, has := valueOpt.Get(); has {
+		return Some(T(!bool(value))), err
+	}
+	return None[T](), err
+}
+
+func readStringOptFlag[T ~string](flags *pflag.FlagSet, name string) (Option[T], error) {
+	value, err := flags.GetString(name)
+	return NewOption(T(value)), err
+}

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -14,9 +14,9 @@ const negate = "no-"
 // AddFunc defines the type signature for helper functions that add a CLI flag to a Cobra command.
 type AddFunc func(*cobra.Command)
 
-func defineNegatedFlag(flags *pflag.FlagSet, name string) {
+func defineNegatedFlag(flags *pflag.FlagSet, name string, nonNegatedDefault bool) {
 	negateName := negate + name
-	flags.Bool(negateName, false, "")
+	flags.Bool(negateName, !nonNegatedDefault, "")
 	if err := flags.MarkHidden(negateName); err != nil {
 		panic(err)
 	}

--- a/internal/cli/flags/doc.go
+++ b/internal/cli/flags/doc.go
@@ -14,6 +14,8 @@ const negate = "no-"
 // AddFunc defines the type signature for helper functions that add a CLI flag to a Cobra command.
 type AddFunc func(*cobra.Command)
 
+// defines the negated form of the flag with the given name and default value
+// You must define the non-negated version yourself, because there are too many things to configure there
 func defineNegatedFlag(flags *pflag.FlagSet, name string, nonNegatedDefault bool) {
 	negateName := negate + name
 	flags.Bool(negateName, !nonNegatedDefault, "")
@@ -22,11 +24,13 @@ func defineNegatedFlag(flags *pflag.FlagSet, name string, nonNegatedDefault bool
 	}
 }
 
+// provides the value of the CLI flag with the given name and bool-based type
 func readBoolFlag[T ~bool](cmd *cobra.Command, name string) (T, error) { //nolint:ireturn
 	value, err := cmd.Flags().GetBool(name)
 	return T(value), err
 }
 
+// provides the value of the CLI flag with the given name and optional bool-based type
 func readBoolOptFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {
 	if flags.Changed(name) {
 		value, err := flags.GetBool(name)
@@ -35,6 +39,7 @@ func readBoolOptFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], err
 	return None[T](), nil
 }
 
+// provides the value of the CLI flag with the given name and optional negatable bool-based type
 func readNegatableFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], error) {
 	if value, err := readBoolOptFlag[T](flags, name); value.IsSome() || err != nil {
 		return value, err
@@ -46,6 +51,7 @@ func readNegatableFlag[T ~bool](flags *pflag.FlagSet, name string) (Option[T], e
 	return None[T](), err
 }
 
+// provides the value of the CLI flag with the given name and optional string-based type
 func readStringOptFlag[T ~string](flags *pflag.FlagSet, name string) (Option[T], error) {
 	value, err := flags.GetString(name)
 	return NewOption(T(value)), err

--- a/internal/cli/flags/dryrun.go
+++ b/internal/cli/flags/dryrun.go
@@ -14,11 +14,7 @@ func DryRun() (AddFunc, ReadDryRunFlagFunc) {
 		cmd.Flags().BoolP(dryRunLong, "", false, "print but do not run the Git commands")
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.DryRun], error) {
-		if !cmd.Flags().Changed(dryRunLong) {
-			return None[configdomain.DryRun](), nil
-		}
-		value, err := cmd.Flags().GetBool(dryRunLong)
-		return Some(configdomain.DryRun(value)), err
+		return readBoolOptFlag[configdomain.DryRun](cmd.Flags(), dryRunLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/force.go
+++ b/internal/cli/flags/force.go
@@ -13,8 +13,7 @@ func Force(desc string) (AddFunc, ReadForceFlagFunc) {
 		cmd.Flags().BoolP(forceLong, "f", false, desc)
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.Force, error) {
-		value, err := cmd.Flags().GetBool(forceLong)
-		return configdomain.Force(value), err
+		return readBoolFlag[configdomain.Force](cmd, forceLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/merge.go
+++ b/internal/cli/flags/merge.go
@@ -13,8 +13,7 @@ func Merge() (AddFunc, ReadMergeFlagFunc) {
 		cmd.Flags().BoolP(mergeLong, "m", false, "merge uncommitted changes into the target branch")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.SwitchUsingMerge, error) {
-		value, err := cmd.Flags().GetBool(mergeLong)
-		return configdomain.SwitchUsingMerge(value), err
+		return readBoolFlag[configdomain.SwitchUsingMerge](cmd, mergeLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/no_verify.go
+++ b/internal/cli/flags/no_verify.go
@@ -13,6 +13,7 @@ func NoVerify() (AddFunc, ReadNoVerifyFlagFunc) {
 		cmd.Flags().BoolP(noVerifyLong, "", false, "do not run pre-commit hooks")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.CommitHook, error) {
+
 		value, err := cmd.Flags().GetBool(noVerifyLong)
 		if value {
 			return configdomain.CommitHookDisabled, err

--- a/internal/cli/flags/no_verify.go
+++ b/internal/cli/flags/no_verify.go
@@ -13,12 +13,8 @@ func NoVerify() (AddFunc, ReadNoVerifyFlagFunc) {
 		cmd.Flags().BoolP(noVerifyLong, "", false, "do not run pre-commit hooks")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.CommitHook, error) {
-
-		value, err := cmd.Flags().GetBool(noVerifyLong)
-		if value {
-			return configdomain.CommitHookDisabled, err
-		}
-		return configdomain.CommitHookEnabled, err
+		result, err := readBoolFlag[configdomain.CommitHook](cmd, noVerifyLong)
+		return !result, err
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/pending.go
+++ b/internal/cli/flags/pending.go
@@ -16,8 +16,7 @@ func Pending() (AddFunc, ReadPendingFlagFunc) {
 		cmd.Flags().BoolP(pendingLong, pendingShort, false, "display just the name of the pending Git Town command")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.Pending, error) {
-		value, err := cmd.Flags().GetBool(pendingLong)
-		return configdomain.Pending(value), err
+		return readBoolFlag[configdomain.Pending](cmd, pendingLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/proposal_body.go
+++ b/internal/cli/flags/proposal_body.go
@@ -16,8 +16,7 @@ func ProposalBody(short string) (AddFunc, ReadProposalBodyFlagFunc) {
 		cmd.Flags().StringP(bodyLong, short, "", "provide a body for the proposal")
 	}
 	readFlag := func(cmd *cobra.Command) (Option[gitdomain.ProposalBody], error) {
-		value, err := cmd.Flags().GetString(bodyLong)
-		return NewOption(gitdomain.ProposalBody(value)), err
+		return readStringOptFlag[gitdomain.ProposalBody](cmd.Flags(), bodyLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/proposal_title.go
+++ b/internal/cli/flags/proposal_title.go
@@ -17,8 +17,7 @@ func ProposalTitle() (AddFunc, ReadProposalTitleFlagFunc) {
 		cmd.Flags().StringP(titleLong, titleShort, "", "provide a title for the proposal")
 	}
 	readFlag := func(cmd *cobra.Command) (Option[gitdomain.ProposalTitle], error) {
-		value, err := cmd.Flags().GetString(titleLong)
-		return NewOption(gitdomain.ProposalTitle(value)), err
+		return readStringOptFlag[gitdomain.ProposalTitle](cmd.Flags(), titleLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/propose.go
+++ b/internal/cli/flags/propose.go
@@ -13,8 +13,7 @@ func Propose() (AddFunc, ReadProposeFlagFunc) {
 		cmd.Flags().BoolP(proposeLong, "", false, "propose the new branch")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.Propose, error) {
-		value, err := cmd.Flags().GetBool(proposeLong)
-		return configdomain.Propose(value), err
+		return readBoolFlag[configdomain.Propose](cmd, proposeLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/prototype.go
+++ b/internal/cli/flags/prototype.go
@@ -13,8 +13,7 @@ func Prototype() (AddFunc, ReadPrototypeFlagFunc) {
 		cmd.Flags().BoolP(prototypeLong, "p", false, "create a prototype branch")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.Prototype, error) {
-		value, err := cmd.Flags().GetBool(prototypeLong)
-		return configdomain.Prototype(value), err
+		return readBoolFlag[configdomain.Prototype](cmd, prototypeLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/prune.go
+++ b/internal/cli/flags/prune.go
@@ -13,8 +13,7 @@ func Prune() (AddFunc, ReadPruneFlagFunc) {
 		cmd.Flags().BoolP(pruneLong, "p", false, "prune empty branches")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.Prune, error) {
-		value, err := cmd.Flags().GetBool(pruneLong)
-		return configdomain.Prune(value), err
+		return readBoolFlag[configdomain.Prune](cmd, pruneLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/ship_into_nonperennial_parent.go
+++ b/internal/cli/flags/ship_into_nonperennial_parent.go
@@ -13,8 +13,7 @@ func ShipIntoNonPerennialParent() (AddFunc, ReadShipIntoNonPerennialParentFlagFu
 		cmd.Flags().BoolP(shipIntoNonPerennialParentLong, "p", false, "allow shipping into non-perennial parent")
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.ShipIntoNonperennialParent, error) {
-		value, err := cmd.Flags().GetBool(shipIntoNonPerennialParentLong)
-		return configdomain.ShipIntoNonperennialParent(value), err
+		return readBoolFlag[configdomain.ShipIntoNonperennialParent](cmd, shipIntoNonPerennialParentLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/ship_strategy.go
+++ b/internal/cli/flags/ship_strategy.go
@@ -18,12 +18,7 @@ func ShipStrategy() (AddFunc, ReadShipStrategyFunc) {
 		if err != nil {
 			return None[configdomain.ShipStrategy](), err
 		}
-		strategyOpt, err := configdomain.ParseShipStrategy(value)
-		strategy, hasStrategy := strategyOpt.Get()
-		if err != nil || !hasStrategy {
-			return None[configdomain.ShipStrategy](), err
-		}
-		return Some(strategy), nil
+		return configdomain.ParseShipStrategy(value)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/stack.go
+++ b/internal/cli/flags/stack.go
@@ -13,8 +13,7 @@ func Stack(description string) (AddFunc, ReadStackFlagFunc) {
 		cmd.Flags().BoolP(stackLong, "s", false, description)
 	}
 	readFlag := func(cmd *cobra.Command) (configdomain.FullStack, error) {
-		value, err := cmd.Flags().GetBool(stackLong)
-		return configdomain.FullStack(value), err
+		return readBoolFlag[configdomain.FullStack](cmd, stackLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/verbose.go
+++ b/internal/cli/flags/verbose.go
@@ -17,11 +17,7 @@ func Verbose() (AddFunc, ReadVerboseFlagFunc) {
 		cmd.Flags().BoolP(verboseLong, verboseShort, false, "display all Git commands run under the hood")
 	}
 	readFlag := func(cmd *cobra.Command) (Option[configdomain.Verbose], error) {
-		if !cmd.Flags().Changed(verboseLong) {
-			return None[configdomain.Verbose](), nil
-		}
-		value, err := cmd.Flags().GetBool(verboseLong)
-		return Some(configdomain.Verbose(value)), err
+		return readBoolOptFlag[configdomain.Verbose](cmd.Flags(), verboseLong)
 	}
 	return addFlag, readFlag
 }

--- a/internal/cli/flags/version.go
+++ b/internal/cli/flags/version.go
@@ -11,8 +11,7 @@ func Version() (AddFunc, ReadBoolFlagFunc) {
 		cmd.Flags().BoolP(versionLong, "V", false, "display the version number")
 	}
 	readFlag := func(cmd *cobra.Command) (bool, error) {
-		value, err := cmd.Flags().GetBool(versionLong)
-		return value, err
+		return cmd.Flags().GetBool(versionLong)
 	}
 	return addFlag, readFlag
 }


### PR DESCRIPTION
This PR dries up the highly repetitive logic for parsing flags by extracting a few high-level helper functions. Going fully functional would simplify the usage further, at the cost of the implementation containing a lot of indirect code flow and a much steeper learning curve to reason about this code. We decided against doing that.