### PR TITLE
Fix message handling for the gh CLI connector

### DIFF
--- a/internal/forge/gh/connector.go
+++ b/internal/forge/gh/connector.go
@@ -152,16 +152,14 @@ var _ forgedomain.ProposalMerger = ghConnector // type-check
 func (self Connector) SquashMergeProposal(number forgedomain.ProposalNumber, message Option[gitdomain.CommitMessage]) error {
 	args := []string{"pr", "merge", "--squash"}
 
-	messageParts := gitdomain.CommitMessageParts{}
 	if commitMessage, hasCommitMessage := message.Get(); hasCommitMessage {
-		messageParts = commitMessage.Parts()
-	}
-
-	if messageParts.Title.String() != "" {
-		args = append(args, "--subject="+messageParts.Title.String())
-	}
-	if messageParts.Body != "" {
-		args = append(args, "--body="+messageParts.Body)
+		messageParts := commitMessage.Parts()
+		if messageParts.Title.String() != "" {
+			args = append(args, "--subject="+messageParts.Title.String())
+		}
+		if messageParts.Body != "" {
+			args = append(args, "--body="+messageParts.Body)
+		}
 	}
 
 	args = append(args, number.String())

--- a/internal/forge/gh/connector.go
+++ b/internal/forge/gh/connector.go
@@ -150,7 +150,12 @@ func (self Connector) SearchProposals(branch gitdomain.LocalBranchName) ([]forge
 var _ forgedomain.ProposalMerger = ghConnector // type-check
 
 func (self Connector) SquashMergeProposal(number forgedomain.ProposalNumber, message gitdomain.CommitMessage) error {
-	return self.Frontend.Run("gh", "pr", "merge", "--squash", "--body="+message.String(), number.String())
+	// Split the supplied message the way Git does: the first line becomes the
+	// commit subject and the rest becomes the body. Passing only "--body" here
+	// would leave the proposal title as the squash-commit subject, which is
+	// inconsistent with all other connectors (see #6254).
+	messageParts := message.Parts()
+	return self.Frontend.Run("gh", "pr", "merge", "--squash", "--subject="+messageParts.Title.String(), "--body="+messageParts.Body, number.String())
 }
 
 // ============================================================================

--- a/internal/forge/gh/connector_test.go
+++ b/internal/forge/gh/connector_test.go
@@ -86,6 +86,36 @@ func TestConnectorCreateProposal(t *testing.T) {
 	})
 }
 
+func TestConnectorSquashMergeProposal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single-line message has an empty body", func(t *testing.T) {
+		t.Parallel()
+		frontend := &recordingRunner{}
+		connector := newTestConnector(frontend)
+
+		err := connector.SquashMergeProposal(123, "my title")
+
+		must.NoError(t, err)
+		must.Eq(t, [][]string{
+			{"gh", "pr", "merge", "--squash", "--subject=my title", "--body=", "123"},
+		}, frontend.calls)
+	})
+
+	t.Run("uses the first line as the commit subject and the rest as the body", func(t *testing.T) {
+		t.Parallel()
+		frontend := &recordingRunner{}
+		connector := newTestConnector(frontend)
+
+		err := connector.SquashMergeProposal(123, "my title\n\nmy body")
+
+		must.NoError(t, err)
+		must.Eq(t, [][]string{
+			{"gh", "pr", "merge", "--squash", "--subject=my title", "--body=my body", "123"},
+		}, frontend.calls)
+	})
+}
+
 func TestParsePermissionsOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/forge/gh/connector_test.go
