### PR TITLE
Install dependencies correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ alphavet:
 fix-optioncompare-in-tests:
 	@(cd tools/optioncompare_in_tests && go build) && ./tools/optioncompare_in_tests/optioncompare_in_tests github.com/git-town/git-town/v22/...
 
-keep-sorted:
+keep-sorted: tools/rta@${RTA_VERSION}
 	tools/rta --install ripgrep
 	tools/rta keep-sorted $(shell tools/rta ripgrep -l 'keep-sorted end' ./ | tools/rta ripgrep -v Makefile)
 


### PR DESCRIPTION
`run-that-app` v0.24 provides an `--install` command. This allows us to install needed dependencies directly.