### PR TITLE
fix: standard version shorthand is always a lowercase -v not -V

### DIFF
--- a/internal/cli/flags/version.go
+++ b/internal/cli/flags/version.go
@@ -8,7 +8,7 @@ const versionLong = "version"
 
 func Version() (AddFunc, ReadBoolFlagFunc) {
 	addFlag := func(cmd *cobra.Command) {
-		cmd.Flags().BoolP(versionLong, "V", false, "display the version number")
+		cmd.Flags().BoolP(versionLong, "v", false, "display the version number")
 	}
 	readFlag := func(cmd *cobra.Command) (bool, error) {
 		return cmd.Flags().GetBool(versionLong)


### PR DESCRIPTION
I believe this to be a mistake. I don't know of any cli that uses capital `-V` as the shorthand for version, rather the standard is lowercase `-v`