### PR TITLE
Descriptive no-TTY errors for lineage and unfinished state dialogs

### DIFF
--- a/features/sync/features/no_tty_unfinished_state.feature
+++ b/features/sync/features/no_tty_unfinished_state.feature
@@ -1,0 +1,24 @@
+Feature: descriptive error when there is unfinished state and no TTY is available
+
+  Background:
+    Given a Git repo with origin
+    And the branches
+      | NAME    | TYPE    | PARENT | LOCATIONS     |
+      | feature | feature | main   | local, origin |
+    And the commits
+      | BRANCH  | LOCATION | MESSAGE                   | FILE NAME        | FILE CONTENT   |
+      | feature | local    | conflicting local commit  | conflicting_file | local content  |
+      |         | origin   | conflicting origin commit | conflicting_file | origin content |
+    And the current branch is "feature"
+    When I run "git-town sync"
+
+  Scenario: sync with unfinished state and no TTY
+    When I run "git-town sync"
+    Then Git Town prints the error:
+      """
+      there is an unfinished "sync" command and no interactive terminal available to resolve it.
+      To continue the command, run: git town continue
+      To skip the current branch, run: git town skip
+      To undo the command, run: git town undo
+      To discard the unfinished state, run: git town status reset
+      """

--- a/features/sync/features/no_tty_unknown_parent.feature
+++ b/features/sync/features/no_tty_unknown_parent.feature
@@ -1,0 +1,15 @@
+Feature: descriptive error when parent is unknown and no TTY is available
+
+  Scenario: sync a branch with unknown parent and no TTY
+    Given a Git repo with origin
+    And the branches
+      | NAME  | TYPE   | LOCATIONS     |
+      | alpha | (none) | local, origin |
+    And the current branch is "alpha"
+    When I run "git-town sync"
+    Then Git Town prints the error:
+      """
+      no parent configured for branch "alpha" and no interactive terminal available.
+      To set the parent, run: git town set-parent <parent>
+      To configure manually, run: git config git-town-branch.alpha.parent <parent>
+      """

