### PR TITLE
docs: complete command summaries with missing flags

### DIFF
--- a/website/src/commands/branch.md
+++ b/website/src/commands/branch.md
@@ -1,7 +1,7 @@
 # git town branch
 
 ```command-summary
-git town branch [-v | --verbose]
+git town branch [-d | --display-types] [-o | --order] [-v | --verbose]
 ```
 
 The _branch_ command is Git Town's equivalent of the

--- a/website/src/commands/hack.md
+++ b/website/src/commands/hack.md
@@ -1,7 +1,7 @@
 # git town hack
 
 ```command-summary
-git town hack [<branch-name>...] [-p | --prototype] [-d | --detached] [-c | --commit] [-m | --message <message>] [--propose] [--dry-run] [-v | --verbose]
+git town hack [<branch-name>...] [-b | --beam] [-p | --prototype] [-d | --detached] [-c | --commit] [-m | --message <message>] [--propose] [--stash | --no-stash] [--sync] [--auto-resolve] [--dry-run] [-v | --verbose]
 ```
 
 The _hack_ command ("let's start hacking") creates a new feature branch with the

--- a/website/src/commands/propose.md
+++ b/website/src/commands/propose.md
@@ -1,7 +1,7 @@
 # git town propose
 
 ```command-summary
-git town propose [-b <text> | --body <text>] [-f <path> | --body-file <path>] [-t <text> | --title <text>] [-d | --detached] [--dry-run] [-v | --verbose]
+git town propose [-b <text> | --body <text>] [-f <path> | --body-file <path>] [-t <text> | --title <text>] [-s | --stack] [--auto-resolve] [--dry-run] [-v | --verbose]
 ```
 
 The _propose_ command helps create a new pull request (also known as merge

--- a/website/src/commands/switch.md
+++ b/website/src/commands/switch.md
@@ -1,7 +1,7 @@
 # git town switch
 
 ```command-summary
-git town switch [<branch-name-regex>...] [-a | --all] [-d | --display-types] [-m | --merge] [-t <name> | --type <name>] [-v | --verbose]
+git town switch [<branch-name-regex>...] [-a | --all] [-d | --display-types] [-m | --merge] [-o | --order] [-t <name> | --type <name>] [-v | --verbose]
 ```
 
 The _switch_ command displays the branch hierarchy on your machine and allows


### PR DESCRIPTION
Updates the command summaries in documentation to include all available command-line flags that were previously omitted:

- branch: Added -d|--display-types and -o|--order flags
- hack: Added -b|--beam, --stash|--no-stash, --sync, and --auto-resolve flags
- propose: Replaced -d|--detached with -s|--stack and added --auto-resolve flag
- switch: Added -o|--order flag

This ensures the command summaries accurately reflect all available options for these commands and helps users discover all functionality.

✅  Checked those changes locally by running `cd website && make serve`