### PR TITLE
[internal/cmd/swap] fix: child proposals should point to parent branch

### DIFF
--- a/internal/cmd/swap/swap_git_operations_program.go
+++ b/internal/cmd/swap/swap_git_operations_program.go
@@ -63,6 +63,14 @@ func swapGitOperationsProgram(args swapGitOperationsProgramArgs) {
 
 	// Finally, update the child branches of current
 	for _, child := range args.children {
+		childBranchProposal, childBranchHasProposal := child.proposal.Get()
+		if childBranchHasProposal {
+			args.program.Value.Add(&opcodes.ProposalUpdateTarget{
+				NewBranch: args.parent.name,
+				OldBranch: args.current.name,
+				Proposal:  childBranchProposal,
+			})
+		}
 		args.program.Value.Add(
 			&opcodes.Checkout{
 				Branch: child.name,

--- a/internal/cmd/swap/swap_git_operations_program.go
+++ b/internal/cmd/swap/swap_git_operations_program.go
@@ -17,8 +17,7 @@ type swapGitOperationsProgramArgs struct {
 
 func swapGitOperationsProgram(args swapGitOperationsProgramArgs) {
 	// first update the current branch proposal (if there is one) target, so the proposal is not closed.
-	currentBranchProposal, currentBranchHasProposal := args.current.proposal.Get()
-	if currentBranchHasProposal {
+	if currentBranchProposal, currentBranchHasProposal := args.current.proposal.Get(); currentBranchHasProposal {
 		args.program.Value.Add(&opcodes.ProposalUpdateTarget{
 			NewBranch: args.grandParent,
 			OldBranch: args.parent.name,
@@ -38,8 +37,7 @@ func swapGitOperationsProgram(args swapGitOperationsProgramArgs) {
 	}
 
 	// next, update the parent proposal (if there is one), then rebase parent branch onto current
-	parentBranchProposal, parentBranchHasProposal := args.parent.proposal.Get()
-	if parentBranchHasProposal {
+	if parentBranchProposal, parentBranchHasProposal := args.parent.proposal.Get(); parentBranchHasProposal {
 		args.program.Value.Add(&opcodes.ProposalUpdateTarget{
 			NewBranch: args.current.name,
 			OldBranch: args.grandParent,
@@ -63,8 +61,7 @@ func swapGitOperationsProgram(args swapGitOperationsProgramArgs) {
 
 	// Finally, update the child branches of current
 	for _, child := range args.children {
-		childBranchProposal, childBranchHasProposal := child.proposal.Get()
-		if childBranchHasProposal {
+		if childBranchProposal, childBranchHasProposal := child.proposal.Get(); childBranchHasProposal {
 			args.program.Value.Add(&opcodes.ProposalUpdateTarget{
 				NewBranch: args.parent.name,
 				OldBranch: args.current.name,


### PR DESCRIPTION
This was a miss in https://github.com/git-town/git-town/pull/5423



<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5495 :point_left:

Stack generated by [Git-Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->