### PR TITLE
[internal/cmd] enhance(set-parent): update proposal lineage when flag is set

### DIFF
--- a/internal/cmd/prepend.go
+++ b/internal/cmd/prepend.go
@@ -507,23 +507,26 @@ func prependProgram(repo execute.OpenRepoResult, data prependData, finalMessages
 			PreviousBranchCandidates: previousBranchCandidates,
 		})
 	}
-	if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
-		if proposalFinder, hasProposalFinder := connector.(forgedomain.ProposalFinder); hasProposalFinder {
-			tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
-				Connector:                proposalFinder,
-				CurrentBranch:            data.initialBranch,
-				Lineage:                  data.config.NormalConfig.Lineage,
-				MainAndPerennialBranches: data.config.MainAndPerennials(),
-			})
-			if err != nil {
-				fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
-			} else {
-				for branch, proposal := range tree.BranchToProposal { // okay to iterate the map in random order
-					prog.Value.Add(&opcodes.ProposalUpdateLineage{
-						Current:         branch,
-						CurrentProposal: proposal,
-						LineageTree:     MutableSome(tree),
-					})
+
+	if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI {
+		if hasConnector {
+			if proposalFinder, hasProposalFinder := connector.(forgedomain.ProposalFinder); hasProposalFinder {
+				tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
+					Connector:                proposalFinder,
+					CurrentBranch:            data.initialBranch,
+					Lineage:                  data.config.NormalConfig.Lineage,
+					MainAndPerennialBranches: data.config.MainAndPerennials(),
+				})
+				if err != nil {
+					fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
+				} else {
+					for branch, proposal := range tree.BranchToProposal { // okay to iterate the map in random order
+						prog.Value.Add(&opcodes.ProposalUpdateLineage{
+							Current:         branch,
+							CurrentProposal: proposal,
+							LineageTree:     MutableSome(tree),
+						})
+					}
 				}
 			}
 		}

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -422,6 +422,26 @@ func setParentProgram(newParentOpt Option[gitdomain.LocalBranchName], data setPa
 					Branch: data.initialBranch,
 				},
 			)
+
+			if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
+				tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
+					Connector:                connector,
+					CurrentBranch:            initialBranchInfo.LocalBranchName(),
+					Lineage:                  data.config.NormalConfig.Lineage,
+					MainAndPerennialBranches: data.config.MainAndPerennials(),
+				})
+				if err != nil {
+					fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
+				} else {
+					for branch, proposal := range tree.BranchToProposal {
+						prog.Add(&opcodes.ProposalUpdateLineage{
+							Current:         branch,
+							CurrentProposal: proposal,
+							LineageTree:     MutableSome(tree),
+						})
+					}
+				}
+			}
 		}
 	}
 	return optimizer.Optimize(prog), false

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -471,7 +471,6 @@ func setParentProgram(newParentOpt Option[gitdomain.LocalBranchName], data setPa
 				}
 			}
 		}
