### PR TITLE
Provide BranchInfos in light-interpreter

### DIFF
--- a/internal/skip/execute.go
+++ b/internal/skip/execute.go
@@ -50,6 +50,7 @@ func Execute(args ExecuteArgs) error {
 	}
 	lightinterpreter.Execute(lightinterpreter.ExecuteArgs{
 		Backend:       args.Backend,
+		BranchInfos:   args.RunState.BeginBranchesSnapshot.Branches,
 		Config:        args.Config,
 		Connector:     args.Connector,
 		FinalMessages: args.FinalMessages,
@@ -123,6 +124,7 @@ func revertChangesToCurrentBranch(args ExecuteArgs) error {
 	})
 	lightinterpreter.Execute(lightinterpreter.ExecuteArgs{
 		Backend:       args.Backend,
+		BranchInfos:   args.RunState.BeginBranchesSnapshot.Branches,
 		Config:        args.Config,
 		Connector:     args.Connector,
 		FinalMessages: args.FinalMessages,

--- a/internal/undo/execute.go
+++ b/internal/undo/execute.go
@@ -49,6 +49,7 @@ func Execute(args ExecuteArgs) error {
 	})
 	lightinterpreter.Execute(lightinterpreter.ExecuteArgs{
 		Backend:       args.Backend,
+		BranchInfos:   args.RunState.BeginBranchesSnapshot.Branches,
 		Config:        args.Config,
 		Connector:     args.Connector,
 		FinalMessages: args.FinalMessages,

--- a/internal/vm/interpreter/fullinterpreter/auto_undo.go
+++ b/internal/vm/interpreter/fullinterpreter/auto_undo.go
@@ -31,6 +31,7 @@ func autoUndo(opcode shared.AutoUndoable, runErr error, args ExecuteArgs) error 
 	}
 	lightinterpreter.Execute(lightinterpreter.ExecuteArgs{
 		Backend:       args.Backend,
+		BranchInfos:   args.RunState.BeginBranchesSnapshot.Branches,
 		Config:        args.Config,
 		Connector:     args.Connector,
 		FinalMessages: args.FinalMessages,

--- a/internal/vm/interpreter/fullinterpreter/execute.go
+++ b/internal/vm/interpreter/fullinterpreter/execute.go
@@ -71,7 +71,7 @@ func Execute(args ExecuteArgs) error {
 		}
 		err := runnable.Run(shared.RunArgs{
 			Backend:                         args.Backend,
-			BranchInfos:                     Some(args.InitialBranchesSnapshot.Branches),
+			BranchInfos:                     args.InitialBranchesSnapshot.Branches,
 			Config:                          NewMutable(&args.Config),
 			Connector:                       args.Connector,
 			FinalMessages:                   args.FinalMessages,

--- a/internal/vm/interpreter/lightinterpreter/execute.go
+++ b/internal/vm/interpreter/lightinterpreter/execute.go
@@ -30,7 +30,7 @@ func Execute(args ExecuteArgs) {
 		}
 		err := runnable.Run(shared.RunArgs{
 			Backend:                         args.Backend,
-			BranchInfos:                     None[gitdomain.BranchInfos](),
+			BranchInfos:                     args.BranchInfos,
 			Config:                          NewMutable(&args.Config),
 			Connector:                       args.Connector,
 			FinalMessages:                   args.FinalMessages,
@@ -49,6 +49,7 @@ func Execute(args ExecuteArgs) {
 
 type ExecuteArgs struct {
 	Backend       subshelldomain.RunnerQuerier
+	BranchInfos   gitdomain.BranchInfos
 	Config        config.ValidatedConfig
 	Connector     Option[forgedomain.Connector]
 	FinalMessages stringslice.Collector

--- a/internal/vm/opcodes/branch_current_reset_to_parent.go
+++ b/internal/vm/opcodes/branch_current_reset_to_parent.go
@@ -2,7 +2,6 @@ package opcodes
 
 import (
 	"github.com/git-town/git-town/v22/internal/git/gitdomain"
-	"github.com/git-town/git-town/v22/internal/messages"
 	"github.com/git-town/git-town/v22/internal/vm/shared"
 )
 
@@ -16,11 +15,7 @@ func (self *BranchCurrentResetToParent) Run(args shared.RunArgs) error {
 	if !hasParent {
 		return nil
 	}
-	branchInfos, hasBranchInfos := args.BranchInfos.Get()
-	if !hasBranchInfos {
-		panic(messages.BranchInfosNotProvided)
-	}
-	parentIsLocal := branchInfos.HasLocalBranch(parent)
+	parentIsLocal := args.BranchInfos.HasLocalBranch(parent)
 	var target gitdomain.BranchName
 	if parentIsLocal {
 		target = parent.BranchName()

--- a/internal/vm/opcodes/rebase_ancestors_until_local.go
+++ b/internal/vm/opcodes/rebase_ancestors_until_local.go
@@ -2,7 +2,6 @@ package opcodes
 
 import (
 	"github.com/git-town/git-town/v22/internal/git/gitdomain"
-	"github.com/git-town/git-town/v22/internal/messages"
 	"github.com/git-town/git-town/v22/internal/vm/shared"
 	. "github.com/git-town/git-town/v22/pkg/prelude"
 )
@@ -16,10 +15,6 @@ type RebaseAncestorsUntilLocal struct {
 
 func (self *RebaseAncestorsUntilLocal) Run(args shared.RunArgs) error {
 	program := []shared.Opcode{}
-	branchInfos, hasBranchInfos := args.BranchInfos.Get()
-	if !hasBranchInfos {
-		panic(messages.BranchInfosNotProvided)
-	}
 	branch := self.Branch
 	for {
 		ancestor, hasAncestor := args.Config.Value.NormalConfig.Lineage.Parent(branch).Get()
@@ -30,7 +25,7 @@ func (self *RebaseAncestorsUntilLocal) Run(args shared.RunArgs) error {
 		if ancestorIsPerennial && args.Config.Value.NormalConfig.Detached.ShouldWorkDetached() {
 			break
 		}
-		ancestorIsLocal := branchInfos.HasLocalBranch(ancestor)
+		ancestorIsLocal := args.BranchInfos.HasLocalBranch(ancestor)
 		if !ancestorIsLocal {
 			// here the parent isn't local --> sync with its tracking branch, then try again with the grandparent until we find a local ancestor
 			program = append(program, &RebaseAncestorRemote{

--- a/internal/vm/opcodes/sync_feature_branch_compress.go
+++ b/internal/vm/opcodes/sync_feature_branch_compress.go
@@ -75,15 +75,13 @@ func (self *SyncFeatureBranchCompress) Run(args shared.RunArgs) error {
 	return nil
 }
 
-func determineParentBranchName(parentLocalName gitdomain.LocalBranchName, branchInfosOpt Option[gitdomain.BranchInfos], devRemote gitdomain.Remote) gitdomain.BranchName {
-	if branchInfos, hasBranchInfos := branchInfosOpt.Get(); hasBranchInfos {
-		if parentInfo, hasParentInfo := branchInfos.FindByLocalName(parentLocalName).Get(); hasParentInfo {
-			return parentInfo.GetLocalOrRemoteName()
-		}
-		parentRemoteName := parentLocalName.AtRemote(devRemote)
-		if _, hasParentInfo := branchInfos.FindByRemoteName(parentRemoteName).Get(); hasParentInfo {
-			return parentRemoteName.BranchName()
-		}
+func determineParentBranchName(parentLocalName gitdomain.LocalBranchName, branchInfos gitdomain.BranchInfos, devRemote gitdomain.Remote) gitdomain.BranchName {
+	if parentInfo, hasParentInfo := branchInfos.FindByLocalName(parentLocalName).Get(); hasParentInfo {
+		return parentInfo.GetLocalOrRemoteName()
+	}
+	parentRemoteName := parentLocalName.AtRemote(devRemote)
+	if _, hasParentInfo := branchInfos.FindByRemoteName(parentRemoteName).Get(); hasParentInfo {
+		return parentRemoteName.BranchName()
 	}
 	return parentLocalName.BranchName()
 }

--- a/internal/vm/opcodes/sync_feature_branch_merge.go
+++ b/internal/vm/opcodes/sync_feature_branch_merge.go
@@ -2,7 +2,6 @@ package opcodes
 
 import (
 	"github.com/git-town/git-town/v22/internal/git/gitdomain"
-	"github.com/git-town/git-town/v22/internal/messages"
 	"github.com/git-town/git-town/v22/internal/vm/shared"
 	. "github.com/git-town/git-town/v22/pkg/prelude"
 )
@@ -17,10 +16,6 @@ type SyncFeatureBranchMerge struct {
 
 func (self *SyncFeatureBranchMerge) Run(args shared.RunArgs) error {
 	program := []shared.Opcode{}
-	branchInfos, hasBranchInfos := args.BranchInfos.Get()
-	if !hasBranchInfos {
-		panic(messages.BranchInfosNotProvided)
-	}
 	branch := self.Branch
 	for {
 		parent, hasParent := args.Config.Value.NormalConfig.Lineage.Parent(branch).Get()
@@ -31,7 +26,7 @@ func (self *SyncFeatureBranchMerge) Run(args shared.RunArgs) error {
 		if args.Config.Value.NormalConfig.Detached.ShouldWorkDetached() && parentIsPerennial {
 			break
 		}
-		if parentBranchInfo, hasParentInfo := branchInfos.FindLocalOrRemote(parent, args.Config.Value.NormalConfig.DevRemote).Get(); hasParentInfo {
+		if parentBranchInfo, hasParentInfo := args.BranchInfos.FindLocalOrRemote(parent, args.Config.Value.NormalConfig.DevRemote).Get(); hasParentInfo {
 			parentIsLocal := parentBranchInfo.LocalName.IsSome()
 			if parentIsLocal {
 				isInSync, err := args.Git.BranchInSyncWithParent(args.Backend, self.Branch, parent.BranchName())

--- a/internal/vm/shared/runargs.go
+++ b/internal/vm/shared/runargs.go
@@ -13,7 +13,7 @@ import (
 
 type RunArgs struct {
 	Backend                         subshelldomain.RunnerQuerier
-	BranchInfos                     Option[gitdomain.BranchInfos]
+	BranchInfos                     gitdomain.BranchInfos
 	Config                          Mutable[config.ValidatedConfig]
 	Connector                       Option[forgedomain.Connector]
 	FinalMessages                   stringslice.Collector


### PR DESCRIPTION
Rather than providing no BranchInfos when executing skip or undo, let's provide
the branch infos from the runstate. This isn't wrong, and simplifies logic
because we don't need to check for the existence of BranchInfos.
