### PR TITLE
fix: add missing 'mr list' subcommand to glab SearchProposals

### DIFF
--- a/internal/forge/glab/connector.go
+++ b/internal/forge/glab/connector.go
@@ -89,7 +89,7 @@ func (self Connector) FindProposal(branch, target gitdomain.LocalBranchName) (Op
 var _ forgedomain.ProposalSearcher = glabConnector // type check
 
 func (self Connector) SearchProposals(branch gitdomain.LocalBranchName) ([]forgedomain.Proposal, error) {
-	out, err := self.Backend.Query("glab", "--source-branch="+branch.String(), "--output=json")
+	out, err := self.Backend.Query("glab", "mr", "list", "--source-branch="+branch.String(), "--output=json")
 	if err != nil {
 		return []forgedomain.Proposal{}, err
 	}


### PR DESCRIPTION
## Bug

`SearchProposals` in `internal/forge/glab/connector.go` was missing the `"mr", "list"` arguments when calling `glab`, causing `--source-branch` to be interpreted as a top-level flag.

## Steps to reproduce

1. Set `git-town.gitlab-connector` to `glab`
2. Create a feature branch
3. Run `git town propose` (or `git town propose --dry-run`)

## Error

```
cannot find proposal:
COMMAND: glab --source-branch=test/glab-connector --output=json
ERROR: exit status 1
OUTPUT: Unknown flag: --source-branch.
```

## Root cause

`FindProposal` (line 67) correctly calls:
```go
self.Backend.Query("glab", "mr", "list", "--source-branch=...", "--target-branch=...", "--output=json")
```

`SearchProposals` (line 92) was missing `"mr", "list"`:
```go
self.Backend.Query("glab", "--source-branch=...", "--output=json")
```

## Fix

Added `"mr", "list"` to the `SearchProposals` query, matching the pattern used in `FindProposal` and the `gh` connector's `SearchProposals`.

## Note

Related to but distinct from #6015 — that issue is about `mr create` failures with `--stack`, this is about the proposal search step.