### PR TITLE
Bitbucket connector fix

### DIFF
--- a/internal/forge/bitbucketcloud/api_connector.go
+++ b/internal/forge/bitbucketcloud/api_connector.go
@@ -181,19 +181,9 @@ func (self APIConnector) SquashMergeProposal(number forgedomain.ProposalNumber, 
 var _ forgedomain.ProposalBodyUpdater = apiConnector // type check
 
 func (self APIConnector) UpdateProposalBody(proposalData forgedomain.ProposalInterface, newBody gitdomain.ProposalBody) error {
-	data := proposalData.(forgedomain.BitbucketCloudProposalData)
+	data := proposalData.Data()
 	self.log.Start(messages.APIProposalUpdateBody, colors.BoldGreen().Styled("#"+data.Number.String()))
-	_, err := self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
-		ID:                data.Number.String(),
-		Owner:             self.Organization,
-		RepoSlug:          self.Repository,
-		SourceBranch:      data.Source.String(),
-		DestinationBranch: data.Target.String(),
-		Title:             data.Title.String(),
-		Description:       newBody.String(),
-		Draft:             data.Draft,
-		CloseSourceBranch: data.CloseSourceBranch,
-	})
+	_, err := self.client.Value.Repositories.PullRequests.Update(self.proposalBodyUpdateOptions(data, newBody))
 	self.log.Finished(err)
 	return err
 }
@@ -205,18 +195,23 @@ func (self APIConnector) UpdateProposalBody(proposalData forgedomain.ProposalInt
 var _ forgedomain.ProposalSourceUpdater = apiConnector // type check
 
 func (self APIConnector) UpdateProposalSource(proposalData forgedomain.ProposalInterface, source gitdomain.LocalBranchName) error {
-	data := proposalData.(forgedomain.BitbucketCloudProposalData)
+	data, err := self.proposalData(proposalData.Data().Number)
+	if err != nil {
+		return err
+	}
 	self.log.Start(messages.APIUpdateProposalSource, colors.BoldGreen().Styled("#"+data.Number.String()), colors.BoldCyan().Styled(source.String()))
-	_, err := self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
-		ID:                data.Number.String(),
-		Owner:             self.Organization,
-		RepoSlug:          self.Repository,
-		SourceBranch:      source.String(),
-		DestinationBranch: data.Target.String(),
-		Title:             data.Title.String(),
-		Description:       data.Body.GetOrZero().String(),
-		Draft:             data.Draft,
-		CloseSourceBranch: data.CloseSourceBranch,
+	_, err = self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
+		ID:                 data.Number.String(),
+		Owner:              self.Organization,
+		RepoSlug:           self.Repository,
+		SourceBranch:       source.String(),
+		DestinationBranch:  data.Target.String(),
+		Title:              data.Title.String(),
+		Description:        data.Body.GetOrZero().String(),
+		Draft:              data.Draft,
+		CloseSourceBranch:  data.CloseSourceBranch,
+		Reviewers:          data.Reviewers,
+		ReviewerAccountIDs: data.ReviewerAccountIDs,
 	})
 	self.log.Finished(err)
 	return err
