### PR TITLE
Prevent unnecessary allocations when sorting naturally

### DIFF
--- a/internal/cli/dialog/switch_branch.go
+++ b/internal/cli/dialog/switch_branch.go
@@ -174,7 +174,7 @@ func (self SwitchModel) View() string {
 func NewSwitchBranchEntries(args NewSwitchBranchEntriesArgs) SwitchBranchEntries {
 	entries := make(SwitchBranchEntries, 0, args.Lineage.Len())
 	roots := args.Lineage.Roots()
-	roots = slice.NaturalSort(roots)
+	slice.NaturalSort(roots)
 	if mainBranch, hasMainBranch := args.MainBranch.Get(); hasMainBranch {
 		if !roots.Contains(mainBranch) {
 			roots = append(roots, mainBranch)

--- a/internal/config/configdomain/lineage.go
+++ b/internal/config/configdomain/lineage.go
@@ -118,7 +118,8 @@ func (self Lineage) Children(branch gitdomain.LocalBranchName) gitdomain.LocalBr
 			result = append(result, child)
 		}
 	}
-	return slice.NaturalSort(result)
+	slice.NaturalSort(result)
+	return result
 }
 
 // Descendants provides all branches that depend on the given branch in its lineage.

--- a/internal/gohacks/slice/natural_sort.go
+++ b/internal/gohacks/slice/natural_sort.go
@@ -8,13 +8,11 @@ import (
 )
 
 // sorts the given elements in natural sort order (https://en.wikipedia.org/wiki/Natural_sort_order)
-func NaturalSort[T fmt.Stringer](list []T) []T {
+func NaturalSort[T fmt.Stringer](list []T) {
 	if len(list) < 2 {
-		return list
+		return
 	}
-	sortableList := newSortable(list)
-	sort.Sort(sortableList)
-	return sortableList
+	sort.Sort(sortable[T](list))
 }
 
 // indicates whether text1 < text2 according to natural sort order
@@ -93,12 +91,6 @@ func (part part) toNumber() int {
 
 // wraps the given []fmt.Stringer with the sort.Interface methods so that we can sort it using the stdlib
 type sortable[T fmt.Stringer] []T
-
-func newSortable[T fmt.Stringer](elements []T) sortable[T] {
-	sortable := make(sortable[T], len(elements))
-	copy(sortable, elements)
-	return sortable
-}
 
 func (self sortable[T]) Len() int {
 	return len(self)

--- a/internal/gohacks/slice/natural_sort_test.go
+++ b/internal/gohacks/slice/natural_sort_test.go
@@ -16,8 +16,8 @@ func TestNaturalSort(t *testing.T) {
 		{"a10b10", "a10b2"}:      {"a10b2", "a10b10"},      // multiple parts of numbers and characters
 	}
 	for give, want := range tests {
-		have := slice.NaturalSort(*give)
-		must.Eq(t, want, &have)
+		slice.NaturalSort(*give)
+		must.Eq(t, want, give)
 	}
 }
 


### PR DESCRIPTION
Let's stay closer to the way Go sorts. There are good reasons for sorting in place.