### PR TITLE
Install RTA at the specified version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ deadcode: tools/rta@${RTA_VERSION}
 
 tools/rta@${RTA_VERSION}:
 	@rm -f tools/rta*
-	@(cd tools && curl https://raw.githubusercontent.com/kevgo/run-that-app/main/download.sh | sh)
+	@(cd tools && curl https://raw.githubusercontent.com/kevgo/run-that-app/main/download.sh | sh -s ${RTA_VERSION})
 	@mv tools/rta tools/rta@${RTA_VERSION}
 	@ln -s rta@${RTA_VERSION} tools/rta
 


### PR DESCRIPTION
RTA's installer script now supports providing the version to install. This PR
calls it with the latest tested version.
