### PR TITLE
Add gh autofill for proposal creation

### DIFF
--- a/internal/forge/gh/connector.go
+++ b/internal/forge/gh/connector.go
@@ -48,11 +48,16 @@ func (self Connector) BrowseRepository(runner subshelldomain.Runner) error {
 
 func (self Connector) CreateProposal(data forgedomain.CreateProposalArgs) error {
 	args := []string{"pr", "create", "--head=" + data.Branch.String(), "--base=" + data.ParentBranch.String()}
-	if title, hasTitle := data.ProposalTitle.Get(); hasTitle {
+	title, hasTitle := data.ProposalTitle.Get()
+	body, hasBody := data.ProposalBody.Get()
+	if hasTitle {
 		args = append(args, "--title="+title.String())
 	}
-	if body, hasBody := data.ProposalBody.Get(); hasBody {
+	if hasBody {
 		args = append(args, "--body="+body.String())
+	}
+	if !hasTitle || !hasBody {
+		args = append(args, "--fill")
 	}
 	if err := self.Frontend.Run("gh", args...); err != nil {
 		return err

--- a/internal/forge/gh/connector_test.go
+++ b/internal/forge/gh/connector_test.go
@@ -4,11 +4,83 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/git-town/git-town/v23/internal/browser/browserdomain"
+	"github.com/git-town/git-town/v23/internal/cli/print"
 	"github.com/git-town/git-town/v23/internal/forge/forgedomain"
 	"github.com/git-town/git-town/v23/internal/forge/gh"
+	"github.com/git-town/git-town/v23/internal/git/gitdomain"
+	"github.com/git-town/git-town/v23/internal/gohacks/stringss"
 	. "github.com/git-town/git-town/v23/pkg/prelude"
 	"github.com/shoenig/test/must"
 )
+
+func TestConnectorCreateProposal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("autofills missing title and body", func(t *testing.T) {
+		t.Parallel()
+		frontend := &recordingRunner{}
+		connector := newTestConnector(frontend)
+		args := createProposalArgs()
+
+		err := connector.CreateProposal(args)
+
+		must.NoError(t, err)
+		must.Eq(t, [][]string{
+			{"gh", "pr", "create", "--head=feature", "--base=main", "--fill"},
+			{"gh", "pr", "view"},
+		}, frontend.calls)
+	})
+
+	t.Run("autofills missing body", func(t *testing.T) {
+		t.Parallel()
+		frontend := &recordingRunner{}
+		connector := newTestConnector(frontend)
+		args := createProposalArgs()
+		args.ProposalTitle = Some(gitdomain.ProposalTitle("my title"))
+
+		err := connector.CreateProposal(args)
+
+		must.NoError(t, err)
+		must.Eq(t, [][]string{
+			{"gh", "pr", "create", "--head=feature", "--base=main", "--title=my title", "--fill"},
+			{"gh", "pr", "view"},
+		}, frontend.calls)
+	})
+
+	t.Run("autofills missing title", func(t *testing.T) {
+		t.Parallel()
+		frontend := &recordingRunner{}
+		connector := newTestConnector(frontend)
+		args := createProposalArgs()
+		args.ProposalBody = Some(gitdomain.ProposalBody("my body"))
+
+		err := connector.CreateProposal(args)
+
+		must.NoError(t, err)
+		must.Eq(t, [][]string{
+			{"gh", "pr", "create", "--head=feature", "--base=main", "--body=my body", "--fill"},
+			{"gh", "pr", "view"},
+		}, frontend.calls)
+	})
+
+	t.Run("uses provided title and body", func(t *testing.T) {
+		t.Parallel()
+		frontend := &recordingRunner{}
+		connector := newTestConnector(frontend)
+		args := createProposalArgs()
+		args.ProposalTitle = Some(gitdomain.ProposalTitle("my title"))
+		args.ProposalBody = Some(gitdomain.ProposalBody("my body"))
+
+		err := connector.CreateProposal(args)
+
+		must.NoError(t, err)
+		must.Eq(t, [][]string{
+			{"gh", "pr", "create", "--head=feature", "--base=main", "--title=my title", "--body=my body"},
+			{"gh", "pr", "view"},
+		}, frontend.calls)
+	})
+}
 
 func TestParsePermissionsOutput(t *testing.T) {
 	t.Parallel()
@@ -60,4 +132,52 @@ github.com
 		}
 		must.Eq(t, want, have)
 	})
+}
+
+func createProposalArgs() forgedomain.CreateProposalArgs {
+	return forgedomain.CreateProposalArgs{
+		Branch:         "feature",
+		FrontendRunner: nil,
+		MainBranch:     "main",
+		ParentBranch:   "main",
+		ProposalBody:   None[gitdomain.ProposalBody](),
+		ProposalTitle:  None[gitdomain.ProposalTitle](),
+	}
+}
+
+func newTestConnector(frontend *recordingRunner) gh.Connector {
+	return gh.Connector{
+		Backend:        proposalQuerier{},
+		BrowserEnabled: browserdomain.BrowserEnabled(false),
+		Frontend:       frontend,
+		Log:            print.Logger{},
+	}
+}
+
+type proposalQuerier struct{}
+
+func (self proposalQuerier) Query(executable string, args ...string) (string, error) {
+	return `[{"baseRefName":"main","body":"body","headRefName":"feature","mergeable":"MERGEABLE","number":123,"title":"title","url":"https://github.com/git-town/git-town/pull/123"}]`, nil
+}
+
+func (self proposalQuerier) QueryTrim(executable string, args ...string) (stringss.Trimmed, error) {
+	return stringss.Trimmed(""), nil
+}
+
+func (self proposalQuerier) QueryZ(executable string, args ...string) (stringss.ZeroDelineated, error) {
+	return stringss.ZeroDelineated(""), nil
+}
+
+type recordingRunner struct {
+	calls [][]string
+}
+
+func (self *recordingRunner) Run(executable string, args ...string) error {
+	call := append([]string{executable}, args...)
+	self.calls = append(self.calls, call)
+	return nil
+}
+
+func (self *recordingRunner) RunWithEnv(env []string, executable string, args ...string) error {
+	return self.Run(executable, args...)
 }