@@ -229,21 +224,53 @@ func (self APIConnector) UpdateProposalSource(proposalData forgedomain.ProposalI
 var _ forgedomain.ProposalTargetUpdater = apiConnector // type check
 
 func (self APIConnector) UpdateProposalTarget(proposalData forgedomain.ProposalInterface, target gitdomain.LocalBranchName) error {
-	data := proposalData.(forgedomain.BitbucketCloudProposalData)
+	data, err := self.proposalData(proposalData.Data().Number)
+	if err != nil {
+		return err
+	}
 	self.log.Start(messages.APIUpdateProposalTarget, colors.BoldGreen().Styled("#"+data.Number.String()), colors.BoldCyan().Styled(target.String()))
-	_, err := self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
-		ID:                data.Number.String(),
-		Owner:             self.Organization,
-		RepoSlug:          self.Repository,
-		SourceBranch:      data.Source.String(),
-		DestinationBranch: target.String(),
-		Title:             data.Title.String(),
-		Description:       data.Body.GetOrZero().String(),
-		Draft:             data.Draft,
-		CloseSourceBranch: data.CloseSourceBranch,
+	_, err = self.client.Value.Repositories.PullRequests.Update(&bitbucket.PullRequestsOptions{
+		ID:                 data.Number.String(),
+		Owner:              self.Organization,
+		RepoSlug:           self.Repository,
+		SourceBranch:       data.Source.String(),
+		DestinationBranch:  target.String(),
+		Title:              data.Title.String(),
+		Description:        data.Body.GetOrZero().String(),
+		Draft:              data.Draft,
+		CloseSourceBranch:  data.CloseSourceBranch,
+		Reviewers:          data.Reviewers,
+		ReviewerAccountIDs: data.ReviewerAccountIDs,
 	})
 	self.log.Finished(err)
 	return err
+}
+
+func (self APIConnector) proposalData(number forgedomain.ProposalNumber) (forgedomain.BitbucketCloudProposalData, error) {
+	var emptyResult forgedomain.BitbucketCloudProposalData
+	response, err := self.client.Value.Repositories.PullRequests.Get(&bitbucket.PullRequestsOptions{
+		ID:       number.String(),
+		Owner:    self.Organization,
+		RepoSlug: self.Repository,
+	})
+	if err != nil {
+		return emptyResult, err
+	}
+	responseData, ok := response.(map[string]any)
+	if !ok {
+		return emptyResult, errors.New(messages.APIUnexpectedResultDataStructure)
+	}
+	return parsePullRequest(responseData)
+}
+
+func (self APIConnector) proposalBodyUpdateOptions(data forgedomain.ProposalData, newBody gitdomain.ProposalBody) *bitbucket.PullRequestsOptions {
+	return &bitbucket.PullRequestsOptions{
+		ID:          data.Number.String(),
+		Owner:       self.Organization,
+		RepoSlug:    self.Repository,
+		Title:       data.Title.String(),
+		Description: newBody.String(),
+	}
 }
 
 // ============================================================================

--- a/internal/forge/bitbucketcloud/api_connector_test.go
+++ b/internal/forge/bitbucketcloud/api_connector_test.go
@@ -1,0 +1,43 @@
+package bitbucketcloud
+
+import (
+	"testing"
+
+	"github.com/git-town/git-town/v24/internal/forge/forgedomain"
+	"github.com/git-town/git-town/v24/internal/git/gitdomain"
+	"github.com/shoenig/test/must"
+)
+
+func TestProposalBodyUpdateOptions(t *testing.T) {
+	t.Parallel()
+
+	connector := APIConnector{
+		WebConnector: WebConnector{
+			HostedRepoInfo: forgedomain.HostedRepoInfo{
+				Organization: "org",
+				Repository:   "repo",
+			},
+		},
+	}
+	proposalData := forgedomain.ProposalData{
+		Number: 123,
+		Source: "feature",
+		Target: "main",
+		Title:  "title",
+		Body:   gitdomain.NewProposalBodyOpt("existing body"),
+	}
+
+	have := connector.proposalBodyUpdateOptions(proposalData, gitdomain.ProposalBody("updated body"))
+
+	must.EqOp(t, "123", have.ID)
+	must.EqOp(t, "org", have.Owner)
+	must.EqOp(t, "repo", have.RepoSlug)
+	must.EqOp(t, "title", have.Title)
+	must.EqOp(t, "updated body", have.Description)
+	must.EqOp(t, "", have.SourceBranch)
+	must.EqOp(t, "", have.DestinationBranch)
+	must.False(t, have.Draft)
+	must.False(t, have.CloseSourceBranch)
+	must.Len(t, 0, have.Reviewers)
+	must.Len(t, 0, have.ReviewerAccountIDs)
+}

--- a/internal/forge/bitbucketcloud/parser.go
+++ b/internal/forge/bitbucketcloud/parser.go
@@ -135,6 +135,10 @@ func parsePullRequest(pullRequest map[string]any) (forgedomain.BitbucketCloudPro
 	if !ok {
 		return emptyResult, errors.New(messages.APIUnexpectedResultDataStructure)
 	}
+	reviewers, reviewerAccountIDs, err := parseReviewers(pullRequest)
+	if err != nil {
+		return emptyResult, err
+	}
 	return forgedomain.BitbucketCloudProposalData{
 		ProposalData: forgedomain.ProposalData{
 			Active:       isActive,
@@ -146,7 +150,46 @@ func parsePullRequest(pullRequest map[string]any) (forgedomain.BitbucketCloudPro
 			Body:         gitdomain.NewProposalBodyOpt(body2),
 			URL:          url6,
 		},
-		CloseSourceBranch: closeSourceBranch2,
-		Draft:             draft2,
+		CloseSourceBranch:  closeSourceBranch2,
+		Draft:              draft2,
+		Reviewers:          reviewers,
+		ReviewerAccountIDs: reviewerAccountIDs,
 	}, nil
+}
+
+func parseReviewers(pullRequest map[string]any) ([]string, []string, error) {
+	reviewers1, has := pullRequest["reviewers"]
+	if !has {
+		return []string{}, []string{}, nil
+	}
+	reviewers2, ok := reviewers1.([]any)
+	if !ok {
+		return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+	}
+	reviewerUUIDs := make([]string, 0, len(reviewers2))
+	reviewerAccountIDs := make([]string, 0, len(reviewers2))
+	for _, reviewer1 := range reviewers2 {
+		reviewer2, ok := reviewer1.(map[string]any)
+		if !ok {
+			return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+		}
+		uuid1, has := reviewer2["uuid"]
+		if !has {
+			return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+		}
+		uuid2, ok := uuid1.(string)
+		if !ok {
+			return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+		}
+		reviewerUUIDs = append(reviewerUUIDs, uuid2)
+		accountID1, has := reviewer2["account_id"]
+		if has {
+			accountID2, ok := accountID1.(string)
+			if !ok {
+				return nil, nil, errors.New(messages.APIUnexpectedResultDataStructure)
+			}
+			reviewerAccountIDs = append(reviewerAccountIDs, accountID2)
+		}
+	}
+	return reviewerUUIDs, reviewerAccountIDs, nil
 }

--- a/internal/forge/bitbucketcloud/parser_test.go
+++ b/internal/forge/bitbucketcloud/parser_test.go
@@ -1,0 +1,87 @@
+package bitbucketcloud
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestParsePullRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves reviewer UUIDs", func(t *testing.T) {
+		t.Parallel()
+
+		give := map[string]any{
+			"id":          float64(123),
+			"title":       "title",
+			"description": "body",
+			"state":       "OPEN",
+			"destination": map[string]any{
+				"branch": map[string]any{
+					"name": "main",
+				},
+			},
+			"source": map[string]any{
+				"branch": map[string]any{
+					"name": "feature",
+				},
+			},
+			"links": map[string]any{
+				"html": map[string]any{
+					"href": "https://bitbucket.org/org/repo/pull-requests/123",
+				},
+			},
+			"close_source_branch": true,
+			"draft":               false,
+			"reviewers": []any{
+				map[string]any{"uuid": "{reviewer-1}", "account_id": "account-1"},
+				map[string]any{"uuid": "{reviewer-2}", "account_id": "account-2"},
+			},
+		}
+
+		have, err := parsePullRequest(give)
+
+		must.NoError(t, err)
+		must.Eq(t, []string{"{reviewer-1}", "{reviewer-2}"}, have.Reviewers)
+		must.Eq(t, []string{"account-1", "account-2"}, have.ReviewerAccountIDs)
+	})
+
+	t.Run("keeps all reviewer uuids when some account ids are missing", func(t *testing.T) {
+		t.Parallel()
+
+		give := map[string]any{
+			"id":          float64(123),
+			"title":       "title",
+			"description": "body",
+			"state":       "OPEN",
+			"destination": map[string]any{
+				"branch": map[string]any{
+					"name": "main",
+				},
+			},
+			"source": map[string]any{
+				"branch": map[string]any{
+					"name": "feature",
+				},
+			},
+			"links": map[string]any{
+				"html": map[string]any{
+					"href": "https://bitbucket.org/org/repo/pull-requests/123",
+				},
+			},
+			"close_source_branch": true,
+			"draft":               false,
+			"reviewers": []any{
+				map[string]any{"uuid": "{reviewer-1}", "account_id": "account-1"},
+				map[string]any{"uuid": "{reviewer-2}"},
+			},
+		}
+
+		have, err := parsePullRequest(give)
+
+		must.NoError(t, err)
+		must.Eq(t, []string{"{reviewer-1}", "{reviewer-2}"}, have.Reviewers)
+		must.Eq(t, []string{"account-1"}, have.ReviewerAccountIDs)
+	})
+}

