### PR TITLE
Remove wrong step from E2E test

### DIFF
--- a/features/hack/detached_head/detached_head.feature
+++ b/features/hack/detached_head/detached_head.feature
@@ -39,4 +39,3 @@ Feature: on a detached head with a clean workspace
       | main                       | git reset --hard {{ sha 'initial commit' }} |
       |                            | git checkout {{ sha 'initial commit' }}     |
       | {{ sha 'initial commit' }} | git branch -D new                           |
-    And the currently checked out commit is "initial commit"


### PR DESCRIPTION
This step sets the currently checked out commit, it doesn't verify it.

We don't really need to verify this, the commit table already documents this.