### PR TITLE
ProposalCreate: inject the branch lineage when creating a proposal

### DIFF
--- a/internal/vm/opcodes/proposal_create.go
+++ b/internal/vm/opcodes/proposal_create.go
@@ -51,6 +51,7 @@ func (self *ProposalCreate) Run(args shared.RunArgs) error {
 				Order:                    args.Config.Value.NormalConfig.Order,
 			})
 			if err != nil {
+				// TODO: make sure error message return from failing to construct lineage is consistent across all invocations
 				fmt.Printf("failed to construct proposal stack lineage: %s\n", err.Error())
 			}
 			proposalOpt, err := proposalFinder.FindProposal(self.Branch, parentBranch)


### PR DESCRIPTION
I quite like the lineage string in the PR description, as it adds useful context for reviewers! However, if I use `git town propose`, it doesn't add the lineage. This change prepends the `ProposalUpdateLineage` opcode after the proposal is created, after which point we have the full lineage including the current proposal.

Since this change puts it into the `ProposalCreate` opcode, I believe it should take effect in these commands:

- append
- prepend
- propose

Perhaps ironically, this PR doesn't have the lineage. As per [the docs](https://www.git-town.com/how-to/forked-repo.html), I have an `upstream` remote set up, but when I did `git town propose`, it created the PR within my fork. Thus, I've made this proposal manually.

### Tests

These tests passed:

- `make unit`
- `make unit-all`
- `make unit-race`

I also tried to run `make cuke`. It failed, but it also seems to fail on `main` for me.

This is my first contribution, so I'm very open to notes and corrections.