### PR TITLE
Added the "GitHub" username configuration

### DIFF
--- a/internal/cmd/config/root.go
+++ b/internal/cmd/config/root.go
@@ -107,6 +107,7 @@ func printConfig(config config.UnvalidatedConfig) {
 	print.Entry("Gitea token", format.OptionalStringerSetting(config.NormalConfig.GiteaToken))
 	print.Entry("GitHub connector type", format.OptionalStringerSetting(config.NormalConfig.GitHubConnectorType))
 	print.Entry("GitHub token", format.OptionalStringerSetting(config.NormalConfig.GitHubToken))
+	print.Entry("GitHub username", format.OptionalStringerSetting(config.NormalConfig.GitHubUsername))
 	print.Entry("GitLab connector type", format.OptionalStringerSetting(config.NormalConfig.GitLabConnectorType))
 	print.Entry("GitLab token", format.OptionalStringerSetting(config.NormalConfig.GitLabToken))
 	fmt.Println()

--- a/internal/config/cliconfig/cli_config.go
+++ b/internal/config/cliconfig/cli_config.go
@@ -37,6 +37,7 @@ func New(args NewArgs) configdomain.PartialConfig {
 		ForgeType:                None[forgedomain.ForgeType](),
 		GitHubConnectorType:      None[forgedomain.GitHubConnectorType](),
 		GitHubToken:              None[forgedomain.GitHubToken](),
+		GitHubUsername:           None[forgedomain.GitHubUsername](),
 		GitLabConnectorType:      None[forgedomain.GitLabConnectorType](),
 		GitLabToken:              None[forgedomain.GitLabToken](),
 		GitUserEmail:             None[gitdomain.GitUserEmail](),

--- a/internal/config/configdomain/key.go
+++ b/internal/config/configdomain/key.go
@@ -89,6 +89,7 @@ const (
 	KeyGiteaToken                          = Key("git-town.gitea-token")
 	KeyGitHubConnectorType                 = Key("git-town.github-connector")
 	KeyGitHubToken                         = Key(pkg.KeyGitHubToken)
+	KeyGitHubUsername                      = Key("git-town.github-username")
 	KeyGitLabConnectorType                 = Key("git-town.gitlab-connector")
 	KeyGitLabToken                         = Key("git-town.gitlab-token")
 	KeyHostingOriginHostname               = Key("git-town.hosting-origin-hostname")
@@ -153,6 +154,7 @@ var keys = []Key{
 	KeyGiteaToken,
 	KeyGitHubConnectorType,
 	KeyGitHubToken,
+	KeyGitHubUsername,
 	KeyGitLabConnectorType,
 	KeyGitLabToken,
 	KeyGitUserEmail,

--- a/internal/config/configdomain/partial_config.go
+++ b/internal/config/configdomain/partial_config.go
@@ -32,6 +32,7 @@ type PartialConfig struct {
 	ForgejoToken             Option[forgedomain.ForgejoToken]
 	GitHubConnectorType      Option[forgedomain.GitHubConnectorType]
 	GitHubToken              Option[forgedomain.GitHubToken]
+	GitHubUsername           Option[forgedomain.GitHubUsername]
 	GitLabConnectorType      Option[forgedomain.GitLabConnectorType]
 	GitLabToken              Option[forgedomain.GitLabToken]
 	GitUserEmail             Option[gitdomain.GitUserEmail]
@@ -88,6 +89,7 @@ func (self PartialConfig) Merge(other PartialConfig) PartialConfig {
 		ForgejoToken:             other.ForgejoToken.Or(self.ForgejoToken),
 		GitHubConnectorType:      other.GitHubConnectorType.Or(self.GitHubConnectorType),
 		GitHubToken:              other.GitHubToken.Or(self.GitHubToken),
+		GitHubUsername:           other.GitHubUsername.Or(self.GitHubUsername),
 		GitLabConnectorType:      other.GitLabConnectorType.Or(self.GitLabConnectorType),
 		GitLabToken:              other.GitLabToken.Or(self.GitLabToken),
 		GitUserEmail:             other.GitUserEmail.Or(self.GitUserEmail),

--- a/internal/config/configfile/load.go
+++ b/internal/config/configfile/load.go
@@ -274,6 +274,7 @@ func Validate(data Data, finalMessages stringslice.Collector) (configdomain.Part
 		ForgeType:                forgeType,
 		GitHubConnectorType:      githubConnectorType,
 		GitHubToken:              None[forgedomain.GitHubToken](),
+		GitHubUsername:           None[forgedomain.GitHubUsername](), // GitHub username is not stored in config file
 		GitLabConnectorType:      gitlabConnectorType,
 		GitLabToken:              None[forgedomain.GitLabToken](),
 		GitUserEmail:             None[gitdomain.GitUserEmail](),

--- a/internal/config/envconfig/load.go
+++ b/internal/config/envconfig/load.go
@@ -140,6 +140,7 @@ func Load(env EnvVars) (configdomain.PartialConfig, error) {
 		ForgeType:                forgeType,
 		GitHubConnectorType:      githubConnectorType,
 		GitHubToken:              forgedomain.ParseGitHubToken(env.Get(githubToken, "GITHUB_TOKEN", "GITHUB_AUTH_TOKEN")),
+		GitHubUsername:           None[forgedomain.GitHubUsername](), // GitHub username is not loaded from env vars
 		GitLabConnectorType:      gitlabConnectorType,
 		GitLabToken:              forgedomain.ParseGitLabToken(env.Get(gitlabToken)),
 		GitUserEmail:             gitUserEmail,

--- a/internal/config/gitconfig/high_level.go
+++ b/internal/config/gitconfig/high_level.go
@@ -86,6 +86,10 @@ func RemoveGitHubToken(runner subshelldomain.Runner) error {
 	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyGitHubToken)
 }
 
+func RemoveGitHubUsername(runner subshelldomain.Runner) error {
+	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyGitHubUsername)
+}
+
 func RemoveGitLabConnectorType(runner subshelldomain.Runner) error {
 	return RemoveConfigValue(runner, configdomain.ConfigScopeLocal, configdomain.KeyGitLabConnectorType)
 }
@@ -233,6 +237,10 @@ func SetGitHubConnectorType(runner subshelldomain.Runner, value forgedomain.GitH
 
 func SetGitHubToken(runner subshelldomain.Runner, value forgedomain.GitHubToken, scope configdomain.ConfigScope) error {
 	return SetConfigValue(runner, scope, configdomain.KeyGitHubToken, value.String())
+}
+
+func SetGitHubUsername(runner subshelldomain.Runner, value forgedomain.GitHubUsername, scope configdomain.ConfigScope) error {
+	return SetConfigValue(runner, scope, configdomain.KeyGitHubUsername, value.String())
 }
 
 func SetGitLabConnectorType(runner subshelldomain.Runner, value forgedomain.GitLabConnectorType, scope configdomain.ConfigScope) error {

--- a/internal/config/normal_config.go
+++ b/internal/config/normal_config.go
@@ -45,6 +45,7 @@ type NormalConfig struct {
 	ForgejoToken             Option[forgedomain.ForgejoToken]
 	GitHubConnectorType      Option[forgedomain.GitHubConnectorType]
 	GitHubToken              Option[forgedomain.GitHubToken]
+	GitHubUsername           Option[forgedomain.GitHubUsername]
 	GitLabConnectorType      Option[forgedomain.GitLabConnectorType]
 	GitLabToken              Option[forgedomain.GitLabToken]
 	GitUserEmail             Option[gitdomain.GitUserEmail]
@@ -111,6 +112,7 @@ func (self *NormalConfig) OverwriteWith(other configdomain.PartialConfig) Normal
 		ForgejoToken:             other.ForgejoToken.Or(self.ForgejoToken),
 		GitHubConnectorType:      other.GitHubConnectorType.Or(self.GitHubConnectorType),
 		GitHubToken:              other.GitHubToken.Or(self.GitHubToken),
+		GitHubUsername:           other.GitHubUsername.Or(self.GitHubUsername),
 		GitLabConnectorType:      other.GitLabConnectorType.Or(self.GitLabConnectorType),
 		GitLabToken:              other.GitLabToken.Or(self.GitLabToken),
 		GitUserEmail:             other.GitUserEmail.Or(self.GitUserEmail),
@@ -263,6 +265,7 @@ func DefaultNormalConfig() NormalConfig {
 		ForgejoToken:             None[forgedomain.ForgejoToken](),
 		GitHubConnectorType:      None[forgedomain.GitHubConnectorType](),
 		GitHubToken:              None[forgedomain.GitHubToken](),
+		GitHubUsername:           None[forgedomain.GitHubUsername](),
 		GitLabConnectorType:      None[forgedomain.GitLabConnectorType](),
 		GitLabToken:              None[forgedomain.GitLabToken](),
 		GitUserEmail:             None[gitdomain.GitUserEmail](),
@@ -312,6 +315,7 @@ func NewNormalConfigFromPartial(partial configdomain.PartialConfig, defaults Nor
 		ForgejoToken:             partial.ForgejoToken,
 		GitHubConnectorType:      partial.GitHubConnectorType,
 		GitHubToken:              partial.GitHubToken,
+		GitHubUsername:           partial.GitHubUsername,
 		GitLabConnectorType:      partial.GitLabConnectorType,
 		GitLabToken:              partial.GitLabToken,
 		GitUserEmail:             partial.GitUserEmail,

--- a/internal/config/parse_snapshot.go
+++ b/internal/config/parse_snapshot.go
@@ -157,6 +157,7 @@ func NewPartialConfigFromSnapshot(snapshot configdomain.SingleSnapshot, updateOu
 		ForgeType:                forgeType,
 		GitHubConnectorType:      githubConnectorType,
 		GitHubToken:              forgedomain.ParseGitHubToken(snapshot[configdomain.KeyGitHubToken]),
+		GitHubUsername:           forgedomain.ParseGitHubUsername(snapshot[configdomain.KeyGitHubUsername]),
 		GitLabConnectorType:      gitlabConnectorType,
 		GitLabToken:              forgedomain.ParseGitLabToken(snapshot[configdomain.KeyGitLabToken]),
 		GitUserEmail:             gitdomain.ParseGitUserEmail(snapshot[configdomain.KeyGitUserEmail]),

--- a/internal/forge/forgedomain/github_username.go
+++ b/internal/forge/forgedomain/github_username.go
@@ -1,0 +1,22 @@
+package forgedomain
+
+import (
+	"strings"
+
+	. "github.com/git-town/git-town/v22/pkg/prelude"
+)
+
+// GitHubUsername is a GitHub username to use as a prefix for branch names.
+type GitHubUsername string
+
+func (self GitHubUsername) String() string {
+	return string(self)
+}
+
+func ParseGitHubUsername(value string) Option[GitHubUsername] {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return None[GitHubUsername]()
+	}
+	return Some(GitHubUsername(value))
+}

--- a/internal/setup/enter.go
+++ b/internal/setup/enter.go
@@ -267,6 +267,7 @@ EnterForgeData:
 		ForgeType:                enteredForgeType,
 		GitHubConnectorType:      githubConnectorTypeOpt,
 		GitHubToken:              githubToken,
+		GitHubUsername:           None[forgedomain.GitHubUsername](), // the setup assistant doesn't ask for this
 		GitLabConnectorType:      gitlabConnectorTypeOpt,
 		GitLabToken:              gitlabToken,
 		GitUserEmail:             None[gitdomain.GitUserEmail](),


### PR DESCRIPTION
- This PR adds the "GithubUsername" configuration option, although it currently does nothing.
- The child PR uses this option in the `append`, `prepend` and `hack` commands. https://github.com/james-harlyy/git-town/pull/2