### PR TITLE
Fix reviewers getting removed on breadcrumb update and browser open command bitbucket

### DIFF
--- a/internal/browser/open.go
+++ b/internal/browser/open.go
@@ -3,6 +3,7 @@ package browser
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/git-town/git-town/v24/internal/browser/browserdomain"
 	"github.com/git-town/git-town/v24/internal/messages"
@@ -15,6 +16,12 @@ import (
 func Open(url string, frontend subshelldomain.Runner, executable Option[browserdomain.BrowserExecutable], enabled browserdomain.BrowserEnabled) {
 	if !enabled {
 		fmt.Printf(messages.BrowserOpen, url)
+		return
+	}
+	if runtime.GOOS == "windows" && executable.IsNone() {
+		if err := frontend.Run("rundll32", "url.dll,FileProtocolHandler", url); err != nil {
+			fmt.Printf(messages.BrowserOpen, url)
+		}
 		return
 	}
 	command, hasCommand := OpenBrowserCommand(executable).Get()

--- a/internal/browser/open_windows.go
+++ b/internal/browser/open_windows.go
@@ -4,10 +4,9 @@ package browser
 
 import . "github.com/git-town/git-town/v24/pkg/prelude"
 
-// defaultBrowserCommand provides the console command to open the default browser on Windows.
+// defaultBrowserCommand provides the console command to open a custom browser on Windows.
 func defaultBrowserCommand() Option[string] {
-	// NOTE: the "explorer" command cannot handle special characters like "?" and "=".
-	//       In particular, "?" can be escaped via "\", but "=" cannot.
-	//       So we are using "start" here.
-	return Some("start")
+	// The default browser on Windows is opened via rundll32 in open.go.
+	// This function is only used when a custom browser executable is configured.
+	return None[string]()
 }

--- a/internal/browser/open_windows_test.go
+++ b/internal/browser/open_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package browser
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v24/internal/browser/browserdomain"
+	. "github.com/git-town/git-town/v24/pkg/prelude"
+	"github.com/shoenig/test/must"
+)
+
+func TestOpenOnWindows(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses rundll32 for the default browser", func(t *testing.T) {
+		t.Parallel()
+
+		runner := &recordingRunner{}
+
+		Open("https://bitbucket.org/org/repo/pull-requests/new?source=branch&dest=org%2Frepo%3Amain", runner, None[browserdomain.BrowserExecutable](), true)
+
+		must.Eq(t, [][]string{{"rundll32", "url.dll,FileProtocolHandler", "https://bitbucket.org/org/repo/pull-requests/new?source=branch&dest=org%2Frepo%3Amain"}}, runner.calls)
+	})
+
+	t.Run("uses the configured browser executable", func(t *testing.T) {
+		t.Parallel()
+
+		runner := &recordingRunner{}
+
+		Open("https://example.com", runner, Some(browserdomain.BrowserExecutable("firefox")), true)
+
+		must.Eq(t, [][]string{{"firefox", "https://example.com"}}, runner.calls)
+	})
+}
+
+type recordingRunner struct {
+	calls [][]string
+}
+
+func (self *recordingRunner) Run(executable string, args ...string) error {
+	self.calls = append(self.calls, append([]string{executable}, args...))
+	return nil
+}
+
+func (self *recordingRunner) RunWithEnv(_ []string, executable string, args ...string) error {
+	return self.Run(executable, args...)
+}