-
 	}
 	return optimizer.Optimize(prog), false
 }

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -434,16 +434,17 @@ func setParentProgram(newParentOpt Option[gitdomain.LocalBranchName], data setPa
 
 // updateProposalLineage updates the proposal stack lineage when changing the parent
 func updateProposalLineage(prog *program.Program, newParentOpt Option[gitdomain.LocalBranchName], data setParentData) {
-	connector, hasConnector := data.connector.Get()
-	if data.config.NormalConfig.ProposalsShowLineage != forgedomain.ProposalsShowLineageCLI || !hasConnector {
+	if data.config.NormalConfig.ProposalsShowLineage != forgedomain.ProposalsShowLineageCLI {
 		return
 	}
-
+	connector, hasConnector := data.connector.Get()
+	if !hasConnector {
+		return
+	}
 	proposalFinder, canFindProposals := connector.(forgedomain.ProposalFinder)
 	if !canFindProposals {
 		return
 	}
-
 	// Update the stack belonging to the initialBranch
 	tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
 		Connector:                proposalFinder,

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -424,21 +424,24 @@ func setParentProgram(newParentOpt Option[gitdomain.LocalBranchName], data setPa
 			)
 
 			if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
-				tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
-					Connector:                connector,
-					CurrentBranch:            initialBranchInfo.LocalBranchName(),
-					Lineage:                  data.config.NormalConfig.Lineage,
-					MainAndPerennialBranches: data.config.MainAndPerennials(),
-				})
-				if err != nil {
-					fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
-				} else {
-					for branch, proposal := range tree.BranchToProposal {
-						prog.Add(&opcodes.ProposalUpdateLineage{
-							Current:         branch,
-							CurrentProposal: proposal,
-							LineageTree:     MutableSome(tree),
-						})
+				proposalFinder, canFindProposals := connector.(forgedomain.ProposalFinder)
+				if canFindProposals {
+					tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
+						Connector:                proposalFinder,
+						CurrentBranch:            initialBranchInfo.LocalBranchName(),
+						Lineage:                  data.config.NormalConfig.Lineage,
+						MainAndPerennialBranches: data.config.MainAndPerennials(),
+					})
+					if err != nil {
+						fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
+					} else {
+						for branch, proposal := range tree.BranchToProposal {
+							prog.Add(&opcodes.ProposalUpdateLineage{
+								Current:         branch,
+								CurrentProposal: proposal,
+								LineageTree:     MutableSome(tree),
+							})
+						}
 					}
 				}
 			}

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -455,7 +455,8 @@ func updateProposalLineage(prog *program.Program, newParentOpt Option[gitdomain.
 	}
 
 	proposalsInStackOfInitialBranch := tree.BranchToProposal
-	for branch, proposal := range proposalsInStackOfInitialBranch {
+
+	for branch, proposal := range proposalsInStackOfInitialBranch { // okay to iterate the map in random order
 		prog.Add(&opcodes.ProposalUpdateLineage{
 			Current:         branch,
 			CurrentProposal: proposal,
@@ -475,7 +476,7 @@ func updateProposalLineage(prog *program.Program, newParentOpt Option[gitdomain.
 		})
 
 		if err == nil {
-			for branch, proposal := range tree.BranchToProposal {
+			for branch, proposal := range tree.BranchToProposal { // okay to iterate the map in random order
 				// Do not update the same proposal more than once because we updated
 				// it in a previous step
 				if _, ok := proposalsInStackOfInitialBranch[branch]; !ok {

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -423,54 +423,71 @@ func setParentProgram(newParentOpt Option[gitdomain.LocalBranchName], data setPa
 				},
 			)
 		}
-		if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
-			proposalFinder, canFindProposals := connector.(forgedomain.ProposalFinder)
-			if canFindProposals {
-				// Update the stack belong to the initialBranch
-				tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
-					Connector:                proposalFinder,
-					CurrentBranch:            data.initialBranch,
-					Lineage:                  data.config.NormalConfig.Lineage,
-					MainAndPerennialBranches: data.config.MainAndPerennials(),
-				})
-				if err == nil {
-					proposalsInStackOfInitialBranch := tree.BranchToProposal
-					for branch, proposal := range proposalsInStackOfInitialBranch {
-						prog.Add(&opcodes.ProposalUpdateLineage{
-							Current:         branch,
-							CurrentProposal: proposal,
-							LineageTree:     MutableSome(tree),
-						})
-					}
-					// If we are moving to parent that is part of a completely different stack,
-					// update the lineage of all members of this other stack
-					err = tree.Rebuild(forge.ProposalStackLineageArgs{
-						Connector:                proposalFinder,
-						CurrentBranch:            newParent,
-						Lineage:                  data.config.NormalConfig.Lineage,
-						MainAndPerennialBranches: data.config.MainAndPerennials(),
+	}
+
+	// Update proposal lineage for both cases (removing parent or setting new parent)
+	updateProposalLineage(&prog, newParentOpt, data)
+	return optimizer.Optimize(prog), false
+}
+
+// updateProposalLineage updates the proposal stack lineage when changing the parent
+func updateProposalLineage(prog *program.Program, newParentOpt Option[gitdomain.LocalBranchName], data setParentData) {
+	connector, hasConnector := data.connector.Get()
+	if data.config.NormalConfig.ProposalsShowLineage != forgedomain.ProposalsShowLineageCLI || !hasConnector {
+		return
+	}
+
+	proposalFinder, canFindProposals := connector.(forgedomain.ProposalFinder)
+	if !canFindProposals {
+		return
+	}
+
+	// Update the stack belonging to the initialBranch
+	tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
+		Connector:                proposalFinder,
+		CurrentBranch:            data.initialBranch,
+		Lineage:                  data.config.NormalConfig.Lineage,
+		MainAndPerennialBranches: data.config.MainAndPerennials(),
+	})
+	if err != nil {
+		fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
+		return
+	}
+
+	proposalsInStackOfInitialBranch := tree.BranchToProposal
+	for branch, proposal := range proposalsInStackOfInitialBranch {
+		prog.Add(&opcodes.ProposalUpdateLineage{
+			Current:         branch,
+			CurrentProposal: proposal,
+			LineageTree:     MutableSome(tree),
+		})
+	}
+
+	// If we are moving to a parent that is part of a completely different stack,
+	// update the lineage of all members of this other stack
+	newParent, hasNewParent := newParentOpt.Get()
+	if hasNewParent {
+		err = tree.Rebuild(forge.ProposalStackLineageArgs{
+			Connector:                proposalFinder,
+			CurrentBranch:            newParent,
+			Lineage:                  data.config.NormalConfig.Lineage,
+			MainAndPerennialBranches: data.config.MainAndPerennials(),
+		})
+
+		if err == nil {
+			for branch, proposal := range tree.BranchToProposal {
+				// Do not update the same proposal more than once because we updated
+				// it in a previous step
+				if _, ok := proposalsInStackOfInitialBranch[branch]; !ok {
+					prog.Add(&opcodes.ProposalUpdateLineage{
+						Current:         branch,
+						CurrentProposal: proposal,
+						LineageTree:     MutableSome(tree),
 					})
-
-					if err == nil {
-						for branch, proposal := range tree.BranchToProposal {
-							// Do not update the same proposal more than once because we updated
-							// it in a previous step
-							if _, ok := proposalsInStackOfInitialBranch[branch]; !ok {
-								prog.Add(&opcodes.ProposalUpdateLineage{
-									Current:         branch,
-									CurrentProposal: proposal,
-									LineageTree:     MutableSome(tree),
-								})
-							}
-						}
-					}
-				}
-
-				if err != nil {
-					fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
 				}
 			}
+		} else {
+			fmt.Printf("failed to update proposal stack lineage for new parent: %s\n", err.Error())
 		}
 	}
-	return optimizer.Optimize(prog), false
 }


### PR DESCRIPTION
## Summary

Updates proposal lineage automatically when reorganizing branch stacks with `set-parent`.

## Changes

- Added proposal lineage update logic to `set-parent` command when `proposals-show-lineage` is configured to `cli`
- Generates `ProposalUpdateLineage` opcodes for each branch in the stack after parent change

## Testing Plan

- [x] Verified that if a branch is moving to a new stack, all proposals in the new stack are updated.
- [x] Verified that if a branch is in an existing stack and moves to a new stack, all the proposals in the original stack are updated.
- [x] Verified PR descriptions update correctly after parent change
- [x] Confirmed no impact when `proposals-show-lineage` is disabled

<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5512 :point_left:

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->