--- a/internal/cli/dialog/dialogcomponents/tty.go
+++ b/internal/cli/dialog/dialogcomponents/tty.go
@@ -10,8 +10,14 @@ import (
 // ErrNoTTY indicates that an interactive terminal is required but not available.
 var ErrNoTTY = errors.New("no interactive terminal available")
 
+// NoTTYEnvVar allows overriding TTY detection via an environment variable.
+const NoTTYEnvVar = "GIT_TOWN_NO_TTY"
+
 // HasTTY reports whether an interactive terminal is available.
 func HasTTY() bool {
+	if _, set := os.LookupEnv(NoTTYEnvVar); set {
+		return false
+	}
 	fd := os.Stdin.Fd()
 	if isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd) {
 		return true

--- a/internal/cli/dialog/lineage.go
+++ b/internal/cli/dialog/lineage.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -96,10 +97,14 @@ func Lineage(args LineageArgs) (LineageResult, dialogdomain.Exit, error) {
 			UncommittedChanges: false,
 		})
 		if err != nil || exit {
-			return LineageResult{
+			result := LineageResult{
 				AdditionalLineage:    additionalLineage,
 				AdditionalPerennials: additionalPerennials,
-			}, exit, err
+			}
+			if errors.Is(err, dialogcomponents.ErrNoTTY) {
+				return result, false, fmt.Errorf(messages.NoTTYParentBranchMissing, branchToVerify, branchToVerify)
+			}
+			return result, exit, err
 		}
 		if newParent == messages.SetParentNoneOption {
 			additionalPerennials = append(additionalPerennials, branchToVerify)

--- a/internal/messages/en.go
+++ b/internal/messages/en.go
@@ -214,7 +214,9 @@ Please upgrade to the new format: create.new-branch-type = "prototype"`
 
 	NewBranchType = "New branch type:"
 
-	NoTTYMainBranchMissing = "no main branch configured and no interactive terminal available.\nTo set up interactively, run: git town init\nTo configure manually, run: git config git-town.main-branch <branch>"
+	NoTTYMainBranchMissing   = "no main branch configured and no interactive terminal available.\nTo set up interactively, run: git town init\nTo configure manually, run: git config git-town.main-branch <branch>"
+	NoTTYParentBranchMissing = "no parent configured for branch %q and no interactive terminal available.\nTo set the parent, run: git town set-parent <parent>\nTo configure manually, run: git config git-town-branch.%s.parent <parent>"
+	NoTTYUnfinishedState     = "there is an unfinished %q command and no interactive terminal available to resolve it.\nTo continue the command, run: git town continue\nTo skip the current branch, run: git town skip\nTo undo the command, run: git town undo\nTo discard the unfinished state, run: git town status reset"
 
 	ObserveBranchIsLocal        = "branch %s is local only - branches you want to observe must have a remote branch because they are per definition other people's branches"
 	ObservedBranchCannotPark    = "cannot park observed branches"

--- a/internal/test/envvars/replace.go
+++ b/internal/test/envvars/replace.go
@@ -2,6 +2,16 @@ package envvars
 
 import "strings"
 
+// HasPrefix indicates whether any environment variable name starts with the given prefix.
+func HasPrefix(envVars []string, prefix string) bool {
+	for _, envVar := range envVars {
+		if strings.HasPrefix(envVar, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // Replace provides a new envvars in which the entry with the given key contains the given value instead of its original value.
 // If no entry with the given key exists, appends one at the end.
 // This function assumes that keys are unique, i.e. no duplicate keys exist.

--- a/internal/test/subshell/test_runner.go
+++ b/internal/test/subshell/test_runner.go
@@ -193,6 +193,10 @@ func (self *TestRunner) QueryWithCode(opts *Options, cmd string, args ...string)
 	}
 	// mark as test run
 	opts.Env = append(opts.Env, subshell.TestToken+"=1")
+	// disable TTY when no dialog inputs are provided to prevent subprocess hangs
+	if !envvars.HasPrefix(opts.Env, "GITTOWN_DIALOG_INPUT") {
+		opts.Env = envvars.Replace(opts.Env, "GIT_TOWN_NO_TTY", "1")
+	}
 	// run the command inside the custom environment
 	subProcess := exec.Command(cmd, args...) // #nosec
 	subProcess.Dir = filepath.Join(self.WorkingDir, opts.Dir)

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -44,6 +44,9 @@ func HandleUnfinishedState(args UnfinishedStateArgs) (configdomain.ProgramFlow, 
 		args.Inputs,
 	)
 	if err != nil {
+		if errors.Is(err, dialogcomponents.ErrNoTTY) {
+			return configdomain.ProgramFlowExit, fmt.Errorf(messages.NoTTYUnfinishedState, runState.Command)
+		}
 		return configdomain.ProgramFlowExit, err
 	}
 	if exit {


### PR DESCRIPTION
Extends the `ErrNoTTY` handling from #6051 to the two remaining dialog points, completing descriptive error message coverage for non-interactive terminals.

## Issue

Related to #5995 (task 1 — descriptive error messages).

When Git Town needs information but cannot open a TTY, the lineage and unfinished state dialogs propagated the raw `ErrNoTTY` without actionable guidance. #6051 solved this for the main branch case; this PR covers the remaining paths.

## Changes

- **`cli/dialog/lineage.go`**: Catch `ErrNoTTY` from `SwitchBranch()` and return a message including the branch name and remediation commands (`git town set-parent`, `git config git-town-branch.<branch>.parent`)
- **`validate/handle_unfinished_state.go`**: Catch `ErrNoTTY` from `AskHowToHandleUnfinishedRunState()` and return a message with the interrupted command name and resolution options (`continue`, `skip`, `undo`, `status reset`)
- **`messages/en.go`**: Add `NoTTYParentBranchMissing` and `NoTTYUnfinishedState` message constants

## Testing

Two new Cucumber scenarios verify the error messages:
- `no_tty_unknown_parent.feature` — syncing a branch with no configured parent
- `no_tty_unfinished_state.feature` — syncing when a prior command was interrupted by a merge conflict

To make these tests portable across environments, a `GIT_TOWN_NO_TTY` env var was added to `HasTTY()`. On Linux CI, `/dev/tty` is accessible even without a real terminal (the CI runner uses `script` to create a PTY), so `HasTTY()` returns `true` and dialog subprocesses hang waiting for input. The alternative — using `Setsid` to detach from the controlling terminal — was not viable because `RequireTTY()` is checked before dialog test inputs are consumed, so detaching would break all existing dialog tests. The test runner now sets `GIT_TOWN_NO_TTY=1` for commands that have no `GITTOWN_DIALOG_INPUT` env vars, ensuring the no-TTY path is reliably triggered without affecting dialog tests.
