### PR TITLE
Remove redundant unit test

### DIFF
--- a/internal/state/runstate/save_load_test.go
+++ b/internal/state/runstate/save_load_test.go
@@ -20,19 +20,6 @@ import (
 func TestLoadSave(t *testing.T) {
 	t.Parallel()
 
-	t.Run("SanitizePath", func(t *testing.T) {
-		t.Parallel()
-		tests := map[string]string{
-			"/home/user/development/git-town":        "home-user-development-git-town",
-			"c:\\Users\\user\\development\\git-town": "c-users-user-development-git-town",
-		}
-		for give, want := range tests {
-			rootDir := gitdomain.NewRepoRootDir(give)
-			have := state.SanitizePath(rootDir)
-			must.EqOp(t, want, have)
-		}
-	})
-
 	t.Run("Save and Load", func(t *testing.T) {
 		t.Parallel()
 		runState := runstate.RunState{


### PR DESCRIPTION
This test also exists at internal/state/sanitize_path_test.go.
