### PR TITLE
Prevent double-loading the connector

### DIFF
--- a/internal/execute/load_repo_snapshot.go
+++ b/internal/execute/load_repo_snapshot.go
@@ -41,7 +41,6 @@ func LoadRepoSnapshot(args LoadRepoSnapshotArgs) (gitdomain.BranchesSnapshot, gi
 			Git:               args.Git,
 			HasOpenChanges:    args.RepoStatus.OpenChanges,
 			Inputs:            args.Inputs,
-			PushHook:          args.UnvalidatedConfig.NormalConfig.PushHook,
 			RepoStatus:        args.RepoStatus,
 			RunState:          runStateOpt,
 			UnvalidatedConfig: args.UnvalidatedConfig,

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -78,7 +78,6 @@ type UnfinishedStateArgs struct {
 	Git               git.Commands
 	HasOpenChanges    bool
 	Inputs            dialogcomponents.Inputs
-	PushHook          configdomain.PushHook
 	RepoStatus        gitdomain.RepoStatus
 	RunState          Option[runstate.RunState]
 	UnvalidatedConfig config.UnvalidatedConfig

--- a/internal/validate/handle_unfinished_state.go
+++ b/internal/validate/handle_unfinished_state.go
@@ -8,10 +8,8 @@ import (
 	"github.com/git-town/git-town/v23/internal/cli/dialog"
 	"github.com/git-town/git-town/v23/internal/cli/dialog/dialogcomponents"
 	"github.com/git-town/git-town/v23/internal/cli/dialog/dialogdomain"
-	"github.com/git-town/git-town/v23/internal/cli/print"
 	"github.com/git-town/git-town/v23/internal/config"
 	"github.com/git-town/git-town/v23/internal/config/configdomain"
-	"github.com/git-town/git-town/v23/internal/forge"
 	"github.com/git-town/git-town/v23/internal/forge/forgedomain"
 	"github.com/git-town/git-town/v23/internal/git"
 	"github.com/git-town/git-town/v23/internal/git/gitdomain"
@@ -49,31 +47,6 @@ func HandleUnfinishedState(args UnfinishedStateArgs) (configdomain.ProgramFlow, 
 	}
 	if exit {
 		return configdomain.ProgramFlowExit, errors.New("user aborted")
-	}
-	// Create the connector now if the Git Town command hasn't provided one yet.
-	if args.Connector.IsNone() {
-		normalConfig := args.UnvalidatedConfig.NormalConfig
-		args.Connector, err = forge.NewConnector(forge.NewConnectorArgs{
-			Backend:              args.Backend,
-			BitbucketAppPassword: normalConfig.BitbucketAppPassword,
-			BitbucketUsername:    normalConfig.BitbucketUsername,
-			BrowserEnabled:       normalConfig.BrowserEnabled,
-			BrowserExecutable:    normalConfig.BrowserExecutable,
-			ConfigDir:            args.ConfigDir,
-			ForgeType:            normalConfig.ForgeType,
-			ForgejoToken:         normalConfig.ForgejoToken,
-			Frontend:             args.Frontend,
-			GiteaToken:           normalConfig.GiteaToken,
-			GithubConnectorType:  normalConfig.GithubConnectorType,
-			GithubToken:          normalConfig.GithubToken,
-			GitlabConnectorType:  normalConfig.GitlabConnectorType,
-			GitlabToken:          normalConfig.GitlabToken,
-			Log:                  print.Logger{},
-			RemoteURL:            normalConfig.DevURL(args.Backend),
-		})
-		if err != nil {
-			return configdomain.ProgramFlowExit, err
-		}
 	}
 	switch response {
 	case dialog.ResponseBoth:


### PR DESCRIPTION
The connector was being lazy-loaded in the past. Now all Git Town commands properly load the connector. This makes lazy-loading unnecessary and wasteful because if the connector doesn't exist, Git Town tries to load it twice. This PR removes the lazy loading logic.
