### PR TITLE
Fix glab squash-merge flag: use --squash-message instead of --body

### DIFF
--- a/internal/forge/glab/connector.go
+++ b/internal/forge/glab/connector.go
@@ -130,7 +130,7 @@ func (self Connector) SearchProposals(branch gitdomain.LocalBranchName) ([]forge
 var _ forgedomain.ProposalMerger = glabConnector // type check
 
 func (self Connector) SquashMergeProposal(number forgedomain.ProposalNumber, message gitdomain.CommitMessage) error {
-	return self.Frontend.Run("glab", "mr", "merge", "--squash", "--body="+message.String(), number.String())
+	return self.Frontend.Run("glab", "mr", "merge", "--squash", "--squash-message="+message.String(), number.String())
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fix `glab mr merge` to use `--squash-message` instead of `--body`
- `--body` was never a valid flag — it was copy-pasted from the `gh` connector where `gh pr merge --squash --body=...` is correct
- `glab mr merge` has `--message` (merge commit msg) and `--squash-message` (squash commit msg); since we pass `--squash`, the correct flag is `--squash-message`

`glab mr merge --help` output:

```
  FLAGS

    --auto-merge               Set auto-merge. (true)
    -h --help                  Show help for this command.
    -m --message               Custom merge commit message.
    -r --rebase                Rebase the commits onto the base branch.
    -d --remove-source-branch  Remove source branch on merge.
    -R --repo                  Select another repository.
    --sha                      Merge only if the HEAD of the source branch matches this SHA.
    -s --squash                Squash commits on merge.
    --squash-message           Custom squash commit message.
    -y --yes                   Skip submission confirmation prompt.
```