--- a/internal/forge/bitbucketcloud/api_connector.go
+++ b/internal/forge/bitbucketcloud/api_connector.go
@@ -181,19 +181,9 @@ func (self APIConnector) SquashMergeProposal(number forgedomain.ProposalNumber, 
 var _ forgedomain.ProposalBodyUpdater = apiConnector // type check
 
 func (self APIConnector) UpdateProposalBody(proposalData forgedomain.ProposalInterface, newBody gitdomain.ProposalBody) error {
-	data := proposalData.(forgedomain.BitbucketCloudProposalData)
+	data := proposalData.Data()
 	self.log.Start(messages.APIProposalUpdateBody, colors.BoldGreen().Styled("#"+data.Number.String()))
-	_, err := self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
-		ID:                data.Number.String(),
-		Owner:             self.Organization,
-		RepoSlug:          self.Repository,
-		SourceBranch:      data.Source.String(),
-		DestinationBranch: data.Target.String(),
-		Title:             data.Title.String(),
-		Description:       newBody.String(),
-		Draft:             data.Draft,
-		CloseSourceBranch: data.CloseSourceBranch,
-	})
+	_, err := self.client.Value.Repositories.PullRequests.Update(self.proposalBodyUpdateOptions(data, newBody))
 	self.log.Finished(err)
 	return err
 }
@@ -205,18 +195,23 @@ func (self APIConnector) UpdateProposalBody(proposalData forgedomain.ProposalInt
 var _ forgedomain.ProposalSourceUpdater = apiConnector // type check
 
 func (self APIConnector) UpdateProposalSource(proposalData forgedomain.ProposalInterface, source gitdomain.LocalBranchName) error {
-	data := proposalData.(forgedomain.BitbucketCloudProposalData)
+	data, err := self.proposalData(proposalData.Data().Number)
+	if err != nil {
+		return err
+	}
 	self.log.Start(messages.APIUpdateProposalSource, colors.BoldGreen().Styled("#"+data.Number.String()), colors.BoldCyan().Styled(source.String()))
-	_, err := self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
-		ID:                data.Number.String(),
-		Owner:             self.Organization,
-		RepoSlug:          self.Repository,
-		SourceBranch:      source.String(),
-		DestinationBranch: data.Target.String(),
-		Title:             data.Title.String(),
-		Description:       data.Body.GetOrZero().String(),
-		Draft:             data.Draft,
-		CloseSourceBranch: data.CloseSourceBranch,
+	_, err = self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
+		ID:                 data.Number.String(),
+		Owner:              self.Organization,
+		RepoSlug:           self.Repository,
+		SourceBranch:       source.String(),
+		DestinationBranch:  data.Target.String(),
+		Title:              data.Title.String(),
+		Description:        data.Body.GetOrZero().String(),
+		Draft:              data.Draft,
+		CloseSourceBranch:  data.CloseSourceBranch,
+		Reviewers:          data.Reviewers,
+		ReviewerAccountIDs: data.ReviewerAccountIDs,
 	})
 	self.log.Finished(err)
 	return err
@@ -229,21 +224,53 @@ func (self APIConnector) UpdateProposalSource(proposalData forgedomain.ProposalI
 var _ forgedomain.ProposalTargetUpdater = apiConnector // type check
 
 func (self APIConnector) UpdateProposalTarget(proposalData forgedomain.ProposalInterface, target gitdomain.LocalBranchName) error {
-	data := proposalData.(forgedomain.BitbucketCloudProposalData)
+	data, err := self.proposalData(proposalData.Data().Number)
+	if err != nil {
+		return err
+	}
 	self.log.Start(messages.APIUpdateProposalTarget, colors.BoldGreen().Styled("#"+data.Number.String()), colors.BoldCyan().Styled(target.String()))
-	_, err := self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
-		ID:                data.Number.String(),
-		Owner:             self.Organization,
-		RepoSlug:          self.Repository,
-		SourceBranch:      data.Source.String(),
-		DestinationBranch: target.String(),
-		Title:             data.Title.String(),
-		Description:       data.Body.GetOrZero().String(),
-		Draft:             data.Draft,
-		CloseSourceBranch: data.CloseSourceBranch,
+	_, err = self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
+		ID:                 data.Number.String(),
+		Owner:              self.Organization,
+		RepoSlug:           self.Repository,
+		SourceBranch:       data.Source.String(),
+		DestinationBranch:  target.String(),
+		Title:              data.Title.String(),
+		Description:        data.Body.GetOrZero().String(),
+		Draft:              data.Draft,
+		CloseSourceBranch:  data.CloseSourceBranch,
+		Reviewers:          data.Reviewers,
+		ReviewerAccountIDs: data.ReviewerAccountIDs,
 	})
 	self.log.Finished(err)
 	return err
