### PR TITLE
Support worktree directories for squash commit messages

### DIFF
--- a/internal/git/commands.go
+++ b/internal/git/commands.go
@@ -257,8 +257,12 @@ func (self *Commands) CherryPickContinue(runner subshelldomain.Runner) error {
 
 // CommentOutSquashCommitMessage comments out the message for the current squash merge
 // If the given prefix has content, adds it together with a newline.
-func (self *Commands) CommentOutSquashCommitMessage(prefix Option[string]) error {
-	squashMessageFile := ".git/SQUASH_MSG"
+func (self *Commands) CommentOutSquashCommitMessage(querier subshelldomain.Querier, prefix Option[string]) error {
+	gitDir, err := self.gitDirectory(querier)
+	if err != nil {
+		return err
+	}
+	squashMessageFile := filepath.Join(gitDir.String(), "SQUASH_MSG")
 	contentBytes, err := os.ReadFile(squashMessageFile)
 	if err != nil {
 		return fmt.Errorf(messages.SquashCannotReadFile, squashMessageFile, err)

--- a/internal/git/commands_test.go
+++ b/internal/git/commands_test.go
@@ -1,6 +1,8 @@
 package git_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/git-town/git-town/v23/internal/config/configdomain"
@@ -908,6 +910,35 @@ func TestBackendCommands(t *testing.T) {
 		runtime.CheckoutBranch(initial)
 		currentBranch = asserts.NoError1(runtime.Git.CurrentBranch(runtime.TestRunner)).GetOrPanic()
 		must.EqOp(t, initial, currentBranch)
+	})
+
+	t.Run("CommentOutSquashCommitMessage", func(t *testing.T) {
+		t.Parallel()
+		t.Run("comments out the squash message in a normal repo", func(t *testing.T) {
+			t.Parallel()
+			runtime := testruntime.Create(t)
+			gitDir := runtime.MustQueryTrim("git", "rev-parse", "--absolute-git-dir").String()
+			squashMessageFile := filepath.Join(gitDir, "SQUASH_MSG")
+			asserts.NoError(os.WriteFile(squashMessageFile, []byte("line 1\nline 2\n"), 0o600))
+			asserts.NoError(runtime.Git.CommentOutSquashCommitMessage(runtime, None[string]()))
+			have := string(asserts.NoError1(os.ReadFile(squashMessageFile)))
+			must.EqOp(t, "# line 1\n# line 2\n# ", have)
+		})
+		t.Run("resolves SQUASH_MSG relative to the per-worktree git dir in a linked worktree", func(t *testing.T) {
+			t.Parallel()
+			// In a linked worktree, ".git" is a file pointing at the real git dir,
+			// so the literal path ".git/SQUASH_MSG" would fail with "not a directory".
+			origin := testruntime.Create(t)
+			worktreeDir := t.TempDir()
+			origin.MustRun("git", "worktree", "add", "-b", "feature", worktreeDir)
+			linked := testruntime.New(worktreeDir, origin.HomeDir, origin.BinDir)
+			gitDir := linked.MustQueryTrim("git", "rev-parse", "--absolute-git-dir").String()
+			squashMessageFile := filepath.Join(gitDir, "SQUASH_MSG")
+			asserts.NoError(os.WriteFile(squashMessageFile, []byte("body\n"), 0o600))
+			asserts.NoError(linked.Git.CommentOutSquashCommitMessage(linked, Some("prefix")))
+			have := string(asserts.NoError1(os.ReadFile(squashMessageFile)))
+			must.EqOp(t, "# prefix\n# body\n# ", have)
+		})
 	})
 
 	t.Run("CommitsInBranch", func(t *testing.T) {

--- a/internal/vm/opcodes/commit_message_comment_out.go
+++ b/internal/vm/opcodes/commit_message_comment_out.go
@@ -12,7 +12,7 @@ import (
 type CommitMessageCommentOut struct{}
 
 func (self *CommitMessageCommentOut) Run(args shared.RunArgs) error {
-	if err := args.Git.CommentOutSquashCommitMessage(None[string]()); err != nil {
+	if err := args.Git.CommentOutSquashCommitMessage(args.Backend, None[string]()); err != nil {
 		return fmt.Errorf(messages.SquashMessageProblem, err)
 	}
 	return nil

--- a/internal/vm/opcodes/connector_proposal_merge.go
+++ b/internal/vm/opcodes/connector_proposal_merge.go
@@ -44,7 +44,7 @@ func (self *ConnectorProposalMerge) Run(args shared.RunArgs) error {
 		if err := args.Git.SquashMerge(args.Frontend, self.Branch); err != nil {
 			return err
 		}
-		if err := args.Git.CommentOutSquashCommitMessage(Some(forgedomain.CommitBody(proposalData, proposalData.Title.String()) + "\n\n")); err != nil {
+		if err := args.Git.CommentOutSquashCommitMessage(args.Backend, Some(forgedomain.CommitBody(proposalData, proposalData.Title.String()) + "\n\n")); err != nil {
 			return fmt.Errorf(messages.SquashMessageProblem, err)
 		}
 		if err := args.Git.CommitStart(args.Frontend); err != nil {


### PR DESCRIPTION
## Summary
Enhancement to the `CommentOutSquashCommitMessage` function to support worktree directories in Git Town. This change ensures the proper handling of squash commit messages in linked worktrees, addressing workflows that utilize multiple repositories effectively.

Closes #6237 

## Changes
- **Refactor of `CommentOutSquashCommitMessage`:**
  - The function now takes in a `querier` parameter for resolving the correct Git directory, accommodating linked worktrees.
  - This change prevents errors associated with relative paths in linked worktrees.

- **Updated Functionality:**
  - Enhanced the process for commenting out squash commit messages to work seamlessly whether in standard repositories or linked worktrees.
  - Tests added to verify correct functionality for both standard and worktree setups to ensure robustness.

- **Support for Worktrees:**
  - Specifically tailored handling for `.git/SQUASH_MSG` in cases where the Git directory is a file pointing to the actual directory used by the worktree, preventing path errors.

## Notes
This update is crucial for users leveraging worktrees as it significantly improves compatibility, ensuring that squash commit messages are managed correctly across different repository structures. Users should test workflows involving linked worktrees to validate the updated functionality.