### PR TITLE
Stop annoying assistant as soon as possible. Allow of user to exit with minimal setup.

### DIFF
--- a/internal/cli/dialog/complete_minimal.go
+++ b/internal/cli/dialog/complete_minimal.go
@@ -1,0 +1,34 @@
+package dialog
+
+import (
+	"github.com/git-town/git-town/v22/internal/cli/dialog/dialogcomponents"
+	"github.com/git-town/git-town/v22/internal/cli/dialog/dialogcomponents/list"
+	"github.com/git-town/git-town/v22/internal/cli/dialog/dialogdomain"
+	"github.com/git-town/git-town/v22/internal/config/configdomain"
+)
+
+const (
+	completeMinimalTitle = `Complete Minimal Setup`
+	completeMinimalHelp  = `
+Complete the minimal setup of Git Town,
+and could end the assistant here
+or continue with cli and forge configuration.
+
+You can re-run this assistant: git town init
+`
+)
+
+func CompleteMinimal(inputs dialogcomponents.Inputs, interactive configdomain.Interactive) (bool, dialogdomain.Exit, error) {
+	entries := list.Entries[bool]{
+		{
+			Data: true,
+			Text: `exit and save`,
+		},
+		{
+			Data: false,
+			Text: `continue to the cli and forge configuration`,
+		},
+	}
+	selection, exit, err := dialogcomponents.RadioList(entries, 0, completeMinimalTitle, completeMinimalHelp, inputs, interactive, "complete-minimal")
+	return selection, exit, err
+}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -94,11 +94,11 @@ Start:
 		goto Start
 	}
 	data.Config.NormalConfig.Interactive = interactive
-	userInput, exit, enterAll, err := setup.Enter(data, repo.ConfigDir)
+	userInput, exit, minimal, enterAll, err := setup.Enter(data, repo.ConfigDir)
 	if err != nil || exit {
 		return err
 	}
-	if err = setup.Save(userInput, repo.UnvalidatedConfig, data, enterAll, repo.Frontend); err != nil {
+	if err = setup.Save(userInput, repo.UnvalidatedConfig, data, minimal, enterAll, repo.Frontend); err != nil {
 		return err
 	}
 	return configinterpreter.Finished(configinterpreter.FinishedArgs{

--- a/internal/setup/enter.go
+++ b/internal/setup/enter.go
@@ -21,36 +21,52 @@ import (
 	. "github.com/git-town/git-town/v22/pkg/prelude"
 )
 
-func Enter(data Data, configDir configdomain.RepoConfigDir) (UserInput, dialogdomain.Exit, bool, error) {
+func Enter(data Data, configDir configdomain.RepoConfigDir) (UserInput, dialogdomain.Exit, bool, bool, error) {
 	var emptyResult UserInput
 	exit, err := dialog.Welcome(data.Inputs, data.Config.NormalConfig.Interactive)
 	if err != nil || exit {
-		return emptyResult, exit, false, err
-	}
-	aliases, exit, err := dialog.Aliases(configdomain.AllAliasableCommands(), data.Config.NormalConfig.Aliases, data.Config.NormalConfig.Interactive, data.Inputs)
-	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
 	}
 	mainBranchResult, exit, err := enterMainBranch(data)
 	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
+	}
+	configStorage, exit, err := dialog.ConfigStorage(data.Inputs, data.Config.NormalConfig.Interactive)
+	if err != nil || exit {
+		return emptyResult, exit, false, false, err
+	}
+	completeMinimal, exit, err := dialog.CompleteMinimal(data.Inputs, data.Config.NormalConfig.Interactive)
+	if err != nil || exit {
+		return emptyResult, exit, false, false, err
+	}
+	if completeMinimal {
+		return UserInput{
+			Data: configdomain.PartialConfig{
+				MainBranch: mainBranchResult.UserChoice,
+			},
+			StorageLocation: configStorage,
+		}, exit, true, false, nil
+	}
+	aliases, exit, err := dialog.Aliases(configdomain.AllAliasableCommands(), data.Config.NormalConfig.Aliases, data.Config.NormalConfig.Interactive, data.Inputs)
+	if err != nil || exit {
+		return emptyResult, exit, false, false, err
 	}
 	perennialBranches, exit, err := enterPerennialBranches(data, mainBranchResult.ActualMainBranch)
 	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
 	}
 EnterForgeData:
 	devRemote, exit, err := enterDevRemote(data)
 	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
 	}
 	hostingOriginHostName, exit, err := enterOriginHostName(data)
 	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
 	}
 	enteredForgeType, exit, err := enterForgeType(data)
 	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
 	}
 	devURL := data.Config.NormalConfig.DevURL(data.Backend)
 	actualForgeType := determineForgeType(enteredForgeType.Or(data.Config.File.ForgeType), devURL)