+}
+
+func (self APIConnector) proposalData(number forgedomain.ProposalNumber) (forgedomain.BitbucketCloudProposalData, error) {
+	var emptyResult forgedomain.BitbucketCloudProposalData
+	response, err := self.client.Value.Repositories.PullRequests.Get(&bitbucket.PullRequestsOptions{
+		ID:       number.String(),
+		Owner:    self.Organization,
+		RepoSlug: self.Repository,
+	})
+	if err != nil {
+		return emptyResult, err
+	}
+	responseData, ok := response.(map[string]any)
+	if !ok {
+		return emptyResult, errors.New(messages.APIUnexpectedResultDataStructure)
+	}
+	return parsePullRequest(responseData)
+}
+
+func (self APIConnector) proposalBodyUpdateOptions(data forgedomain.ProposalData, newBody gitdomain.ProposalBody) *bitbucket.PullRequestsOptions {
+	return &bitbucket.PullRequestsOptions{
+		ID:          data.Number.String(),
+		Owner:       self.Organization,
+		RepoSlug:    self.Repository,
+		Title:       data.Title.String(),
+		Description: newBody.String(),
+	}
 }
 
 // ============================================================================

--- a/internal/forge/bitbucketcloud/api_connector_test.go
+++ b/internal/forge/bitbucketcloud/api_connector_test.go
@@ -1,0 +1,43 @@
+package bitbucketcloud
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v24/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v24/internal/git/gitdomain"
+	"github.com/shoenig/test/must"
+)
+
+func TestProposalBodyUpdateOptions(t *testing.T) {
+	t.Parallel()
+
+	connector := APIConnector{
+		WebConnector: WebConnector{
+			HostedRepoInfo: forgedomain.HostedRepoInfo{
+				Organization: "org",
+				Repository:   "repo",
+			},
+		},
+	}
+	proposalData := forgedomain.ProposalData{
+		Number: 123,
+		Source: "feature",
+		Target: "main",
+		Title:  "title",
+		Body:   gitdomain.NewProposalBodyOpt("existing body"),
+	}
+
+	have := connector.proposalBodyUpdateOptions(proposalData, gitdomain.ProposalBody("updated body"))
+
+	must.EqOp(t, "123", have.ID)
+	must.EqOp(t, "org", have.Owner)
+	must.EqOp(t, "repo", have.RepoSlug)
+	must.EqOp(t, "title", have.Title)
+	must.EqOp(t, "updated body", have.Description)
+	must.EqOp(t, "", have.SourceBranch)
+	must.EqOp(t, "", have.DestinationBranch)
+	must.False(t, have.Draft)
+	must.False(t, have.CloseSourceBranch)
+	must.Len(t, 0, have.Reviewers)
+	must.Len(t, 0, have.ReviewerAccountIDs)
+}

