### PR TITLE
docs: update CONTRIBUTING.md to link to docs/ subdir

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please [open an issue](https://github.com/git-town/git-town/issues/new).
 
 ### I want to fix a bug or add a feature
 
-- see our [developer guidelines](DEVELOPMENT.md) to get started
+- see our [developer guidelines](docs/DEVELOPMENT.md) to get started
 - if you plan a larger change or need guidance, connect with the maintainers by
   [opening an issue](https://github.com/git-town/git-town/issues/new)
 - otherwise, hack away and


### PR DESCRIPTION
When I went to the Github page "Contributing" tab (right above the rendered readme), I found that the "developer guidelines" link gave a 404. The one directly on the README.md is fine though.

I merged this change on my fork, and the link seems to work (can be seen on [my fork's "Contributing" page](https://github.com/j2fw/git-town?tab=contributing-ov-file))