### PR TITLE
Remove deadcode from make test-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,6 @@ test: fix doc unit lint-all cuke  # runs all the tests
 test-go: install tools/rta@${RTA_VERSION}  # smoke tests while working on the Go code
 	@tools/rta conc --show=failed \
 		"make --no-print-directory unit" \
-		"make --no-print-directory deadcode" \
 		"make --no-print-directory lint"
 
 todo:  # displays all TODO items


### PR DESCRIPTION
It is already running as part of make lint.
