### PR TITLE
Keep the context linter disabled for now

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,6 @@ linters:
     - wsl_v5 # this linter creates too many false positives, our policy is to not have any empty lines in code blocks
 
     - godoclint # TODO: enable
-    - contextcheck # TODO: enable
     - modernize # TODO: enable
 
   settings:


### PR DESCRIPTION
We aren't using contexts yet. Might be interesting in the future.