@@ -69,33 +85,33 @@ EnterForgeData:
 		case forgedomain.ForgeTypeBitbucket, forgedomain.ForgeTypeBitbucketDatacenter:
 			bitbucketUsername, exit, err = enterBitbucketUserName(data)
 			if err != nil || exit {
-				return emptyResult, exit, false, err
+				return emptyResult, exit, false, false, err
 			}
 			bitbucketAppPassword, exit, err = enterBitbucketAppPassword(data)
 			if err != nil || exit {
-				return emptyResult, exit, false, err
+				return emptyResult, exit, false, false, err
 			}
 		case forgedomain.ForgeTypeForgejo:
 			forgejoToken, exit, err = enterForgejoToken(data)
 			if err != nil || exit {
-				return emptyResult, exit, false, err
+				return emptyResult, exit, false, false, err
 			}
 		case forgedomain.ForgeTypeGitea:
 			giteaToken, exit, err = enterGiteaToken(data)
 			if err != nil || exit {
-				return emptyResult, exit, false, err
+				return emptyResult, exit, false, false, err
 			}
 		case forgedomain.ForgeTypeGithub:
 			githubConnectorTypeOpt, exit, err = enterGithubConnectorType(data)
 			if err != nil || exit {
-				return emptyResult, exit, false, err
+				return emptyResult, exit, false, false, err
 			}
 			if githubConnectorType, has := githubConnectorTypeOpt.Or(data.Config.File.GithubConnectorType).Get(); has {
 				switch githubConnectorType {
 				case forgedomain.GithubConnectorTypeAPI:
 					githubToken, exit, err = enterGithubToken(data)
 					if err != nil || exit {
-						return emptyResult, exit, false, err
+						return emptyResult, exit, false, false, err
 					}
 				case forgedomain.GithubConnectorTypeGh:
 				}
@@ -103,14 +119,14 @@ EnterForgeData:
 		case forgedomain.ForgeTypeGitlab:
 			gitlabConnectorTypeOpt, exit, err = enterGitlabConnectorType(data)
 			if err != nil || exit {
-				return emptyResult, exit, false, err
+				return emptyResult, exit, false, false, err
 			}
 			if gitlabConnectorType, has := gitlabConnectorTypeOpt.Or(data.Config.File.GitlabConnectorType).Get(); has {
 				switch gitlabConnectorType {
 				case forgedomain.GitlabConnectorTypeAPI:
 					gitlabToken, exit, err = enterGitlabToken(data)
 					if err != nil || exit {
-						return emptyResult, exit, false, err
+						return emptyResult, exit, false, false, err
 					}
 				case forgedomain.GitlabConnectorTypeGlab:
 				}
@@ -135,7 +151,7 @@ EnterForgeData:
 		remoteURL:            data.Config.NormalConfig.RemoteURL(data.Backend, devRemote.GetOr(config.DefaultNormalConfig().DevRemote)),
 	})
 	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
 	}
 	if flow == configdomain.ProgramFlowRestart {
 		goto EnterForgeData
@@ -153,11 +169,11 @@ EnterForgeData:
 		inputs:               data.Inputs,
 	})
 	if err != nil || exit {
-		return emptyResult, exit, false, err
+		return emptyResult, exit, false, false, err
 	}
 	enterAll, exit, err := dialog.EnterAll(data.Inputs, data.Config.NormalConfig.Interactive)
 	if err != nil || exit {
-		return emptyResult, exit, enterAll, err
+		return emptyResult, exit, false, enterAll, err
 	}
 	// keep-sorted start
 	autoSync := None[configdomain.AutoSync]()