--- a/internal/forge/gh/connector_test.go
+++ b/internal/forge/gh/connector_test.go
@@ -23,6 +23,7 @@ func TestConnectorCreateProposal(t *testing.T) {
 		connector := newTestConnector(frontend)
 		args := createProposalArgs()
 		args.ProposalTitle = Some(gitdomain.ProposalTitle("my title"))
+		args.ProposalBody = None[gitdomain.ProposalBody]()
 
 		err := connector.CreateProposal(args)
 
@@ -38,6 +39,7 @@ func TestConnectorCreateProposal(t *testing.T) {
 		frontend := &recordingRunner{}
 		connector := newTestConnector(frontend)
 		args := createProposalArgs()
+		args.ProposalTitle = None[gitdomain.ProposalTitle]()
 		args.ProposalBody = Some(gitdomain.ProposalBody("my body"))
 
 		err := connector.CreateProposal(args)
@@ -54,6 +56,8 @@ func TestConnectorCreateProposal(t *testing.T) {
 		frontend := &recordingRunner{}
 		connector := newTestConnector(frontend)
 		args := createProposalArgs()
+		args.ProposalTitle = None[gitdomain.ProposalTitle]()
+		args.ProposalBody = None[gitdomain.ProposalBody]()
 
 		err := connector.CreateProposal(args)
 

--- a/internal/forge/gh/connector_test.go
+++ b/internal/forge/gh/connector_test.go
@@ -17,21 +17,6 @@ import (
 func TestConnectorCreateProposal(t *testing.T) {
 	t.Parallel()
 
-	t.Run("autofills missing title and body", func(t *testing.T) {
-		t.Parallel()
-		frontend := &recordingRunner{}
-		connector := newTestConnector(frontend)
-		args := createProposalArgs()
-
-		err := connector.CreateProposal(args)
-
-		must.NoError(t, err)
-		must.Eq(t, [][]string{
-			{"gh", "pr", "create", "--head=feature", "--base=main", "--fill"},
-			{"gh", "pr", "view"},
-		}, frontend.calls)
-	})
-
 	t.Run("autofills missing body", func(t *testing.T) {
 		t.Parallel()
 		frontend := &recordingRunner{}
@@ -60,6 +45,21 @@ func TestConnectorCreateProposal(t *testing.T) {
 		must.NoError(t, err)
 		must.Eq(t, [][]string{
 			{"gh", "pr", "create", "--head=feature", "--base=main", "--body=my body", "--fill"},
+			{"gh", "pr", "view"},
+		}, frontend.calls)
+	})
+
+	t.Run("autofills missing title and body", func(t *testing.T) {
+		t.Parallel()
+		frontend := &recordingRunner{}
+		connector := newTestConnector(frontend)
+		args := createProposalArgs()
+
+		err := connector.CreateProposal(args)
+
+		must.NoError(t, err)
+		must.Eq(t, [][]string{
+			{"gh", "pr", "create", "--head=feature", "--base=main", "--fill"},
 			{"gh", "pr", "view"},
 		}, frontend.calls)
 	})
@@ -156,15 +156,15 @@ func newTestConnector(frontend *recordingRunner) gh.Connector {
 
 type proposalQuerier struct{}
 
-func (self proposalQuerier) Query(executable string, args ...string) (string, error) {
+func (self proposalQuerier) Query(_ string, _ ...string) (string, error) {
 	return `[{"baseRefName":"main","body":"body","headRefName":"feature","mergeable":"MERGEABLE","number":123,"title":"title","url":"https://github.com/git-town/git-town/pull/123"}]`, nil
 }
 
-func (self proposalQuerier) QueryTrim(executable string, args ...string) (stringss.Trimmed, error) {
+func (self proposalQuerier) QueryTrim(_ string, _ ...string) (stringss.Trimmed, error) {
 	return stringss.Trimmed(""), nil
 }
 
-func (self proposalQuerier) QueryZ(executable string, args ...string) (stringss.ZeroDelineated, error) {
+func (self proposalQuerier) QueryZ(_ string, _ ...string) (stringss.ZeroDelineated, error) {
 	return stringss.ZeroDelineated(""), nil
 }
 
@@ -178,6 +178,6 @@ func (self *recordingRunner) Run(executable string, args ...string) error {
 	return nil
 }
 
-func (self *recordingRunner) RunWithEnv(env []string, executable string, args ...string) error {
+func (self *recordingRunner) RunWithEnv(_ []string, executable string, args ...string) error {
 	return self.Run(executable, args...)
 }


### PR DESCRIPTION
Fixes #6224

## Summary
- add `--fill` to `gh pr create` when Git Town does not provide both title and body
- keep existing behavior unchanged when both title and body are provided
- add unit coverage for all title/body combinations in the gh connector

## Verification
- `go test ./internal/forge/gh`
- `go test ./internal/forge/...`
- `git diff --check`

## Notes
- `make cuke` failed in unrelated append/lang and append/propose scenarios around localized Git output and missing browser-open commands.
- `go test ./...` failed only in the Cucumber package with unrelated append/beam scenario diffs; regular Go packages passed.