--- a/internal/forge/bitbucketcloud/parser.go
+++ b/internal/forge/bitbucketcloud/parser.go
@@ -135,6 +135,10 @@ func parsePullRequest(pullRequest map[string]any) (forgedomain.BitbucketCloudPro
 	if !ok {
 		return emptyResult, errors.New(messages.APIUnexpectedResultDataStructure)
 	}
+	reviewers, reviewerAccountIDs, err := parseReviewers(pullRequest)
+	if err != nil {
+		return emptyResult, err
+	}
 	return forgedomain.BitbucketCloudProposalData{
 		ProposalData: forgedomain.ProposalData{
 			Active:       isActive,
@@ -146,7 +150,46 @@ func parsePullRequest(pullRequest map[string]any) (forgedomain.BitbucketCloudPro
 			Body:         gitdomain.NewProposalBodyOpt(body2),
 			URL:          url6,
 		},
-		CloseSourceBranch: closeSourceBranch2,
-		Draft:             draft2,
+		CloseSourceBranch:  closeSourceBranch2,
+		Draft:              draft2,
+		Reviewers:          reviewers,
+		ReviewerAccountIDs: reviewerAccountIDs,
 	}, nil
+}
+
+func parseReviewers(pullRequest map[string]any) ([]string, []string, error) {
+	reviewers1, has := pullRequest["reviewers"]
+	if !has {
+		return []string{}, []string{}, nil
+	}
+	reviewers2, ok := reviewers1.([]any)
+	if !ok {
+		return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+	}
+	reviewerUUIDs := make([]string, 0, len(reviewers2))
+	reviewerAccountIDs := make([]string, 0, len(reviewers2))
+	for _, reviewer1 := range reviewers2 {
+		reviewer2, ok := reviewer1.(map[string]any)
+		if !ok {
+			return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+		}
+		uuid1, has := reviewer2["uuid"]
+		if !has {
+			return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+		}
+		uuid2, ok := uuid1.(string)
+		if !ok {
+			return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+		}
+		reviewerUUIDs = append(reviewerUUIDs, uuid2)
+		accountID1, has := reviewer2["account_id"]
+		if has {
+			accountID2, ok := accountID1.(string)
+			if !ok {
+				return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+			}
+			reviewerAccountIDs = append(reviewerAccountIDs, accountID2)
+		}
+	}
+	return reviewerUUIDs, reviewerAccountIDs, nil
 }

--- a/internal/forge/bitbucketcloud/parser_test.go
+++ b/internal/forge/bitbucketcloud/parser_test.go
@@ -1,0 +1,49 @@
+package bitbucketcloud
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestParsePullRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves reviewer UUIDs", func(t *testing.T) {
+		t.Parallel()
+
+		give := map[string]any{
+			"id":          float64(123),
+			"title":       "title",
+			"description": "body",
+			"state":       "OPEN",
+			"destination": map[string]any{
+				"branch": map[string]any{
+					"name": "main",
+				},
+			},
+			"source": map[string]any{
+				"branch": map[string]any{
+					"name": "feature",
+				},
+			},
+			"links": map[string]any{
+				"html": map[string]any{
+					"href": "https://bitbucket.org/org/repo/pull-requests/123",
+				},
+			},
+			"close_source_branch": true,
+			"draft":               false,
+			"reviewers": []any{
+				map[string]any{"uuid": "{reviewer-1}", "account_id": "account-1"},
+				map[string]any{"uuid": "{reviewer-2}", "account_id": "account-2"},
+			},
+		}
+
+		have, err := parsePullRequest(give)
+
+		must.NoError(t, err)
+		must.Eq(t, []string{"{reviewer-1}", "{reviewer-2}"}, have.Reviewers)
+		must.Eq(t, []string{"account-1", "account-2"}, have.ReviewerAccountIDs)
+	})
+}

