### PR TITLE
Disable govulncheck for the time being

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ lint: node_modules tools/rta@${RTA_VERSION}  # lints the main codebase concurren
 
 lint-all: lint tools/rta@${RTA_VERSION}  # runs all linters
 	(cd website && make test)
-# tools/rta govulncheck ./...
+# tools/rta govulncheck ./...   TODO: enable when Go 1.24.11 is available widely
 	@echo lint tools/format_self
 	@(cd tools/format_self && make test)
 	@echo lint tools/format_unittests


### PR DESCRIPTION
This tools throws irrelevant alerts that require Go versions that are so recent
that they aren't available on the latest Fedora, which is itself a pretty
leading edge distro.