@@ -189,108 +205,104 @@ EnterForgeData:
 	if enterAll {
 		perennialRegex, exit, err = enterPerennialRegex(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		featureRegex, exit, err = enterFeatureRegex(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		contributionRegex, exit, err = enterContributionRegex(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		observedRegex, exit, err = enterObservedRegex(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		branchPrefix, exit, err = enterBranchPrefix(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		newBranchType, exit, err = enterNewBranchType(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		unknownBranchType, exit, err = enterUnknownBranchType(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		syncFeatureStrategy, exit, err = enterSyncFeatureStrategy(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		syncPerennialStrategy, exit, err = enterSyncPerennialStrategy(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		syncPrototypeStrategy, exit, err = enterSyncPrototypeStrategy(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		syncUpstream, exit, err = enterSyncUpstream(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		autoSync, exit, err = enterAutoSync(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		syncTags, exit, err = enterSyncTags(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		detached, exit, err = enterDetached(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		stash, exit, err = enterStash(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		shareNewBranches, exit, err = enterShareNewBranches(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		pushBranches, exit, err = enterPushBranches(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		pushHook, exit, err = enterPushHook(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		shipStrategy, exit, err = enterShipStrategy(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		shipDeleteTrackingBranch, exit, err = enterShipDeleteTrackingBranch(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		ignoreUncommitted, exit, err = enterIgnoreUncommitted(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		order, exit, err = enterOrder(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		proposalBreadcrumb, exit, err = enterProposalBreadcrumb(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		proposalBreadcrumbDirection, exit, err = enterProposalBreadcrumbDirection(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
 		interactive, exit, err = enterInteractive(data)
 		if err != nil || exit {
-			return emptyResult, exit, false, err
+			return emptyResult, exit, false, false, err
 		}
-	}
-	configStorage, exit, err := dialog.ConfigStorage(data.Inputs, data.Config.NormalConfig.Interactive)
-	if err != nil || exit {
-		return emptyResult, exit, false, err
 	}
 	normalData := configdomain.PartialConfig{
 		Aliases:                     aliases,
@@ -347,7 +359,7 @@ EnterForgeData:
 	validatedData := configdomain.ValidatedConfigData{
 		MainBranch: mainBranchResult.ActualMainBranch,
 	}
-	return UserInput{normalData, actualForgeType, tokenScope, configStorage, validatedData}, false, enterAll, nil
+	return UserInput{normalData, actualForgeType, tokenScope, configStorage, validatedData}, false, false, enterAll, nil
 }
 
 // data entered by the user in the setup assistant

--- a/internal/setup/save.go
+++ b/internal/setup/save.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/git-town/git-town/v22/pkg/prelude"
 )
 
-func Save(userInput UserInput, unvalidatedConfig config.UnvalidatedConfig, data Data, enterAll bool, frontend subshelldomain.Runner) error {
+func Save(userInput UserInput, unvalidatedConfig config.UnvalidatedConfig, data Data, minimal, enterAll bool, frontend subshelldomain.Runner) error {
 	fc := gohacks.ErrorCollector{}
 	fc.Check(
 		saveAliases(userInput.Data.Aliases, unvalidatedConfig.GitGlobal.Aliases, frontend),
@@ -56,7 +56,7 @@ func Save(userInput UserInput, unvalidatedConfig config.UnvalidatedConfig, data 
 	case dialog.ConfigStorageOptionFile:
 		return saveAllToFile(userInput, unvalidatedConfig.File, unvalidatedConfig.GitLocal, frontend)
 	case dialog.ConfigStorageOptionGit:
-		return saveAllToGit(userInput, unvalidatedConfig.GitLocal, unvalidatedConfig.File, data, enterAll, frontend)
+		return saveAllToGit(userInput, unvalidatedConfig.GitLocal, unvalidatedConfig.File, data, minimal, enterAll, frontend)
 	}
 	return nil
 }
@@ -189,7 +189,7 @@ func saveAllToFile(userInput UserInput, existingConfigFile configdomain.PartialC
 	return saveFeatureRegex(userInput.Data.FeatureRegex, gitConfig.FeatureRegex, runner)
 }
 
-func saveAllToGit(userInput UserInput, existingGitConfig configdomain.PartialConfig, configFile configdomain.PartialConfig, data Data, enterAll bool, frontend subshelldomain.Runner) error {
+func saveAllToGit(userInput UserInput, existingGitConfig configdomain.PartialConfig, configFile configdomain.PartialConfig, data Data, minimal, enterAll bool, frontend subshelldomain.Runner) error {
 	fc := gohacks.ErrorCollector{}
 
 	// BASIC CONFIGURATION
@@ -198,6 +198,11 @@ func saveAllToGit(userInput UserInput, existingGitConfig configdomain.PartialCon
 			saveMainBranch(userInput.Data.MainBranch, existingGitConfig.MainBranch, frontend),
 		)
 	}
+
+	if minimal {
+		return fc.Err
+	}
+
 	fc.Check(
 		savePerennialBranches(userInput.Data.PerennialBranches, existingGitConfig.PerennialBranches, frontend),
 	)

--- a/internal/validate/config.go
+++ b/internal/validate/config.go
@@ -33,7 +33,7 @@ func Config(args ConfigArgs) (config.ValidatedConfig, dialogdomain.Exit, error) 
 			Snapshot:      args.ConfigSnapshot,
 		}
 		var exit dialogdomain.Exit
-		userInput, exit, enterAll, err := setup.Enter(setupData, args.ConfigDir)
+		userInput, exit, minimal, enterAll, err := setup.Enter(setupData, args.ConfigDir)
 		if err != nil {
 			if interactivityError, ok := errors.AsType[*configdomain.InteractivityError](err); ok {
 				return config.EmptyValidatedConfig(), true, fmt.Errorf(messages.NoTTYMainBranchMissing, interactivityError) //lint:ignore ST1005 This error contains user-visible guidance, and therefore needs to end with a period.
@@ -43,7 +43,7 @@ func Config(args ConfigArgs) (config.ValidatedConfig, dialogdomain.Exit, error) 
 		if exit {
 			return config.EmptyValidatedConfig(), exit, nil
 		}
-		err = setup.Save(userInput, args.Unvalidated.Immutable(), setupData, enterAll, args.Frontend)
+		err = setup.Save(userInput, args.Unvalidated.Immutable(), setupData, minimal, enterAll, args.Frontend)
 		if err != nil {
 			return config.EmptyValidatedConfig(), exit, err
 		}


### PR DESCRIPTION
Add a "Complete Minimal Setup" dialog step so users can end setup as soon as the required configuration is entered. Propagate minimal-mode through enter/save flows to persist only essential settings and stop the annoying assistant as early as possible.