--- a/internal/forge/forgedomain/proposal_data.go
+++ b/internal/forge/forgedomain/proposal_data.go
@@ -22,8 +22,10 @@ func (self ProposalData) Data() ProposalData {
 
 type BitbucketCloudProposalData struct {
 	ProposalData
-	CloseSourceBranch bool
-	Draft             bool
+	CloseSourceBranch  bool
+	Draft              bool
+	Reviewers          []string `json:",omitempty"`
+	ReviewerAccountIDs []string `json:",omitempty"`
 }
 
 func (self BitbucketCloudProposalData) Data() ProposalData {

--- a/internal/forge/forgedomain/proposal_data_test.go
+++ b/internal/forge/forgedomain/proposal_data_test.go
@@ -25,8 +25,10 @@ func TestBitbucketCloudProposalData(t *testing.T) {
 				Title:        "title",
 				URL:          "url",
 			},
-			CloseSourceBranch: true,
-			Draft:             true,
+			CloseSourceBranch:  true,
+			Draft:              true,
+			Reviewers:          []string{"{reviewer-1}", "{reviewer-2}"},
+			ReviewerAccountIDs: []string{"account-1", "account-2"},
 		}
 		serialized, err := json.MarshalIndent(data, "", "  ")
 		must.NoError(t, err)
@@ -41,7 +43,15 @@ func TestBitbucketCloudProposalData(t *testing.T) {
   "Title": "title",
   "URL": "url",
   "CloseSourceBranch": true,
-  "Draft": true
+  "Draft": true,
+  "Reviewers": [
+    "{reviewer-1}",
+    "{reviewer-2}"
+  ],
+  "ReviewerAccountIDs": [
+    "account-1",
+    "account-2"
+  ]
 }`[1:]
 		must.EqOp(t, want, string(serialized))
 
@@ -50,5 +60,7 @@ func TestBitbucketCloudProposalData(t *testing.T) {
 		must.Eq(t, data, data2)
 		must.True(t, data2.CloseSourceBranch)
 		must.True(t, data2.Draft)
+		must.Eq(t, []string{"{reviewer-1}", "{reviewer-2}"}, data2.Reviewers)
+		must.Eq(t, []string{"account-1", "account-2"}, data2.ReviewerAccountIDs)
 	})
 }

--- a/internal/subshell/frontend_runner.go
+++ b/internal/subshell/frontend_runner.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -88,10 +87,6 @@ func (self *FrontendRunner) execute(env []string, cmd string, args ...string) er
 	}
 	if self.PrintCommands {
 		PrintCommand(location, self.PrintBranchNames, env, cmd, args...)
-	}
-	if runtime.GOOS == "windows" && cmd == "start" {
-		args = append([]string{"/C", cmd}, args...)
-		cmd = "cmd"
 	}
 	concurrentGitRetriesLeft := concurrentGitRetries
 	var err error

--- a/vendor/github.com/ktrysmt/go-bitbucket/bitbucket.go
+++ b/vendor/github.com/ktrysmt/go-bitbucket/bitbucket.go
@@ -344,26 +344,27 @@ const (
 )
 
 type PullRequestsOptions struct {
-	ID                string                    `json:"id"`
-	CommentID         string                    `json:"comment_id"`
-	Owner             string                    `json:"owner"`
-	RepoSlug          string                    `json:"repo_slug"`
-	Title             string                    `json:"title"`
-	Description       string                    `json:"description"`
-	CloseSourceBranch bool                      `json:"close_source_branch"`
-	SourceBranch      string                    `json:"source_branch"`
-	SourceRepository  string                    `json:"source_repository"`
-	DestinationBranch string                    `json:"destination_branch"`
-	DestinationCommit string                    `json:"destination_repository"`
-	MergeStrategy     PullRequestsMergeStrategy `json:"merge_strategy"`
-	Message           string                    `json:"message"`
-	Reviewers         []string                  `json:"reviewers"`
-	States            []string                  `json:"states"`
-	Query             string                    `json:"query"`
-	Sort              string                    `json:"sort"`
-	Draft             bool                      `json:"draft"`
-	Commit            string                    `json:"commit"`
-	ctx               context.Context
+	ID                 string                    `json:"id"`
+	CommentID          string                    `json:"comment_id"`
+	Owner              string                    `json:"owner"`
+	RepoSlug           string                    `json:"repo_slug"`
+	Title              string                    `json:"title"`
+	Description        string                    `json:"description"`
+	CloseSourceBranch  bool                      `json:"close_source_branch"`
+	SourceBranch       string                    `json:"source_branch"`
+	SourceRepository   string                    `json:"source_repository"`
+	DestinationBranch  string                    `json:"destination_branch"`
+	DestinationCommit  string                    `json:"destination_repository"`
+	MergeStrategy      PullRequestsMergeStrategy `json:"merge_strategy"`
+	Message            string                    `json:"message"`
+	Reviewers          []string                  `json:"reviewers"`
+	ReviewerAccountIDs []string                  `json:"reviewer_account_ids"`
+	States             []string                  `json:"states"`
+	Query              string                    `json:"query"`
+	Sort               string                    `json:"sort"`
+	Draft              bool                      `json:"draft"`
+	Commit             string                    `json:"commit"`
+	ctx                context.Context
 }
 
 func (po *PullRequestsOptions) WithContext(ctx context.Context) *PullRequestsOptions {

--- a/vendor/github.com/ktrysmt/go-bitbucket/pullrequests.go
+++ b/vendor/github.com/ktrysmt/go-bitbucket/pullrequests.go
@@ -218,15 +218,15 @@ func (p *PullRequests) Statuses(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, error) {
 	body := map[string]interface{}{}
-	body["source"] = map[string]interface{}{}
-	body["destination"] = map[string]interface{}{}
-	body["reviewers"] = []map[string]string{}
-	body["title"] = ""
-	body["description"] = ""
-	body["message"] = ""
-	body["close_source_branch"] = false
-
-	if n := len(po.Reviewers); n > 0 {
+	if n := len(po.ReviewerAccountIDs); n > 0 {
+		body["reviewers"] = make([]map[string]string, n)
+		for i, accountID := range po.ReviewerAccountIDs {
+			body["reviewers"].([]map[string]string)[i] = map[string]string{
+				"type":       "user",
+				"account_id": accountID,
+			}
+		}
+	} else if n := len(po.Reviewers); n > 0 {
 		body["reviewers"] = make([]map[string]string, n)
 		for i, uuid := range po.Reviewers {
 			body["reviewers"].([]map[string]string)[i] = map[string]string{"uuid": uuid}
@@ -234,19 +234,33 @@ func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, er
 	}
 
 	if po.SourceBranch != "" {
-		body["source"].(map[string]interface{})["branch"] = map[string]string{"name": po.SourceBranch}
+		body["source"] = map[string]interface{}{
+			"branch": map[string]string{"name": po.SourceBranch},
+		}
 	}
 
 	if po.SourceRepository != "" {
-		body["source"].(map[string]interface{})["repository"] = map[string]interface{}{"full_name": po.SourceRepository}
+		source, hasSource := body["source"].(map[string]interface{})
+		if !hasSource {
+			source = map[string]interface{}{}
+			body["source"] = source
+		}
+		source["repository"] = map[string]interface{}{"full_name": po.SourceRepository}
 	}
 
 	if po.DestinationBranch != "" {
-		body["destination"].(map[string]interface{})["branch"] = map[string]interface{}{"name": po.DestinationBranch}
+		body["destination"] = map[string]interface{}{
+			"branch": map[string]interface{}{"name": po.DestinationBranch},
+		}
 	}
 
 	if po.DestinationCommit != "" {
-		body["destination"].(map[string]interface{})["commit"] = map[string]interface{}{"hash": po.DestinationCommit}
+		destination, hasDestination := body["destination"].(map[string]interface{})
+		if !hasDestination {
+			destination = map[string]interface{}{}
+			body["destination"] = destination
+		}
+		destination["commit"] = map[string]interface{}{"hash": po.DestinationCommit}
 	}
 
 	if po.Title != "" {
@@ -261,7 +275,7 @@ func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, er
 		body["message"] = po.Message
 	}
 
-	if po.CloseSourceBranch || !po.CloseSourceBranch {
+	if po.CloseSourceBranch {
 		body["close_source_branch"] = po.CloseSourceBranch
 	}
 

--- a/vendor/github.com/ktrysmt/go-bitbucket/pullrequests_test.go
+++ b/vendor/github.com/ktrysmt/go-bitbucket/pullrequests_test.go
@@ -1,0 +1,76 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestBuildPullRequestBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omits empty fields", func(t *testing.T) {
+		t.Parallel()
+
+		pullRequests := PullRequests{}
+
+		have, err := pullRequests.buildPullRequestBody(&PullRequestsOptions{
+			Owner:             "workspace",
+			RepoSlug:          "repo",
+			Title:             "title",
+			Description:       "body",
+			SourceBranch:      "feature",
+			DestinationBranch: "main",
+		})
+
+		must.NoError(t, err)
+		var payload map[string]any
+		must.NoError(t, json.Unmarshal([]byte(have), &payload))
+		must.Eq(t, "title", payload["title"])
+		must.Eq(t, "body", payload["description"])
+		_, hasReviewers := payload["reviewers"]
+		must.False(t, hasReviewers)
+		_, hasMessage := payload["message"]
+		must.False(t, hasMessage)
+		_, hasCloseSourceBranch := payload["close_source_branch"]
+		must.False(t, hasCloseSourceBranch)
+	})
+
+	t.Run("includes reviewers when provided", func(t *testing.T) {
+		t.Parallel()
+
+		pullRequests := PullRequests{}
+
+		have, err := pullRequests.buildPullRequestBody(&PullRequestsOptions{
+			Reviewers: []string{"{reviewer-1}", "{reviewer-2}"},
+		})
+
+		must.NoError(t, err)
+		var payload map[string]any
+		must.NoError(t, json.Unmarshal([]byte(have), &payload))
+		reviewers, hasReviewers := payload["reviewers"].([]any)
+		must.True(t, hasReviewers)
+		must.Len(t, 2, reviewers)
+	})
+
+	t.Run("prefers reviewer account ids when provided", func(t *testing.T) {
+		t.Parallel()
+
+		pullRequests := PullRequests{}
+
+		have, err := pullRequests.buildPullRequestBody(&PullRequestsOptions{
+			ReviewerAccountIDs: []string{"account-1", "account-2"},
+		})
+
+		must.NoError(t, err)
+		var payload map[string]any
+		must.NoError(t, json.Unmarshal([]byte(have), &payload))
+		reviewers, hasReviewers := payload["reviewers"].([]any)
+		must.True(t, hasReviewers)
+		firstReviewer, ok := reviewers[0].(map[string]any)
+		must.True(t, ok)
+		must.Eq(t, "user", firstReviewer["type"])
+		must.Eq(t, "account-1", firstReviewer["account_id"])
+	})
+}


### PR DESCRIPTION
Hello! Thanks for maitaining git-town, it's an awesome tool, I use it all the time 👍 

Some context on my setup: I use windows and bitbucket cloud

I had two painpoints which were causing issues

1. When I would do git town propose on a stacked PR (i.e. not against main), the "browser open" would fail out saying `dest` is not a recognized program: (It tries to open `<url>&dest=target-branch`). This issue has existed forever, but I figured I would try to fix it since my second problem was much more serious.
2. I recently upgraded to 24.0 (from something ~21, there are some great new features!) and enabled the `breadcrumb` feature, which works fine however when I would do a sync on a stack of PRs, all my reviewers would get removed :( 

I'm not really a go programmer, so I tried some debugging and fixing with AI and was able to get both pain-points resolve with what seem like reasonable changes... It was having a lot of trouble figuring out why the escape of the `&` didn't work and decided the easiest fix was to use:

```
rundll32 url.dll,FileProtocolHandler url
```

Changing the program used here seems odd to me, but apparently this is equivalent to asking the OS for the "configured browser" and opening using that, and ships in all windows installs... If you think this is the wrong approach I can try to make the actual escaping work instead..

As for wiping the reviewer, it ended up being kind of similar to https://github.com/git-town/git-town/issues/4900 where the body being sent in the PUT to update the PR did not have all the information from the PR loaded into it and the PUT defaults to clearing out the fields that are unspecified.. The solution was to load the particular PR's data and populate the PUT accordingly!

I have a build of this working on my machine, and I haven't seen any other regressions so far.. Let me know if you have any feedback I'm happy to help make it work for other windows and bitbucket cloud users (maybe only me 😆 )