### PR TITLE
Redirect golangci-lint cache to sandbox-writable path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
-    "DISABLE_NON_ESSENTIAL_MODEL_CALLS": "1"
+    "DISABLE_NON_ESSENTIAL_MODEL_CALLS": "1",
+    "GOLANGCI_LINT_CACHE": "/tmp/claude/golangci-lint"
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
The Claude Code sandbox blocks writes to `~/Library/Caches/golangci-lint`, causing `golangci-lint cache clean` (run by `make lint`) to fail. This created an infinite loop with the Stop hook: lint fails, failure reported to Claude, Claude responds, Stop hook fires again.

Redirects the `golangci-lint` cache to `/tmp/claude/golangci-lint` via the `GOLANGCI_LINT_CACHE` env var. This path is already in the sandbox write allowlist and is portable across platforms.

https://golangci-lint.run/docs/configuration/cli/#cache