### PR TITLE
fix up/down command doc example graphs

### DIFF
--- a/website/src/commands/down.md
+++ b/website/src/commands/down.md
@@ -29,9 +29,9 @@ stack:
 ```
 main
  \
-* branch-2
+* branch-1
    \
-    branch-1
+    branch-2
 ```
 
 ## Options

--- a/website/src/commands/up.md
+++ b/website/src/commands/up.md
@@ -32,9 +32,9 @@ stack:
 ```
 main
  \
-  branch-2
+  branch-1
    \
-*   branch-1
+*   branch-2
 ```
 
 ## Options


### PR DESCRIPTION
I believe the `up` and `down` command example branch graphs are fundamentally wrong in a very confusing way. They both show the branches being reordered in the stack, as with a `swap`, but that does not seem to match the description of what they do nor what they do in practice.