### PR TITLE
docs: update 'compile from source' to use 'go install'

### DIFF
--- a/website/src/install.md
+++ b/website/src/install.md
@@ -117,7 +117,7 @@ If you have the [Go compiler](https://go.dev) installed, you can compile the
 latest version of Git Town from source by running:
 
 ```
-go get github.com/git-town/git-town/v22
+go install github.com/git-town/git-town/v22@latest
 ```
 
 ## New releases


### PR DESCRIPTION
Hi!

First of all, thanks for such a great tool!

I tried installation from the source, per instructions:
```
go get github.com/git-town/git-town/v22
```

And this is the error message:

>  go: go.mod file not found in current directory or any parent directory.
> `go get` is no longer supported outside a module.
> To build and install a command, use `go install` with a version, like `go install example.com/cmd@latest`
> For more information, see [https://golang.org/doc/go-get-install-deprecation](https://golang.org/doc/go-get-install-deprecation) or run 'go help get' or 'go help install'.


On the other hand, this is working:
```
go install github.com/git-town/git-town/v22@latest
```

