### PR TITLE
[internal/cmd] enhance(detach): update proposal stack lineage on detach

### DIFF
--- a/internal/cmd/detach.go
+++ b/internal/cmd/detach.go
@@ -431,6 +431,25 @@ func detachProgram(repo execute.OpenRepoResult, data detachData, finalMessages s
 			}
 		}
 	}
+	if data.config.NormalConfig.ProposalsShowLineage == forgedomain.ProposalsShowLineageCLI {
+		if connector, hasConnector := data.connector.Get(); hasConnector {
+			if proposalFinder, hasProposalFinder := connector.(forgedomain.ProposalFinder); hasProposalFinder {
+				sync.BranchProposalsProgram(
+					sync.BranchProposalsProgramArgs{
+						Current:   data.initialBranch,
+						FullStack: true,
+						Program:   prog,
+						ProposalStackLineageArgs: forge.ProposalStackLineageArgs{
+							Connector:                proposalFinder,
+							CurrentBranch:            data.initialBranch,
+							Lineage:                  data.config.NormalConfig.Lineage,
+							MainAndPerennialBranches: data.config.MainAndPerennials(),
+						},
+					},
+				)
+			}
+		}
+	}
 	cmdhelpers.Wrap(prog, cmdhelpers.WrapOptions{
 		DryRun:                   data.config.NormalConfig.DryRun,
 		InitialStashSize:         data.stashSize,


### PR DESCRIPTION
### Background

Update proposal stack lineage when performing `git-town detach`

### Testing

- [ ] Detaching a branch without a proposal but the child and/or previous parent
      branch have proposals
- [ ] Detaching a branch with an existing proposal


<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5606
     - https://github.com/git-town/git-town/pull/5607 :point_left:

Stack generated by [Git Town](https://github.com/git-town/git-town)

<!-- branch-stack-end -->