### PR TITLE
Correctly mark Node dependencies as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "dependencies": {
+  "devDependencies": {
     "gherkin-lint": "4.2.4",
     "text-runner": "7.4.0",
     "textrun-make": "0.6.0"


### PR DESCRIPTION
Hopefully this prevents tagging Git Town as vulnerable when one of the Node dev
dependencies has a security alert.
