### PR TITLE
[internal/cmd] enhance: add ability to update proposal lineage on delete command

### DIFF
--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -361,6 +361,13 @@ func deleteFeatureBranch(prog, finalUndoProgram Mutable[program.Program], data d
 					fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
 				} else {
 					for branch, proposal := range tree.BranchToProposal { // okay to iterate the map in random order
+						// Do not update the proposal of the deleted branch.
+						// At this point, a forge (like github) would close
+						// the proposal because there is no longer a remote
+						// branch.
+						if branch == data.initialBranch {
+							continue
+						}
 						prog.Value.Add(&opcodes.ProposalUpdateLineage{
 							Current:         branch,
 							CurrentProposal: proposal,

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -348,6 +348,27 @@ func deleteFeatureBranch(prog, finalUndoProgram Mutable[program.Program], data d
 		prog.Value.Add(&opcodes.BranchTrackingDelete{Branch: trackingBranchToDelete})
 	}
 	deleteLocalBranch(prog, finalUndoProgram, data)
+	if connector, hasConnector := data.connector.Get(); data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI && hasConnector {
+		if proposalFinder, hasProposalFinder := connector.(forgedomain.ProposalFinder); hasProposalFinder {
+			tree, err := forge.NewProposalStackLineageTree(forge.ProposalStackLineageArgs{
+				Connector:                proposalFinder,
+				CurrentBranch:            data.initialBranch,
+				Lineage:                  data.config.NormalConfig.Lineage,
+				MainAndPerennialBranches: data.config.MainAndPerennials(),
+			})
+			if err != nil {
+				fmt.Printf("failed to update proposal stack lineage: %s\n", err.Error())
+			} else {
+				for branch, proposal := range tree.BranchToProposal { // okay to iterate the map in random order
+					prog.Value.Add(&opcodes.ProposalUpdateLineage{
+						Current:         branch,
+						CurrentProposal: proposal,
+						LineageTree:     MutableSome(tree),
+					})
+				}
+			}
+		}
+	}
 }
 
 func deleteLocalBranch(prog, finalUndoProgram Mutable[program.Program], data deleteData) {


### PR DESCRIPTION
## Summary

Add ability to update proposal lineage when executing

```zsh
$ git-town delete
```

## Testing

- [x] Proposal lineage updated when deleting a branch in the stack that does not have a proposal
- [x] Proposal lineage updated when deleting a branch in the stack that does have a proposal

<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5596 :point_left:

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->