### PR TITLE
Push the new parent to the forge before retargeting its proposal

### DIFF
--- a/features/set_parent/parent_has_no_tracking_branch.feature
+++ b/features/set_parent/parent_has_no_tracking_branch.feature
@@ -1,0 +1,59 @@
+Feature: set the parent to a branch that has no tracking branch
+
+  Background:
+    Given a Git repo with origin
+    And the origin is "git@github.com:git-town/git-town.git"
+    And the branches
+      | NAME     | TYPE    | PARENT | LOCATIONS     |
+      | branch-1 | feature | main   | local         |
+      | branch-2 | feature | main   | local, origin |
+    And the commits
+      | BRANCH   | LOCATION      | MESSAGE  |
+      | branch-1 | local         | commit 1 |
+      | branch-2 | local, origin | commit 2 |
+    And the proposals
+      | ID | SOURCE BRANCH | TARGET BRANCH | TITLE             | BODY | URL                       |
+      | 92 | branch-2      | main          | branch-2 proposal |      | https://example.com/pr/92 |
+    And local Git setting "git-town.sync-feature-strategy" is "merge"
+    And the current branch is "branch-2"
+    When I run "git-town set-parent branch-1"
+
+  Scenario: result
+    Then Git Town runs the commands
+      | BRANCH   | COMMAND                                                              |
+      |          | Finding proposal from branch-2 into main ... #92 (branch-2 proposal) |
+      | branch-2 | git push -u origin branch-1                                          |
+      |          | Updating target branch of proposal #92 to branch-1 ... ok            |
+    And this lineage exists now
+      """
+      main
+        branch-1
+          branch-2
+      """
+    And the branches are now
+      | REPOSITORY    | BRANCHES                 |
+      | local, origin | main, branch-1, branch-2 |
+    And the proposals are now
+      """
+      url: https://example.com/pr/92
+      number: 92
+      source: branch-2
+      target: branch-1
+      body:
+      """
+
+  Scenario: undo
+    When I run "git-town undo"
+    Then Git Town runs the commands
+      | BRANCH   | COMMAND                                               |
+      |          | Updating target branch of proposal #92 to main ... ok |
+      | branch-2 | git push origin :branch-1                             |
+    And the initial branches and lineage exist now
+    And the proposals are now
+      """
+      url: https://example.com/pr/92
+      number: 92
+      source: branch-2
+      target: main
+      body:
+      """

--- a/internal/cmd/set_parent.go
+++ b/internal/cmd/set_parent.go
@@ -386,6 +386,11 @@ func setParentProgram(newParentOpt Option[gitdomain.LocalBranchName], data setPa
 		connector, hasConnector := data.connector.Get()
 		_, canUpdateProposalTarget := connector.(forgedomain.ProposalTargetUpdater)
 		if hasProposal && hasConnector && canUpdateProposalTarget {
+			// The forge can only retarget the proposal to the new parent if that branch exists at the forge.
+			// Push it first if it doesn't have a tracking branch yet.
+			if newParentInfo, hasNewParentInfo := data.branchesSnapshot.Branches.FindByLocalName(newParent).Get(); hasNewParentInfo && !newParentInfo.HasTrackingBranch() {
+				prog.Add(&opcodes.BranchTrackingCreate{Branch: newParent})
+			}
 			prog.Add(&opcodes.ProposalUpdateTarget{
 				NewBranch: newParent,
 				OldBranch: proposal.Data.Data().Target,


### PR DESCRIPTION
Fixes #5937.

## Problem

When `git town set-parent` moves a branch under a new parent that has **no tracking branch**, Git Town retargets the branch's proposal to that parent without pushing it first. The forge then rejects the update:

```
Updating target branch of proposal #92 to branch-1 ... PATCH .../pulls/92: 422 Validation Failed
[{Resource:PullRequest Field:base Code:invalid Message:Proposed base branch 'branch-1' was not found}]
```

## Fix

In `setParentProgram`, before emitting `ProposalUpdateTarget`, push the new parent (creating its tracking branch) when it doesn't have one yet — so the branch exists on the forge when the proposal is retargeted to it. Guarded by `!HasTrackingBranch()`, so it's a no-op when the new parent is already pushed.

## Tests

New feature `features/set_parent/parent_has_no_tracking_branch.feature` with `result` + `undo` scenarios. The test asserts the new parent is pushed (`git push -u origin branch-1`) before the retarget; it fails against the pre-fix code (which retargets without pushing) and passes after. The undo scenario verifies the proposal is retargeted back and the created tracking branch is removed (`git push origin :branch-1`).

Note: the cucumber mock forge doesn't validate that a retarget's target branch exists, so it can't reproduce GitHub's literal 422. The test instead asserts the correct behavior (parent pushed before retarget) — a faithful reproduction of the root cause.

## Findings / follow-ups (not in this PR)

- **`propose` is not affected**, despite the issue title mentioning it. For `git town propose`, `branchesToSync` includes the ancestors and syncs with `PushBranches: true`, so the untracked parent is pushed *before* the proposal targets it (verified empirically: `git checkout branch-1` → `git push -u origin branch-1` runs before "Finding proposal from branch-2 into branch-1"). The real failing path is `set-parent`'s retarget.
- **Other commands emit `ProposalUpdateTarget` too** — `rename`, `detach`, `prepend`, and `swap`. Some likely push via sync like `propose` does, but a couple (e.g. `prepend`, which retargets a child proposal onto a newly-created branch) may share this gap. Worth a separate audit; I kept this PR focused on the confirmed `set-parent` bug.