+++ b/internal/forge/gh/connector_test.go
@@ -17,13 +17,22 @@ import (
 func TestConnectorSquashMergeProposal(t *testing.T) {
 	t.Parallel()
 
-	t.Run("with a commit message sends it as the body", func(t *testing.T) {
+	t.Run("multi-line message uses the first line as the subject and the rest as the body", func(t *testing.T) {
 		t.Parallel()
 		runner := &recordingRunner{}
 		connector := gh.Connector{Frontend: runner}
-		err := connector.SquashMergeProposal(forgedomain.ProposalNumber(1), Some(gitdomain.CommitMessage("my message")))
+		err := connector.SquashMergeProposal(forgedomain.ProposalNumber(1), Some(gitdomain.CommitMessage("my title\n\nmy body")))
 		must.NoError(t, err)
-		must.Eq(t, [][]string{{"gh", "pr", "merge", "--squash", "--body=my message", "1"}}, runner.calls)
+		must.Eq(t, [][]string{{"gh", "pr", "merge", "--squash", "--subject=my title", "--body=my body", "1"}}, runner.calls)
+	})
+
+	t.Run("single-line message sends it as the commit subject", func(t *testing.T) {
+		t.Parallel()
+		runner := &recordingRunner{}
+		connector := gh.Connector{Frontend: runner}
+		err := connector.SquashMergeProposal(forgedomain.ProposalNumber(1), Some(gitdomain.CommitMessage("my title")))
+		must.NoError(t, err)
+		must.Eq(t, [][]string{{"gh", "pr", "merge", "--squash", "--subject=my title", "1"}}, runner.calls)
 	})
 
 	t.Run("without a commit message lets the forge choose it", func(t *testing.T) {
@@ -104,36 +113,6 @@ func TestConnectorCreateProposal(t *testing.T) {
 		must.Eq(t, [][]string{
 			{"gh", "pr", "create", "--head=feature", "--base=main", "--title=my title", "--body=my body"},
 			{"gh", "pr", "view"},
-		}, frontend.calls)
-	})
-}
-
-func TestConnectorSquashMergeProposal(t *testing.T) {
-	t.Parallel()
-
-	t.Run("single-line message has an empty body", func(t *testing.T) {
-		t.Parallel()
-		frontend := &recordingRunner{}
-		connector := newTestConnector(frontend)
-
-		err := connector.SquashMergeProposal(123, "my title")
-
-		must.NoError(t, err)
-		must.Eq(t, [][]string{
-			{"gh", "pr", "merge", "--squash", "--subject=my title", "--body=", "123"},
-		}, frontend.calls)
-	})
-
-	t.Run("uses the first line as the commit subject and the rest as the body", func(t *testing.T) {
-		t.Parallel()
-		frontend := &recordingRunner{}
-		connector := newTestConnector(frontend)
-
-		err := connector.SquashMergeProposal(123, "my title\n\nmy body")
-
-		must.NoError(t, err)
-		must.Eq(t, [][]string{
-			{"gh", "pr", "merge", "--squash", "--subject=my title", "--body=my body", "123"},
 		}, frontend.calls)
 	})
 }


### PR DESCRIPTION
## What

`git town ship` with the [`gh` CLI connector](https://cli.github.com/) now splits a supplied commit message the way Git's `-m` does — the **first line becomes the squash-commit subject** and the **rest becomes the body** — instead of dumping the entire message into the body and leaving the proposal title as the commit subject.

This applies to every way of supplying the message, since they all funnel into a single `CommitMessage` before the connector runs:

- `-m` / `--message`
- `-f` / `--message-file <path>`
- `-f -` (message piped in via STDIN)

Concretely, the merge call changes from:

```
gh pr merge --squash --body="<full message>" <number>
```

to:

```
gh pr merge --squash --subject="<first line>" --body="<rest>" <number>
```

## Why

As reported in #6254, connectors disagreed on whether a supplied message's first line becomes the squash-commit subject or whether the whole message is dumped into the body with the proposal title left as the subject. The same `git town ship -m "…"` could therefore produce a different squash-commit subject depending on which connector was active — and for GitHub specifically, switching between the `api` and `gh` connector types (which users otherwise treat as interchangeable) silently changed whether their message could set the commit subject. This also interacts with "PR/commit title must match rules" CI checks.

A supplied message should behave like `git commit -m`: the text is the whole commit, its first line is the subject, the remainder is the body.

## Scope

Investigation showed the **`gh` CLI connector was the only one that actually deviated** from this contract:

- **GitHub API, Gitea, Forgejo** already split the message into an explicit `Title` + `Body`.
- **GitLab (API + `glab`) and Bitbucket Cloud** hand the whole message to a single commit-message field, whose first line Git already treats as the subject — i.e. the desired behavior, and their APIs expose no separate title field to change.
- **`gh` CLI** passed only `--body`, so `gh` kept the *proposal title* as the squash-commit subject and put the whole message in the body.

So this PR fixes the one outlier rather than touching every connector.

## A note on classification

I'm proposing this as a fix, even though it changes behavior: it makes `gh` consistent with what every other connector already does, so there's no opt-out or migration to add.

## Tests

- Unit tests (`internal/forge/gh/connector_test.go`) assert the exact `gh pr merge` arguments: a multi-line message splits into `--subject`/`--body`, and a single-line message produces an empty body.
- The split happens at the single point where `-m`, `-f`, and STDIN are collapsed into one `CommitMessage`, so all three inputs are covered by the same code path.
- No Cucumber scenario: the `gh` connector shells out to a real `gh` binary and the end-to-end harness has no `gh` stub, so this path is only observable at the command-argument level, which the unit tests cover.

Closes #6254.


<!-- branch-stack-start -->

<!-- branch-stack-end -->