--- a/internal/forge/forgedomain/proposal_data.go
+++ b/internal/forge/forgedomain/proposal_data.go
@@ -22,8 +22,10 @@ func (self ProposalData) Data() ProposalData {
 
 type BitbucketCloudProposalData struct {
 	ProposalData
-	CloseSourceBranch bool
-	Draft             bool
+	CloseSourceBranch  bool
+	Draft              bool
+	Reviewers          []string `json:",omitempty"`
+	ReviewerAccountIDs []string `json:",omitempty"`
 }
 
 func (self BitbucketCloudProposalData) Data() ProposalData {

--- a/internal/forge/forgedomain/proposal_data_test.go
+++ b/internal/forge/forgedomain/proposal_data_test.go
@@ -25,8 +25,10 @@ func TestBitbucketCloudProposalData(t *testing.T) {
 				Title:        "title",
 				URL:          "url",
 			},
-			CloseSourceBranch: true,
-			Draft:             true,
+			CloseSourceBranch:  true,
+			Draft:              true,
+			Reviewers:          []string{"{reviewer-1}", "{reviewer-2}"},
+			ReviewerAccountIDs: []string{"account-1", "account-2"},
 		}
 		serialized, err := json.MarshalIndent(data, "", "  ")
 		must.NoError(t, err)
@@ -41,7 +43,15 @@ func TestBitbucketCloudProposalData(t *testing.T) {
   "Title": "title",
   "URL": "url",
   "CloseSourceBranch": true,
-  "Draft": true
+  "Draft": true,
+  "Reviewers": [
+    "{reviewer-1}",
+    "{reviewer-2}"
+  ],
+  "ReviewerAccountIDs": [
+    "account-1",
+    "account-2"
+  ]
 }`[1:]
 		must.EqOp(t, want, string(serialized))
 
@@ -50,5 +60,7 @@ func TestBitbucketCloudProposalData(t *testing.T) {
 		must.Eq(t, data, data2)
 		must.True(t, data2.CloseSourceBranch)
 		must.True(t, data2.Draft)
+		must.Eq(t, []string{"{reviewer-1}", "{reviewer-2}"}, data2.Reviewers)
+		must.Eq(t, []string{"account-1", "account-2"}, data2.ReviewerAccountIDs)
 	})
 }

--- a/vendor/github.com/ktrysmt/go-bitbucket/bitbucket.go
+++ b/vendor/github.com/ktrysmt/go-bitbucket/bitbucket.go
@@ -344,26 +344,27 @@ const (
 )
 
 type PullRequestsOptions struct {
-	ID                string                    `json:"id"`
-	CommentID         string                    `json:"comment_id"`
-	Owner             string                    `json:"owner"`
-	RepoSlug          string                    `json:"repo_slug"`
-	Title             string                    `json:"title"`
-	Description       string                    `json:"description"`
-	CloseSourceBranch bool                      `json:"close_source_branch"`
-	SourceBranch      string                    `json:"source_branch"`
-	SourceRepository  string                    `json:"source_repository"`
-	DestinationBranch string                    `json:"destination_branch"`
-	DestinationCommit string                    `json:"destination_repository"`
-	MergeStrategy     PullRequestsMergeStrategy `json:"merge_strategy"`
-	Message           string                    `json:"message"`
-	Reviewers         []string                  `json:"reviewers"`
-	States            []string                  `json:"states"`
-	Query             string                    `json:"query"`
-	Sort              string                    `json:"sort"`
-	Draft             bool                      `json:"draft"`
-	Commit            string                    `json:"commit"`
-	ctx               context.Context
+	ID                 string                    `json:"id"`
+	CommentID          string                    `json:"comment_id"`
+	Owner              string                    `json:"owner"`
+	RepoSlug           string                    `json:"repo_slug"`
+	Title              string                    `json:"title"`
+	Description        string                    `json:"description"`
+	CloseSourceBranch  bool                      `json:"close_source_branch"`
+	SourceBranch       string                    `json:"source_branch"`
+	SourceRepository   string                    `json:"source_repository"`
+	DestinationBranch  string                    `json:"destination_branch"`
+	DestinationCommit  string                    `json:"destination_repository"`
+	MergeStrategy      PullRequestsMergeStrategy `json:"merge_strategy"`
+	Message            string                    `json:"message"`
+	Reviewers          []string                  `json:"reviewers"`
+	ReviewerAccountIDs []string                  `json:"reviewer_account_ids"`
+	States             []string                  `json:"states"`
+	Query              string                    `json:"query"`
+	Sort               string                    `json:"sort"`
+	Draft              bool                      `json:"draft"`
+	Commit             string                    `json:"commit"`
+	ctx                context.Context
 }
 
 func (po *PullRequestsOptions) WithContext(ctx context.Context) *PullRequestsOptions {

--- a/vendor/github.com/ktrysmt/go-bitbucket/pullrequests.go
+++ b/vendor/github.com/ktrysmt/go-bitbucket/pullrequests.go
@@ -218,15 +218,15 @@ func (p *PullRequests) Statuses(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, error) {
 	body := map[string]interface{}{}
-	body["source"] = map[string]interface{}{}
-	body["destination"] = map[string]interface{}{}
-	body["reviewers"] = []map[string]string{}
-	body["title"] = ""
-	body["description"] = ""
-	body["message"] = ""
-	body["close_source_branch"] = false
-
-	if n := len(po.Reviewers); n > 0 {
+	if n := len(po.ReviewerAccountIDs); n > 0 {
+		body["reviewers"] = make([]map[string]string, n)
+		for i, accountID := range po.ReviewerAccountIDs {
+			body["reviewers"].([]map[string]string)[i] = map[string]string{
+				"type":       "user",
+				"account_id": accountID,
+			}
+		}
+	} else if n := len(po.Reviewers); n > 0 {
 		body["reviewers"] = make([]map[string]string, n)
 		for i, uuid := range po.Reviewers {
 			body["reviewers"].([]map[string]string)[i] = map[string]string{"uuid": uuid}
@@ -234,19 +234,33 @@ func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, er
 	}
 
 	if po.SourceBranch != "" {
-		body["source"].(map[string]interface{})["branch"] = map[string]string{"name": po.SourceBranch}
+		body["source"] = map[string]interface{}{
+			"branch": map[string]string{"name": po.SourceBranch},
+		}
 	}
 
 	if po.SourceRepository != "" {
-		body["source"].(map[string]interface{})["repository"] = map[string]interface{}{"full_name": po.SourceRepository}
+		source, hasSource := body["source"].(map[string]interface{})
+		if !hasSource {
+			source = map[string]interface{}{}
+			body["source"] = source
+		}
+		source["repository"] = map[string]interface{}{"full_name": po.SourceRepository}
 	}
 
 	if po.DestinationBranch != "" {
-		body["destination"].(map[string]interface{})["branch"] = map[string]interface{}{"name": po.DestinationBranch}
+		body["destination"] = map[string]interface{}{
+			"branch": map[string]interface{}{"name": po.DestinationBranch},
+		}
 	}
 
 	if po.DestinationCommit != "" {
-		body["destination"].(map[string]interface{})["commit"] = map[string]interface{}{"hash": po.DestinationCommit}
+		destination, hasDestination := body["destination"].(map[string]interface{})
+		if !hasDestination {
+			destination = map[string]interface{}{}
+			body["destination"] = destination
+		}
+		destination["commit"] = map[string]interface{}{"hash": po.DestinationCommit}
 	}
 
 	if po.Title != "" {
@@ -261,7 +275,7 @@ func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, er
 		body["message"] = po.Message
 	}
 
-	if po.CloseSourceBranch || !po.CloseSourceBranch {
+	if po.CloseSourceBranch {
 		body["close_source_branch"] = po.CloseSourceBranch
 	}
 

--- a/vendor/github.com/ktrysmt/go-bitbucket/pullrequests_test.go
+++ b/vendor/github.com/ktrysmt/go-bitbucket/pullrequests_test.go
@@ -1,0 +1,76 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+func TestBuildPullRequestBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omits empty fields", func(t *testing.T) {
+		t.Parallel()
+
+		pullRequests := PullRequests{}
+
+		have, err := pullRequests.buildPullRequestBody(&PullRequestsOptions{
+			Owner:             "workspace",
+			RepoSlug:          "repo",
+			Title:             "title",
+			Description:       "body",
+			SourceBranch:      "feature",
+			DestinationBranch: "main",
+		})
+
+		must.NoError(t, err)
+		var payload map[string]any
+		must.NoError(t, json.Unmarshal([]byte(have), &payload))
+		must.Eq(t, "title", payload["title"])
+		must.Eq(t, "body", payload["description"])
+		_, hasReviewers := payload["reviewers"]
+		must.False(t, hasReviewers)
+		_, hasMessage := payload["message"]
+		must.False(t, hasMessage)
+		_, hasCloseSourceBranch := payload["close_source_branch"]
+		must.False(t, hasCloseSourceBranch)
+	})
+
+	t.Run("includes reviewers when provided", func(t *testing.T) {
+		t.Parallel()
+
+		pullRequests := PullRequests{}
+
+		have, err := pullRequests.buildPullRequestBody(&PullRequestsOptions{
+			Reviewers: []string{"{reviewer-1}", "{reviewer-2}"},
+		})
+
+		must.NoError(t, err)
+		var payload map[string]any
+		must.NoError(t, json.Unmarshal([]byte(have), &payload))
+		reviewers, hasReviewers := payload["reviewers"].([]any)
+		must.True(t, hasReviewers)
+		must.Len(t, 2, reviewers)
+	})
+
+	t.Run("prefers reviewer account ids when provided", func(t *testing.T) {
+		t.Parallel()
+
+		pullRequests := PullRequests{}
+
+		have, err := pullRequests.buildPullRequestBody(&PullRequestsOptions{
+			ReviewerAccountIDs: []string{"account-1", "account-2"},
+		})
+
+		must.NoError(t, err)
+		var payload map[string]any
+		must.NoError(t, json.Unmarshal([]byte(have), &payload))
+		reviewers, hasReviewers := payload["reviewers"].([]any)
+		must.True(t, hasReviewers)
+		firstReviewer, ok := reviewers[0].(map[string]any)
+		must.True(t, ok)
+		must.Eq(t, "user", firstReviewer["type"])
+		must.Eq(t, "account-1", firstReviewer["account_id"])
+	})
+}


### PR DESCRIPTION
Only the bitbucket connector fixes from https://github.com/git-town/git-town/pull/6276

Decently involved compared to the browser opening PR... I'm not really sure if patching vendored stuff direclty in this repo is a good practice or not, so that's my biggest uncertainty.. Also it's unclear to me if I'm patching this and in so doing breaking possibly working version for other people

Tested that this:
1. Syncs breadcrumbs correctly on stacked PRs
2. Does not wipe reviewers when syncing breadcrumb