### PR TITLE
Improve config data precedence

### DIFF
--- a/internal/config/unvalidated_config.go
+++ b/internal/config/unvalidated_config.go
@@ -123,9 +123,9 @@ type NewUnvalidatedConfigArgs struct {
 func mergeConfigs(args mergeConfigsArgs) (configdomain.UnvalidatedConfigData, NormalConfig) {
 	result := configdomain.EmptyPartialConfig()
 	result = result.Merge(args.system)
+	result = result.Merge(args.env)
 	result = result.Merge(args.file)
 	result = result.Merge(args.git)
-	result = result.Merge(args.env)
 	result = result.Merge(args.cli)
 	return result.ToUnvalidatedConfig(), NewNormalConfigFromPartial(result, args.defaults)
 }


### PR DESCRIPTION
Now the config data precedence is (later values overwrite earlier ones):

- Defaults
- System 
- Env
- config file
- Git metadata
- CLI
