### PR TITLE
[internal/cmd] fix(ship): api program correct order of lineage operations

### DIFF
--- a/internal/cmd/ship/api.go
+++ b/internal/cmd/ship/api.go
@@ -69,11 +69,11 @@ func shipAPIProgram(prog Mutable[program.Program], repo execute.OpenRepoResult, 
 	if hasLocalBranchToShip {
 		prog.Value.Add(&opcodes.BranchLocalDelete{Branch: branchToShipLocal})
 	}
-	if !repo.UnvalidatedConfig.NormalConfig.DryRun {
-		prog.Value.Add(&opcodes.LineageParentRemove{Branch: branchToShipLocal})
-	}
 	for _, child := range sharedData.childBranches {
 		prog.Value.Add(&opcodes.LineageParentSetToGrandParent{Branch: child})
+	}
+	if !repo.UnvalidatedConfig.NormalConfig.DryRun {
+		prog.Value.Add(&opcodes.LineageParentRemove{Branch: branchToShipLocal})
 	}
 	previousBranchCandidates := []Option[gitdomain.LocalBranchName]{sharedData.previousBranch}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{


### PR DESCRIPTION
Child branches of the branch being shipped should have their lineage updated to
be the grandParent and THEN the parent branch is removed from the lineage

## Context

There is a bug I found in the existing code where if you have the following
stack

```
$ git-town branch
main
   * branch_a
         branch_c
```

And you ship `branch_a` into main (a perennial branch), the stack lineage
becomes

```main
$ git-town branch
main
branch_c
```

and branch_c becomes a branch without a parent. What should happen is that
`main` becomes the new parent of `branch_c`. Because this bug is with existing
code, it will be handled in a separate pull-request

This pull-request fixes this :bug:


<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5600 :point_left:
     - https://github.com/git-town/git-town/pull/5599

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->