### PR TITLE
sync: only delete actually existing tracking branches when pruning

### DIFF
--- a/features/sync/current_branch/feature_branch/merge_sync_strategy/prune/fresh_branch.feature
+++ b/features/sync/current_branch/feature_branch/merge_sync_strategy/prune/fresh_branch.feature
@@ -13,8 +13,7 @@ Feature: prune a freshly created branch
       | BRANCH  | COMMAND                  |
       | feature | git fetch --prune --tags |
       |         | git checkout main        |
-      | main    | git push origin :feature |
-      |         | git branch -D feature    |
+      | main    | git branch -D feature    |
     And the branches are now
       | REPOSITORY    | BRANCHES |
       | local, origin | main     |


### PR DESCRIPTION
<!-- branch-stack -->

-------------------------
 - main
   - https://github.com/git-town/git-town/pull/5881 :point_left:

<sup>[Stack](https://www.git-town.com/how-to/github-actions-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->